### PR TITLE
USHIFT-88: Removing duplicated authorization API resources

### DIFF
--- a/pkg/controllers/apiservice.go
+++ b/pkg/controllers/apiservice.go
@@ -151,7 +151,6 @@ func createAPIRegistration(cfg *config.MicroshiftConfig) error {
 	}
 	client := apiregistrationclientv1.NewForConfigOrDie(rest.AddUserAgent(restConfig, "apiregistration-agent"))
 	for _, apiSvc := range []string{
-		"v1.authorization.openshift.io",
 		"v1.route.openshift.io",
 	} {
 		api := &apiregistrationv1.APIService{

--- a/pkg/controllers/openshift-apiserver.go
+++ b/pkg/controllers/openshift-apiserver.go
@@ -127,7 +127,6 @@ func waitForOCPAPIServer(client kubernetes.Interface, timeout time.Duration) err
 
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		for _, apiSvc := range []string{
-			"authorization.openshift.io",
 			"route.openshift.io",
 		} {
 			status := 0


### PR DESCRIPTION
  Duplicated authorization API resources cause garbage
  collection issues.

Signed-off-by: Ricardo Noriega <rnoriega@redhat.com>

Closes [USHIFT-88](https://issues.redhat.com/browse/USHIFT-88)
