### PR TITLE
USHIFT-362: consolidate all build output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,7 @@
 .idea/
 .vagrant/
 .vscode/
-/microshift
-/paack-result/
 Vagrantfile
 _output/*
-bin
-packaging/rpm/_rpmbuild
-packaging/selinux/*.pp*
-packaging/selinux/microshift_selinux.8
-packaging/selinux/tmp/
-scripts/image-builder/_builds/
+_output
 sshfile

--- a/Makefile
+++ b/Makefile
@@ -270,11 +270,11 @@ tar-ocp-containers:
 ###############################
 
 clean-cross-build:
-	$(RM) -r '$(CROSS_BUILD_BINDIR)'
-	$(RM) -rf $(OUTPUT_DIR)/staging
+	if [ -d '$(CROSS_BUILD_BINDIR)' ]; then $(RM) -rf '$(CROSS_BUILD_BINDIR)'; fi
+	if [ -d '$(OUTPUT_DIR)/staging' ]; then $(RM) -rf '$(OUTPUT_DIR)/staging'; fi
+	if [ -d '$(RPM_BUILD_DIR)' ]; then $(RM) -rf '$(RPM_BUILD_DIR)'; fi
+	if [ -d '$(ISO_DIR)' ]; then $(RM) -rf '$(ISO_DIR)'; fi
 	if [ -d '$(OUTPUT_DIR)' ]; then rmdir --ignore-fail-on-non-empty '$(OUTPUT_DIR)'; fi
-	if [ -d '$(RPM_BUILD_DIR)' ]; then $(RM) -rf '$(RPM_BUILD_DIR)' ; fi
-	if [ -d '$(ISO_DIR)' ]; then $(RM) -rf '$(ISO_DIR)' ; fi
 .PHONY: clean-cross-build
 
 clean: clean-cross-build

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ SRC_ROOT :=$(shell pwd)
 IMAGE_REPO :=quay.io/microshift/microshift
 IMAGE_REPO_AIO :=quay.io/microshift/microshift-aio
 OUTPUT_DIR :=_output
-RPM_BUILD_DIR :=packaging/rpm/_rpmbuild
-ISO_DIR :=scripts/image-builder/_builds
+RPM_BUILD_DIR :=$(OUTPUT_DIR)/rpmbuild
+ISO_DIR :=$(OUTPUT_DIR)/image-builder
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 FROM_SOURCE :=false
 CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/null))
@@ -48,6 +48,9 @@ endif
 
 # restrict included verify-* targets to only process project files
 GO_PACKAGES=$(go list ./cmd/... ./pkg/...)
+
+# Build to a place we can ignore
+GO_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 
 ifeq ($(DEBUG),true)
 	# throw all the debug info in!

--- a/docs/devenv_rhel8.md
+++ b/docs/devenv_rhel8.md
@@ -82,13 +82,13 @@ make rpm
 make srpm
 ```
 
-The artifacts of the build are located in the `packaging` directory.
+The artifacts of the build are located in the `_output/rpmbuild` directory.
 ```bash
-$ find ~/microshift/packaging -name \*.rpm
-packaging/rpm/_rpmbuild/RPMS/x86_64/microshift-4.10.0-nightly_1654189204_34_gc871db21.el8.x86_64.rpm
-packaging/rpm/_rpmbuild/RPMS/x86_64/microshift-4.10.0-networking-nightly_1654189204_34_gc871db21.el8.x86_64.rpm
-packaging/rpm/_rpmbuild/RPMS/noarch/microshift-selinux-4.10.0-nightly_1654189204_34_gc871db21.el8.noarch.rpm
-packaging/rpm/_rpmbuild/SRPMS/microshift-4.10.0-nightly_1654189204_34_gc871db21.el8.src.rpm
+$ find ~/microshift/_output/rpmbuild -name \*.rpm
+_output/rpmbuild/RPMS/x86_64/microshift-4.10.0-nightly_1654189204_34_gc871db21.el8.x86_64.rpm
+_output/rpmbuild/RPMS/x86_64/microshift-4.10.0-networking-nightly_1654189204_34_gc871db21.el8.x86_64.rpm
+_output/rpmbuild/RPMS/noarch/microshift-selinux-4.10.0-nightly_1654189204_34_gc871db21.el8.noarch.rpm
+_output/rpmbuild/SRPMS/microshift-4.10.0-nightly_1654189204_34_gc871db21.el8.src.rpm
 ```
 
 ## Run MicroShift Executable
@@ -100,7 +100,7 @@ Enable the needed repositories and install the MicroShift RPM packages. This pro
 sudo subscription-manager repos \
     --enable rhocp-4.10-for-rhel-8-$(uname -i)-rpms \
     --enable fast-datapath-for-rhel-8-$(uname -i)-rpms
-sudo dnf localinstall -y ~/microshift/packaging/rpm/_rpmbuild/RPMS/*/*.rpm
+sudo dnf localinstall -y ~/microshift/_output/rpmbuild/RPMS/*/*.rpm
 ```
 
 Download the OpenShift pull secret from the https://console.redhat.com/openshift/downloads#tool-pull-secret page. Copy it to `/etc/crio/openshift-pull-secret` and update its file permissions so CRI-O can use it when fetching container images:

--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -12,7 +12,7 @@ The scripts for building the installer are located in the `scripts/image-builder
 ### Prerequisites
 Execute the `scripts/image-builder/configure.sh` script to install the tools necessary for building the installer image.
 
-Download the OpenShift pull secret from the https://console.redhat.com/openshift/downloads#tool-pull-secret page and save it into the `~microshift/.pull-secret.json` file. 
+Download the OpenShift pull secret from the https://console.redhat.com/openshift/downloads#tool-pull-secret page and save it into the `~microshift/.pull-secret.json` file.
 
 Make sure there is more than 20GB of free disk space necessary for the build artifacts. Run the following command to free the space if necessary.
 ```bash
@@ -20,7 +20,7 @@ Make sure there is more than 20GB of free disk space necessary for the build art
 ```
 
 Note that the command deletes various user and system data, including:
-- The `scripts/image-builder/_builds` directory containing image build artifacts
+- The `_output/image-builder/` directory containing image build artifacts
 - MicroShift `ostree` server container and all the unused container images
 - All the Image Builder jobs are canceled and deleted
 - Project-specific Image Builder sources are deleted
@@ -28,7 +28,7 @@ Note that the command deletes various user and system data, including:
 - The `/var/cache/osbuild-worker` directory contents are deleted to clean Image Builder cache files
 
 ### Building Installer
-It is recommended to execute the partial cleanup procedure (without `-full` argument) before each build to reclaim cached disk space from previous builds. 
+It is recommended to execute the partial cleanup procedure (without `-full` argument) before each build to reclaim cached disk space from previous builds.
 ```bash
 ~/microshift/scripts/image-builder/cleanup.sh
 ```
@@ -100,9 +100,9 @@ As an example, a 20GB disk is partitioned in the following manner by default.
 ```
 $ lsblk /dev/sda
 NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
-sda             8:0    0  20G  0 disk 
+sda             8:0    0  20G  0 disk
 ├─sda1          8:1    0   1G  0 part /boot
-└─sda2          8:2    0  19G  0 part 
+└─sda2          8:2    0  19G  0 part
   └─rhel-root 253:0    0   8G  0 lvm  /sysroot
 
 $ sudo vgdisplay -s
@@ -183,7 +183,7 @@ virt-install \
 "
 ```
 
-Watch the OS console to see the progress of the installation, waiting until the machine is rebooted and the login prompt appears. 
+Watch the OS console to see the progress of the installation, waiting until the machine is rebooted and the login prompt appears.
 
 Note that it may be more convenient to access the machine using SSH. Run the following command to get its IP address and use it to remotely connect to the system.
 ```bash

--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -50,7 +50,7 @@ Usage: build.sh <-pull_secret_file path_to_file> [OPTION]...
 Optional arguments:
   -microshift_rpms path_or_URL
           Path or URL to the MicroShift RPM packages to be included
-          in the image (default: packaging/rpm/_rpmbuild/RPMS)
+          in the image (default: _output/rpmbuild/RPMS)
   -custom_rpms /path/to/file1.rpm,...,/path/to/fileN.rpm
           Path to one or more comma-separated RPM packages to be
           included in the image (default: none)

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -96,3 +96,6 @@ case $1 in
       echo "Usage: $0 local|commit <commit-id>|tag <tag-name>"
       exit 1
 esac
+
+# TODO: Remove this workaround again as soon as CI got updated to the new RPM location
+ln -sF ../../_output/rpmbuild packaging/rpm/_rpmbuild

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail
+set -x
 
 # must be passed down to this script from Makefile
 RELEASE_BASE=${RELEASE_BASE:-4.10.0}
@@ -17,15 +18,15 @@ GIT_SHA=$(git rev-parse HEAD)
 # using this instead of rev-parse --short because github's is 1 char shorter than --short
 GIT_SHORTHASH="${GIT_SHA:0:7}"
 TARBALL_FILE="microshift-${GIT_SHORTHASH}.tar.gz"
-RPMBUILD_DIR="${SCRIPT_DIR}/_rpmbuild/"
+RPMBUILD_DIR="$(git rev-parse --show-toplevel)/_output/rpmbuild/"
 
 SOURCE_GIT_TAG="$(git describe --tags | sed s/nightly-/nightly-$(git show -s --format=%ct)_/g )"
 
 
 create_local_tarball() {
-  tar -czf "${RPMBUILD_DIR}/SOURCES/${TARBALL_FILE}" \
+  tar -czvf "${RPMBUILD_DIR}/SOURCES/${TARBALL_FILE}" \
             --exclude='.git' --exclude='.idea' --exclude='.vagrant' \
-            --exclude='_output' --exclude='rpm/_rpmbuild' --exclude='image-builder/_builds' \
+            --exclude='_output' \
             --transform="s|^|microshift-${GIT_SHA}/|"  \
             --exclude="${TARBALL_FILE}" "${SCRIPT_DIR}/../../"
 }

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e -o pipefail
-set -x
 
 # must be passed down to this script from Makefile
 RELEASE_BASE=${RELEASE_BASE:-4.10.0}
@@ -24,7 +23,7 @@ SOURCE_GIT_TAG="$(git describe --tags | sed s/nightly-/nightly-$(git show -s --f
 
 
 create_local_tarball() {
-  tar -czvf "${RPMBUILD_DIR}/SOURCES/${TARBALL_FILE}" \
+  tar -czf "${RPMBUILD_DIR}/SOURCES/${TARBALL_FILE}" \
             --exclude='.git' --exclude='.idea' --exclude='.vagrant' \
             --exclude='_output' \
             --transform="s|^|microshift-${GIT_SHA}/|"  \

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -49,7 +49,7 @@ make srpm
 # Run MicroShift Executable > Runtime Prerequisites
 # https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#runtime-prerequisites
 sudo subscription-manager repos --enable rhocp-4.10-for-rhel-8-$(uname -i)-rpms --enable fast-datapath-for-rhel-8-$(uname -i)-rpms
-sudo dnf localinstall -y ~/microshift/packaging/rpm/_rpmbuild/RPMS/*/*.rpm
+sudo dnf localinstall -y ~/microshift/_output/rpmbuild/RPMS/*/*.rpm
 
 sudo cp -f ${OCP_PULL_SECRET} /etc/crio/openshift-pull-secret
 sudo chmod 600                /etc/crio/openshift-pull-secret

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 set -e -o pipefail
 
-ROOTDIR=$(git rev-parse --show-toplevel)/scripts/image-builder
+ROOTDIR=$(git rev-parse --show-toplevel)
+SCRIPTDIR=${ROOTDIR}/scripts/image-builder
 IMGNAME=microshift
-IMAGE_VERSION=$(${ROOTDIR}/../../pkg/release/get.sh base)
+IMAGE_VERSION=$(${ROOTDIR}/pkg/release/get.sh base)
 BUILD_ARCH=$(uname -i)
 OSTREE_SERVER_NAME=127.0.0.1:8080
 LVM_SYSROOT_SIZE_MIN=8192
 LVM_SYSROOT_SIZE=${LVM_SYSROOT_SIZE_MIN}
 OCP_PULL_SECRET_FILE=
-MICROSHIFT_RPM_SOURCE=${ROOTDIR}/../../packaging/rpm/_rpmbuild/RPMS
+MICROSHIFT_RPM_SOURCE=${ROOTDIR}/_output/rpmbuild/
 AUTHORIZED_KEYS_FILE=
 AUTHORIZED_KEYS=
 STARTTIME=$(date +%s)
+BUILDDIR=${ROOTDIR}/_output/image-builder/
 
-trap ${ROOTDIR}/cleanup.sh INT
+trap ${SCRIPTDIR}/cleanup.sh INT
 
 usage() {
     local error_message="$1"
@@ -85,7 +87,7 @@ download_image() {
         sudo composer-cli compose metadata ${uuid}
         sudo composer-cli compose image ${uuid}
     fi
-    sudo chown -R $(whoami). "${ROOTDIR}/_builds"
+    sudo chown -R $(whoami). "${BUILDDIR}"
 }
 
 build_image() {
@@ -98,7 +100,7 @@ build_image() {
 
     title "Loading ${blueprint} blueprint v${version}"
     sudo composer-cli blueprints delete ${blueprint} 2>/dev/null || true
-    sudo composer-cli blueprints push "${ROOTDIR}/_builds/${blueprint_file}"
+    sudo composer-cli blueprints push "${BUILDDIR}/${blueprint_file}"
     sudo composer-cli blueprints depsolve ${blueprint} 1>/dev/null
 
     if [ -n "$parent_version" ]; then
@@ -192,8 +194,8 @@ fi
 # Set the elapsed time trap only if command line parsing was successful
 trap 'echo "Execution time: $(( ($(date +%s) - STARTTIME) / 60 )) minutes"' EXIT
 
-mkdir -p ${ROOTDIR}/_builds
-pushd ${ROOTDIR}/_builds &>/dev/null
+mkdir -p ${BUILDDIR}
+pushd ${BUILDDIR} &>/dev/null
 
 # Also enter sudo password in the beginning if necessary
 title "Checking available disk space"
@@ -247,13 +249,13 @@ fi
 title "Loading sources for OpenShift and MicroShift"
 for f in openshift-local microshift-local custom-rpms ; do
     [ ! -d $f ] && continue
-    cat ../config/${f}.toml.template | sed "s;REPLACE_IMAGE_BUILDER_DIR;${ROOTDIR};g" > ${f}.toml
+    cat ${SCRIPTDIR}/config/${f}.toml.template | sed "s;REPLACE_IMAGE_BUILDER_DIR;${SCRIPTDIR};g" > ${f}.toml
     sudo composer-cli sources delete $f 2>/dev/null || true
-    sudo composer-cli sources add ${ROOTDIR}/_builds/${f}.toml
+    sudo composer-cli sources add ${BUILDDIR}/${f}.toml
 done
 
 title "Preparing blueprints"
-cp -f ../config/{blueprint_v0.0.1.toml,installer.toml} .
+cp -f ${SCRIPTDIR}/config/{blueprint_v0.0.1.toml,installer.toml} .
 if [ ! -z ${CUSTOM_RPM_FILES} ] ; then
     for rpm in ${CUSTOM_RPM_FILES//,/ } ; do
         rpm_name=$(basename $rpm | sed 's/.rpm//g')
@@ -271,7 +273,7 @@ build_image installer.toml        "${IMGNAME}-installer" 0.0.0 edge-installer "$
 
 title "Embedding kickstart in the installer image"
 # Create a kickstart file from a template, compacting pull secret contents if necessary
-cat "../config/kickstart.ks.template" \
+cat "${SCRIPTDIR}/config/kickstart.ks.template" \
     | sed "s;REPLACE_LVM_SYSROOT_SIZE;${LVM_SYSROOT_SIZE};g" \
     | sed "s;REPLACE_OSTREE_SERVER_NAME;${OSTREE_SERVER_NAME};g" \
     | sed "s;REPLACE_OCP_PULL_SECRET_CONTENTS;$(cat $OCP_PULL_SECRET_FILE | jq -c);g" \
@@ -281,12 +283,12 @@ cat "../config/kickstart.ks.template" \
 
 # Run the ISO creation procedure
 sudo mkksiso kickstart.ks ${IMGNAME}-installer-0.0.0-installer.iso ${IMGNAME}-installer-${IMAGE_VERSION}.${BUILD_ARCH}.iso
-sudo chown -R $(whoami). "${ROOTDIR}/_builds"
+sudo chown -R $(whoami). "${BUILDDIR}"
 
 # Remove intermediate artifacts to free disk space
 rm -f ${IMGNAME}-installer-0.0.0-installer.iso
 
-${ROOTDIR}/cleanup.sh
+${SCRIPTDIR}/cleanup.sh
 
 title "Done"
 popd &>/dev/null

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -35,7 +35,7 @@ usage() {
     echo "Optional arguments:"
     echo "  -microshift_rpms path_or_URL"
     echo "          Path or URL to the MicroShift RPM packages to be included"
-    echo "          in the image (default: packaging/rpm/_rpmbuild/RPMS)"
+    echo "          in the image (default: _output/rpmbuild/RPMS)"
     echo "  -custom_rpms /path/to/file1.rpm,...,/path/to/fileN.rpm"
     echo "          Path to one or more comma-separated RPM packages to be"
     echo "          included in the image (default: none)"

--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e -o pipefail
 
-ROOTDIR=$(git rev-parse --show-toplevel)/scripts/image-builder
+ROOTDIR=$(git rev-parse --show-toplevel)
+BUILDDIR=${ROOTDIR}/_output/image-builder/
 
 title() {
     echo -e "\E[34m\n# $1\E[00m";
@@ -22,7 +23,7 @@ fi
 
 if [ "$FULL_CLEAN" = 1 ] ; then
     title "Cleaning the build directory"
-    rm -rf ${ROOTDIR}/_builds
+    rm -rf ${BUILDDIR}
 fi
 
 title "Cleaning up local ostree container server"


### PR DESCRIPTION
Move all of the build output under an `_output` directory at the root
of the repository to make it easier to clean it all up at one time and
to make the .gitignore file easier to manage.

/assign @fzdarsky