### PR TITLE
Set node-role.kubernetes.io based on MicroShift roles

### DIFF
--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -70,6 +70,15 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 	kubeletFlags.NodeIP = cfg.NodeIP
 	kubeletFlags.ContainerRuntime = "remote"
 	kubeletFlags.RemoteRuntimeEndpoint = "unix:///var/run/crio/crio.sock"
+	for _, role := range cfg.Roles {
+		if role == "controlplane" {
+			kubeletFlags.NodeLabels["node-role.kubernetes.io/control-plane"] = ""
+			kubeletFlags.NodeLabels["node-role.kubernetes.io/master"] = ""
+		}
+		if role == "node" {
+			kubeletFlags.NodeLabels["node-role.kubernetes.io/worker"] = ""
+		}
+	}
 
 	kubeletConfig, err := loadConfigFile(cfg.DataDir + "/resources/kubelet/config/config.yaml")
 


### PR DESCRIPTION
**Which issue(s) this PR addresses**:
Closes #661  [USHIFT-28](https://issues.redhat.com/browse/USHIFT-28)

**Desc**
Adds node labeling based on MicroShift roles. There's a slight difference between MicroShift's and kubelet's roles: [control-plane vs controlplane, worker vs node](https://github.com/openshift/microshift/blob/79b64b05d843d2a4aa2c7a406276ece69d019f81/vendor/k8s.io/kubelet/pkg/apis/well_known_labels.go#L50)