### PR TITLE
USHIFT-180: version controller should only wait for kube-apiserver

### DIFF
--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -37,7 +37,7 @@ func NewVersionManager(cfg *config.MicroshiftConfig) *VersionManager {
 
 func (s *VersionManager) Name() string { return "version-manager" }
 func (s *VersionManager) Dependencies() []string {
-	return []string{"kube-apiserver", "openshift-apiserver"}
+	return []string{"kube-apiserver"}
 }
 
 func (s *VersionManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {


### PR DESCRIPTION
This is a follow-up to #776 

/assign @mangelajo 