### PR TITLE
fix mdns unqulified name

### DIFF
--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -69,7 +69,7 @@ func (c *MicroShiftmDNSController) Run(ctx context.Context, ready chan<- struct{
 		}
 
 		klog.Infof("Host FQDN will be announced via mDNS", "fqdn", c.NodeName, "ips", ips)
-		c.resolver.AddDomain(c.NodeName, ips)
+		c.resolver.AddDomain(c.NodeName+".", ips)
 		c.myIPs = ips
 	}
 


### PR DESCRIPTION
Recorded resolver name doesn't match mdns query name.

Assuming local hostname is "localhost.local", resolver
records domain name as "localhost.local", but a mdns
client would send query with name "localhost.local."
which results in no response from mdns server.

Signed-off-by: Zenghui Shi <zshi@redhat.com>
