### PR TITLE
service-ca pod run as non-root

### DIFF
--- a/assets/apps/0000_60_service-ca_05_deploy.yaml
+++ b/assets/apps/0000_60_service-ca_05_deploy.yaml
@@ -23,7 +23,10 @@ spec:
         app: service-ca
         service-ca: "true"
     spec:
-      securityContext: {}
+      securityContext:
+        runAsGroup: 1001
+        runAsNonRoot: true
+        runAsUser: 1001
       serviceAccount: service-ca
       serviceAccountName: service-ca
       containers:
@@ -33,8 +36,6 @@ spec:
         command: ["service-ca-operator", "controller"]
         ports:
         - containerPort: 8443
-        # securityContext:
-        #   runAsNonRoot: true
         resources:
           requests:
             memory: 120Mi

--- a/pkg/assets/apps/bindata.go
+++ b/pkg/assets/apps/bindata.go
@@ -204,7 +204,10 @@ spec:
         app: service-ca
         service-ca: "true"
     spec:
-      securityContext: {}
+      securityContext:
+        runAsGroup: 1001
+        runAsNonRoot: true
+        runAsUser: 1001
       serviceAccount: service-ca
       serviceAccountName: service-ca
       containers:
@@ -214,8 +217,6 @@ spec:
         command: ["service-ca-operator", "controller"]
         ports:
         - containerPort: 8443
-        # securityContext:
-        #   runAsNonRoot: true
         resources:
           requests:
             memory: 120Mi


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

**NOTE** In order for `service-ca` to run with `non-root`, have to modify the signing-bundle and TLS crt,key volumes to be a configmap & secret, otherwise the non-root uid in the pod can't access the `service-ca.crt, tls.crt, tls.key` files it needs. Also, the OCP cluster-policy-controller must be running.

This PR depends on 
https://github.com/redhat-et/microshift/pull/504 (service-ca volumes as CA configmap, TLS secret)
https://github.com/redhat-et/microshift/pull/478 (cluster-policy-controller)
Closes #<Issue Number>
