### PR TITLE
mDNS: Avoid listening on internal interfaces and reduce footprint

### DIFF
--- a/pkg/mdns/server/server.go
+++ b/pkg/mdns/server/server.go
@@ -66,7 +66,10 @@ func New(iface *net.Interface, responder Responder, stopCh chan struct{}) (*Serv
 }
 
 func (s *Server) listenerLoop(c *net.UDPConn) {
-	buf := make([]byte, 65536)
+	// most queries will be smaller than 512bytes, and FQDNs are limited to 253 characters
+	// but multiple queries can be grouped into a single UDP request. We use 2048 which is
+	// slightly above the standard mtu of 1500 bytes
+	buf := make([]byte, 2048)
 	for {
 		length, addr, err := c.ReadFromUDP(buf)
 		if length == 0 {


### PR DESCRIPTION
mDNS was listening on internal ovn interfaces (pods) and allocating
way too much memory per server, regular mDNS queries fit on unfragmented
regular 1500 MTU packets.

Closes: https://issues.redhat.com/browse/USHIFT-264

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
