### PR TITLE
ignore rpm build location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 Vagrantfile
 _output/*
 bin
-packaging/rpm/_rpmbuild/
+packaging/rpm/_rpmbuild
 packaging/selinux/*.pp*
 packaging/selinux/microshift_selinux.8
 packaging/selinux/tmp/


### PR DESCRIPTION
Update the ignore pattern so if _rpmbuild is a symlink it is still
ignored.

/type cleanup
/assign @ggiguash