### PR TITLE
USHIFT-133: Improve image build script error handling

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -10,6 +10,14 @@ STARTTIME=$(date +%s)
 trap ${ROOTDIR}/cleanup.sh INT
 
 usage() {
+    local error_message="$1"
+
+    if [ -n "$error_message" ];
+    then
+        echo "ERROR: $error_message"
+        echo
+    fi
+
     echo "Usage: $(basename $0) <-pull_secret_file path_to_file> [-ostree_server_name name_or_ip] [-custom_rpms /path/to/file1.rpm,...,/path/to/fileN.rpm]"
     echo "   -pull_secret_file   Path to a file containing the OpenShift pull secret"
     echo "   -ostree_server_name Name or IP address of the OS tree server (default: ${OSTREE_SERVER_IP})"
@@ -97,13 +105,13 @@ while [ $# -gt 0 ] ; do
     -ostree_server_name)
         shift
         OSTREE_SERVER_NAME="$1"
-        [ -z "${OSTREE_SERVER_NAME}" ] && usage
+        [ -z "${OSTREE_SERVER_NAME}" ] && usage "ostree server name not specified"
         shift
         ;;
     -pull_secret_file)
         shift
         OCP_PULL_SECRET_FILE="$1"
-        [ -z "${OCP_PULL_SECRET_FILE}" ] && usage
+        [ -z "${OCP_PULL_SECRET_FILE}" ] && usage "Pull secret file not specified"
         shift
         ;;
     -custom_rpms)

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -38,7 +38,7 @@ waitfor_image() {
 
     local tend=$(date +%s)
     echo "$(date +'%Y-%m-%d %H:%M:%S') ${status} - elapsed $(( (tend - tstart) / 60 )) minutes"
-    
+
     if [ "${status}" = "FAILED" ]; then
         download_image ${uuid} 1
         echo "Blueprint build has failed. For more information, review the downloaded logs"
@@ -114,7 +114,7 @@ while [ $# -gt 0 ] ; do
         ;;
     *)
         usage
-        ;;    
+        ;;
     esac
 done
 if [ -z "${OSTREE_SERVER_NAME}" ] || [ -z "${OCP_PULL_SECRET_FILE}" ] ; then

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -112,6 +112,7 @@ while [ $# -gt 0 ] ; do
         shift
         OCP_PULL_SECRET_FILE="$1"
         [ -z "${OCP_PULL_SECRET_FILE}" ] && usage "Pull secret file not specified"
+        [ ! -s "${OCP_PULL_SECRET_FILE}" ] && usage "Empty or missing pull secret file"
         shift
         ;;
     -custom_rpms)


### PR DESCRIPTION
Report an error when the pull secret file specified on the command line does not exist or is empty.

Also adds general error message support to the usage function in the script so that it is clear what problem triggered a failure.