### PR TITLE
USHIFT-272: start debugging tips doc with version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To install, configure and run MicroShift, refer to the following documentation:
 - [AMQ Broker on MicroShift](./docs/howto_amq_broker.md)
 - [MicroShift Mitigation of System Configuration Changes](./docs/howto_sysconf_watch.md)
 - [Firewall Configuration](./docs/howto_firewall.md)
+- [Debugging Tips](./docs/debugging_tips.md)
 
 ## Developer Documentation
 To build MicroShift from source and contribute to its development, refer to the following documentation:

--- a/docs/debugging_tips.md
+++ b/docs/debugging_tips.md
@@ -1,0 +1,29 @@
+# Debugging Tips
+
+## Checking the MicroShift Version
+
+From the command line, use `microshift version` to check the version
+information.
+
+```bash
+$ microshift version
+MicroShift Version: 4.10.0-0.microshift-e6980e25
+Base OCP Version: 4.10.18
+```
+
+Through the API, access the `kube-public/microshift-version` ConfigMap
+to retrieve the same information.
+
+```bash
+$ oc get configmap -n kube-public microshift-version -o yaml
+apiVersion: v1
+data:
+  major: "4"
+  minor: "10"
+  version: 4.10.0-0.microshift-e6980e25
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2022-08-08T21:06:11Z"
+  name: microshift-version
+  namespace: kube-public
+```


### PR DESCRIPTION
Start a new section of the user documentation with debugging tips by
including information about how to determine the version of
MicroShift.

Closes: [USHIFT-271](https://issues.redhat.com//browse/USHIFT-271)