### PR TITLE
Wait for default route to become available after boot

### DIFF
--- a/packaging/systemd/microshift-ovs-init.service
+++ b/packaging/systemd/microshift-ovs-init.service
@@ -8,4 +8,4 @@ Requires=openvswitch.service NetworkManager.service
 Type=oneshot
 ExecStart=/bin/bash /usr/bin/configure-ovs.sh OVNKubernetes
 ExecStart=/bin/bash /usr/bin/configure-ovs-microshift.sh
-TimeoutSec=30
+TimeoutSec=2m


### PR DESCRIPTION
MicroShift service runs right after system boot when
dhcp address may not be available on node interface.
This results in configure-ovs.sh script getting non
default route interface on lo device which cannot be
added to ovn gateway interface br-ex.

Closes #[USHIFT-340](https://issues.redhat.com//browse/USHIFT-340)

Signed-off-by: Zenghui Shi <zshi@redhat.com>