### PR TITLE
Set application/json content-type for OCM clients.

### DIFF
--- a/pkg/controllers/openshift-controller-manager.go
+++ b/pkg/controllers/openshift-controller-manager.go
@@ -76,6 +76,8 @@ func (s *OCPControllerManager) writeConfig(cfg *config.MicroshiftConfig) error {
 kind: OpenShiftControllerManagerConfig
 kubeClientConfig:
   kubeConfig: ` + cfg.DataDir + `/resources/kubeadmin/kubeconfig
+  connectionOverrides:
+    contentType: "application/json"
 servingInfo:
   bindAddress: "0.0.0.0:8445"
   certFile: ` + cfg.DataDir + `/resources/openshift-controller-manager/secrets/tls.crt


### PR DESCRIPTION
Route requests from openshift-controller-manager using protobuf
encoding aren't supported by the CRD-based custom resource handler.
