### PR TITLE
USHIFT-364: add command to show default configuration

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -44,5 +44,6 @@ func newCommand() *cobra.Command {
 
 	cmd.AddCommand(cmds.NewRunMicroshiftCommand())
 	cmd.AddCommand(cmds.NewVersionCommand(ioStreams))
+	cmd.AddCommand(cmds.NewShowConfigCommand(ioStreams))
 	return cmd
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -30,6 +30,18 @@ const (
 	gracefulShutdownTimeout = 60
 )
 
+func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
+	flags := cmd.Flags()
+	// Read the config flag directly into the struct, so it's immediately available.
+	flags.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "File to read configuration from.")
+	cmd.MarkFlagFilename("config", "yaml", "yml")
+	// All other flags will be read after reading both config file and env vars.
+	flags.String("data-dir", cfg.DataDir, "Directory for storing runtime data.")
+	flags.String("audit-log-dir", cfg.AuditLogDir, "Directory for storing audit logs.")
+	flags.StringSlice("roles", cfg.Roles, "Roles of this MicroShift instance.")
+	flags.Bool("debug.pprof", false, "Enable golang pprof debugging")
+}
+
 func NewRunMicroshiftCommand() *cobra.Command {
 	cfg := config.NewMicroshiftConfig()
 
@@ -41,15 +53,7 @@ func NewRunMicroshiftCommand() *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
-	// Read the config flag directly into the struct, so it's immediately available.
-	flags.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "File to read configuration from.")
-	cmd.MarkFlagFilename("config", "yaml", "yml")
-	// All other flags will be read after reading both config file and env vars.
-	flags.String("data-dir", cfg.DataDir, "Directory for storing runtime data.")
-	flags.String("audit-log-dir", cfg.AuditLogDir, "Directory for storing audit logs.")
-	flags.StringSlice("roles", cfg.Roles, "Roles of this MicroShift instance.")
-	flags.Bool("debug.pprof", false, "Enable golang pprof debugging")
+	addRunFlags(cmd, cfg)
 
 	return cmd
 }

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/microshift/pkg/config"
+)
+
+type showConfigOptions struct {
+	Mode string
+	genericclioptions.IOStreams
+}
+
+func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	opts := showConfigOptions{
+		Mode: "default",
+	}
+
+	cfg := config.NewMicroshiftConfig()
+
+	cmd := &cobra.Command{
+		Use:   "show-config",
+		Short: "Print MicroShift's configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			switch opts.Mode {
+			case "default":
+				// Override a few settings to always use the global locations
+				cfg.DataDir = config.DefaultGlobalDataDir
+				cfg.Manifests = cfg.Manifests[:len(cfg.Manifests)-1]
+				cfg.NodeIP = ""
+				cfg.NodeName = ""
+			case "effective":
+				// Load the current configuration
+				if err := cfg.ReadAndValidate(cmd.Flags()); err != nil {
+					cmdutil.CheckErr(err)
+				}
+			default:
+				cmdutil.CheckErr(fmt.Errorf("Unknown mode %q", opts.Mode))
+			}
+
+			marshalled, err := yaml.Marshal(cfg)
+			cmdutil.CheckErr(err)
+
+			fmt.Fprintf(ioStreams.Out, "%s\n", string(marshalled))
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Mode, "mode", "m", opts.Mode, "One of 'default' or 'effective'.")
+	addRunFlags(cmd, cfg)
+
+	return cmd
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ const (
 	defaultUserConfigFile   = "~/.microshift/config.yaml"
 	defaultUserDataDir      = "~/.microshift/data"
 	defaultGlobalConfigFile = "/etc/microshift/config.yaml"
-	defaultGlobalDataDir    = "/var/lib/microshift"
+	DefaultGlobalDataDir    = "/var/lib/microshift"
 	// for files managed via management system in /etc, i.e. user applications
 	defaultManifestDirEtc = "/etc/microshift/manifests"
 	// for files embedded in ostree. i.e. cni/other component customizations
@@ -156,7 +156,7 @@ func findDataDir() string {
 		if os.Geteuid() > 0 {
 			return userDataDir
 		} else {
-			return defaultGlobalDataDir
+			return DefaultGlobalDataDir
 		}
 	} else {
 		return userDataDir


### PR DESCRIPTION
Add a command to show the default configuration, modified to make it
suitable for global use on the host.

Related to [USHIFT-19](https://issues.redhat.com//browse/USHIFT-19)