### PR TITLE
Add the jq dependency

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -105,6 +105,7 @@ Summary: Networking elements for MicroShift
 Requires: openvswitch2.16
 Requires: NetworkManager
 Requires: NetworkManager-ovs
+Requires: jq
 
 %description networking
 This package contains the networking elements necessary to MicroShift's default CNI.


### PR DESCRIPTION
microshift-ovs-init / configure-ovs.sh uses jq, and fails if it's not
installed. RHEL4Edge comes with jq by default but RHEL8 doesn't,
and we test on GCE with RHEL8.
