### PR TITLE
Move conmon to pod slice

### DIFF
--- a/packaging/crio.conf.d/microshift.conf
+++ b/packaging/crio.conf.d/microshift.conf
@@ -1,3 +1,9 @@
+[crio.runtime]
+selinux = true
+conmon = ""
+conmon_cgroup = "pod"
+cgroup_manager = "systemd"
+
 [crio.network]
 # cbr0 is the name configured by flannel in /etc/cni/net.d/ config file
 # by declaring this crio will wait until that network is configured.


### PR DESCRIPTION
Moves conmon to the pod cgroup slice.

Combined with #620 addresses [USHIFT-25](https://issues.redhat.com/browse/USHIFT-25).

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>
