### PR TITLE
AUTH-296: Separate kubelet client trust

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -89,6 +89,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	s.verbosity = cfg.LogVLevel
 
 	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	kubeletClientDir := cryptomaterial.KubeAPIServerToKubeletClientCertDir(certsDir)
 	caCertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	clientCABundlePath := cryptomaterial.TotalClientCABundlePath(certsDir)
 	kasSecretsDir := filepath.Join(certsDir, "kube-apiserver", "secrets")
@@ -120,8 +121,8 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 				"https://127.0.0.1:2379",
 			},
 			"kubelet-certificate-authority": {caCertFile},
-			"kubelet-client-certificate":    {cfg.DataDir + "/resources/kube-apiserver/secrets/kubelet-client/tls.crt"},
-			"kubelet-client-key":            {cfg.DataDir + "/resources/kube-apiserver/secrets/kubelet-client/tls.key"},
+			"kubelet-client-certificate":    {cryptomaterial.ClientCertPath(kubeletClientDir)},
+			"kubelet-client-key":            {cryptomaterial.ClientKeyPath(kubeletClientDir)},
 
 			"proxy-client-cert-file":           {filepath.Join(kasSecretsDir, "aggregator-client", "tls.crt")},
 			"proxy-client-key-file":            {filepath.Join(kasSecretsDir, "aggregator-client", "tls.key")},

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -193,9 +193,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 					}
 				}
 
-				for _, adding := range src.([]interface{}) {
-					result = append(result, adding)
-				}
+				result = append(result, src.([]interface{})...)
 
 				return result, nil
 			},

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -97,7 +97,7 @@ kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
 authentication:
   x509:
-    clientCAFile: ` + cryptomaterial.UltimateTrustBundlePath(cryptomaterial.CertsDirectory(cfg.DataDir)) + `
+    clientCAFile: ` + cryptomaterial.KubeletClientCAPath(cryptomaterial.CertsDirectory(cfg.DataDir)) + `
   anonymous:
     enabled: false
 tlsCertFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-client/tls.crt

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -100,8 +100,8 @@ authentication:
     clientCAFile: ` + cryptomaterial.KubeletClientCAPath(cryptomaterial.CertsDirectory(cfg.DataDir)) + `
   anonymous:
     enabled: false
-tlsCertFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-client/tls.crt
-tlsPrivateKeyFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-client/tls.key
+tlsCertFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-server/tls.crt
+tlsPrivateKeyFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-server/tls.key
 cgroupDriver: "systemd"
 failSwapOn: false
 volumePluginDir: ` + cfg.DataDir + `/kubelet-plugins/volume/exec

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -13,8 +13,9 @@ const (
 	ClientCertFileName = "client.crt"
 	ClientKeyFileName  = "client.key"
 
-	ClientCAValidityDays   = 60
-	ClientCertValidityDays = 30
+	ClientCAValidityDays                  = 60
+	ClientCertValidityDays                = 30
+	AdminKubeconfigClientCertValidityDays = 365 * 10
 )
 
 func CertsDirectory(dataPath string) string { return filepath.Join(dataPath, "certs") }
@@ -44,6 +45,14 @@ func KubeAPIServerToKubeletSignerCertDir(certsDir string) string {
 
 func KubeAPIServerToKubeletClientCertDir(certsDir string) string {
 	return filepath.Join(KubeAPIServerToKubeletSignerCertDir(certsDir), "kube-apiserver-to-kubelet-client")
+}
+
+func AdminKubeconfigSignerDir(certsDir string) string {
+	return filepath.Join(certsDir, "admin-kubeconfig-signer")
+}
+
+func AdminKubeconfigClientCertDir(certsDir string) string {
+	return filepath.Join(AdminKubeconfigSignerDir(certsDir), "admin-kubeconfig-client")
 }
 
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -1,6 +1,8 @@
 package cryptomaterial
 
-import "path/filepath"
+import (
+	"path/filepath"
+)
 
 const (
 	CACertFileName     = "ca.crt"
@@ -36,6 +38,14 @@ func KubeControllerManagerClientCertDir(certsDir string) string {
 	return filepath.Join(KubeControlPlaneSignerCertDir(certsDir), "kube-controller-manager")
 }
 
+func KubeAPIServerToKubeletSignerCertDir(certsDir string) string {
+	return filepath.Join(certsDir, "kube-apiserver-to-kubelet-client-signer")
+}
+
+func KubeAPIServerToKubeletClientCertDir(certsDir string) string {
+	return filepath.Join(KubeAPIServerToKubeletSignerCertDir(certsDir), "kube-apiserver-to-kubelet-client")
+}
+
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers
 func TotalClientCABundlePath(certsDir string) string {
 	return filepath.Join(certsDir, "ca-bundle", "client-ca.crt")
@@ -44,4 +54,9 @@ func TotalClientCABundlePath(certsDir string) string {
 // UltimateTrustBundlePath returns the path to the cert bundle with the root certificate
 func UltimateTrustBundlePath(certsDir string) string {
 	return filepath.Join(certsDir, "ca-bundle", "ca-bundle.crt")
+}
+
+// KubeletClientCAPath returns the path to the cert bundle with all client certificate signers that kubelet should respect
+func KubeletClientCAPath(certsDir string) string {
+	return filepath.Join(certsDir, "ca-bundle", "kubelet-ca.crt")
 }

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -55,6 +55,20 @@ func AdminKubeconfigClientCertDir(certsDir string) string {
 	return filepath.Join(AdminKubeconfigSignerDir(certsDir), "admin-kubeconfig-client")
 }
 
+// KubeletCSRSignerSignerCertDir returns path to the signer that signs kubelet CSRs
+// and the signer that signs CSRs of the CSR API
+func KubeletCSRSignerSignerCertDir(certsDir string) string {
+	return filepath.Join(certsDir, "kubelet-csr-signer-signer")
+}
+
+func CSRSignerCertDir(certsDir string) string {
+	return filepath.Join(KubeletCSRSignerSignerCertDir(certsDir), "csr-signer")
+}
+
+func KubeletClientCertDir(certsDir string) string {
+	return filepath.Join(KubeletCSRSignerSignerCertDir(certsDir), "kubelet-client")
+}
+
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers
 func TotalClientCABundlePath(certsDir string) string {
 	return filepath.Join(certsDir, "ca-bundle", "client-ca.crt")

--- a/pkg/util/cryptomaterial/trustupdates.go
+++ b/pkg/util/cryptomaterial/trustupdates.go
@@ -5,17 +5,25 @@ import (
 	"os"
 )
 
-func AddToTotalClientCABundle(certsDir string, cacert []byte) error {
-	clientCABundlePath := TotalClientCABundlePath(certsDir)
+func AddToTotalClientCABundle(certsDir string, cacerts ...[]byte) error {
+	return appendCertsToFile(TotalClientCABundlePath(certsDir), cacerts...)
+}
 
-	f, err := os.OpenFile(clientCABundlePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+func AddToKubeletClientCABundle(certsDir string, cacerts ...[]byte) error {
+	return appendCertsToFile(KubeletClientCAPath(certsDir), cacerts...)
+}
+
+func appendCertsToFile(bundlePath string, certs ...[]byte) error {
+	f, err := os.OpenFile(bundlePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
-		return fmt.Errorf("failed to open %q for writing: %w", clientCABundlePath, err)
+		return fmt.Errorf("failed to open %q for writing: %w", bundlePath, err)
 	}
 	defer f.Close()
 
-	f.WriteString("\n")
-	f.Write(cacert)
+	for _, c := range certs {
+		f.WriteString("\n")
+		f.Write(c)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR separates the CAs that are trusted by the kubelet for client cert authentication.

The `cmd/init.go` is starting to be a little messy, we will probably want to refactor it eventually.

---

This is currenly untested, I would be surprised if everything worked because this finally cuts the trust of a kubelet to the ultimate bundle for client cert authentication, but let's see what happens,
