### PR TITLE
Make nodeport range configurable

### DIFF
--- a/assets/components/openshift-router/service-cloud.yaml
+++ b/assets/components/openshift-router/service-cloud.yaml
@@ -15,8 +15,6 @@ spec:
     - name: http
       port: 80
       targetPort: 80
-      nodePort: 30001
     - name: https
       port: 443
       targetPort: 443
-      nodePort: 30002

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2695,11 +2695,9 @@ spec:
     - name: http
       port: 80
       targetPort: 80
-      nodePort: 30001
     - name: https
       port: 443
       targetPort: 443
-      nodePort: 30002
 `)
 
 func assetsComponentsOpenshiftRouterServiceCloudYamlBytes() ([]byte, error) {
@@ -2712,7 +2710,7 @@ func assetsComponentsOpenshiftRouterServiceCloudYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/openshift-router/service-cloud.yaml", size: 567, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
+	info := bindataFileInfo{name: "assets/components/openshift-router/service-cloud.yaml", size: 523, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -127,6 +127,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"proxy-client-key-file":            {filepath.Join(kasSecretsDir, "aggregator-client", "tls.key")},
 			"requestheader-client-ca-file":     {clientCABundlePath},
 			"service-account-signing-key-file": {cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key"},
+			"service-node-port-range":          {cfg.Cluster.ServiceNodePortRange},
 			"tls-cert-file":                    {filepath.Join(servingCertsDir, "tls.crt")},
 			"tls-private-key-file":             {filepath.Join(servingCertsDir, "tls.key")},
 			"disable-admission-plugins": {

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -485,8 +485,6 @@ update_manifests() {
     yq -i '.spec.template.spec.containers[0].ports[2].hostPort = 1936' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     #    Change LoadBalancer to NodePort as long as we do not add a default LB. Add the necessary nodePorts
     yq -i '.spec.type = "NodePort"' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
-    yq -i '.spec.ports[0].nodePort = 30001' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
-    yq -i '.spec.ports[1].nodePort = 30002' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
     # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
     sed -i 's|REPLACE_ROUTER_IMAGE|{{ .ReleaseImage.haproxy_router }}|' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
 


### PR DESCRIPTION
Setting service nodeport range to KubeAPIServerConfig.ServicesNodePortRange
doesn't take effect, needs to use service-node-port-range in
KubeAPIServerConfig.APIServerArguments

Closes #[USHIFT-334](https://issues.redhat.com//browse/USHIFT-334)
