### PR TITLE
USHIFT-337: Support topolvm disk, building external etcd, etc

### DIFF
--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -63,6 +63,7 @@ du_dirs:
   - /usr/
   - /usr/bin/*
 
+vg_name: rhel
 lvm_disk: /dev/xvdb
 
 sample_interval: 5

--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -6,6 +6,7 @@ install_packages:
   - firewalld
   - git
   - golang
+  - lvm2
   - make
   - python3-firewall
   - perf
@@ -24,6 +25,7 @@ firewall_services:
 firewall_ports:
   - 80/tcp
   - 443/tcp
+  - 2379/tcp
   - 5353/udp
   - 6443/tcp
   - 8080/tcp
@@ -38,7 +40,12 @@ firewall_trusted_cidr:
   - 169.254.169.1/32
 
 root_bin_dir: /usr/bin
+
+etcd_dir: "{{ ansible_env.HOME }}/etcd"
+etcd_repo: https://github.com/openshift/etcd.git
+
 microshift_dir: "{{ ansible_env.HOME }}/microshift"
+microshift_repo: https://github.com/openshift/microshift.git
 microshift_rpms: []
 
 systemd_services:
@@ -55,3 +62,7 @@ du_dirs:
   - /var/lib/containers/storage/
   - /usr/
   - /usr/bin/*
+
+lvm_disk: /dev/xvdb
+
+sample_interval: 5

--- a/ansible/roles/install-microshift/files/etcd.service
+++ b/ansible/roles/install-microshift/files/etcd.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=etcd key-value store
+Documentation=https://github.com/etcd-io/etcd
+After=network-online.target local-fs.target remote-fs.target time-sync.target
+Wants=network-online.target local-fs.target remote-fs.target time-sync.target
+
+[Service]
+User=root
+Type=notify
+Environment=ETCD_DATA_DIR=/var/lib/microshift
+Environment=ETCD_NAME=%m
+ExecStart=/usr/bin/etcd \
+	--cert-file=${ETCD_DATA_DIR}/resources/kube-apiserver/secrets/etcd-client/tls.crt \
+	--key-file=${ETCD_DATA_DIR}/resources/kube-apiserver/secrets/etcd-client/tls.key \
+	--trusted-ca-file=${ETCD_DATA_DIR}/certs/ca-bundle/ca-bundle.crt \
+	--advertise-client-urls=https://localhost:2379 \
+	--listen-client-urls=https://localhost:2379,unixs://localhost:0 \
+	--client-cert-auth=true
+Restart=always
+RestartSec=10s
+LimitNOFILE=40000
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/install-microshift/tasks/main.yml
+++ b/ansible/roles/install-microshift/tasks/main.yml
@@ -7,13 +7,19 @@
     state: present
     update_cache: true
 
+- name: check if rhel vg exists
+  ansible.builtin.command: vgdisplay -s {{ vg_name }}
+  register: rhel_vg_present
+  ignore_errors: true
+
 - name: create a volume group on top of secondary disk for topolvm
   community.general.lvg:
-    vg: rhel
+    vg: "{{ vg_name }}"
     pvs: "{{ lvm_disk }}"
+  when: rhel_vg_present.rc != 0
 
 - name: check if we have oc installed
-  command: which oc
+  ansible.builtin.command: which oc
   register: oc_present
   ignore_errors: true
 
@@ -281,6 +287,13 @@
     create: yes
   delegate_to: localhost
 
+- name: stress etcd with configmap loading
+  ansible.builtin.shell: |
+    for i in {5255..5355}; do
+      oc new-project project-$i
+      oc create configmap project-$i --from-file=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+    done
+
 #- name: copy kubeconfig to localhost
 #  ansible.builtin.fetch:
 #    src: "{{ remote_kubeconfig_path }}"
@@ -294,7 +307,7 @@
       jid: "{{ pbench_user_benchmark_result.ansible_job_id }}"
     register: job_result
     until: job_result.finished
-    retries: 80
+    retries: 240
     delay: 15
   
   - name: source pbench-agent & move results

--- a/ansible/roles/install-microshift/tasks/main.yml
+++ b/ansible/roles/install-microshift/tasks/main.yml
@@ -7,6 +7,11 @@
     state: present
     update_cache: true
 
+- name: create a volume group on top of secondary disk for topolvm
+  community.general.lvg:
+    vg: rhel
+    pvs: "{{ lvm_disk }}"
+
 - name: check if we have oc installed
   command: which oc
   register: oc_present
@@ -117,7 +122,7 @@
 
     - name: clone microshift git repo
       ansible.builtin.git:
-        repo: 'https://github.com/openshift/microshift.git'
+        repo: "{{ microshift_repo }}"
         dest: "{{ microshift_dir }}"
 
     - name: make microshift RPMs
@@ -161,6 +166,40 @@
         update_cache: true
   when: ansible_distribution == "CentOS"
 
+- name: build & install etcd
+  block:
+    - name: clone etcd git repo
+      ansible.builtin.git:
+        repo: "{{ etcd_repo }}"
+        dest: "{{ etcd_dir }}"
+
+    - name: make etcd binary
+      ansible.builtin.command: make
+      args:
+        chdir: "{{ etcd_dir }}"
+
+    - name: install etcd binary
+      ansible.builtin.copy:
+        src: "{{ etcd_dir }}/bin/etcd"
+        dest: "/usr/bin/etcd"
+        remote_src: yes
+        mode: '0755'
+
+    - name: copy etcd systemd unit to node
+      ansible.builtin.copy:
+        src: etcd.service
+        dest: /usr/lib/systemd/system/etcd.service
+        owner: root
+        group: root
+        mode: '0664'
+
+    - name: start etcd service
+      ansible.builtin.systemd:
+        daemon_reload: yes
+        state: started
+        name: etcd
+  when: build_etcd_binary | bool
+
 - name: copy pull-secret to node
   ansible.builtin.copy:
     src: pull-secret.txt
@@ -174,6 +213,9 @@
   - name: source pbench-agent & register-tool-set
     ansible.builtin.shell: source /etc/profile.d/pbench-agent.sh && pbench-register-tool-set
   
+  - name: set new pidstat interval
+    ansible.builtin.shell: source /etc/profile.d/pbench-agent.sh && pbench-register-tool --name=pidstat -- --interval={{ sample_interval }}
+
   - name: start pbench-user-benchmark recording
     ansible.builtin.shell: source /etc/profile.d/pbench-agent.sh && pbench-user-benchmark --config=microshift -- sleep {{ pbench_record_duration }}
     async: "{{ pbench_record_duration|int * 2 }}"

--- a/ansible/roles/manage-repos/defaults/main.yml
+++ b/ansible/roles/manage-repos/defaults/main.yml
@@ -2,5 +2,6 @@
 # manage-repos default vars
 
 rhel_repos:
+  - codeready-builder-for-rhel-8-x86_64-rpms
   - fast-datapath-for-rhel-8-x86_64-rpms
   - rhocp-4.10-for-rhel-8-x86_64-rpms

--- a/ansible/vars/all.yml
+++ b/ansible/vars/all.yml
@@ -1,3 +1,4 @@
+build_etcd_binary: false
 install_pbench: false
 pbench_record_duration: 360
 local_kubeconfig_path: ~/.kube/config.microshift


### PR DESCRIPTION
- Support topolvm disk, building external etcd, and alternative microshift repos.
- Add pidstat sample interval and additional RHEL repo.

**Which issue(s) this PR addresses**: https://issues.redhat.com/browse/USHIFT-337