### PR TITLE
Remove embedded CLI calls

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,17 +108,24 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 }
 
 // extract the api server port from the cluster URL
-func (c *ClusterConfig) ApiServerPort() (string, error) {
+func (c *ClusterConfig) ApiServerPort() (int, error) {
+	var port string
+
 	parsed, err := url.Parse(c.URL)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 
 	// default empty URL to port 6443
-	if parsed.Port() == "" {
-		return "6443", nil
+	port = parsed.Port()
+	if port == "" {
+		port = "6443"
 	}
-	return parsed.Port(), nil
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return 0, err
+	}
+	return portNum, nil
 }
 
 // Returns the default user config file if that exists, else the default global

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/util"
-	"github.com/spf13/cobra"
 
 	klog "k8s.io/klog/v2"
 	kubescheduler "k8s.io/kubernetes/cmd/kube-scheduler/app"
@@ -55,29 +54,8 @@ func (s *KubeScheduler) configure(cfg *config.MicroshiftConfig) {
 		klog.Fatalf("failed to write kube-scheduler config: %v", err)
 	}
 
-	opts := schedulerOptions.NewOptions()
-
-	args := []string{
-		"--config=" + cfg.DataDir + "/resources/kube-scheduler/config/config.yaml",
-	}
-
-	cmd := &cobra.Command{
-		Use:          "kube-scheduler",
-		Long:         `kube-scheduler`,
-		SilenceUsage: true,
-		RunE:         func(cmd *cobra.Command, args []string) error { return nil },
-	}
-
-	namedFlagSets := opts.Flags
-	fs := cmd.Flags()
-	for _, f := range namedFlagSets.FlagSets {
-		fs.AddFlagSet(f)
-	}
-	if err := cmd.ParseFlags(args); err != nil {
-		klog.Fatalf("", fmt.Errorf("%s failed to parse flags: %v", s.Name(), err))
-	}
-
-	s.options = opts
+	s.options = schedulerOptions.NewOptions()
+	s.options.ConfigFile = cfg.DataDir + "/resources/kube-scheduler/config/config.yaml"
 	s.kubeconfig = filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
 }
 

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/openshift/microshift/pkg/config"
 	openshift_apiserver "github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver"
-	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/kubernetes"
@@ -55,9 +54,6 @@ func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
 		klog.Infof("Failed to create a new openshift-apiserver configuration: %v", err)
 		return err
 	}
-	args := []string{
-		"--config=" + configFilePath,
-	}
 
 	options := openshift_apiserver.OpenShiftAPIServer{
 		Output:         os.Stdout,
@@ -67,23 +63,11 @@ func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	options.Authentication.RemoteKubeConfigFile = cfg.DataDir + "/resources/kubeadmin/kubeconfig"
 	options.Authorization.RemoteKubeConfigFile = cfg.DataDir + "/resources/kubeadmin/kubeconfig"
 
-	cmd := &cobra.Command{
-		Use:          "openshift-apiserver",
-		Long:         "openshift-apiserver",
-		SilenceUsage: true,
-		RunE:         func(cmd *cobra.Command, args []string) error { return nil },
-	}
-
-	cmd.SetArgs(args)
-	cmd.MarkFlagFilename("config", "yaml", "yml")
-	cmd.MarkFlagRequired("config")
-	cmd.ParseFlags(args)
-
 	s.cfg = cfg
 	s.options = options
 	s.options.ConfigFile = configFilePath
 
-	klog.Infof("starting openshift-apiserver %s, args: %v", cfg.NodeIP, args)
+	klog.Infof("starting openshift-apiserver %s")
 	return nil
 
 }

--- a/pkg/controllers/openshift-controller-manager.go
+++ b/pkg/controllers/openshift-controller-manager.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
 	openshift_controller_manager "github.com/openshift/openshift-controller-manager/pkg/cmd/openshift-controller-manager"
@@ -60,29 +59,9 @@ func (s *OCPControllerManager) configure(cfg *config.MicroshiftConfig) {
 	}
 
 	var configFilePath = cfg.DataDir + "/resources/openshift-controller-manager/config/config.yaml"
-	args := []string{
-		"--config=" + configFilePath,
-	}
-
-	options := openshift_controller_manager.OpenShiftControllerManager{Output: os.Stdout}
-	options.ConfigFilePath = configFilePath
-
-	cmd := &cobra.Command{
-		Use:          componentOCM,
-		Long:         componentOCM,
-		SilenceUsage: true,
-		RunE:         func(cmd *cobra.Command, args []string) error { return nil },
-	}
-
-	flags := cmd.Flags()
-	cmd.SetArgs(args)
-	flags.StringVar(&options.ConfigFilePath, "config", options.ConfigFilePath, "Location of the master configuration file to run from.")
-	cmd.MarkFlagFilename("config", "yaml", "yml")
-	cmd.MarkFlagRequired("config")
-
 	s.kubeconfig = filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
-	s.ConfigFilePath = options.ConfigFilePath
-	s.Output = options.Output
+	s.ConfigFilePath = configFilePath
+	s.Output = os.Stdout
 }
 
 func (s *OCPControllerManager) writeConfig(cfg *config.MicroshiftConfig) error {


### PR DESCRIPTION
The previous conversion from using the cobra interface to run embedded components left some cruft behind in places where there is a public options type. This PR removes that unneeded code to make the logic easier to follow.