### PR TITLE
disables projects api

### DIFF
--- a/pkg/controllers/apiservice.go
+++ b/pkg/controllers/apiservice.go
@@ -152,7 +152,6 @@ func createAPIRegistration(cfg *config.MicroshiftConfig) error {
 	client := apiregistrationclientv1.NewForConfigOrDie(rest.AddUserAgent(restConfig, "apiregistration-agent"))
 	for _, apiSvc := range []string{
 		"v1.authorization.openshift.io",
-		"v1.project.openshift.io",
 		"v1.route.openshift.io",
 		"v1.security.openshift.io",
 	} {

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -128,7 +128,6 @@ func waitForOCPAPIServer(client kubernetes.Interface, timeout time.Duration) err
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		for _, apiSvc := range []string{
 			"authorization.openshift.io",
-			"project.openshift.io",
 			"route.openshift.io",
 			"security.openshift.io",
 		} {


### PR DESCRIPTION
Address USHIFT-81

MicroShift does not register the user.openshift.io/v1 API, reducing the usefulness of the projects API. 