### PR TITLE
automate rebasing of manifests

### DIFF
--- a/assets/components/openshift-dns/node-resolver/daemonset.yaml.tmpl
+++ b/assets/components/openshift-dns/node-resolver/daemonset.yaml.tmpl
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-resolver
+  namespace: openshift-dns
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      dns.operator.openshift.io/daemonset-node-resolver: ""
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        dns.operator.openshift.io/daemonset-node-resolver: ""
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+${NODE_RESOLVER_SCRIPT}
+        env:
+        - name: SERVICES
+          # Comma or space separated list of services
+          # NOTE: For now, ensure these are relative names; for each relative name,
+          # an alias with the CLUSTER_DOMAIN suffix will also be added.
+          value: "image-registry.openshift-image-registry.svc"
+        - name: NAMESERVER
+          value: 172.30.0.10
+        - name: CLUSTER_DOMAIN
+          value: cluster.local
+        image: {{ .ReleaseImage.cli }}
+        imagePullPolicy: IfNotPresent
+        name: dns-node-resolver
+        resources:
+          requests:
+            cpu: 5m
+            memory: 21Mi
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/hosts
+          name: hosts-file
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: node-resolver
+      serviceAccountName: node-resolver
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: hosts-file
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 33%
+    type: RollingUpdate

--- a/assets/components/openshift-dns/node-resolver/update-node-resolver.sh
+++ b/assets/components/openshift-dns/node-resolver/update-node-resolver.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -uo pipefail
+
+trap 'jobs -p | xargs kill || true; wait; exit 0' TERM
+
+OPENSHIFT_MARKER="openshift-generated-node-resolver"
+HOSTS_FILE="/etc/hosts"
+TEMP_FILE="/etc/hosts.tmp"
+
+IFS=', ' read -r -a services <<< "${SERVICES}"
+
+# Make a temporary file with the old hosts file's attributes.
+cp -f --attributes-only "${HOSTS_FILE}" "${TEMP_FILE}"
+
+while true; do
+  declare -A svc_ips
+  for svc in "${services[@]}"; do
+    # Fetch service IP from cluster dns if present. We make several tries
+    # to do it: IPv4, IPv6, IPv4 over TCP and IPv6 over TCP. The two last ones
+    # are for deployments with Kuryr on older OpenStack (OSP13) - those do not
+    # support UDP loadbalancers and require reaching DNS through TCP.
+    cmds=('dig -t A @"${NAMESERVER}" +short "${svc}.${CLUSTER_DOMAIN}"|grep -v "^;"'
+          'dig -t AAAA @"${NAMESERVER}" +short "${svc}.${CLUSTER_DOMAIN}"|grep -v "^;"'
+          'dig -t A +tcp +retry=0 @"${NAMESERVER}" +short "${svc}.${CLUSTER_DOMAIN}"|grep -v "^;"'
+          'dig -t AAAA +tcp +retry=0 @"${NAMESERVER}" +short "${svc}.${CLUSTER_DOMAIN}"|grep -v "^;"')
+    for i in ${!cmds[*]}
+    do
+      ips=($(eval "${cmds[i]}"))
+      if [[ "$?" -eq 0 && "${#ips[@]}" -ne 0 ]]; then
+        svc_ips["${svc}"]="${ips[@]}"
+        break
+      fi
+    done
+  done
+
+  # Update /etc/hosts only if we get valid service IPs
+  # We will not update /etc/hosts when there is coredns service outage or api unavailability
+  # Stale entries could exist in /etc/hosts if the service is deleted
+  if [[ -n "${svc_ips[*]-}" ]]; then
+    # Build a new hosts file from /etc/hosts with our custom entries filtered out
+    grep -v "# ${OPENSHIFT_MARKER}" "${HOSTS_FILE}" > "${TEMP_FILE}"
+
+    # Append resolver entries for services
+    for svc in "${!svc_ips[@]}"; do
+      for ip in ${svc_ips[${svc}]}; do
+        echo "${ip} ${svc} ${svc}.${CLUSTER_DOMAIN} # ${OPENSHIFT_MARKER}" >> "${TEMP_FILE}"
+      done
+    done
+
+    # TODO: Update /etc/hosts atomically to avoid any inconsistent behavior
+    # Replace /etc/hosts with our modified version if needed
+    cmp "${TEMP_FILE}" "${HOSTS_FILE}" || cp -f "${TEMP_FILE}" "${HOSTS_FILE}"
+    # TEMP_FILE is not removed to avoid file create/delete and attributes copy churn
+  fi
+  sleep 60 & wait
+  unset svc_ips
+done

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -18,7 +18,7 @@ The following describes the current rebase process in more detail.
 
 On the machine used for the rebase,
 
-* install `git`, `golang` (>= 1.17), `oc`, and `jq`,
+* install `git`, `golang` (>= 1.17), `oc`, `yq`, and `jq`,
 * add a pull secret into `~/.pull-secret.json`, and
 * git clone your personal fork of microshift and `cd` into it.
 


### PR DESCRIPTION
Adds the automation of rebasing assets like the hosted component manifests.

Ensures running `./scriptsrebase.sh manifests` on a staged upstream release always produces the same results.
For each component, the script runs 4 steps:
1. Copying relevant manifests from the release image or the operand manifests from the respective component's Operator.
2. Making the changes that the respective Operator would apply at runtime (e.g. set names, namespaces, etc.).
3. Making MicroShift-specific changes (overrides).
4. Replacing static values with the go template variables which MicroShift fills in.

If you run this script to test changes, not that there may be changes where fields change order in the YAML files. This is due to the YAML editor `yq` adding new files at the end, not in alphabetical order.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>