### PR TITLE
Fix mDNS package logging

### DIFF
--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -53,7 +53,7 @@ func (c *MicroShiftmDNSController) Run(ctx context.Context, ready chan<- struct{
 			strings.HasPrefix(name, "cni") {
 			continue
 		}
-		klog.Infof("starting mDNS server", "interface", name, "NodeIP", c.NodeIP, "Node", c.NodeName)
+		klog.Infof("mDNS: Starting server on interface %q, NodeIP %q, NodeName %q", name, c.NodeIP, c.NodeName)
 		server.New(&ifs[n], c.resolver, c.stopCh)
 	}
 
@@ -68,7 +68,7 @@ func (c *MicroShiftmDNSController) Run(ctx context.Context, ready chan<- struct{
 			}
 		}
 
-		klog.Infof("Host FQDN will be announced via mDNS", "fqdn", c.NodeName, "ips", ips)
+		klog.Infof("mDNS: Host FQDN %q will be announced via mDNS on IPs %q", c.NodeName, ips)
 		c.resolver.AddDomain(c.NodeName+".", ips)
 		c.myIPs = ips
 	}


### PR DESCRIPTION
The logging parameters were set for structured logging (InfoS) in
some cases, while Infof is being used (same for Errorf).

Closes: https://issues.redhat.com/browse/USHIFT-263

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
