### PR TITLE
Use OpenShift Infra NS from KCM operator

### DIFF
--- a/assets/core/namespace-openshift-infra.yaml
+++ b/assets/core/namespace-openshift-infra.yaml
@@ -1,12 +1,6 @@
-kind: Namespace
 apiVersion: v1
+kind: Namespace
 metadata:
   annotations:
-    openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   name: openshift-infra
-  labels:
-    # set value to avoid depending on kube admission that depends on openshift apis
-    openshift.io/run-level: "0"
-    # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
-    openshift.io/cluster-monitoring: "true"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4277,18 +4277,12 @@ func assetsCoreCsr_approver_clusterrolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
-var _assetsCoreNamespaceOpenshiftInfraYaml = []byte(`kind: Namespace
-apiVersion: v1
+var _assetsCoreNamespaceOpenshiftInfraYaml = []byte(`apiVersion: v1
+kind: Namespace
 metadata:
   annotations:
-    openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   name: openshift-infra
-  labels:
-    # set value to avoid depending on kube admission that depends on openshift apis
-    openshift.io/run-level: "0"
-    # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
-    openshift.io/cluster-monitoring: "true"
 `)
 
 func assetsCoreNamespaceOpenshiftInfraYamlBytes() ([]byte, error) {
@@ -4301,7 +4295,7 @@ func assetsCoreNamespaceOpenshiftInfraYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/core/namespace-openshift-infra.yaml", size: 419, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
+	info := bindataFileInfo{name: "assets/core/namespace-openshift-infra.yaml", size: 128, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -392,6 +392,7 @@ update_manifests() {
     #    Selectively copy in only those CRD manifests that MicroShift is already using
     cp "${STAGING_DIR}/release-manifests/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml" "${REPOROOT}"/assets/crd
     cp "${STAGING_DIR}/release-manifests/0000_03_security-openshift_01_scc.crd.yaml" "${REPOROOT}"/assets/crd
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-openshift-infra.yaml" "${REPOROOT}"/assets/core
     # TODO: add route CRD (https://github.com/openshift/api/blob/master/route/v1/route.crd.yaml) when we rebase to a release that contains it
     #    Replace all SCC manifests.
     rm -f "${REPOROOT}"/assets/scc/*.yaml


### PR DESCRIPTION
The openshift-infra namespace is now gathered from the
cluster-kube-controller-manager-operator assets.

This rebases #885.

/cc @oglok