### PR TITLE
USHIFT-93: kube-scheduler: remove dead configuration code

### DIFF
--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/util"
-	"github.com/spf13/cobra"
 
 	klog "k8s.io/klog/v2"
 	kubescheduler "k8s.io/kubernetes/cmd/kube-scheduler/app"
@@ -55,29 +54,8 @@ func (s *KubeScheduler) configure(cfg *config.MicroshiftConfig) {
 		klog.Fatalf("failed to write kube-scheduler config: %v", err)
 	}
 
-	opts := schedulerOptions.NewOptions()
-
-	args := []string{
-		"--config=" + cfg.DataDir + "/resources/kube-scheduler/config/config.yaml",
-	}
-
-	cmd := &cobra.Command{
-		Use:          "kube-scheduler",
-		Long:         `kube-scheduler`,
-		SilenceUsage: true,
-		RunE:         func(cmd *cobra.Command, args []string) error { return nil },
-	}
-
-	namedFlagSets := opts.Flags
-	fs := cmd.Flags()
-	for _, f := range namedFlagSets.FlagSets {
-		fs.AddFlagSet(f)
-	}
-	if err := cmd.ParseFlags(args); err != nil {
-		klog.Fatalf("", fmt.Errorf("%s failed to parse flags: %v", s.Name(), err))
-	}
-
-	s.options = opts
+	s.options = schedulerOptions.NewOptions()
+	s.options.ConfigFile = cfg.DataDir + "/resources/kube-scheduler/config/config.yaml"
 	s.kubeconfig = filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
 }
 


### PR DESCRIPTION
The mocked command line parsing code is not needed to configure the
kube-scheduler, since we can construct an options struct directly.
