### PR TITLE
Hack scripts to help us debug scc

### DIFF
--- a/hack/nginx-scc-test.yaml
+++ b/hack/nginx-scc-test.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+  namespace: scc-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:stable
+        imagePullPolicy: IfNotPresent
+        name: nginx
+      securityContext:
+        runAsUser: 0

--- a/hack/scc-prep.sh
+++ b/hack/scc-prep.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig
+
+oc apply -f - <<EOF
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scc-check
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-role 
+  namespace: scc-check 
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-rolebinding
+  namespace: scc-check 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: default-role # Should match name of Role
+subjects:
+- namespace: scc-check # Should match namespace where SA lives
+  kind: ServiceAccount
+  name: default 
+EOF
+
+SERVICE_ACCOUNT_NAME=default
+NAMESPACE=scc-check
+SERVER=https://127.0.0.1:6443
+SECRET_NAME=$(kubectl get serviceaccount ${SERVICE_ACCOUNT_NAME} \
+  --namespace ${NAMESPACE} \
+  -o jsonpath='{.secrets[0].name}')
+
+ca=$(kubectl get -n $NAMESPACE secret/$SECRET_NAME -o jsonpath='{.data.ca\.crt}')
+token=$(kubectl get -n $NAMESPACE secret/$SECRET_NAME -o jsonpath='{.data.token}' | base64 --decode)
+namespace=$(kubectl get -n $NAMESPACE secret/$SECRET_NAME -o jsonpath='{.data.namespace}' | base64 --decode)
+
+echo "
+apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    certificate-authority-data: ${ca}
+    server: ${SERVER}
+contexts:
+- name: default-context
+  context:
+    cluster: default-cluster
+    namespace: ${NAMESPACE} 
+    user: default-user
+current-context: default-context
+users:
+- name: default-user
+  user:
+    token: ${token}
+" > sa.kubeconfig
+
+


### PR DESCRIPTION
Creates an scc-test namespace, and a service account with
privileges on such namespace, but no admin privileges.

Then it creates an sa.kubeconfig file which can be used
to install a privileged nginx deployment which should
be forbidden.

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
