### PR TITLE
cleanup ovn kubernetes CNI binary and config file

### DIFF
--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -40,6 +40,8 @@ sudo bash -c "
     echo Removing MicroShift and OVN configuration
     rm -rf /var/lib/{microshift,ovnk}
     rm -rf /var/run/ovn
+    rm -f /etc/cni/net.d/10-ovn-kubernetes.conf
+    rm -f /opt/cni/bin/ovn-k8s-cni-overlay
 
     echo Cleanup succeeded
 "


### PR DESCRIPTION
ovn-kubernetes CNI config file is written by ovnkube-node
process and will be left over if ovnkube-node doesn't
exit gracefully (which is the case when stopping MicroShift
service).

Crio waits for the existence of ovn-kubernetes CNI config
to mark the node as Ready. If ovn-kubernetes CNI config is
not cleaned up, node will become ready immediately on next
boot w/o waiting for ovn network become ready.

Signed-off-by: Zenghui Shi <zshi@redhat.com>
