### PR TITLE
Remove SSH key from kickstart and clean up intermediate ISO image file

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -3,8 +3,10 @@ set -e -o pipefail
 
 IMGNAME=microshift
 ROOTDIR=$(git rev-parse --show-toplevel)/scripts/image-builder
+STARTTIME=$(date +%s)
 
 trap ${ROOTDIR}/cleanup.sh INT
+trap 'echo "Execution time: $(( ($(date +%s) - STARTTIME) / 60 )) minutes"' EXIT
 
 title() {
     echo -e "\E[34m\n# $1\E[00m";

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -121,6 +121,9 @@ sudo podman run --rm --privileged -ti -v "${ROOTDIR}/_builds":/data -v /dev:/dev
     exit"
 sudo chown -R $(whoami). "${ROOTDIR}/_builds"
 
+# Remove intermediate artifacts to free disk space
+rm -f ${IMGNAME}-installer-0.0.0-installer.iso
+
 ${ROOTDIR}/cleanup.sh
 
 title "Done"

--- a/scripts/image-builder/kickstart.ks
+++ b/scripts/image-builder/kickstart.ks
@@ -15,11 +15,9 @@ ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/o
 echo -e 'url=http://REPLACE_OSTREE_SERVER_IP/repo/' >> /etc/ostree/remotes.d/edge.conf
 
 useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat
-mkdir -p /home/redhat/.ssh
-chmod 755 /home/redhat/.ssh
-tee /home/redhat/.ssh/authorized_keys > /dev/null << EOF
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCxnQB1tTWJBbt4sGwV9AEfz+Y8FKRvrOaeP3+1O3C0VhBjgsYtroH8g7oJWBHS+mXYjY7SpmV5ML5zw6rT4DjL2XKgxZFglWoF9aKs4Hm4hqzx1MvtIlGozqh7tPxDFiyi/u4yNZhnF46lS9OzFp82g/ejRinuG7TTq5WNFSTpElDMpXOqzFx0l5IBNjsDLL2Cj7gHEuCVBP9bEXOEqZkNDFDqqZRrFlnosdikoqaCVzPCfXf1obWAuLLGb2NjUd/xuRl/hTjMiuXxqbmkRzEkjwnoVQ/bUKmfZPEcLPBQ+ttugDq+fbeTNdJi5ucuqTigiFNZJt26yMK7Ic2YDlycOhZsiSwRJ1PNCFUFUGhSyt5GnudhxJTVlOmKPWgzCoCgLypVDkledkSXSH+Y+q+4yXZDh1J7h0al6DBkH/XqxmSQU7jbCGWNhlSMYgeuqUhvySmv1o5EvWJLMxQXCp5gxcgLeM4LWkIpqrwnGv66Nw2JQ4GPGkemhdnf77xuWA5wgml5jAOtrTiLYKi71Tb8bRrOxIXqRMIXcU2I9FYZ1/db/IVoYYQRV9ZHvVMrxKeX0sL3d6wH9E39z9fTdNf6HOXucIJ7dXDkhC8GktTlPZ5f1YbfcB4JQTP7hHxWWIA9ouPb+tU35myV+IykV3ll7OASh166ZuKzWPAo6NWGZQ== edge@lab
-EOF
+mkdir -p -m 0700 /home/redhat/.ssh
+chown redhat. /home/redhat/.ssh
+
 echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
 firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16

--- a/scripts/image-builder/kickstart.ks
+++ b/scripts/image-builder/kickstart.ks
@@ -15,8 +15,6 @@ ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/o
 echo -e 'url=http://REPLACE_OSTREE_SERVER_IP/repo/' >> /etc/ostree/remotes.d/edge.conf
 
 useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat
-mkdir -p -m 0700 /home/redhat/.ssh
-chown redhat. /home/redhat/.ssh
 
 echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 


### PR DESCRIPTION
Minor enhancement to remove the SSH public key from kickstart and delete intermediate ISO to clean up disk space.
[USHIFT-54](https://issues.redhat.com//browse/USHIFT-54)