### PR TITLE
USHIFT-266: Don't send second SIGTERM on context.Canceled.

### DIFF
--- a/pkg/servicemanager/manager.go
+++ b/pkg/servicemanager/manager.go
@@ -2,6 +2,7 @@ package servicemanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"syscall"
 
@@ -110,7 +111,7 @@ func (m *ServiceManager) asyncRun(ctx context.Context, service Service) (<-chan 
 		}()
 
 		klog.Infof("Starting %s", service.Name())
-		if err := service.Run(ctx, ready, stopped); err != nil {
+		if err := service.Run(ctx, ready, stopped); err != nil && !errors.Is(err, context.Canceled) {
 			klog.Errorf("service %s exited with error: %s, stopping MicroShift", service.Name(), err)
 			syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 		} else {


### PR DESCRIPTION
If the context is canceled, the first `context.Canceled` error returned from a component results in a second SIGTERM that ends the process without waiting for other components to stop.