### PR TITLE
Image builder using local RPM packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-_output/*
-/microshift
-packaging/rpm/_rpmbuild/
-bin
 .idea/
-.vscode/
 .vagrant/
+.vscode/
+/microshift
 Vagrantfile
+_output/*
+bin
+packaging/rpm/_rpmbuild/
+scripts/image-builder/_builds/
 sshfile

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -25,7 +25,7 @@ SOURCE_GIT_TAG="$(git describe --tags | sed s/nightly-/nightly-$(git show -s --f
 create_local_tarball() {
   tar -czf "${RPMBUILD_DIR}/SOURCES/${TARBALL_FILE}" \
             --exclude='.git' --exclude='.idea' --exclude='.vagrant' \
-            --exclude='_output' --exclude='rpm/_rpmbuild' \
+            --exclude='_output' --exclude='rpm/_rpmbuild' --exclude='image-builder/_builds' \
             --transform="s|^|microshift-${GIT_SHA}/|"  \
             --exclude="${TARBALL_FILE}" "${SCRIPT_DIR}/../../"
 }

--- a/scripts/image-builder/blueprint_v0.0.1.toml
+++ b/scripts/image-builder/blueprint_v0.0.1.toml
@@ -1,0 +1,51 @@
+name = "microshift-container"
+
+description = ""
+version = "0.0.1"
+modules = []
+groups = []
+
+# MicroShift and dependencies
+
+[[packages]]
+name = "microshift"
+version = "*"
+
+[[packages]]
+name = "conntrack-tools"
+version = "*"
+
+[[packages]]
+name = "openshift-clients"
+version = "*"
+
+# troubleshooting tools
+
+[[packages]]
+name = "iputils"
+version = "*"
+
+[[packages]]
+name = "bind-utils"
+version = "*"
+
+[[packages]]
+name = "net-tools"
+version = "*"
+
+[[packages]]
+name = "iotop"
+version = "*"
+
+# other
+
+[[packages]]
+name = "redhat-release"
+version = "*"
+
+# customizations
+
+[customizations]
+
+[customizations.services]
+enabled = ["crio", "microshift"]

--- a/scripts/image-builder/blueprint_v0.0.1.toml
+++ b/scripts/image-builder/blueprint_v0.0.1.toml
@@ -12,10 +12,6 @@ name = "microshift"
 version = "*"
 
 [[packages]]
-name = "conntrack-tools"
-version = "*"
-
-[[packages]]
 name = "openshift-clients"
 version = "*"
 

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -e -o pipefail
+
+IMGNAME=microshift
+ROOTDIR=$(git rev-parse --show-toplevel)/scripts/image-builder
+
+trap ${ROOTDIR}/cleanup.sh INT
+
+title() {
+    echo -e "\E[34m\n# $1\E[00m";
+}
+
+waitfor_image() {
+    local uuid=$1
+
+    local tstart=$(date +%s)
+    local status=$(sudo composer-cli compose status | grep ${uuid} | awk '{print $2}')
+    while [ "${status}" = "RUNNING" ]; do
+        sleep 10
+        status=$(sudo composer-cli compose status | grep ${uuid} | awk '{print $2}')
+        echo -en "$(date +'%Y-%m-%d %H:%M:%S') ${status}\r"
+    done
+    local tend=$(date +%s)
+    echo "$(date +'%Y-%m-%d %H:%M:%S') ${status} - elapsed $(( (tend - tstart) / 60 )) minutes"
+    
+    if [ "${status}" = "FAILED" ]; then
+        download_image ${uuid}
+        echo "Blueprint build has failed. For more information, review the downloaded logs"
+        exit 1
+    fi
+}
+
+download_image() {
+    local uuid=$1
+
+    sudo composer-cli compose logs ${uuid}
+    sudo composer-cli compose metadata ${uuid}
+    sudo composer-cli compose image ${uuid}
+    sudo chown -R $(whoami). "${ROOTDIR}/_builds"
+}
+
+build_image() {
+    local blueprint_file=$1
+    local blueprint=$2
+    local version=$3
+    local image_type=$4
+    local parent_blueprint=$5
+    local parent_version=$6
+
+    title "Loading ${blueprint} blueprint v${version}"
+    sudo composer-cli blueprints delete ${blueprint} 2>/dev/null || true
+    sudo composer-cli blueprints push "${ROOTDIR}/${blueprint_file}"
+    sudo composer-cli blueprints depsolve ${blueprint} 1>/dev/null
+
+    if [ -n "$parent_version" ]; then
+        title "Serving ${parent_blueprint} v${parent_version} container locally"
+        sudo podman rm -f ${parent_blueprint}-server 2>/dev/null || true
+        sudo podman rmi -f localhost/${parent_blueprint}:${parent_version} 2>/dev/null || true
+        imageid=$(cat ./${parent_blueprint}-${parent_version}-container.tar | sudo podman load | grep -o -P '(?<=sha256[@:])[a-z0-9]*')
+        sudo podman tag ${imageid} localhost/${parent_blueprint}:${parent_version}
+        sudo podman run -d --name=${parent_blueprint}-server -p 8080:8080 localhost/${parent_blueprint}:${parent_version}
+
+        title "Building ${image_type} for ${blueprint} v${version}, parent ${parent_blueprint} v${parent_version}"
+        buildid=$(sudo composer-cli compose start-ostree --ref rhel/8/$(uname -i)/edge --url http://localhost:8080/repo/ ${blueprint} ${image_type} | awk '{print $2}')
+    else
+        title "Building ${image_type} for ${blueprint} v${version}"
+        buildid=$(sudo composer-cli compose start-ostree --ref rhel/8/$(uname -i)/edge ${blueprint} ${image_type} | awk '{print $2}')
+    fi
+
+    waitfor_image ${buildid}
+    download_image ${buildid}
+    rename ${buildid} ${blueprint}-${version} ${buildid}*.{tar,iso} 2>/dev/null || true
+}
+
+mkdir -p ${ROOTDIR}/_builds
+pushd ${ROOTDIR}/_builds &>/dev/null
+
+# Also enter sudo password in the beginning if necessary
+title "Checking available disk space"
+build_disk=$(sudo df -k --output=avail . | tail -1)
+if [ ${build_disk} -lt 15728640 ] ; then
+    echo "WARNING: Less then 15GB of disk space is available for the build"
+    exit 1
+fi
+
+title "Downloading local OpenShift and MicroShift repositories"
+# Copy microshift local RPM packages
+rm -rf microshift-local 2>/dev/null || true
+cp -TR "${ROOTDIR}/../../packaging/rpm/_rpmbuild/RPMS" microshift-local
+createrepo microshift-local >/dev/null
+
+# Download openshift local RPM packages
+rm -rf openshift-local 2>/dev/null || true
+reposync -n -a x86_64 --download-path openshift-local --repo=rhocp-4.10-for-rhel-8-x86_64-rpms >/dev/null
+createrepo openshift-local >/dev/null
+
+title "Loading sources for OpenShift and MicroShift"
+for f in openshift-local microshift-local ; do
+    cat ../${f}.toml | sed "s;REPLACE_IMAGE_BUILDER_DIR;${ROOTDIR};g" > ${f}.toml
+    sudo composer-cli sources delete $f 2>/dev/null || true
+    sudo composer-cli sources add ${ROOTDIR}/_builds/${f}.toml
+done
+
+build_image blueprint_v0.0.1.toml "${IMGNAME}-container" 0.0.1 edge-container
+build_image installer.toml        "${IMGNAME}-installer" 0.0.0 edge-installer "${IMGNAME}-container" 0.0.1
+
+title "Embedding kickstart in the installer image"
+# TODO: Replace with the real server
+cat "../kickstart.ks" | sed "s;REPLACE_OSTREE_SERVER_IP;localhost:8080;g" > kickstart.ks
+sudo podman run --rm --privileged -ti -v "${ROOTDIR}/_builds":/data -v /dev:/dev fedora /bin/bash -c \
+    "dnf -y install lorax; cd /data; \
+    mkksiso kickstart.ks ${IMGNAME}-installer-0.0.0-installer.iso ${IMGNAME}-installer.$(uname -i).iso; \
+    exit"
+sudo chown -R $(whoami). "${ROOTDIR}/_builds"
+
+title "Done"
+${ROOTDIR}/cleanup.sh
+popd &>/dev/null

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -121,6 +121,7 @@ sudo podman run --rm --privileged -ti -v "${ROOTDIR}/_builds":/data -v /dev:/dev
     exit"
 sudo chown -R $(whoami). "${ROOTDIR}/_builds"
 
-title "Done"
 ${ROOTDIR}/cleanup.sh
+
+title "Done"
 popd &>/dev/null

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -78,8 +78,8 @@ pushd ${ROOTDIR}/_builds &>/dev/null
 # Also enter sudo password in the beginning if necessary
 title "Checking available disk space"
 build_disk=$(sudo df -k --output=avail . | tail -1)
-if [ ${build_disk} -lt 15728640 ] ; then
-    echo "WARNING: Less then 15GB of disk space is available for the build"
+if [ ${build_disk} -lt 10485760 ] ; then
+    echo "ERROR: Less then 10GB of disk space is available for the build"
     exit 1
 fi
 

--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -32,7 +32,6 @@ sudo podman rm  -f microshift-container-server 2>/dev/null || true
 title "Cancelling composer jobs"
 for uid in $(sudo composer-cli compose list | awk '{print $1}') ; do
     sudo composer-cli compose cancel $uid 2>/dev/null || true
-    [ "$FULL_CLEAN" = 1 ] && sudo composer-cli compose delete $uid || true
 done
 
 if [ "$FULL_CLEAN" = 1 ] ; then

--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e -o pipefail
 
-IMGNAME=microshift
 ROOTDIR=$(git rev-parse --show-toplevel)/scripts/image-builder
 
 title() {
@@ -27,7 +26,8 @@ if [ "$FULL_CLEAN" = 1 ] ; then
 fi
 
 title "Cleaning up local ostree container server"
-sudo podman rm -f ${IMGNAME}-server 2>/dev/null || true
+sudo podman rm  -f microshift-container-server 2>/dev/null || true
+[ "$FULL_CLEAN" = 1 ] && sudo podman rmi -a
 
 title "Cancelling composer jobs"
 for uid in $(sudo composer-cli compose list | awk '{print $1}') ; do
@@ -45,6 +45,11 @@ fi
 title "Cleaning up composer sources"
 sudo composer-cli sources delete openshift-local  2>/dev/null || true
 sudo composer-cli sources delete microshift-local 2>/dev/null || true
+
+if [ "$FULL_CLEAN" = 1 ] ; then
+    title "Clean up user cache"
+    rm -rf ~/.cache 2>/dev/null || true
+fi
 
 title "Clean osbuild worker cache"
 sudo systemctl stop osbuild-composer.socket osbuild-composer.service osbuild-worker@1.service

--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e -o pipefail
+
+IMGNAME=microshift
+ROOTDIR=$(git rev-parse --show-toplevel)/scripts/image-builder
+
+title() {
+    echo -e "\E[34m\n# $1\E[00m";
+}
+
+# Parse command line
+if [ $# -ge 1 ] ; then
+    case "$1" in
+    -full)
+        FULL_CLEAN=1
+        ;;
+    *)
+        echo "Usage: $(basename $0) [-full]"
+        exit 0
+        ;;
+    esac
+fi
+
+if [ "$FULL_CLEAN" = 1 ] ; then
+    title "Cleaning the build directory"
+    rm -rf ${ROOTDIR}/_builds
+fi
+
+title "Cleaning up local ostree container server"
+sudo podman rm -f ${IMGNAME}-server 2>/dev/null || true
+
+title "Cancelling composer jobs"
+for uid in $(sudo composer-cli compose list | awk '{print $1}') ; do
+    sudo composer-cli compose cancel $uid 2>/dev/null || true
+    [ "$FULL_CLEAN" = 1 ] && sudo composer-cli compose delete $uid || true
+done
+
+if [ "$FULL_CLEAN" = 1 ] ; then
+    title "Deleting composer jobs"
+    for uid in $(sudo composer-cli compose list | awk '{print $1}') ; do
+        sudo composer-cli compose delete $uid || true
+    done
+fi
+
+title "Cleaning up composer sources"
+sudo composer-cli sources delete openshift-local  2>/dev/null || true
+sudo composer-cli sources delete microshift-local 2>/dev/null || true
+
+title "Clean osbuild worker cache"
+sudo systemctl stop osbuild-composer.socket osbuild-composer.service osbuild-worker@1.service
+sleep 3
+sudo rm -rf /var/cache/osbuild-worker/*
+sudo systemctl start osbuild-composer.socket

--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exo pipefail
+
+sudo dnf install -y git osbuild-composer composer-cli cockpit-composer bash-completion podman genisoimage createrepo syslinux
+sudo systemctl enable osbuild-composer.socket --now
+sudo systemctl enable cockpit.socket --now
+sudo firewall-cmd -q --add-service=cockpit
+sudo firewall-cmd -q --add-service=cockpit --permanent

--- a/scripts/image-builder/installer.toml
+++ b/scripts/image-builder/installer.toml
@@ -1,0 +1,7 @@
+name = "microshift-installer"
+
+description = ""
+version = "0.0.0"
+modules = []
+groups = []
+packages = []

--- a/scripts/image-builder/kickstart.ks
+++ b/scripts/image-builder/kickstart.ks
@@ -1,0 +1,28 @@
+lang en_US.UTF-8
+keyboard us
+timezone UTC
+zerombr
+clearpart --all --initlabel
+autopart --type=plain --fstype=xfs --nohome
+reboot
+text
+network --bootproto=dhcp --device=link --activate --onboot=on
+
+ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/ostree/repo --ref=rhel/8/x86_64/edge
+
+%post --log=/var/log/anaconda/post-install.log --erroronfail
+
+# TODO: Replace localhost by the actual server IP
+echo -e 'url=http://REPLACE_OSTREE_SERVER_IP/repo/' >> /etc/ostree/remotes.d/edge.conf
+
+useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat
+mkdir -p /home/redhat/.ssh
+chmod 755 /home/redhat/.ssh
+tee /home/redhat/.ssh/authorized_keys > /dev/null << EOF
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxnQB1tTWJBbt4sGwV9AEfz+Y8FKRvrOaeP3+1O3C0VhBjgsYtroH8g7oJWBHS+mXYjY7SpmV5ML5zw6rT4DjL2XKgxZFglWoF9aKs4Hm4hqzx1MvtIlGozqh7tPxDFiyi/u4yNZhnF46lS9OzFp82g/ejRinuG7TTq5WNFSTpElDMpXOqzFx0l5IBNjsDLL2Cj7gHEuCVBP9bEXOEqZkNDFDqqZRrFlnosdikoqaCVzPCfXf1obWAuLLGb2NjUd/xuRl/hTjMiuXxqbmkRzEkjwnoVQ/bUKmfZPEcLPBQ+ttugDq+fbeTNdJi5ucuqTigiFNZJt26yMK7Ic2YDlycOhZsiSwRJ1PNCFUFUGhSyt5GnudhxJTVlOmKPWgzCoCgLypVDkledkSXSH+Y+q+4yXZDh1J7h0al6DBkH/XqxmSQU7jbCGWNhlSMYgeuqUhvySmv1o5EvWJLMxQXCp5gxcgLeM4LWkIpqrwnGv66Nw2JQ4GPGkemhdnf77xuWA5wgml5jAOtrTiLYKi71Tb8bRrOxIXqRMIXcU2I9FYZ1/db/IVoYYQRV9ZHvVMrxKeX0sL3d6wH9E39z9fTdNf6HOXucIJ7dXDkhC8GktTlPZ5f1YbfcB4JQTP7hHxWWIA9ouPb+tU35myV+IykV3ll7OASh166ZuKzWPAo6NWGZQ== edge@lab
+EOF
+echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+
+firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
+
+%end

--- a/scripts/image-builder/kickstart.ks
+++ b/scripts/image-builder/kickstart.ks
@@ -12,7 +12,6 @@ ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/o
 
 %post --log=/var/log/anaconda/post-install.log --erroronfail
 
-# TODO: Replace localhost by the actual server IP
 echo -e 'url=http://REPLACE_OSTREE_SERVER_IP/repo/' >> /etc/ostree/remotes.d/edge.conf
 
 useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat

--- a/scripts/image-builder/microshift-local.toml
+++ b/scripts/image-builder/microshift-local.toml
@@ -1,0 +1,7 @@
+id = "microshift-local"
+name = "MicroShift Local Repo"
+type = "yum-baseurl"
+url = "file://REPLACE_IMAGE_BUILDER_DIR/_builds/microshift-local/"
+check_gpg = false
+check_ssl = false
+system = false

--- a/scripts/image-builder/openshift-local.toml
+++ b/scripts/image-builder/openshift-local.toml
@@ -1,0 +1,7 @@
+id = "openshift-local"
+name = "OpenShift Local Repo"
+type = "yum-baseurl"
+url = "file://REPLACE_IMAGE_BUILDER_DIR/_builds/openshift-local/"
+check_gpg = false
+check_ssl = false
+system = false


### PR DESCRIPTION
Implement a procedure for building microshift installer ISO using the locally built (for microshift) & downloaded (for OCP) RPM packages.

The build procedure amounts to running the following scripts from scripts/image-builder directory:
- configure.sh - One time build tool installation and system configuration
- cleanup.sh - Delete all the previous artifacts, podman & osbuilder images to conserve disk space
- make rpm - Build MicroShift locally and prepare its RPM packages
- build.sh - Build the _builds/microshift-installer.x86_64.iso

[USHIFT-54](https://issues.redhat.com//browse/USHIFT-54)