### PR TITLE
Fix copr integration

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -13,5 +13,5 @@
 outdir ?= /tmp
 
 srpm:
-	cd .. && make srpm
-	cp ../packaging/rpm/_rpmbuild/SRPMS/*.src.rpm $(outdir)
+	make srpm # from the project top level makefile
+	cp packaging/rpm/_rpmbuild/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
It's called from the project root directory with

make -f .copr/Makefile srpm outdir=...

This means that we are already on the project root directory,
otherwise this fails on copr with:

```
stdout: cd .. && make srpm
make[1]: Entering directory '/mnt/workdir-8s69h1kn'
make[1]: Leaving directory '/mnt/workdir-8s69h1kn'
make[1]: *** No rule to make target 'srpm'.  Stop.
```

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
