### PR TITLE
Bring design doc up-to-date

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -35,15 +35,22 @@ MicroShift aims at meeting all of the following design goals:
   * MicroShift makes frugal use of system resources. It runs on <1GB RAM and <1 CPU core (Intel Atom- or ARM Cortex-class). It consumes <500MB on the wire (per install/update) and <1GB at rest (excl. etcd state).
 
 * **Consistency with OpenShift:**
-  * MicroShift runs all workloads that OpenShift runs, except those which depend on OpenShift's cluster operators.
-  * MicroShift clusters can be managed like OpenShift clusters through [Open Cluster Management](https://github.com/open-cluster-management), except where functions depend on OpenShift's cluster operators.
+  * MicroShift is binary compatible with OpenShift and Kubernetes conforming.
+  * MicroShift runs all OpenShift workloads without modification, except for if these rely on OpenShift APIs that are
+    * provided by OpenShift's Operators for cluster infrastructure or lifecycle management (not applicable in MicroShift and thus removed) or
+    * not relevant to a pure non-interactive, runtime-only cluster (as opposed to a build-cluster with multiple interactive users).
+  * MicroShift workloads can be managed like OpenShift workloads through [Red Hat Advanced Cluster Management for Kubernetes](https://www.redhat.com/en/technologies/management/advanced-cluster-management), except where functions depend on unsupported OpenShift APIs (see above).
 
 
 ## Design Principles
 When deciding between different design options, we follow the following principles:
 
 * **Minimal core**: We keep MicroShift to a minimal set of functionality, but provide mechanisms for extension.
-  * Discriminator: If a functionality can be added post-cluster-up with reasonable effort, then it should not be part of the MicroShift core/binary.
+  * Discriminator 1: If a functionality implements changes to the OS or its configuration, it should probably be done as pre-requisite for running MicroShift binary.
+  * Discriminator 2: If a functionality is essential to MicroShift's atomic start/stop/update behavior (i.e. MicroShift running/stopped means the OpenShift control plane is running/stopped) it must be part of the binary, otherwise it should be hosted on the cluster.
+  * Discriminator 3: If can be installed "post-cluster-up" and isn't used by 90% of MicroShift users, it should probably not be pre-integrated with MicroShift at all.
+* **Least-privileged**: We minimize privileges needed by MicroShift and its workloads; unlike with OpenShift, even kubeadmin should not be able to compromise the host system.
+* **Offline-first**: We prefer mechanisms that seamlessly work with poor or no network connectivity.
 * **Minimal configuration**: We minimize the number of configuration parameters exposed to users. Where parameters cannot be avoided, we provide robust defaults or try to auto-configure them.
   * Discriminator: If a parameter can be infered from another parameter, auto-detected, or only covers rare use cases, then likely it should not be exposed to users.
 * **Robustness to failure modes**: We expect and gracefully handle failure modes stemming from field-deployment and that MicroShift is just an app on somebody else's OS it cannot control.
@@ -58,12 +65,12 @@ When deciding between different design options, we follow the following principl
 
 ## Design Decisions
 ### Overall Architecture
-* MicroShift is an application deployed onto a running OS, preferably as container on `podman`, managed through `systemd`. As such, it cannot assume any responsiblity or control over the device or OS it runs on, including OS software or configuration updates or typical device management tasks such as configuring host CA certs or host telemetry. 
+* MicroShift is an application deployed onto a running OS. As such, it cannot assume any responsiblity or control over the device or OS it runs on, including OS software or configuration updates or typical device management tasks such as configuring host CA certs or host telemetry.
 * MicroShift runs as a single binary embedding as goroutines only those services strictly necessary to bring up a *minimal Kubernetes/OpenShift control and data plane*. Motivation:
   * Maximizes reproducibility; cluster will come up fully or not at all.
   * Does not require external orchestration, for example through operators, and allows for very fast start-up/update times.
   * Makes it simple to grok as workload for a a Linux admin persona, works well / easier to implement with systemd.
-  * Smaller resource footprint has _not_ been a motivation, it may be a welcome side-effect.
+  * Reduces resource footprint by downloading and running "less stuff".
 * MicroShift provides a small, optional set of infrastructure services to support common use cases and reuses OpenShift's container images for these:
   * openshift-dns, openshift-router, service-ca, local storage provider
 * MicroShift instances (processes) run directly on the host or containerized on Podman. They can take on the roles of Control Plane, Node, or both:
@@ -96,6 +103,7 @@ When deciding between different design options, we follow the following principl
 ### Networking
 * Host networking is configured by device management. MicroShift has to work with what it's been given by the host OS.
 * No Multus.
+* Provide escape hatch to add own CNI.
 * Open issues / questions:
   * Lightweight CNI?
   * API Load Balancing?
@@ -104,13 +112,9 @@ When deciding between different design options, we follow the following principl
 
 ### Storage
 * MicroShift defaults to local ephemeral storage (enough for basic use cases).
-* Open issues / questions:
-  * Provide escape hatch to add own CSI (which?).
+* Provide escape hatch to add own CSI (which?).
 
 ### Production / Supply Chain / Release Management
-* MicroShift vendors OCP source code without modification. Where it deploys container images for additional services, it deploys OCP's published container images, not the OpenShift downstream's.
-* MicroShift's versioning scheme follows OCP's. This scheme signals the base OpenShift version (4.x) and order/age of builds, but intentionally avoids signaling patch level, backward compatibility (as SemVer, for example), or stability.
-* We ensure the tip of our development branch is deployable and while MicroShift is still early days and experimental we expect developers (and users who want the "latest") to build & deploy from source.
-* Releases are mainly provided for convenience to users that just want to give MicroShift a quick try without friction. They are cut irregularly, e.g. to make a new feature available.
-* When rebasing onto a new OCP version, we vendor that version's packages and update the container image digests of the infrastructure services MicroShift deploys, i.e. the "release metadata" is baked into the MicroShift binary.
-* Eventually, we expect there to be a "MicroShift Release Image" that is based on / derived from the OpenShift Release Image: It references the MicroShift container image plus the subset of container images shared with and published by OpenShift. Defining a release image should allow to reuse the proven OpenShift CI and release tooling later.
+* MicroShift vendors OCP source code without modification. Where it deploys container images for additional services, it deploys OCP's published container images.
+* MicroShift's versioning scheme follows OCP's.
+* We ensure the tip of our development branch is deployable.


### PR DESCRIPTION
Updates the design doc to adjust to moving towards productisation and to recent decisions on the shape of deliverables (only RPMs, pruning of APIs, etc.).

Closes USHIFT-65
