### PR TITLE
Disable CGO when building MicroShift binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi 
 GO_TEST_FLAGS=$(GO_BUILD_FLAGS)
 GO_TEST_PACKAGES=./cmd/... ./pkg/...
 
+# targets "all:" and "build:" defined in vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
 # Disable CGO when building microshift binary
 all: export CGO_ENABLED=0
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,11 @@ GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi 
 GO_TEST_FLAGS=$(GO_BUILD_FLAGS)
 GO_TEST_PACKAGES=./cmd/... ./pkg/...
 
-# targets "all:" and "build:" defined in vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
+# Disable CGO when building microshift binary
+all: export CGO_ENABLED=0
+
+build: export CGO_ENABLED=0
+
 microshift: build
 
 microshift-aio: build-containerized-all-in-one-amd64


### PR DESCRIPTION
Disabling CGO would remove runtime dependency
of glibc and reduce the MicroShift binary size

Signed-off-by: Zenghui Shi <zshi@redhat.com>
Co-authored-by: Miguel Angel Ajo Pelayo <majopela@redhat.com>
