### PR TITLE
Add support for authorized_keys to the kickstart file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/nu
 ARCH :=$(shell uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
 IPTABLES :=nft
 PULLSECRET :=~/.pull-secret.json
+AUTHORIZED_KEYS :=$(PROJECT_DIR)/authorized_keys
+IMAGE_BUILDER_ARGS := -pull_secret_file $(PULLSECRET)
+ifneq ("$(wildcard $(AUTHORIZED_KEYS))","")
+	IMAGE_BUILDER_ARGS := $(IMAGE_BUILDER_ARGS) -authorized_keys_file $(AUTHORIZED_KEYS)
+endif
 
 # restrict included verify-* targets to only process project files
 GO_PACKAGES=$(go list ./cmd/... ./pkg/...)
@@ -168,7 +173,7 @@ image-build-configure:
 .PHONY: image-build-configure
 
 image-build-iso: rpm 
-	./scripts/image-builder/build.sh -pull_secret_file $(PULLSECRET)
+	./scripts/image-builder/build.sh $(IMAGE_BUILDER_ARGS)
 .PHONY: image-build-iso
 
 iso: image-build-configure image-build-iso

--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -45,9 +45,12 @@ Usage: build.sh <-pull_secret_file path_to_file> [-ostree_server_name name_or_ip
    -pull_secret_file   Path to a file containing the OpenShift pull secret
    -ostree_server_name Name or IP address and optionally port of the ostree server (default: 127.0.0.1:8080)
    -lvm_sysroot_size   Size of the system root LVM partition. The remaining disk space will be allocated for data (default: 5120)
+   -authorized_keys_file
+                       Path to an ssh authorized_keys file, to use with the redhat user account.
    -custom_rpms        Path to one or more comma-separated RPM packages to be included in the image
 
 Note: The OpenShift pull secret can be downloaded from https://console.redhat.com/openshift/downloads#tool-pull-secret.
+Note: To allow ssh access into the default redhat account using authorized keys, add the -authorized_keys_file option and provide a path to an authorized_keys file.
 ```
 
 Continue by running the build script with the pull secret file argument and wait until build process is finished. It may take over 30 minutes to complete a full build cycle.

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -46,6 +46,15 @@ chmod 600 /etc/crio/openshift-pull-secret
 useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat
 echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
+# Add authorized ssh keys
+mkdir /home/redhat/.ssh
+chmod 700 /home/redhat/.ssh
+cat > /home/redhat/.ssh/authorized_keys << EOF
+REPLACE_REDHAT_AUTHORIZED_KEYS_CONTENTS
+EOF
+chmod 600 /home/redhat/.ssh/authorized_keys
+chown -R redhat:redhat /home/redhat/.ssh
+
 # Configure the firewall
 firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
 


### PR DESCRIPTION
This PR adds support for inserting authorized keys into the kickstart file used to deploy Microshift.
It supports test automation under https://issues.redhat.com/browse/USHIFT-104