### PR TITLE
cleanup extra format

### DIFF
--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -67,7 +67,7 @@ func (s *OCPAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	s.options = options
 	s.options.ConfigFile = configFilePath
 
-	klog.Infof("starting openshift-apiserver %s")
+	klog.Infof("starting openshift-apiserver")
 	return nil
 
 }


### PR DESCRIPTION
- Fix AIO image to properly configure crio for MicroShift networking (#628)
- update LICENSE (#625)
- Reorganize assets (#619)
- build(deps): bump actions/upload-artifact from 2.3.1 to 3 (#612)
- build(deps): bump actions/checkout from 2 to 3 (#609)
- build(deps): bump technote-space/broken-link-checker-action (#572)
- Equalise service stop or failures (#637)
- Format value of error for stopped services (#644)
- Add conntrack-tools dependency to rpms (#624)
- add default annotation to kubevirt-hostprovisioner storageclass (#647)
- Expose service node port range as MicroShift config (#649)
- build(deps): bump actions/setup-go from 2 to 3 (#651)
- Build container rpms from docker repositories (#645)
- Restart MicroShift when IP address changes (#650)
- Allow multiple kustomization paths (#659)
- Support manifest embedding in user-app rpms & fixes (#670)
- rebase 4.10, 1.23 update CI & build images
- remove 4.8, kube1.21 rebase_patches
- rebase 4.10, kube1.23 update kustomize apply
- rebase 4.10, kube1.23 kubelet fix & remove deprecated feature-gates
- rebase 4.10, kube-1.23 update  kube-scheduler controller
- rebase 4.10, kube1.23, etcd 3.5 update to etcd/server/v3
- Makefile: update to 4.10, 1.23
- rebase 4.10, kube1.23, etcd3.5 go.mod
- rebase 4.10, kube1.23 rebase patches
- rebase.sh 4.10.0-0.okd-2022-04-23-131357
- rebase 4.10, kube1.23 apply patches
- update bindata
- update microshift.spec & workflows go 1.17, fedora 36
- update to fedora-36
- Fix typo in paack.py (#684)
- Do not create .build-ids in rpms for containers (paack) (#687)
- Fix [ushift-52](https://issues.redhat.com//browse/ushift-52) (#690)
- Update OWNERS (#691)
- Change redhat-et to openshift (#685)
- kuttl should be minimally used to ensure the cluster infra has deployed (#692)
- remove create-resources kuttl yaml (#694)
- Enable kubelet cgroup management.  All user workload pods are partitioned under kubepods.slice to more easily track consumption (#620)
- Update microshift release url (#698)
- remove github actions, these are no long useable do to the legacy payment plan of the openshift org (#696)
- Package HPP systemd service in Microshift RPM for SELinux policies (#695)
- Add openshift-apiserver as dependency for OCM (#681)
- Move conmon to pod slice (#697)
- Replacing ocp by openshift for naming consistency (#706)
- Image builder using local RPM packages (#704)
- remove proxy crds from list (#634)
- Refactor rebase.sh (#705)
- image-builder: add missing dependencies (#707)
- Remove SSH key from kickstart and clean up intermediate ISO image file (#708)
- okd 4.10.0-0.okd-2022-04-23-131357 rebase to ocp 4.10.16 (#686)
- Convert MicroShift DevEnv on RHEL 8.x to Markdown format (#710)
- Reference customer workload (#716)
- Pull secret integration into the devenv flows and Edge build procedure (#714)
- kube-apiserver: remove dead configuration code (#717)
- kube-scheduler: remove dead configuration code (#718)
- openshift-apiserver: remove dead configuration code (#719)
- openshift-controller-manager: remove dead configuration code (#720)
- Update top-level README and remove docs/README file (#722)
- Remove stray klog format %s
