### PR TITLE
Add required firewall configuration in post-networking RPM stage

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -218,6 +218,9 @@ sed -i -n -e '/^OPTIONS=/!p' -e '$aOPTIONS="--no-mlockall"' /etc/sysconfig/openv
 %systemd_post microshift-ovs-init.service
 systemctl is-active --quiet NetworkManager && systemctl restart --quiet NetworkManager || true
 systemctl enable --now --quiet openvswitch || true
+# configure the firewall rules for pods to intercommunicate
+systemctl is-active --quiet firewalld || firewall-offline-cmd -q --zone=trusted --add-source=10.42.0.0/16
+systemctl is-active --quiet firewalld && firewall-cmd         -q --zone=trusted --add-source=10.42.0.0/16
 
 %preun networking
 %systemd_preun microshift-ovs-init.service

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -56,7 +56,4 @@ chmod 600 /home/redhat/.ssh/authorized_keys
 # Make sure redhat user directory contents ownership is correct
 chown -R redhat:redhat /home/redhat/
 
-# Configure the firewall
-firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
-
 %end


### PR DESCRIPTION
Test when firewalld is DOWN (sudo -i)
```
# systemctl is-active firewalld.service 
inactive
# firewall-offline-cmd --zone=trusted --list-sources

# systemctl is-active --quiet firewalld || firewall-offline-cmd -q --zone=trusted --add-source=10.42.0.0/16
# systemctl is-active --quiet firewalld && firewall-cmd         -q --zone=trusted --add-source=10.42.0.0/16
# firewall-offline-cmd --zone=trusted --list-sources
10.42.0.0/16
```
Test when firewalld is UP (sudo -i)
```
# systemctl is-active firewalld.service 
active
# firewall-cmd --zone=trusted --list-sources

# systemctl is-active --quiet firewalld || firewall-offline-cmd -q --zone=trusted --add-source=10.42.0.0/16
# systemctl is-active --quiet firewalld && firewall-cmd         -q --zone=trusted --add-source=10.42.0.0/16
# firewall-cmd --zone=trusted --list-sources
10.42.0.0/16
```

Closes [USHIFT-245](https://issues.redhat.com//browse/USHIFT-245)
