### PR TITLE
USHIFT-238: Set type of microshift.service to "notify".

### DIFF
--- a/packaging/systemd/microshift.service
+++ b/packaging/systemd/microshift.service
@@ -8,6 +8,7 @@ WorkingDirectory=/usr/bin/
 ExecStart=microshift run
 Restart=always
 User=root
+Type=notify
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -137,7 +137,13 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	select {
 	case <-ready:
 		klog.Infof("MicroShift is ready")
-		daemon.SdNotify(false, daemon.SdNotifyReady)
+		if supported, err := daemon.SdNotify(false, daemon.SdNotifyReady); err != nil {
+			klog.Warningf("error sending sd_notify readiness message: %v", err)
+		} else if supported {
+			klog.Info("sent sd_notify readiness message")
+		} else {
+			klog.Info("service does not support sd_notify readiness messages")
+		}
 
 		<-sigTerm
 	case <-sigTerm:


### PR DESCRIPTION
With the default type "simple", microshift is considered ready
immediately after its process has forked instead of waiting for an
sd_notify message.
