### PR TITLE
USHIFT-240: fix verify-bindata target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ update: update-bindata
 .PHONY: verify-bindata
 verify: verify-bindata
 verify-bindata: update-bindata
-	git diff --exit-code pkg/assets/bindata.go || echo "Found changes in pkg/assets/bindata.go, run 'make update-bindata' and commit the changes"
+	./scripts/verify_bindata.sh
 
 ###############################
 # post install validate       #

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -141,7 +141,7 @@ func assetsBindata_timestampTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/bindata_timestamp.txt", size: 11, mode: os.FileMode(436), modTime: time.Unix(1654679854, 0)}
+	info := bindataFileInfo{name: "assets/bindata_timestamp.txt", size: 11, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/scripts/bindata.sh
+++ b/scripts/bindata.sh
@@ -17,11 +17,6 @@ if [ -z "$GOPATH" ]; then
     export GOPATH=$(go env GOPATH)
 fi
 
-# Ensure the assets have the expected permissions before we package
-# them, in case the user's umask changes them from the desired
-# settings.
-find ./assets -name '*.yaml' | xargs chmod 0644
-
 OUTPUT="pkg/assets/bindata.go"
 IGNORE_REGEXES=".+.tmpl$|.+.sh$"
 "${GOPATH}"/bin/go-bindata \
@@ -29,6 +24,7 @@ IGNORE_REGEXES=".+.tmpl$|.+.sh$"
            -nocompress \
            -prefix "pkg/assets" \
            -pkg assets \
+           -mode '0644' \
            -ignore "$IGNORE_REGEXES" \
            -o ${OUTPUT} "./assets/..."
 gofmt -s -w "${OUTPUT}"

--- a/scripts/verify_bindata.sh
+++ b/scripts/verify_bindata.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+git diff --exit-code pkg/assets/bindata.go
+RC=$?
+
+if [ $RC -ne 0 ]; then
+    echo "Found changes in pkg/assets/bindata.go, run 'make update-bindata' and commit the changes"
+fi
+exit $RC


### PR DESCRIPTION
Exit from make with an error when there are changes to the assets directory not captured in bindata.go.
