### PR TITLE
USHIFT-367: apply rebase.sh to router manifests and align with OCP 

### DIFF
--- a/assets/components/openshift-router/deployment.yaml
+++ b/assets/components/openshift-router/deployment.yaml
@@ -1,24 +1,8 @@
 # Deployment with default values
-# Ingress Controller specific values are applied at runtime.
 kind: Deployment
 apiVersion: apps/v1
-metadata:
-  name: router-default
-  namespace: openshift-ingress
-  labels:
-    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
-  strategy:
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -28,80 +12,66 @@ spec:
         ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
     spec:
       serviceAccountName: router
-      # nodeSelector is set at runtime.
       priorityClassName: system-cluster-critical
       containers:
         - name: router
-          image: {{ .ReleaseImage.haproxy_router }}
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
-          - name: http
-            containerPort: 80
-            hostPort: 80
-            protocol: TCP
-          - name: https
-            containerPort: 443
-            hostPort: 443
-            protocol: TCP
-          - name: metrics
-            containerPort: 1936
-            hostPort: 1936
-            protocol: TCP
-          # Merged at runtime.
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            - name: metrics
+              containerPort: 1936
+              protocol: TCP
           env:
-          # stats username and password are generated at runtime
-          - name: STATS_PORT
-            value: "1936"
-          - name: ROUTER_SERVICE_NAMESPACE
-            value: openshift-ingress
-          - name: DEFAULT_CERTIFICATE_DIR
-            value: /etc/pki/tls/private
-          - name: DEFAULT_DESTINATION_CA_PATH
-            value: /var/run/configmaps/service-ca/service-ca.crt
-          - name: ROUTER_CIPHERS
-            value: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
-          - name: ROUTER_DISABLE_HTTP2
-            value: "true"
-          - name: ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK
-            value: "false"
-          #FIXME: use metrics tls
-          - name: ROUTER_METRICS_TLS_CERT_FILE
-            value: /etc/pki/tls/private/tls.crt
-          - name: ROUTER_METRICS_TLS_KEY_FILE
-            value: /etc/pki/tls/private/tls.key
-          - name: ROUTER_METRICS_TYPE
-            value: haproxy
-          - name: ROUTER_SERVICE_NAME
-            value: default
-          - name: ROUTER_SET_FORWARDED_HEADERS
-            value: append
-          - name: ROUTER_THREADS
-            value: "4"
-          - name: SSL_MIN_VERSION
-            value: TLSv1.2
+            - name: STATS_PORT
+              value: "1936"
+            - name: ROUTER_SERVICE_NAMESPACE
+              value: openshift-ingress
+            - name: DEFAULT_CERTIFICATE_DIR
+              value: /etc/pki/tls/private
+            - name: DEFAULT_DESTINATION_CA_PATH
+              value: /var/run/configmaps/service-ca/service-ca.crt
+            - name: RELOAD_INTERVAL
+              value: 5s
+            - name: ROUTER_ALLOW_WILDCARD_ROUTES
+              value: "false"
+            - name: ROUTER_CANONICAL_HOSTNAME
+              value: router-default.apps.{{ .ClusterDomain }}
+            - name: ROUTER_CIPHERS
+              value: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+            - name: ROUTER_CIPHERSUITES
+              value: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+            - name: ROUTER_DISABLE_HTTP2
+              value: "true"
+            - name: ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK
+              value: "false"
+            - name: ROUTER_LOAD_BALANCE_ALGORITHM
+              value: leastconn
+            - name: ROUTER_METRICS_TYPE
+              value: haproxy
+            - name: ROUTER_SERVICE_NAME
+              value: default
+            - name: ROUTER_SET_FORWARDED_HEADERS
+              value: append
+            - name: ROUTER_TCP_BALANCE_SCHEME
+              value: source
+            - name: ROUTER_THREADS
+              value: "4"
+            - name: SSL_MIN_VERSION
+              value: TLSv1.2
           livenessProbe:
-            failureThreshold: 3
             httpGet:
-              host: localhost
               path: /healthz
               port: 1936
-              scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           readinessProbe:
-            failureThreshold: 3
             httpGet:
-              host: localhost
               path: /healthz/ready
               port: 1936
-              scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           startupProbe:
             failureThreshold: 120
             httpGet:
@@ -113,28 +83,42 @@ spec:
               cpu: 100m
               memory: 256Mi
           volumeMounts:
-          - mountPath: /etc/pki/tls/private
-            name: default-certificate
-            readOnly: true
-          - mountPath: /var/run/configmaps/service-ca
-            name: service-ca-bundle
-            readOnly: true
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      serviceAccount: router
+            - mountPath: /etc/pki/tls/private
+              name: default-certificate
+              readOnly: true
+            - mountPath: /var/run/configmaps/service-ca
+              name: service-ca-bundle
+              readOnly: true
+          image: {{ .ReleaseImage.haproxy_router }}
       volumes:
-      - name: default-certificate
-        secret:
+        - name: default-certificate
+          secret:
+            defaultMode: 420
+            secretName: router-certs-default
+        - name: service-ca-bundle
+          configMap:
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+            name: service-ca-bundle
+            optional: false
           defaultMode: 420
-          secretName: router-certs-default
-      - name: service-ca-bundle
-        configMap:
-          items:
-          - key: service-ca.crt
-            path: service-ca.crt
-          name: service-ca-bundle
-          optional: false
-        defaultMode: 420
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 3600
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/worker: ""
+      serviceAccount: router
+      securityContext: {}
+      schedulerName: default-scheduler
+  minReadySeconds: 30
+  selector:
+    matchLabels:
+      ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
+  replicas: 1
+metadata:
+  name: router-default
+  namespace: openshift-ingress
+  labels:
+    ingresscontroller.operator.openshift.io/owning-ingresscontroller: default

--- a/assets/components/openshift-router/namespace.yaml
+++ b/assets/components/openshift-router/namespace.yaml
@@ -12,4 +12,3 @@ metadata:
     # old and new forms of the label for matching with NetworkPolicy
     network.openshift.io/policy-group: ingress
     policy-group.network.openshift.io/ingress: ""
-    

--- a/assets/components/openshift-router/service-cloud.yaml
+++ b/assets/components/openshift-router/service-cloud.yaml
@@ -1,20 +1,29 @@
+# Load Balancer Service to place in front of the router in cloud environments.
+# Ingress Controller specific values are applied at runtime.
 kind: Service
 apiVersion: v1
 metadata:
-  annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: router-certs-default
-  labels:
-    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
-  name: router-external-default
   namespace: openshift-ingress
+  labels:
+    app: router
+    ingresscontroller.operator.openshift.io/owning-ingresscontroller: default
+    router: router-default
+  annotations:
+    traffic-policy.network.alpha.openshift.io/local-with-fallback: ""
+  name: router-default
 spec:
+  type: NodePort
   selector:
     ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
-  type: NodePort 
+  # This also has the effect of marking LB pool targets as unhealthy when no
+  # router pods are present on a node behind the service.
+  externalTrafficPolicy: Local
   ports:
     - name: http
+      protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: http
     - name: https
+      protocol: TCP
       port: 443
-      targetPort: 443
+      targetPort: https

--- a/assets/components/openshift-router/service-internal.yaml
+++ b/assets/components/openshift-router/service-internal.yaml
@@ -2,27 +2,27 @@
 # Ingress Controller specific annotations are applied at runtime.
 kind: Service
 apiVersion: v1
-metadata:
-  annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: router-certs-default
-  labels:
-    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
-  name: router-internal-default
-  namespace: openshift-ingress
 spec:
-  selector:
-    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
   type: ClusterIP
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: http
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: https
-  - name: metrics
-    port: 1936
-    protocol: TCP
-    targetPort: 1936
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+    - name: metrics
+      port: 1936
+      protocol: TCP
+      targetPort: 1936
+  selector:
+    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
+metadata:
+  labels:
+    ingresscontroller.operator.openshift.io/owning-ingresscontroller: default
+  name: router-internal-default
+  namespace: openshift-ingress
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: router-certs-default

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -463,29 +463,66 @@ update_manifests() {
     git restore "${REPOROOT}"/assets/components/openshift-router/configmap.yaml
     # 2) Render operand manifest templates like the operator would
     yq -i '.metadata += {"name": "router-default", "namespace": "openshift-ingress"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.metadata += {"labels": {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.metadata += {"labels": {"ingresscontroller.operator.openshift.io/owning-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.minReadySeconds = 30' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.selector = {"matchLabels": {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.metadata += {"labels": {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].image = "REPLACE_ROUTER_IMAGE"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "RELOAD_INTERVAL", "value": "5s"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_ALLOW_WILDCARD_ROUTES", "value": "false"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CANONICAL_HOSTNAME", "value": "router-default.apps.REPLACE_CLUSTER_DOMAIN"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CIPHERS", "value": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CIPHERSUITES", "value": "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DISABLE_HTTP2", "value": "true"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", "value": "false"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_LOAD_BALANCE_ALGORITHM", "value": "leastconn"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # TODO: Generate and volume mount the metrics-certs secret
+    # yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_METRICS_TLS_CERT_FILE", "value": "/etc/pki/tls/metrics-certs/tls.crt"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_METRICS_TLS_KEY_FILE", "value": "/etc/pki/tls/metrics-certs/tls.key"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_METRICS_TYPE", "value": "haproxy"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_SERVICE_NAME", "value": "default"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_SET_FORWARDED_HEADERS", "value": "append"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_TCP_BALANCE_SCHEME", "value": "source"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_THREADS", "value": "4"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "SSL_MIN_VERSION", "value": "TLSv1.2"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # TODO: Generate and volume mount the router-stats-default secret
+    # yq -i '.spec.template.spec.containers[0].env += {"name": "STATS_PASSWORD_FILE", "value": "/var/lib/haproxy/conf/metrics-auth/statsPassword"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # yq -i '.spec.template.spec.containers[0].env += {"name": "STATS_USERNAME_FILE", "value": "/var/lib/haproxy/conf/metrics-auth/statsUsername"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.restartPolicy = "Always"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.terminationGracePeriodSeconds = 3600' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.dnsPolicy = "ClusterFirst"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.nodeSelector = {"kubernetes.io/os": "linux", "node-role.kubernetes.io/worker": ""}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.serviceAccount = "router"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.securityContext = {}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.schedulerName = "default-scheduler"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.volumes[0].secret.secretName = "router-certs-default"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.metadata += {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "router-certs-default"}}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
-    yq -i '.metadata += {"labels": {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
+    sed -i '/#.*at runtime/d' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    sed -i '/#.*at run-time/d' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.metadata.labels += {"ingresscontroller.operator.openshift.io/owning-ingresscontroller": "default"}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
     yq -i '.metadata += {"name": "router-internal-default", "namespace": "openshift-ingress"}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
     yq -i '.spec.selector = {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
-    yq -i '.metadata += {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "router-certs-default"}}' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
-    yq -i '.metadata += {"name": "router-external-default"}' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
+    yq -i '.metadata += {"annotations": {"traffic-policy.network.alpha.openshift.io/local-with-fallback": ""}}' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
+    yq -i '.metadata.labels += {"ingresscontroller.operator.openshift.io/owning-ingresscontroller": "default", "router": "router-default"}' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
+    yq -i '.metadata += {"name": "router-default"}' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
+    yq -i '.spec.selector = {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
-    # sed -i 's|# Name is set at runtime.|name: router-external-default|' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
+    # 3) Make MicroShift-specific changes
     #    Set replica count to 1, as we're single-node.
     yq -i '.spec.replicas = 1' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    #    Use router-certs-default instead of the router-metrics-certs-default that the CIO sets
+    yq -i '.metadata += {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "router-certs-default"}}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
+    #    Use host networking
+    # yq -i '.spec.template.spec.dnsPolicy = "ClusterFirstWithHostNet"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # yq -i '.spec.template.spec.hostNetwork = "true"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     #    Add hostPorts for routes and metrics
-    yq -i '.spec.template.spec.containers[0].ports[0].hostPort = 80' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.containers[0].ports[1].hostPort = 443' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.containers[0].ports[2].hostPort = 1936' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    #    Change LoadBalancer to NodePort as long as we do not add a default LB. Add the necessary nodePorts
+    # yq -i '.spec.template.spec.containers[0].ports[0].hostPort = 80' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # yq -i '.spec.template.spec.containers[0].ports[1].hostPort = 443' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    # yq -i '.spec.template.spec.containers[0].ports[2].hostPort = 1936' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    #    Change LoadBalancer to NodePort as long as we do not add a default LB.
     yq -i '.spec.type = "NodePort"' "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
     # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
+    sed -i 's|REPLACE_CLUSTER_DOMAIN|{{ .ClusterDomain }}|' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     sed -i 's|REPLACE_ROUTER_IMAGE|{{ .ReleaseImage.haproxy_router }}|' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
 
 


### PR DESCRIPTION
Updates the openshift-router manifests using the latest rebase.sh automation.

Some of the changes are completely neutral and result from the adoption of yq, e.g. reordering of fields resulting from yq appending added fields at the end rather than ordering them in alphabetically or different indentation.

More importantly, though, it also aligns manifests more closely with those found on an equivalent running OpenShift cluster. This includes different labels, annotations, and selectors, environment variables.

Signed-off-by: Frank A. Zdarsky [fzdarsky@redhat.com](mailto:fzdarsky@redhat.com)