### PR TITLE
Install go binaries and git during .copr build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -13,5 +13,6 @@
 outdir ?= /tmp
 
 srpm:
+	dnf -y install golang-bin git
 	make srpm # from the project top level makefile
 	cp packaging/rpm/_rpmbuild/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
Fixes:

```
stdout: make srpm # from the project top level makefile
make[1]: Entering directory '/mnt/workdir-yagcubnt/microshift'
/usr/bin/bash: line 1: go: command not found
```

Based on the example from : https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm
Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
