### PR TITLE
enable podman build from source for microshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ _build_containerized:
 		--build-arg BIN_TIMESTAMP=$(BIN_TIMESTAMP) \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg MAKE_TARGET="cross-build-linux-$(ARCH)" \
+		--build-arg FROM_SOURCE=$(FROM_SOURCE) \
 		--platform="linux/$(ARCH)" \
 		.
 .PHONY: _build_containerized


### PR DESCRIPTION
Signed-off-by: Parul <parsingh@redhat.com>

Currently only aio images can be built from source. This PR adds `"$FROM_SOURCE" == "true"` in the Makefile for `_build_containerized:`
