### PR TITLE
Fix paack issue with podman4 where overlay2 storage is used

### DIFF
--- a/packaging/rpm/paack.py
+++ b/packaging/rpm/paack.py
@@ -89,6 +89,9 @@ find ./ -perm 000 -exec chmod 400 {} +
 
 %%_POST_%%
 
+# rpm-ostree seems to be unhappy about this, but crio storage (read-only) works without it
+# mknod -m 600 "%{imageStore}/overlay/backingFsBlockDev" b 253 0
+
 %postun
 
 %%_POSTUN_%%
@@ -259,7 +262,7 @@ class SpecFile(object):
                 output += "%%dir %%attr(%o,%s,%s) \"%%{imageStore}%s\"\n" % (info.mode, self._get_symbolic_uid(info.uid), self._get_symbolic_gid(info.gid), filename)
 
         self._files_data += "\n\n%ifarch " + arch + "\n" + output + "%endif\n"
-        self._extract_archs += "\n\n%ifarch " + arch + "\n" + IMAGE_INSTALLPREP + "tar xfj %{SOURCE"+str(self._source_i) + "}\n%endif"
+        self._extract_archs += "\n\n%ifarch " + arch + "\n" + IMAGE_INSTALLPREP + "tar xfj %{SOURCE"+str(self._source_i) + "} --exclude=./overlay/backingFsBlockDev\n%endif"
         self._add_source(tar)
 
     def _read_caps(self, filename):


### PR DESCRIPTION
overlay2 format includes a block device inside the overlay directory
but tar can't unpack that during the install phase.

We exclude that file and move it to %post

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes [USHIFT-122](https://issues.redhat.com/browse/USHIFT-122)
