### PR TITLE
[WIP]: Remove redunant volume create command

### DIFF
--- a/packaging/systemd/microshift-aio
+++ b/packaging/systemd/microshift-aio
@@ -4,12 +4,8 @@ set -euxo pipefail
 
 setsebool -P container_manage_cgroup true
 
-if ! /usr/bin/podman volume exists microshift-data
-then
-  /usr/bin/podman volume create microshift-data
-fi
-
 [[ -d /etc/microshift-aio ]] || mkdir /etc/microshift-aio
+
 cat <<EOF > /etc/microshift-aio/microshift-aio.conf
 export KUBECONFIG=$(/usr/bin/podman volume inspect microshift-data --format "{{.Mountpoint}}")/microshift/resources/kubeadmin/kubeconfig
 EOF


### PR DESCRIPTION
Default behavior for `podman run -v <named_volumed>:/xyz` is to create
the volume if it does not exist[0].

```
Similarly, SOURCE-VOLUME:/CONTAINER-DIR will mount the volume in the
host to the container. If no such named volume exists, Podman will
create one.
```

[0]: https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options

```
microshift  redunant-volume-creation [$] 43s
❯ podman volume exists majora

microshift  redunant-volume-creation [$]
❯ echo $?
1

microshift  redunant-volume-creation [$]
❯ podman run --rm -v majora:/majora fedora:34 sleep 1

microshift  redunant-volume-creation [$] 1s
❯ podman volume exists majora

microshift  redunant-volume-creation [$]
❯ echo $?
0
```