### PR TITLE
Rebase arm64 images too

### DIFF
--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -61,7 +61,7 @@ download_release() {
     title "# Fetching release info for ${release_image_arm64} (arm64)"
     oc adm release info ${authentication} "${release_image_arm64}" -o json > release_arm64.json
 
-    title "# Extracing ${release_image_amd64} manifest content"
+    title "# Extracting ${release_image_amd64} manifest content"
     mkdir -p release-manifests
     pushd release-manifests >/dev/null
     content=$(oc adm release info ${authentication} --contents "${release_image_amd64}")
@@ -241,7 +241,7 @@ get_release_images() {
 
 # Updates the image digests in pkg/release/release*.go
 update_images() {
-    if [ ! -f "${STAGING_DIR}/release_amd64.json" ]; then
+    if [ ! -f "${STAGING_DIR}/release_amd64.json" ] || [ ! -f "${STAGING_DIR}/release_arm64.json" ]; then
         >&2 echo "No release found in ${STAGING_DIR}, you need to download one first."
         exit 1
     fi


### PR DESCRIPTION
Makes the rebase script accept _two_ pull specs for release images, the first the one for the amd64 architecture (as before), the second the one for the arm64 architecture. Then uses the arm64 release image to update that architecture's container image digests.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>

[USHIFT-177](https://issues.redhat.com//browse/USHIFT-177)