### PR TITLE
iptables-legacy support for AIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 FROM_SOURCE :=false
 CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/null))
 ARCH :=$(shell uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
+IPTABLES :=nft
 
 # restrict included verify-* targets to only process project files
 GO_PACKAGES=$(go list ./cmd/... ./pkg/...)
@@ -156,13 +157,14 @@ _build_containerized:
 _build_containerized_aio:
 	@if [ -z '$(CTR_CMD)' ] ; then echo '!! ERROR: containerized builds require podman||docker CLI, none found $$PATH' >&2 && exit 1; fi
 	echo BIN_TIMESTAMP==$(BIN_TIMESTAMP)
-	$(CTR_CMD) build -t $(IMAGE_REPO_AIO):$(SOURCE_GIT_TAG)-linux-$(ARCH) \
+	$(CTR_CMD) build -t $(IMAGE_REPO_AIO):$(SOURCE_GIT_TAG)-linux-$(IPTABLES)-$(ARCH) \
 		-f "$(SRC_ROOT)"/packaging/images/microshift-aio/Dockerfile \
 		--build-arg SOURCE_GIT_TAG=$(SOURCE_GIT_TAG) \
 		--build-arg BIN_TIMESTAMP=$(BIN_TIMESTAMP) \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg MAKE_TARGET="cross-build-linux-$(ARCH)" \
 		--build-arg FROM_SOURCE=$(FROM_SOURCE) \
+		--build-arg IPTABLES=$(IPTABLES) \
 		--platform="linux/$(ARCH)" \
 		.
 .PHONY: _build_containerized_aio
@@ -187,6 +189,11 @@ build-containerized-all-in-one-amd64:
 build-containerized-all-in-one-arm64:
 	+$(MAKE) _build_containerized_aio ARCH=arm64
 .PHONY: build-containerized-all-in-one
+
+build-containerized-all-in-one-iptables-arm64:
+	+$(MAKE) _build_containerized_aio ARCH=arm64 IPTABLES=iptables
+.PHONY: build-containerized-all-in-one-iptables-arm64
+
 ###############################
 # dev targets                 #
 ###############################

--- a/packaging/images/microshift-aio/Dockerfile
+++ b/packaging/images/microshift-aio/Dockerfile
@@ -5,6 +5,7 @@ FROM registry.access.redhat.com/ubi8/go-toolset as builder
 ARG FROM_SOURCE=false
 
 ARG ARCH
+ARG IPTABLES=nft
 
 ENV GOPATH=/opt/app-root GOCACHE=/mnt/cache GO111MODULE=on
 
@@ -59,14 +60,20 @@ RUN dnf install -y cri-o \
 
 RUN sed -i 's|/usr/libexec/crio/conmon|/usr/bin/conmon|' /etc/crio/crio.conf && \
     systemctl enable microshift.service && \
-    systemctl enable crio 
+    systemctl enable crio
 
-RUN if [ "$HOST" == "rhel8" ]; then  \
-        dnf install -y iptables; \
+# rhel7 hosts, or hosts with legacy iptables need the specific iptables binaries, ubi8 comes with iptables-nft translator
+
+RUN if [ "$HOST" == "rhel7" ] || [ "$IPTABLES" != "nft" ]; then  \
+      dnf install -y libnetfilter_conntrack libnfnetlink && dnf clean all && \
+      export ARCH=$(uname -m) && \
+      rpm -v -i --force https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/$ARCH/os/Packages/i/iptables-libs-1.6.2-2.fc28.$ARCH.rpm \
+                   https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/$ARCH/os/Packages/i/iptables-1.6.2-2.fc28.$ARCH.rpm ; \
     else \
-      dnf install -y libnetfilter_conntrack libnfnetlink && \
-      rpm -v -i --force https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/i/iptables-libs-1.6.2-2.fc28.x86_64.rpm \
-                   https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/i/iptables-1.6.2-2.fc28.x86_64.rpm && \
+        dnf install -y iptables && dnf clean all; \
+    fi
+
+RUN if [ "$HOST" == "rhel8" ]; then \
       sed -e '/mountopt/s/,\?metacopy=on,\?//' -i /etc/containers/storage.conf; \
     fi
 


### PR DESCRIPTION
This allows using non-nft enabled kernels, like the ubuntu 18.04LTS on the Nvidia Jetson boards

```
 make build-containerized-all-in-one-iptables-arm64 FROM_SOURCE=true
```

or 

```
 make build-containerized-all-in-one-iptables-arm64
```

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
