### PR TITLE
Adds a .copr/Makefile for copr.fedorainfracloud.org to consume

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,17 @@
+# This Makefile provides a wrapper script for copr [1] to consume
+# [1] https://copr.fedorainfracloud.org/coprs/g/redhat-et/microshift-nightly/
+#
+# The process looks like:
+# 1) github webhooks call copr on git pushes
+# 2) copr downloads the git repository
+# 3) copr executes make -f .copr/Makefile srpm outdir=.....
+# 4) copr consumes the resulting source rpms to build the repositories
+#
+# additional details can be found here:
+#   https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm
+
+outdir ?= /tmp
+
+srpm:
+	cd .. && make srpm
+	cp ../packaging/rpm/_rpmbuild/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
This is used in the following way:

1) github webhooks call copr on git pushes
2) copr downloads the git repository
3) copr executes make -f .copr/Makefile srpm outdir=.....
4) copr consumes the resulting source rpms to build the repositories

 additional details can be found here:
   https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm
   https://copr.fedorainfracloud.org/coprs/g/redhat-et/microshift-nightly/

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
