### PR TITLE
Enable LVM partitioning with custom sysroom volume size and separate data volume

### DIFF
--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -3,7 +3,7 @@ keyboard us
 timezone UTC
 zerombr
 clearpart --all --initlabel
-autopart --type=plain --fstype=xfs --nohome
+autopart --type=lvm --fstype=xfs --nohome --noswap
 reboot
 text
 network --bootproto=dhcp --device=link --activate --onboot=on

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -8,6 +8,8 @@ reboot
 network --bootproto=dhcp --device=link --activate --onboot=on
 
 # Partition disk with a 1GB boot XFS partition and an LVM volume containing a 5GB+ system root
+# The remainder of the volume will be used by the CSI driver for storing data
+#
 # For example, a 20GB disk would be partitioned in the following way:
 #
 # NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
@@ -29,25 +31,6 @@ logvol / --vgname=rhel --fstype=xfs --size=REPLACE_LVM_SYSROOT_SIZE --name=root
 ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/ostree/repo --ref=rhel/8/x86_64/edge
 
 %post --log=/var/log/anaconda/post-install.log --erroronfail
-
-# Note: this step can only be performed in the post-install stage because 
-# the Image Builder does not support custom mountpoints for ostree image types
-#
-# Create an LVM data volume using all the remaining LVM space
-# Format and mount the data disk at /var/mnt/data directory
-# For example, a 20GB disk would be partitioned in the following way:
-#
-# NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
-# sda             8:0    0  20G  0 disk
-# ├─sda1          8:1    0   1G  0 part /boot
-# └─sda2          8:2    0  19G  0 part
-#   ├─rhel-root 253:0    0   5G  0 lvm  /sysroot
-#   └─rhel-data 253:1    0  14G  0 lvm  /var/mnt/data
-#
-lvcreate --name data -l 100%FREE rhel
-mkfs.xfs -f /dev/rhel/data
-mkdir -p /mnt/data
-echo -e "/dev/mapper/rhel-data\t/var/mnt/data\t\txfs\tdefaults\t0 0" >> /etc/fstab
 
 # Replace the ostree server name
 echo -e 'url=http://REPLACE_OSTREE_SERVER_NAME/repo/' >> /etc/ostree/remotes.d/edge.conf

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -1,16 +1,53 @@
 lang en_US.UTF-8
 keyboard us
 timezone UTC
-zerombr
-clearpart --all --initlabel
-autopart --type=lvm --fstype=xfs --nohome --noswap
-reboot
 text
+reboot
+
+# Configure network to use DHCP and activate on boot
 network --bootproto=dhcp --device=link --activate --onboot=on
 
+# Partition disk with a 1GB boot XFS partition and an LVM volume containing a 5GB+ system root
+# For example, a 20GB disk would be partitioned in the following way:
+#
+# NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
+# sda             8:0    0  20G  0 disk 
+# ├─sda1          8:1    0   1G  0 part /boot
+# └─sda2          8:2    0  19G  0 part 
+#  └─rhel-root  253:0    0   5G  0 lvm  /sysroot
+#
+zerombr
+clearpart --all --initlabel
+part /boot --fstype=xfs --asprimary --size=1024
+# Uncomment this line to add a SWAP partition of the recommended size
+#part swap --fstype=swap --recommended
+part pv.01 --grow
+volgroup rhel pv.01
+logvol / --vgname=rhel --fstype=xfs --size=REPLACE_LVM_SYSROOT_SIZE --name=root
+
+# Configure ostree
 ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/ostree/repo --ref=rhel/8/x86_64/edge
 
 %post --log=/var/log/anaconda/post-install.log --erroronfail
+
+# Note: this step can only be performed in the post-install stage because 
+# the Image Builder does not support custom mountpoints for ostree image types
+#
+# Create an LVM data volume using all the remaining LVM space
+# Format and mount the data disk at /var/mnt/data directory
+# For example, a 20GB disk would be partitioned in the following way:
+#
+# NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
+# sda             8:0    0  20G  0 disk
+# ├─sda1          8:1    0   1G  0 part /boot
+# └─sda2          8:2    0  19G  0 part
+#   ├─rhel-root 253:0    0   5G  0 lvm  /sysroot
+#   └─rhel-data 253:1    0  14G  0 lvm  /var/mnt/data
+#
+lvcreate --name data -l 100%FREE rhel
+mkfs.xfs -f /dev/rhel/data
+mkdir -p /mnt/data
+echo -e "/dev/mapper/rhel-data\t/var/mnt/data\t\txfs\tdefaults\t0 0" >> /etc/fstab
 
 # Replace the ostree server name
 echo -e 'url=http://REPLACE_OSTREE_SERVER_NAME/repo/' >> /etc/ostree/remotes.d/edge.conf
@@ -22,10 +59,11 @@ REPLACE_OCP_PULL_SECRET_CONTENTS
 EOF
 chmod 600 /etc/crio/openshift-pull-secret
 
+# Create a default redhat user, allowing it to run sudo commands without password
 useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat
-
 echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
+# Configure the firewall
 firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
 
 %end


### PR DESCRIPTION
* Added -lvm_sysroot_size optional command line to scripts/image-builder/build.sh script
* Implemented custom LVM partitioning for sysroot volume, minimal size of 5GB
* The rest of the disk is left unallocated to be used by the CSI driver
* Documentation updated to describe the new functionality

[USHIFT-134](https://issues.redhat.com//browse/USHIFT-134)