### PR TITLE
cmd: add debug.pprof option to serve pprof on local port 29500

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,10 @@ type NodeConfig struct {
 	// Token string `yaml:"token", envconfig:"NODE_TOKEN"`
 }
 
+type DebugConfig struct {
+	Pprof bool
+}
+
 type MicroshiftConfig struct {
 	ConfigFile string
 	DataDir    string `yaml:"dataDir"`
@@ -69,7 +73,8 @@ type MicroshiftConfig struct {
 	ControlPlane ControlPlaneConfig `yaml:"controlPlane"`
 	Node         NodeConfig         `yaml:"node"`
 
-	Manifests []string `yaml:"manifests"`
+	Manifests []string    `yaml:"manifests"`
+	Debug     DebugConfig `yaml:"debug"`
 }
 
 func NewMicroshiftConfig() *MicroshiftConfig {
@@ -217,6 +222,9 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 	}
 	if roles, err := flags.GetStringSlice("roles"); err == nil && flags.Changed("roles") {
 		c.Roles = roles
+	}
+	if pprofFlag, err := flags.GetBool("debug.pprof"); err == nil && flags.Changed("debug.pprof") {
+		c.Debug.Pprof = pprofFlag
 	}
 	return nil
 }


### PR DESCRIPTION
pprof is useful tool for profiling and finding hot cpu/mem spots
and should not be enabled in production deployment.

To start microshift with pprof enabled (disabled by default):

$ microshift run --debug.pprof=true

As an example to get golang heap memory snapshot of microshift main
process:

$ go tool pprof http://127.0.0.1:29500/debug/pprof/heap
Fetching profile over HTTP from http://127.0.0.1:29500/debug/pprof/heap
Saved profile in /root/pprof/pprof.microshift.alloc_objects.alloc_space.inuse_objects.inuse_space.007.pb.gz
File: microshift
Build ID: 6b04bb6b4868ae9806a35aa9be8cef4fc448c606
Type: inuse_space
Time: Aug 4, 2022 at 10:45pm (EDT)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 75.06MB, 51.65% of 145.31MB total
Dropped 454 nodes (cum <= 0.73MB)
Showing top 10 nodes out of 399
      flat  flat%   sum%        cum   cum%
   33.76MB 23.23% 23.23%    33.76MB 23.23%  go.uber.org/zap/zapcore.newCounters
   10.51MB  7.23% 30.47%    10.51MB  7.23%  runtime.allocm
    5.50MB  3.79% 34.25%     5.50MB  3.79%  runtime.malg
    4.79MB  3.29% 37.55%     4.79MB  3.29%  github.com/openshift/microshift/pkg/mdns/server.(*Server).listenerLoop
    3.69MB  2.54% 40.09%     3.69MB  2.54%  encoding/json.Marshal
    3.56MB  2.45% 42.53%     3.56MB  2.45%  bytes.makeSlice
    3.51MB  2.41% 44.95%     3.51MB  2.41%  reflect.unsafe_NewArray
    3.50MB  2.41% 47.36%     3.50MB  2.41%  encoding/json.(*decodeState).literalStore
    3.19MB  2.20% 49.55%     3.19MB  2.20%  google.golang.org/grpc/internal/transport.newBufWriter
    3.05MB  2.10% 51.65%     4.55MB  3.13%  k8s.io/kube-openapi/pkg/builder.(*openAPI).buildPaths
(pprof)

The address of pprof http server is coded as 127.0.0.1:29500

Port 29500 is chosen to not conflict with:
1) registried host ports in openshift as documented in: https://github.com/openshift/enhancements/blob/master/dev-guide/host-port-registry.md
2) default nodePort range 30000-32767

Signed-off-by: Zenghui Shi <zshi@redhat.com>
