### PR TITLE
USHIFT-16: Use /readyz for kube-apiserver readiness checks instead of /healthz.

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -242,7 +242,7 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 			}
 
 			var status int
-			if err := restClient.Get().AbsPath("/healthz").Do(ctx).StatusCode(&status).Error(); err != nil {
+			if err := restClient.Get().AbsPath("/readyz").Do(ctx).StatusCode(&status).Error(); err != nil {
 				klog.Infof("%q not yet ready: %v", s.Name(), err)
 				return false, nil
 			}


### PR DESCRIPTION
They're nearly equivalent, but there are behaviors that are controlled
by whether or not the apiserver has signaled readiness at least
once (e.g. warnings are logged about receiving requests before ready).

/hold

I'd originally included this in https://github.com/openshift/microshift/pull/794 and later separated it accounting reasons. This patch depends on the other.