### PR TITLE
Adds a licensecheck make target that runs lichen

### DIFF
--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -1,0 +1,36 @@
+---
+# Licenses other than Apache-2.0 are governed by
+# https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist
+# Note that Allowlist also requires that projects were created
+# on GitHub at least 12 months prior and have at least 10 stars
+# or 10 forks
+allow:
+  - "Apache-2.0"
+  - "BSD-2-Clause"
+  - "BSD-2-Clause-FreeBSD"
+  - "BSD-3-Clause"
+  - "MIT"
+  - "ISC"
+  - "Python-2.0"
+  - "PostgreSQL"
+  - "X11"
+  - "Zlib"
+
+exceptions:
+  # The following references belong to OpenShift, and lichen is unable to find any referece
+  # to the type of license, it comes from RedHat, so we assume it's safe to import.
+  unresolvableLicense:
+  - path: "github.com/openshift/openshift-apiserver"
+  - path: "github.com/openshift/openshift-controller-manager"
+  # The CNFC maintains a list of project license exceptions which are safe or Apache-2
+  # compliant, those exceptions are maintained here:
+  # https://github.com/cncf/foundation/tree/main/license-exceptions
+  licenseNotPermitted:
+  - path: "github.com/docker/go-metrics"
+    licenses: ["CC-BY-SA-4.0"] # also dual licensed as Apache-2.0
+  - path: "github.com/heketi/heketi"
+    licenses: ["GPL-2.0", "LGPL-2.0", "LGPL-3.0"]  # also dual licensed as Apache-2.0
+  - path: "github.com/opencontainers/go-digest"
+    licenses: ["CC-BY-SA-4.0"]  # also dual licensed as Apache-2.0
+  - path: "github.com/hashicorp/golang-lru"
+    licenses: ["MPL-2.0"]

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,7 @@ debug:
 GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo'
 
 # targets "all:" and "build:" defined in vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
-microshift: build-containerized-cross-build-linux-amd64
-.PHONY: microshift
+microshift: build
 
 microshift-aio: build-containerized-all-in-one-amd64
 .PHONY: microshift-aio
@@ -253,3 +252,12 @@ release-nightly:
 component-images:
 	cd packaging/images/components && ./build.sh
 .PHONY: component-images
+
+licensecheck: microshift bin/lichen
+	bin/lichen -c .lichen.yaml microshift
+
+bin:
+	mkdir -p $@
+
+bin/lichen: bin vendor/modules.txt
+	GOBIN=$(realpath ./bin) go install github.com/uw-labs/lichen@latest


### PR DESCRIPTION
Some exceptions have been added to .lichen.yaml for dual-licensed
go modules, as well as for some OpenShift components which
didn't specify licenses anywhere in their repositories.

Related-Issue: https://issues.redhat.com/browse/USHIFT-111

Signed-off-by: Miguel Angel Ajo Pelayo <majopela@redhat.com>
