### PR TITLE
Get node IP through ovn gateway interface when no default route

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,7 +84,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	}
 	nodeIP, err := util.GetHostIP()
 	if err != nil {
-		klog.Warningf("failed to get host IP: %v, using: %q", err, nodeIP)
+		klog.Fatalf("failed to get host IP: %v", err)
 	}
 
 	dataDir := findDataDir()

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -104,6 +104,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 
 	overrides := &kubecontrolplanev1.KubeAPIServerConfig{
 		APIServerArguments: map[string]kubecontrolplanev1.Arguments{
+			"advertise-address": {cfg.NodeIP},
 			"audit-log-path":    {cfg.AuditLogDir},
 			"audit-policy-file": {cfg.DataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
 			"client-ca-file":    {caCertFile},


### PR DESCRIPTION
MicroShift and some service components (e.g. kube-apiserver)
get nodeIP through the default route interface. When there is
no internet connection, default route won't exist which results
in failure starting services.

For example,

kubelet expects nodeIP to not be 127.0.0.1:

kubelet_node_status.go:622] "Failed to set some node status fields"
err="failed to validate nodeIP: nodeIP can't be loopback address"
node="localhost.localdomain"

kube-apiserver fails to find suitable network address:

service kube-apiserver exited with error: kube-apiserver configuration
error: Unable to find suitable network address.error='no default routes
found in "/proc/net/route" or "/proc/net/ipv6_route"'. Try to set the
AdvertiseAddress directly or provide a valid BindAddress to fix this.

Closes #[USHIFT-22](https://issues.redhat.com//browse/USHIFT-22)

Signed-off-by: Zenghui Shi <zshi@redhat.com>
