### PR TITLE
USHIFT-333: add ingress-to-route-controller RBAC

### DIFF
--- a/assets/components/openshift-router/ingress-to-route-controller-clusterrole.yaml
+++ b/assets/components/openshift-router/ingress-to-route-controller-clusterrole.yaml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingress
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update

--- a/assets/components/openshift-router/ingress-to-route-controller-clusterrolebinding.yaml
+++ b/assets/components/openshift-router/ingress-to-route-controller-clusterrolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-infra
+  name: ingress-to-route-controller

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -42,6 +42,8 @@
 // assets/components/openshift-router/cluster-role.yaml
 // assets/components/openshift-router/configmap.yaml
 // assets/components/openshift-router/deployment.yaml
+// assets/components/openshift-router/ingress-to-route-controller-clusterrole.yaml
+// assets/components/openshift-router/ingress-to-route-controller-clusterrolebinding.yaml
 // assets/components/openshift-router/namespace.yaml
 // assets/components/openshift-router/service-account.yaml
 // assets/components/openshift-router/service-cloud.yaml
@@ -2517,6 +2519,106 @@ func assetsComponentsOpenshiftRouterDeploymentYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "assets/components/openshift-router/deployment.yaml", size: 4746, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingress
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+`)
+
+func assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYamlBytes() ([]byte, error) {
+	return _assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYaml, nil
+}
+
+func assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYaml() (*asset, error) {
+	bytes, err := assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "assets/components/openshift-router/ingress-to-route-controller-clusterrole.yaml", size: 764, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-infra
+  name: ingress-to-route-controller
+`)
+
+func assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYamlBytes() ([]byte, error) {
+	return _assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYaml, nil
+}
+
+func assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYaml() (*asset, error) {
+	bytes, err := assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "assets/components/openshift-router/ingress-to-route-controller-clusterrolebinding.yaml", size: 367, mode: os.FileMode(420), modTime: time.Unix(1658914160, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5919,6 +6021,8 @@ var _bindata = map[string]func() (*asset, error){
 	"assets/components/openshift-router/cluster-role.yaml":                                                   assetsComponentsOpenshiftRouterClusterRoleYaml,
 	"assets/components/openshift-router/configmap.yaml":                                                      assetsComponentsOpenshiftRouterConfigmapYaml,
 	"assets/components/openshift-router/deployment.yaml":                                                     assetsComponentsOpenshiftRouterDeploymentYaml,
+	"assets/components/openshift-router/ingress-to-route-controller-clusterrole.yaml":                        assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYaml,
+	"assets/components/openshift-router/ingress-to-route-controller-clusterrolebinding.yaml":                 assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYaml,
 	"assets/components/openshift-router/namespace.yaml":                                                      assetsComponentsOpenshiftRouterNamespaceYaml,
 	"assets/components/openshift-router/service-account.yaml":                                                assetsComponentsOpenshiftRouterServiceAccountYaml,
 	"assets/components/openshift-router/service-cloud.yaml":                                                  assetsComponentsOpenshiftRouterServiceCloudYaml,
@@ -6055,14 +6159,16 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 			}},
 			"openshift-router": {nil, map[string]*bintree{
-				"cluster-role-binding.yaml": {assetsComponentsOpenshiftRouterClusterRoleBindingYaml, map[string]*bintree{}},
-				"cluster-role.yaml":         {assetsComponentsOpenshiftRouterClusterRoleYaml, map[string]*bintree{}},
-				"configmap.yaml":            {assetsComponentsOpenshiftRouterConfigmapYaml, map[string]*bintree{}},
-				"deployment.yaml":           {assetsComponentsOpenshiftRouterDeploymentYaml, map[string]*bintree{}},
-				"namespace.yaml":            {assetsComponentsOpenshiftRouterNamespaceYaml, map[string]*bintree{}},
-				"service-account.yaml":      {assetsComponentsOpenshiftRouterServiceAccountYaml, map[string]*bintree{}},
-				"service-cloud.yaml":        {assetsComponentsOpenshiftRouterServiceCloudYaml, map[string]*bintree{}},
-				"service-internal.yaml":     {assetsComponentsOpenshiftRouterServiceInternalYaml, map[string]*bintree{}},
+				"cluster-role-binding.yaml":                           {assetsComponentsOpenshiftRouterClusterRoleBindingYaml, map[string]*bintree{}},
+				"cluster-role.yaml":                                   {assetsComponentsOpenshiftRouterClusterRoleYaml, map[string]*bintree{}},
+				"configmap.yaml":                                      {assetsComponentsOpenshiftRouterConfigmapYaml, map[string]*bintree{}},
+				"deployment.yaml":                                     {assetsComponentsOpenshiftRouterDeploymentYaml, map[string]*bintree{}},
+				"ingress-to-route-controller-clusterrole.yaml":        {assetsComponentsOpenshiftRouterIngressToRouteControllerClusterroleYaml, map[string]*bintree{}},
+				"ingress-to-route-controller-clusterrolebinding.yaml": {assetsComponentsOpenshiftRouterIngressToRouteControllerClusterrolebindingYaml, map[string]*bintree{}},
+				"namespace.yaml":                                      {assetsComponentsOpenshiftRouterNamespaceYaml, map[string]*bintree{}},
+				"service-account.yaml":                                {assetsComponentsOpenshiftRouterServiceAccountYaml, map[string]*bintree{}},
+				"service-cloud.yaml":                                  {assetsComponentsOpenshiftRouterServiceCloudYaml, map[string]*bintree{}},
+				"service-internal.yaml":                               {assetsComponentsOpenshiftRouterServiceInternalYaml, map[string]*bintree{}},
 			}},
 			"ovn": {nil, map[string]*bintree{
 				"clusterrole.yaml":        {assetsComponentsOvnClusterroleYaml, map[string]*bintree{}},

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -103,9 +103,11 @@ func startIngressController(cfg *config.MicroshiftConfig, kubeconfigPath string)
 	var (
 		clusterRoleBinding = []string{
 			"assets/components/openshift-router/cluster-role-binding.yaml",
+			"assets/components/openshift-router/ingress-to-route-controller-clusterrolebinding.yaml",
 		}
 		clusterRole = []string{
 			"assets/components/openshift-router/cluster-role.yaml",
+			"assets/components/openshift-router/ingress-to-route-controller-clusterrole.yaml",
 		}
 		apps = []string{
 			"assets/components/openshift-router/deployment.yaml",

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -455,6 +455,9 @@ update_manifests() {
     #    Replace all openshift-router operand manifests
     rm -f "${REPOROOT}"/assets/components/openshift-router/*
     cp "${STAGING_DIR}"/cluster-ingress-operator/assets/router/* "${REPOROOT}"/assets/components/openshift-router 2>/dev/null || true
+    # Copy embedded manifests applied by the COCMO rather than CVO
+    cp "${STAGING_DIR}"/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrole.yaml "${REPOROOT}"/assets/components/openshift-router 2>/dev/null || true
+    cp "${STAGING_DIR}"/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrolebinding.yaml "${REPOROOT}"/assets/components/openshift-router 2>/dev/null || true
     #    Restore the openshift-router's service-ca ConfigMap
     git restore "${REPOROOT}"/assets/components/openshift-router/configmap.yaml
     # 2) Render operand manifest templates like the operator would


### PR DESCRIPTION
Add assets for RBAC for ingress-to-route-controller.
Update rebase.sh to pull updates to those assets in the future.

Partial fix for [USHIFT-333](https://issues.redhat.com//browse/USHIFT-333)
Partial fix for #860 