### PR TITLE
Make srpm package versions incremental for nightlies

### DIFF
--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -9,6 +9,10 @@ BUILD=${BUILD:-all}
 # generated from other info
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 RPM_REL=$(git describe --tags | sed s/"${RELEASE_PRE}-"//g | sed s/-/_/g )
+
+# add the git commit timestamp for nightlies, so updates will always work on devices old pkg < new pkg
+RPM_REL=$(echo "${RPM_REL}" | sed s/nightly_/nightly_$(git show -s --format=%ct)_/g)
+
 GIT_SHA=$(git rev-parse HEAD)
 # using this instead of rev-parse --short because github's is 1 char shorter than --short
 GIT_SHORTHASH="${GIT_SHA:0:7}"


### PR DESCRIPTION
Every new srpm package for a non-release version (nightly releases)
will contain a timestamp based on the latest commit.
```
[majopela@fedora microshift]$ git show -s --format=%ct
1635423510
[majopela@fedora microshift]$ make srpm
--> microshift-4.8.0-nightly_1635423510_1_gf324a3dc.fc34.src.rpm
```
This makes updates possible for consumers of the nightly copr
repository.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
