### PR TITLE
Update microshift release url

### DIFF
--- a/hack/all-in-one/Dockerfile
+++ b/hack/all-in-one/Dockerfile
@@ -10,7 +10,7 @@ USER root
 RUN if [ "$FROM_SOURCE" == "true" ]; then \
         mv microshift /usr/local/bin/microshift; \
     else \
-        export VERSION=$(curl -s https://api.github.com/repos/redhat-et/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
+        export VERSION=$(curl -s https://api.github.com/repos/openshift/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
         curl -LO https://github.com/openshift/microshift/releases/download/$VERSION/microshift-linux-${ARCH} && \
         mv microshift-linux-${ARCH} /usr/local/bin/microshift; \
      fi

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -12,7 +12,7 @@ CONFIG_ENV_ONLY=${CONFIG_ENV_ONLY:=false}
 
 # Only get the version number if installing a release version
 [ $CONFIG_ENV_ONLY = false ] && \
-  VERSION=$(curl -s https://api.github.com/repos/redhat-et/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4)
+  VERSION=$(curl -s https://api.github.com/repos/openshift/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4)
 
 # Function to get Linux distribution
 get_distro() {

--- a/packaging/images/microshift-aio/Dockerfile
+++ b/packaging/images/microshift-aio/Dockerfile
@@ -28,7 +28,7 @@ RUN if [ "$FROM_SOURCE" == "true" ]; then \
       make clean $MAKE_TARGET SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP && \
       mv _output/bin/linux_$ARCH/microshift microshift; \
     else \
-      export VERSION=$(curl -s https://api.github.com/repos/redhat-et/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
+      export VERSION=$(curl -s https://api.github.com/repos/openshift/microshift/releases | grep tag_name | head -n 1 | cut -d '"' -f 4) && \
       curl -LO https://github.com/openshift/microshift/releases/download/$VERSION/microshift-linux-$ARCH && \
       mv microshift-linux-$ARCH microshift; \
     fi


### PR DESCRIPTION
Get the following response when curling release version:

$ curl -s https://api.github.com/repos/redhat-et/microshift/releases
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/361784175/releases",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}

Signed-off-by: Zenghui Shi <zshi@redhat.com>
