### PR TITLE
USHIFT-233: move the version config map to match where it will be in OCP

### DIFF
--- a/assets/version/microshift-version.yaml
+++ b/assets/version/microshift-version.yaml
@@ -2,9 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: microshift-version
-  namespace: kube-public
+  name: version
+  namespace: openshift
 data:
+  product: "MicroShift"
   major: ""
   minor: ""
   version: ""

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -5309,9 +5309,10 @@ var _assetsVersionMicroshiftVersionYaml = []byte(`# Values are filled in at runt
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: microshift-version
-  namespace: kube-public
+  name: version
+  namespace: openshift
 data:
+  product: "MicroShift"
   major: ""
   minor: ""
   version: ""
@@ -5327,7 +5328,7 @@ func assetsVersionMicroshiftVersionYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/version/microshift-version.yaml", size: 196, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
+	info := bindataFileInfo{name: "assets/version/microshift-version.yaml", size: 207, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -49,6 +49,7 @@ func (s *VersionManager) Run(ctx context.Context, ready chan<- struct{}, stopped
 
 	versionInfo := version.Get()
 	var data = map[string]string{
+		"product": "MicroShift",
 		"major":   versionInfo.Major,
 		"minor":   versionInfo.Minor,
 		"version": versionInfo.String(),


### PR DESCRIPTION
Closes: [USHIFT-233](https://issues.redhat.com//browse/USHIFT-233)

This is related to https://github.com/openshift/enhancements/pull/1203, but we can go ahead and take it now to make less work to update test suite changes later.