### PR TITLE
skip extra make step in dev environment automation

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -41,10 +41,6 @@ if [ ! -e ~/microshift ] ; then
 fi
 cd ~/microshift
 
-# Build MicroShift > Executable
-# https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#executable
-make
-
 # Build MicroShift > RPM Packages
 # https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#rpm-packages
 make rpm 


### PR DESCRIPTION
Building the rpm runs make to build the binary so there is no need to
run it separately in the dev environment configure script.

/kind cleanup
/assign @ggiguash