### PR TITLE
USHIFT-269: Carry patch for CSI plugin initialization conflicts between kubelet and kube-controller-manager.

### DIFF
--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -532,7 +532,7 @@ rebase_to() {
 
         if [ "$(ls -A scripts/rebase_patches)" ]; then
             title "## Patching vendor directory"
-            git apply scripts/rebase_patches/*.patch || true
+            git am scripts/rebase_patches/*.patch || true
         fi
 
         regenerate_openapi

--- a/scripts/rebase_patches/0001-Fix-CSI-initialization-conflict.patch
+++ b/scripts/rebase_patches/0001-Fix-CSI-initialization-conflict.patch
@@ -1,0 +1,51 @@
+From daf17df5a5dba93a0e3ca44d48c00e73314f4558 Mon Sep 17 00:00:00 2001
+From: Darren Shepherd <darren@rancher.com>
+Date: Fri, 30 Aug 2019 11:22:18 -0700
+Subject: [PATCH] Fix CSI initialization conflict
+
+CSI is used by both the kubelet and kube-controller-manager.  Both
+components will initialize the csiPlugin with different VolumeHost
+objects.  The csiPlugin will then assign a global variable for
+the node info manager.  It is then possible that the kubelet gets
+the credentials of the kube-controller-manager and that will cause
+CSI to fail.
+---
+ vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
+index 0ae6d084f0e..f63bfb337e6 100644
+--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
++++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
+@@ -243,20 +243,24 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
+ 	}
+ 
+ 	// Initializing the label management channels
+-	nim = nodeinfomanager.NewNodeInfoManager(host.GetNodeName(), host, migratedPlugins)
++	localNim := nodeinfomanager.NewNodeInfoManager(host.GetNodeName(), host, migratedPlugins)
+ 
+ 	if utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) {
+ 		// This function prevents Kubelet from posting Ready status until CSINode
+ 		// is both installed and initialized
+-		if err := initializeCSINode(host); err != nil {
+-			return errors.New(log("failed to initialize CSINode: %v", err))
++		if err := initializeCSINode(host, localNim); err != nil {
++			return errors.New(log("failed to initialize CSINodeInfo: %v", err))
+ 		}
+ 	}
+ 
++	if _, ok := host.(volume.KubeletVolumeHost); ok {
++		nim = localNim
++	}
++
+ 	return nil
+ }
+ 
+-func initializeCSINode(host volume.VolumeHost) error {
++func initializeCSINode(host volume.VolumeHost, nim nodeinfomanager.Interface) error {
+ 	kvh, ok := host.(volume.KubeletVolumeHost)
+ 	if !ok {
+ 		klog.V(4).Info("Cast from VolumeHost to KubeletVolumeHost failed. Skipping CSINode initialization, not running on kubelet")
+-- 
+2.36.1
+


### PR DESCRIPTION
Node information (e.g. node name) is stored in a global variable during initialization of the CSI volume plugin. Both kubelet and kube-controller-manager initialize the CSI volume plugin, so whichever one initializes last "wins" and their state is persisted. The kube-controller-manager initializes the plugin in such a way that it can't be used to register kubelet plugins. This is responsible for the inconsistent failures we were seeing in E2E storage tests.

K3S (which also embeds kubelet and kube-controller-manager) discovered and is affected by the same issue. This PR adds their patch. I'm opening a Microshift issue to attempt an upstream change that will allow both projects to drop this patch.