### PR TITLE
USHIFT-251: Sync more core and CRD manifests

### DIFF
--- a/assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml
+++ b/assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: openshift-controller-manager
   annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-controller-manager

--- a/assets/crd/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
+++ b/assets/crd/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
@@ -1,4 +1,3 @@
-# 0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4279,12 +4279,12 @@ func assetsComponentsServiceCaSigningSecretYaml() (*asset, error) {
 var _assetsCore0000_50_clusterOpenshiftControllerManager_00_namespaceYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
+  name: openshift-controller-manager
   annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-controller-manager
 `)
 
 func assetsCore0000_50_clusterOpenshiftControllerManager_00_namespaceYamlBytes() ([]byte, error) {
@@ -4297,7 +4297,7 @@ func assetsCore0000_50_clusterOpenshiftControllerManager_00_namespaceYaml() (*as
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml", size: 254, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
+	info := bindataFileInfo{name: "assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml", size: 230, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5402,8 +5402,7 @@ func assetsCrd0000_03_securityOpenshift_01_sccCrdYaml() (*asset, error) {
 	return a, nil
 }
 
-var _assetsCrd0000_03_securityinternalOpenshift_02_rangeallocationCrdYaml = []byte(`# 0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
-apiVersion: apiextensions.k8s.io/v1
+var _assetsCrd0000_03_securityinternalOpenshift_02_rangeallocationCrdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -5465,7 +5464,7 @@ func assetsCrd0000_03_securityinternalOpenshift_02_rangeallocationCrdYaml() (*as
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/crd/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml", size: 2388, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
+	info := bindataFileInfo{name: "assets/crd/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml", size: 2323, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -403,6 +403,10 @@ update_manifests() {
     cp "${STAGING_DIR}/release-manifests/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml" "${REPOROOT}"/assets/crd
     cp "${STAGING_DIR}/release-manifests/0000_03_security-openshift_01_scc.crd.yaml" "${REPOROOT}"/assets/crd
     cp "${STAGING_DIR}/release-manifests/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml" "${REPOROOT}"/assets/crd
+    # The following manifests are just MicroShift specific and are not present in any other OpenShift repo.
+    # - assets/crd/authorizationv1-local-apiservice.yaml (local API service for authorization API group, needed if OpenShift API server is not present)
+    # - assets/crd/securityv1-local-apiservice.yaml (local API service for security API group, needed if OpenShift API server is not present)
+
     #    Replace all SCC manifests
     rm -f "${REPOROOT}"/assets/scc/*.yaml
     cp "${STAGING_DIR}"/release-manifests/0000_20_kube-apiserver-operator_00_scc-*.yaml "${REPOROOT}"/assets/scc || true

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -389,12 +389,21 @@ update_manifests() {
 
     #-- OpenShift control plane ---------------------------
     # 1) Adopt resource manifests
+    #    Selectively copy in only those core manifests that MicroShift is already using
+    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ns.yaml" "${REPOROOT}"/assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/csr_approver_clusterrole.yaml" "${REPOROOT}"/assets/core
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/csr_approver_clusterrolebinding.yaml" "${REPOROOT}"/assets/core
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-openshift-infra.yaml" "${REPOROOT}"/assets/core
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/ns.yaml" "${REPOROOT}"/assets/core/namespace-openshift-kube-controller-manager.yaml
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-security-allocation-controller-clusterrole.yaml" "${REPOROOT}"/assets/core
+    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-security-allocation-controller-clusterrolebinding.yaml" "${REPOROOT}"/assets/core
     #    Selectively copy in only those CRD manifests that MicroShift is already using
+    # TODO: add route CRD (https://github.com/openshift/api/blob/master/route/v1/route.crd.yaml) once we rebase to a release that contains it
+    #cp "${STAGING_DIR}/release-manifests/0000_01_route.crd.yaml" "${REPOROOT}"/assets/crd
     cp "${STAGING_DIR}/release-manifests/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml" "${REPOROOT}"/assets/crd
     cp "${STAGING_DIR}/release-manifests/0000_03_security-openshift_01_scc.crd.yaml" "${REPOROOT}"/assets/crd
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-openshift-infra.yaml" "${REPOROOT}"/assets/core
-    # TODO: add route CRD (https://github.com/openshift/api/blob/master/route/v1/route.crd.yaml) when we rebase to a release that contains it
-    #    Replace all SCC manifests.
+    cp "${STAGING_DIR}/release-manifests/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml" "${REPOROOT}"/assets/crd
+    #    Replace all SCC manifests
     rm -f "${REPOROOT}"/assets/scc/*.yaml
     cp "${STAGING_DIR}"/release-manifests/0000_20_kube-apiserver-operator_00_scc-*.yaml "${REPOROOT}"/assets/scc || true
     # 2) Render operand manifest templates like the operator would


### PR DESCRIPTION
Updates rebase script to copy in more of the assets/core and assets/crd manifests from the respective OpenShift components.

Signed-off-by: Frank A. Zdarsky [fzdarsky@redhat.com](mailto:fzdarsky@redhat.com)

Closes [USHIFT-251](https://issues.redhat.com//browse/USHIFT-251)
