### PR TITLE
Add an iso target to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ IMAGE_REPO :=quay.io/microshift/microshift
 IMAGE_REPO_AIO :=quay.io/microshift/microshift-aio
 OUTPUT_DIR :=_output
 RPM_BUILD_DIR :=packaging/rpm/_rpmbuild
+ISO_DIR :=scripts/image-builder/_builds
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 FROM_SOURCE :=false
 CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/null))
 ARCH :=$(shell uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
 IPTABLES :=nft
+PULLSECRET :=~/pullsecret
 
 # restrict included verify-* targets to only process project files
 GO_PACKAGES=$(go list ./cmd/... ./pkg/...)
@@ -156,6 +158,17 @@ srpm:
 	RELEASE_PRE=${RELEASE_PRE} ./packaging/rpm/make-rpm.sh local
 .PHONY: srpm
 
+image-build-configure:
+	./scripts/image-builder/configure.sh
+.PHONY: image-build-configure
+
+image-build-iso: rpm 
+	./scripts/image-builder/build.sh -pull_secret_file $(PULLSECRET)
+.PHONY: image-build-iso
+
+iso: image-build-configure image-build-iso
+.PHONY: iso
+
 ###############################
 # containerized build targets #
 ###############################
@@ -235,6 +248,7 @@ clean-cross-build:
 	$(RM) -rf $(OUTPUT_DIR)/staging
 	if [ -d '$(OUTPUT_DIR)' ]; then rmdir --ignore-fail-on-non-empty '$(OUTPUT_DIR)'; fi
 	if [ -d '$(RPM_BUILD_DIR)' ]; then $(RM) -rf '$(RPM_BUILD_DIR)' ; fi
+	if [ -d '$(ISO_DIR)' ]; then $(RM) -rf '$(ISO_DIR)' ; fi
 .PHONY: clean-cross-build
 
 clean: clean-cross-build

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ FROM_SOURCE :=false
 CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/null))
 ARCH :=$(shell uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
 IPTABLES :=nft
-PULLSECRET :=~/pullsecret
+PULLSECRET :=~/.pull-secret.json
 
 # restrict included verify-* targets to only process project files
 GO_PACKAGES=$(go list ./cmd/... ./pkg/...)

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -19,7 +19,7 @@ The following describes the current rebase process in more detail.
 On the machine used for the rebase,
 
 * install `git`, `golang` (>= 1.17), `oc`, and `jq`,
-* add a pull secret into `~/.docker/config.json`, and
+* add a pull secret into `~/.pull-secret.json`, and
 * git clone your personal fork of microshift and `cd` into it.
 
 ### Downloading the target OpenShift release

--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -12,7 +12,7 @@ The scripts for building the installer are located in the `scripts/image-builder
 ### Prerequisites
 Execute the `scripts/image-builder/configure.sh` script to install the tools necessary for building the installer image.
 
-Download the OpenShift pull secret from the https://console.redhat.com/openshift/downloads#tool-pull-secret page and save it into the `~microshift/pull-secret.txt` file. 
+Download the OpenShift pull secret from the https://console.redhat.com/openshift/downloads#tool-pull-secret page and save it into the `~microshift/.pull-secret.json` file. 
 
 Make sure there is more than 20GB of free disk space necessary for the build artifacts. Run the following command to free the space if necessary.
 ```bash
@@ -51,7 +51,7 @@ Note: The OpenShift pull secret can be downloaded from https://console.redhat.co
 
 Continue by running the build script with the pull secret file argument and wait until build process is finished. It may take over 30 minutes to complete a full build cycle.
 ```bash
-./scripts/image-builder/build.sh -pull_secret_file ~/pull-secret.txt
+./scripts/image-builder/build.sh -pull_secret_file ~/.pull-secret.json
 ```
 The script performs the following tasks:
 - Check for minimum 10GB of available disk space
@@ -93,7 +93,7 @@ Notes:
 
 Run the script in the `rpm` mode to pull the images required by MicroShift and generate the RPMs including those image data.
 ```bash
-./packaging/rpm/make-microshift-images-rpm.sh rpm ~/pull-secret.txt x86_64:amd64 rhel-8-x86_64
+./packaging/rpm/make-microshift-images-rpm.sh rpm ~/.pull-secret.json x86_64:amd64 rhel-8-x86_64
 ```
 
 If the procedure runs successfully, the RPM artifacts can be found in the `packaging/rpm/paack-result` directory.
@@ -105,7 +105,7 @@ $ ls -1 ~/microshift/packaging/rpm/paack-result/*.rpm
 
 Finally, run the build script with the `-custom_rpms` argument to include the specified container image RPMs into the generated ISO.
 ```bash
-./scripts/image-builder/build.sh -pull_secret_file ~/pull-secret.txt -custom_rpms ~/microshift/packaging/rpm/paack-result/microshift-containers-4.10.18-1.x86_64.rpm
+./scripts/image-builder/build.sh -pull_secret_file ~/.pull-secret.json -custom_rpms ~/microshift/packaging/rpm/paack-result/microshift-containers-4.10.18-1.x86_64.rpm
 ```
 > If user-specific container images need to be included into the ISO, multiple comma-separated RPM files can be specified as the `-custom_rpms` argument value.
 

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -27,7 +27,7 @@ shopt -s extglob
 
 REPOROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
 STAGING_DIR="$REPOROOT/_output/staging"
-PULL_SECRET_FILE="${HOME}/.docker/config.json"
+PULL_SECRET_FILE="${HOME}/.pull-secret.json"
 
 EMBEDDED_COMPONENTS="openshift-apiserver openshift-controller-manager oauth-apiserver hyperkube etcd"
 EMBEDDED_COMPONENT_OPERATORS="cluster-kube-apiserver-operator cluster-openshift-apiserver-operator cluster-kube-controller-manager-operator cluster-openshift-controller-manager-operator cluster-kube-scheduler-operator machine-config-operator"


### PR DESCRIPTION
This PR adds make targets, which call the existing image-builder scripts. Adding the 'iso' target provides a convenient single step, for example when building the install ISO for use in a test environment.  