### PR TITLE
USHIFT-373: add priorityClassName to topoLVM

### DIFF
--- a/assets/components/odf-lvm/topolvm-controller_deployment.yaml
+++ b/assets/components/odf-lvm/topolvm-controller_deployment.yaml
@@ -130,6 +130,7 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: certs
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/assets/components/odf-lvm/topolvm-node_daemonset.yaml
+++ b/assets/components/odf-lvm/topolvm-node_daemonset.yaml
@@ -132,6 +132,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/topolvm
           name: lvmd-config-dir
+      priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -552,6 +552,7 @@ spec:
         volumeMounts:
         - mountPath: /certs
           name: certs
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
@@ -574,7 +575,7 @@ func assetsComponentsOdfLvmTopolvmController_deploymentYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/odf-lvm/topolvm-controller_deployment.yaml", size: 4161, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
+	info := bindataFileInfo{name: "assets/components/odf-lvm/topolvm-controller_deployment.yaml", size: 4210, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1407,6 +1408,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/topolvm
           name: lvmd-config-dir
+      priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
@@ -1456,7 +1458,7 @@ func assetsComponentsOdfLvmTopolvmNode_daemonsetYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/odf-lvm/topolvm-node_daemonset.yaml", size: 5212, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
+	info := bindataFileInfo{name: "assets/components/odf-lvm/topolvm-node_daemonset.yaml", size: 5258, mode: os.FileMode(420), modTime: time.Unix(1654679854, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Add priorityClassName to TopoLVM pods for better scheduling/preemption capabilities.

Currently, MicroShift does not have a default priority for pods, which means they resolve to 0. In order to have pods properly scheduled for the cluster to be in healthy status, and also be able to support features like [graceful node shutdown](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown), we must have all critical pods with the correct priority.
[Pod preemption reference](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)