### PR TITLE
Fix ISO kickstart to check if firewall is active, not enabled

### DIFF
--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -59,6 +59,6 @@ chown -R redhat:redhat /home/redhat/
 # Configure the firewall
 firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
 firewall-offline-cmd --zone=trusted --add-source=169.254.169.1
-systemctl is-enabled --quiet firewalld.service && firewall-cmd --reload
+systemctl is-active --quiet firewalld.service && firewall-cmd --reload
 
 %end


### PR DESCRIPTION
During the installation, firewall is enabled, but not active - thus "firewall-cmd --reload" is returning an error.

Closes [USHIFT-253](https://issues.redhat.com//browse/USHIFT-253)
