### PR TITLE
Store host IPs for mDNS routes even if hostname is not .local

### DIFF
--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -57,20 +57,22 @@ func (c *MicroShiftmDNSController) Run(ctx context.Context, ready chan<- struct{
 		server.New(&ifs[n], c.resolver, c.stopCh)
 	}
 
-	if strings.HasSuffix(c.NodeName, server.DefaultmDNSTLD) {
-		ips := []string{c.NodeIP}
+	ips := []string{c.NodeIP}
 
-		// Discover additional IPs for the interface (IPv6 LLA ...)
-		for n := range ifs {
-			addrs, _ := ifs[n].Addrs()
-			if ipInAddrs(c.NodeIP, addrs) {
-				ips = addrsToStrings(addrs)
-			}
+	// Discover additional IPs for the interface (IPv6 LLA ...)
+	for n := range ifs {
+		addrs, _ := ifs[n].Addrs()
+		if ipInAddrs(c.NodeIP, addrs) {
+			ips = addrsToStrings(addrs)
 		}
+	}
+
+	c.myIPs = ips
+
+	if strings.HasSuffix(c.NodeName, server.DefaultmDNSTLD) {
 
 		klog.Infof("Host FQDN will be announced via mDNS", "fqdn", c.NodeName, "ips", ips)
 		c.resolver.AddDomain(c.NodeName+".", ips)
-		c.myIPs = ips
 	}
 
 	close(ready)


### PR DESCRIPTION
A bug prevented route mDNS hosts from being announced when the host
doesn't have an mdns compliant hostname, while that fact should
be independent.

Closes Issue: https://issues.redhat.com/browse/USHIFT-271

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
