### PR TITLE
Remove Flannel in favor of Bridge CNI plugin

### DIFF
--- a/pkg/release/release_arm64.go
+++ b/pkg/release/release_arm64.go
@@ -24,8 +24,6 @@ func init() {
 		"cli":                           "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:65889fde898f3025462f1344bd93e4a1d8ae5a764224b61b4f0b7e46cc1108e4",
 		"coredns":                       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2619cbcbc5ea990bd8349848d410cc4040aea0265821b9d1e46b364f0519481b",
 		"haproxy_router":                "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:972f3fadc1b7eab2eaa02eff4128149eabe9577943dcb3e56f44dad7fc14059e",
-		"kube_flannel":                  "quay.io/coreos/flannel:v0.14.0",
-		"kube_flannel_cni":              "quay.io/microshift/flannel-cni:v0.14.0",
 		"kube_rbac_proxy":               "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2d8319a33aa781918a3173e2061635d8534cc5e4a39171775830ff7e2ce646ac",
 		"kubevirt_hostpath_provisioner": "quay.io/microshift/hostpath-provisioner:4.10.0-0.okd-2022-04-23-131357",
 		"pause":                         "k8s.gcr.io/pause:3.6",


### PR DESCRIPTION
Removes the Flannel images from ARM release.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>