### PR TITLE
[WIP] Enable kube-apiserver option send-retry-after-while-not-ready-once

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -148,6 +148,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 				"quota.openshift.io/ValidateClusterResourceQuota",
 			},
 			"enable-admission-plugins": {},
+			"send-retry-after-while-not-ready-once": {"true"},
 		},
 		GenericAPIServerConfig: configv1.GenericAPIServerConfig{
 			// from cluster-kube-apiserver-operator


### PR DESCRIPTION
Relates to: [API-1437](https://issues.redhat.com//browse/API-1437): Clients (including internal clients) must not use an unready Kubernetes apiserver

This is expected to fail since https://github.com/openshift/kubernetes/pull/1346 has not merged yet, and we need to wait microshift  rebase 1.25 is done.

 


