### PR TITLE
Reference customer workload

### DIFF
--- a/hack/reference-workload/amq-broker.yaml
+++ b/hack/reference-workload/amq-broker.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: amq-broker
+--- 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: amq-broker
+  namespace: amq-broker
+  labels:
+    app: amq-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: amq-broker
+  template:
+    metadata:
+      labels:
+        app: amq-broker
+    spec:
+      containers:
+      - name: amq-broker
+        image: registry.redhat.io/amq7/amq-broker:7.6
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: AMQ_USER
+          value: admin
+        - name: AMQ_PASSWORD
+          value: admin
+        - name: AMQ_PROTOCOL
+          value: amqp,mqtt 
+        ports:
+         - containerPort: 61616 # general
+         - containerPort: 8161  # web
+         - containerPort: 5672  # amqp
+         - containerPort: 1883  # mqtt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: amq-broker
+  name: amq-web
+  namespace: amq-broker
+spec:
+  ports:
+  - port: 8161
+    protocol: TCP
+    targetPort: 8161
+  selector:
+    app:  amq-broker
+  sessionAffinity: None
+  type: ClusterIP
+  
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: amq-broker
+  name: mqtt
+  namespace: amq-broker
+spec:
+  ports:
+  - port: 1883
+    protocol: TCP
+    targetPort: 1883
+  selector:
+    app:  amq-broker
+  sessionAffinity: None
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: amq-broker
+  name: amqp
+  namespace: amq-broker
+spec:
+  ports:
+  - port: 5672
+    protocol: TCP
+    targetPort: 5672
+  selector:
+    app:  amq-broker
+  sessionAffinity: None
+  type: NodePort
+
+# Routes seem to be not working as of 4.10 rebase
+# ---
+# apiVersion: route.openshift.io/v1
+# kind: Route
+# metadata:
+#   labels:
+#     app: amq-broker
+#   name: amq-broker
+#   namespace: amq-broker
+# spec:
+#   host: amq-microshift.local
+#   port:
+#     targetPort: 8161
+#   to:
+#     kind: Service
+#     name: amq-web
+#     weight: 100
+#   wildcardPolicy: None

--- a/hack/reference-workload/app-logic.yaml
+++ b/hack/reference-workload/app-logic.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-logic
+  labels:
+    app: app-logic
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-core
+  namespace: app-logic
+  labels:
+    app: app-core
+    # the core app connects to the amqp / mqtt queues
+    # and contains the core app logic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-core
+  template:
+    metadata:
+      labels:
+        app: app-core
+    spec:
+      containers:
+      - name: app-core
+        image: quay.io/submariner/nettest:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sleep"]
+        args: ["3600"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-api
+  namespace: app-logic
+  labels:
+    app: app-api
+    # the app API provides an api to talk to the core app via database
+    # (database tbd) and AMQP queues
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-api
+  template:
+    metadata:
+      labels:
+        app: app-api
+    spec:
+      containers:
+      - name: app-api
+        image: quay.io/submariner/nettest:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sleep"]
+        args: ["3600"]
+        ports:
+         - containerPort: 8080 # API
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: app-api
+  name: app-api
+  namespace: app-logic
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app:  app-api
+  sessionAffinity: None
+  type: ClusterIP

--- a/hack/reference-workload/app-web-interface.yaml
+++ b/hack/reference-workload/app-web-interface.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-web
+  namespace: app-web
+  labels:
+    app: app-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-web
+  template:
+    metadata:
+      labels:
+        app: app-web
+    spec:
+      containers:
+      - name: app-web
+        image: quay.io/microshift/hello-world:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+         - containerPort: 8080 # general
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: app-web
+  name: app-web
+  namespace: app-web
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app:  app-web
+  sessionAffinity: None
+  type: ClusterIP
+
+# re-enable once routes work again:
+# Error from server (Forbidden): error when creating ".": routes.route.openshift.io "app-web" is forbidden: caches not synchronized
+#---
+#apiVersion: route.openshift.io/v1
+#kind: Route
+#metadata:
+#  labels:
+#    app: app-web
+#  name: app-web
+#spec:
+#  host: app-interface.local
+#  port:
+#    targetPort: 8080
+#  to:
+#    kind: Service
+#    name: app-web
+#    weight: 100
+#  wildcardPolicy: None

--- a/hack/reference-workload/kustomization.yaml
+++ b/hack/reference-workload/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - amq-broker.yaml
+  - app-logic.yaml
+  - app-web-interface.yaml
+  - untrusted-app-plugin.yaml

--- a/hack/reference-workload/readme.md
+++ b/hack/reference-workload/readme.md
@@ -1,0 +1,41 @@
+# Reference Workload
+
+This directory contains the manifects and necessary scripts to deploy
+a reference application into MicroShift.
+
+The architecture of this reference application looks like:
+
+```
+    amq-broker        app-logic           app-web              app-plugin1
+
+           ┌────────────────────────────────────┐
+           │                                    │
+    ┌──────┴─────┐     ┌───────────┐     ┌──────┴───────┐
+    │            │     │           │     │              │
+    │ amq-broker │◄────┤ app-core  │ ◄───┤ app-web      │
+    │            │     │           │     │              │
+    └────────────┘     ├───────────┤     └───┬──────────┘
+        ▲ ▲  ▲  ▲      │           │         │         ▲
+        │ │  │  └──────┤ app-api   │◄────────┘         │      ┌─────────────┐
+        │ │  │         │           │                   │      │             │
+        │ │  │         └───────────┘◄──────────────────┼──────┤ app-plugin1 │
+        │ │  │                            (only this)  │      │             │
+        │ │  │                                         │      └─────────────┘
+        │ │  │                                         │
+ ────── │ │  │  ───────────────────────────────────────┼─────────────────────
+        │ │  │                                         │            LAN
+             │                                         │
+AMQP & MQTT  │                                         │
+(NodePorts)  amq-microshift.local              app-interface.local
+             (Route)                           (Route)
+
+```
+
+Can be applied via:
+`kubectl apply -k .`
+
+While this application doesn´t do anything meaningful (yet), it serves as
+a reference in terms of features and workloads to be ran.
+
+The purpose of this reference workload is to help measure the impact on
+MicroShift, the CNI (and eventually CSI) resource consumptions.

--- a/hack/reference-workload/untrusted-app-plugin.yaml
+++ b/hack/reference-workload/untrusted-app-plugin.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: app-plugin1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-plugin1
+  namespace: app-plugin1
+  labels:
+    app: app-plugin1
+    # the core app connects to the amqp / mqtt queues
+    # and contains the core app logic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-plugin1
+  template:
+    metadata:
+      labels:
+        app: app-plugin1
+    spec:
+      containers:
+      - name: app-plugin1
+        image: quay.io/submariner/nettest:latest
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sleep"]
+        args: ["3600"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: app-plugin1
+  name: app-plugin1
+  namespace: app-plugin1
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app:  app-plugin1
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: untrusted-plugin-to-api-only
+  namespace: app-plugin1
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            app: app-logic
+        podSelector:
+          matchLabels:
+            app: app-api
+      ports:
+        - protocol: TCP
+          port: 8080
+
+
+# Routes seem to be not working as of 4.10 rebase
+# ---
+# apiVersion: route.openshift.io/v1
+# kind: Route
+# metadata:
+#   labels:
+#     app: amq-broker
+#   name: amq-broker
+# spec:
+#   host: amq-microshift.local
+#   port:
+#     targetPort: 8161
+#   to:
+#     kind: Service
+#     name: amq-web
+#     weight: 100
+#   wildcardPolicy: None


### PR DESCRIPTION
This adds an example customer workload which includes:

- amq-broker (AMQP + MQTT), volatile, no volumes or storage yet.
- app-api
- app-core
- app-web
- app-plugin1 restristed to talk only to app-api:8080

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
