### PR TITLE
Fix early systemd readiness

### DIFF
--- a/packaging/systemd/microshift.service
+++ b/packaging/systemd/microshift.service
@@ -14,6 +14,7 @@ CPUAccounting=yes
 BlockIOAccounting=yes
 MemoryAccounting=yes
 LimitNOFILE=1048576
+TimeoutStartSec=2m
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/sysconfwatch/sysconfwatch_linux.go
+++ b/pkg/sysconfwatch/sysconfwatch_linux.go
@@ -91,6 +91,9 @@ func (c *SysConfWatchController) Run(ctx context.Context, ready chan<- struct{},
 	var buf []byte = make([]byte, 8)
 	// Take a snapshot of the system and monototic clocks as a base reference
 	stimeRef, mtimeRef := getSysMonTimes()
+
+	klog.Infof("sysconfwatch-controller is ready")
+	close(ready)
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
**Which issue(s) this PR addresses**:
Closes [USHIFT-242](https://issues.redhat.com/browse/USHIFT-242)

**Description**:
- Fixes premature systemd service readiness by clearing `NOTIFY_SOCKET` environment variable so apiserver, kubelet, or openshift-controller-manager won't send `READY=1`. The variable is restored when MicroShift is considered ready.
- Adds closure of `sysconfwatch`'s `ready` channel, so MicroShift's readiness is no longer blocked.
- Adds 2m service start timeout. If service does not start in that time, it'll be terminated and restarted.
- `systemctl start microshift` won't return until MicroShift is ready which now will happen much later (currently ~45s based on several tries).