### PR TITLE
AUTH-296: certificate chains init refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/microshift
 
-go 1.18
+go 1.17
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // openshift-controller-manager

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/microshift
 
-go 1.17
+go 1.18
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // openshift-controller-manager

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -27,6 +27,9 @@ func CASerialsPath(dir string) string { return filepath.Join(dir, CASerialsFileN
 func ClientCertPath(dir string) string { return filepath.Join(dir, ClientCertFileName) }
 func ClientKeyPath(dir string) string  { return filepath.Join(dir, ClientKeyFileName) }
 
+func ServingCertPath(dir string) string { return filepath.Join(dir, ServerCertFileName) }
+func ServingKeyPath(dir string) string  { return filepath.Join(dir, ServerKeyFileName) }
+
 func KubeControlPlaneSignerCertDir(certsDir string) string {
 	return filepath.Join(certsDir, "kube-control-plane-signer")
 }

--- a/pkg/util/cryptomaterial/signers.go
+++ b/pkg/util/cryptomaterial/signers.go
@@ -1,0 +1,340 @@
+package cryptomaterial
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+type certificateChains struct {
+	signers []*certificateSigner
+
+	// fileBundles maps fileName -> signers, where fileName is the filename of a CA bundle
+	// where PEM certificates should be stored
+	fileBundles map[string][]string
+}
+
+type CertificateChains struct {
+	signers map[string]*CertificateSigner
+}
+
+func NewCertificateChains(signers ...*certificateSigner) *certificateChains {
+	return &certificateChains{
+		signers: signers,
+
+		fileBundles: make(map[string][]string),
+	}
+}
+
+func (cs *certificateChains) WithSigners(signers ...*certificateSigner) *certificateChains {
+	cs.signers = append(cs.signers, signers...)
+	return cs
+}
+
+func (cs *certificateChains) WithCABundle(bundlePath string, signerNames ...string) *certificateChains {
+	cs.fileBundles[bundlePath] = signerNames
+	return cs
+}
+
+func (cs *certificateChains) Complete() (*CertificateChains, error) {
+	completeChains := &CertificateChains{
+		signers: make(map[string]*CertificateSigner),
+	}
+
+	for _, s := range cs.signers {
+		s := s
+		if _, ok := completeChains.signers[s.signerName]; ok {
+			return nil, fmt.Errorf("signer name clash: %s", s.signerName)
+		}
+
+		completedSigner, err := s.Complete()
+		if err != nil {
+			return nil, fmt.Errorf("failed to complete signer %q: %w", s.signerName, err)
+		}
+		completeChains.signers[completedSigner.signerName] = completedSigner
+	}
+
+	bundlePreWrite := make(map[string][]byte, len(cs.fileBundles))
+	for bundlePath, signers := range cs.fileBundles {
+		for _, s := range signers {
+			signerCACertPEM, err := completeChains.GetSigner(s).GetSignerCertPEM()
+			if err != nil {
+				return nil, fmt.Errorf("failed to retrieve cert PEM for signer %q: %w", s, err)
+			}
+			bundlePreWrite[bundlePath] = append(bundlePreWrite[bundlePath], append(signerCACertPEM, byte('\n'))...)
+		}
+	}
+
+	for bundlePath, pemChain := range bundlePreWrite {
+		if err := appendCertsToFile(bundlePath, pemChain); err != nil {
+			return nil, err
+		}
+	}
+
+	return completeChains, nil
+}
+
+func (cs *CertificateChains) GetSignerNames() []string {
+	return stringMapKeysOrdered(cs.signers)
+}
+
+func (cs *CertificateChains) GetSigner(signerPath ...string) *CertificateSigner {
+	if len(signerPath) == 0 {
+		return nil
+	}
+
+	currentSigner := cs.signers[signerPath[0]]
+	for _, fragment := range signerPath[1:] {
+		if currentSigner != nil {
+			currentSigner = currentSigner.GetSubCA(fragment)
+		} else {
+			return nil
+		}
+	}
+
+	return currentSigner
+}
+
+func (cs *CertificateChains) GetCertKey(certPath ...string) ([]byte, []byte, error) {
+	if len(certPath) == 0 {
+		return nil, nil, fmt.Errorf("empty certificate path")
+	}
+	if len(certPath) == 1 {
+		return nil, nil, fmt.Errorf("the CertificateChains struct only stores signers, the path must be at least 1 level deep")
+	}
+
+	signerPath := certPath[:len(certPath)-1]
+	signer := cs.GetSigner(signerPath...)
+	if signer == nil {
+		return nil, nil, fmt.Errorf("no such signer in the path: %v", signerPath)
+	}
+
+	return signer.GetCertKey(certPath[len(certPath)-1])
+}
+
+type certificateSigner struct {
+	signerName         string
+	signerDir          string
+	signerValidityDays int
+
+	// signerConfig should only be used in case this is a sub-ca signer
+	// It should be populated during CertificateSigner.SignSubCA()
+	signerConfig             *crypto.CA
+	subCAs                   []*certificateSigner
+	clientCertificatesToSign []*ClientCertificateSigningRequestInfo
+	serverCertificatesToSign []*ServingCertificateSigningRequestInfo
+}
+
+type CertificateSigner struct {
+	signerName   string
+	signerConfig *crypto.CA
+	signerDir    string
+
+	subCAs             map[string]*CertificateSigner
+	signedCertificates map[string]*signedCertificateInfo
+}
+
+type ClientCertificateSigningRequestInfo struct {
+	CertificateSigningRequestInfo
+
+	UserInfo user.Info
+}
+
+type ServingCertificateSigningRequestInfo struct {
+	CertificateSigningRequestInfo
+
+	Hostnames []string
+}
+
+type CertificateSigningRequestInfo struct {
+	Name         string
+	ValidityDays int
+}
+
+type signedCertificateInfo struct {
+	certDir   string
+	tlsConfig *crypto.TLSCertificateConfig
+}
+
+// NewCertificateSigner returns a builder object for a certificate chain for the given signer
+func NewCertificateSigner(signerName, signerDir string, validityDays int) *certificateSigner {
+	return &certificateSigner{
+		signerName:         signerName,
+		signerDir:          signerDir,
+		signerValidityDays: validityDays,
+	}
+}
+
+func (s *certificateSigner) WithClientCertificates(signInfos ...*ClientCertificateSigningRequestInfo) *certificateSigner {
+	s.clientCertificatesToSign = append(s.clientCertificatesToSign, signInfos...)
+	return s
+}
+
+func (s *certificateSigner) WithServingCertificates(signInfos ...*ServingCertificateSigningRequestInfo) *certificateSigner {
+	s.serverCertificatesToSign = append(s.serverCertificatesToSign, signInfos...)
+	return s
+}
+
+func (s *certificateSigner) WithSubCAs(subCAsInfo ...*certificateSigner) *certificateSigner {
+	s.subCAs = append(s.subCAs, subCAsInfo...)
+	return s
+}
+
+func (s *certificateSigner) Complete() (*CertificateSigner, error) {
+	// in case this is a sub-ca, it's already going to have the signer-config populated
+	signerConfig := s.signerConfig
+	if signerConfig == nil {
+		var err error
+		signerConfig, _, err = crypto.EnsureCA(
+			CACertPath(s.signerDir),
+			CAKeyPath(s.signerDir),
+			CASerialsPath(s.signerDir),
+			s.signerName,
+			s.signerValidityDays,
+		)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate %s CA certificate: %w", s.signerName, err)
+		}
+	}
+
+	signerCompleted := &CertificateSigner{
+		signerName:   s.signerName,
+		signerConfig: signerConfig,
+		signerDir:    s.signerDir,
+
+		subCAs:             make(map[string]*CertificateSigner),
+		signedCertificates: make(map[string]*signedCertificateInfo),
+	}
+
+	for _, subCA := range s.subCAs {
+		subCA := subCA
+		if err := signerCompleted.SignSubCA(subCA); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, si := range s.clientCertificatesToSign {
+		si := si
+		if err := signerCompleted.SignClientCertificate(si); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, si := range s.serverCertificatesToSign {
+		si := si
+		if err := signerCompleted.SignServingCertificate(si); err != nil {
+			return nil, err
+		}
+	}
+
+	return signerCompleted, nil
+}
+
+func (s *CertificateSigner) GetSignerCertPEM() ([]byte, error) {
+	certPem, _, err := s.signerConfig.Config.GetPEMBytes()
+	return certPem, err
+}
+
+func (s *CertificateSigner) SignSubCA(signerInfo *certificateSigner) error {
+	subCAConfig, err := crypto.MakeCAConfigForDuration(
+		signerInfo.signerName,
+		time.Duration(signerInfo.signerValidityDays)*time.Hour*24,
+		s.signerConfig,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to generate sub-CA %q: %w", signerInfo.signerName, err)
+	}
+
+	signerInfo.signerConfig = &crypto.CA{
+		Config:          subCAConfig,
+		SerialGenerator: &crypto.RandomSerialGenerator{},
+	}
+
+	subCertSigner, err := signerInfo.Complete()
+	if err != nil {
+		return err
+	}
+
+	s.subCAs[subCertSigner.signerName] = subCertSigner
+	return nil
+}
+
+func (s *CertificateSigner) SignClientCertificate(signInfo *ClientCertificateSigningRequestInfo) error {
+	certDir := filepath.Join(s.signerDir, signInfo.Name)
+
+	tlsConfig, _, err := s.signerConfig.EnsureClientCertificate(
+		ClientCertPath(certDir),
+		ClientKeyPath(certDir),
+		signInfo.UserInfo,
+		signInfo.ValidityDays,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to generate client certificate for %q: %w", signInfo.Name, err)
+	}
+
+	s.signedCertificates[signInfo.Name] = &signedCertificateInfo{
+		certDir:   certDir,
+		tlsConfig: tlsConfig,
+	}
+	return nil
+}
+
+func (s *CertificateSigner) SignServingCertificate(signInfo *ServingCertificateSigningRequestInfo) error {
+	certDir := filepath.Join(s.signerDir, signInfo.Name)
+
+	tlsConfig, _, err := s.signerConfig.EnsureServerCert(
+		ServingCertPath(certDir),
+		ServingKeyPath(certDir),
+		sets.NewString(signInfo.Hostnames...),
+		signInfo.ValidityDays,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to generate serving certificate for %q: %w", signInfo.Name, err)
+	}
+
+	s.signedCertificates[signInfo.Name] = &signedCertificateInfo{
+		certDir:   certDir,
+		tlsConfig: tlsConfig,
+	}
+	return nil
+}
+
+func (s *CertificateSigner) GetCertNames() []string {
+	return stringMapKeysOrdered(s.signedCertificates)
+}
+
+func (s *CertificateSigner) GetCertKey(subjectName string) ([]byte, []byte, error) {
+	certConfig, exists := s.signedCertificates[subjectName]
+	if !exists {
+		return nil, nil, fmt.Errorf("no certificate with name %q was found", subjectName)
+	}
+
+	return certConfig.tlsConfig.GetPEMBytes()
+}
+
+func (s *CertificateSigner) GetSubCANames() []string {
+	return stringMapKeysOrdered(s.subCAs)
+}
+
+func (s *CertificateSigner) GetSubCA(signerName string) *CertificateSigner {
+	return s.subCAs[signerName]
+}
+
+func stringMapKeysOrdered[T CertificateSigner | signedCertificateInfo](stringMap map[string]*T) []string {
+	keys := make(sort.StringSlice, 0, len(stringMap))
+	for k := range stringMap {
+		keys = append(keys, k)
+	}
+
+	keys.Sort()
+	return keys
+}

--- a/pkg/util/cryptomaterial/signers.go
+++ b/pkg/util/cryptomaterial/signers.go
@@ -81,7 +81,7 @@ func (cs *certificateChains) Complete() (*CertificateChains, error) {
 }
 
 func (cs *CertificateChains) GetSignerNames() []string {
-	return stringMapKeysOrdered(cs.signers)
+	return certificateSignersMapKeysOrdered(cs.signers)
 }
 
 func (cs *CertificateChains) GetSigner(signerPath ...string) *CertificateSigner {
@@ -309,7 +309,7 @@ func (s *CertificateSigner) SignServingCertificate(signInfo *ServingCertificateS
 }
 
 func (s *CertificateSigner) GetCertNames() []string {
-	return stringMapKeysOrdered(s.signedCertificates)
+	return signedCertificateInfoMapKeysOrdered(s.signedCertificates)
 }
 
 func (s *CertificateSigner) GetCertKey(subjectName string) ([]byte, []byte, error) {
@@ -322,14 +322,25 @@ func (s *CertificateSigner) GetCertKey(subjectName string) ([]byte, []byte, erro
 }
 
 func (s *CertificateSigner) GetSubCANames() []string {
-	return stringMapKeysOrdered(s.subCAs)
+	return certificateSignersMapKeysOrdered(s.subCAs)
 }
 
 func (s *CertificateSigner) GetSubCA(signerName string) *CertificateSigner {
 	return s.subCAs[signerName]
 }
 
-func stringMapKeysOrdered[T CertificateSigner | signedCertificateInfo](stringMap map[string]*T) []string {
+// TODO: merge the two below functions with generics once we've got go 1.18
+func certificateSignersMapKeysOrdered(stringMap map[string]*CertificateSigner) []string {
+	keys := make(sort.StringSlice, 0, len(stringMap))
+	for k := range stringMap {
+		keys = append(keys, k)
+	}
+
+	keys.Sort()
+	return keys
+}
+
+func signedCertificateInfoMapKeysOrdered(stringMap map[string]*signedCertificateInfo) []string {
 	keys := make(sort.StringSlice, 0, len(stringMap))
 	for k := range stringMap {
 		keys = append(keys, k)

--- a/pkg/util/cryptomaterial/signers_test.go
+++ b/pkg/util/cryptomaterial/signers_test.go
@@ -1,0 +1,206 @@
+package cryptomaterial
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func Test_certificateSigner_Complete(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name       string
+		testSigner *certificateSigner
+		wantCerts  []string
+		wantSubCAs []string
+		wantErr    bool
+	}{
+		{
+			name: "general test",
+			testSigner: NewCertificateSigner("test-signer-signer", filepath.Join(tmpDir, "generalTest"), 1).
+				WithClientCertificates(
+					&ClientCertificateSigningRequestInfo{
+						CertificateSigningRequestInfo: CertificateSigningRequestInfo{
+							Name:         "test-client",
+							ValidityDays: 1,
+						},
+						UserInfo: &user.DefaultInfo{Name: "test-user", Groups: []string{"test-group1", "test-group2"}},
+					},
+					&ClientCertificateSigningRequestInfo{
+						CertificateSigningRequestInfo: CertificateSigningRequestInfo{
+							Name:         "test-client2",
+							ValidityDays: 1,
+						},
+						UserInfo: &user.DefaultInfo{Name: "test-user", Groups: []string{"test-group1", "test-group2"}},
+					},
+				).WithServingCertificates(
+				&ServingCertificateSigningRequestInfo{
+					CertificateSigningRequestInfo: CertificateSigningRequestInfo{
+						Name:         "test-server",
+						ValidityDays: 1,
+					},
+					Hostnames: []string{"localhost", "127.0.0.1"},
+				},
+			).
+				WithSubCAs(NewCertificateSigner("test-signer", filepath.Join(tmpDir, "test-signer"), 1)),
+			wantCerts:  []string{"test-client", "test-client2", "test-server"},
+			wantSubCAs: []string{"test-signer"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.testSigner.Complete()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("certificateSigner.Complete() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotCertNames := got.GetCertNames(); !reflect.DeepEqual(gotCertNames, tt.wantCerts) {
+				t.Errorf("the completed signer cert names = %v, want %v", gotCertNames, tt.wantCerts)
+			}
+			if gotSubCANames := got.GetSubCANames(); !reflect.DeepEqual(gotSubCANames, tt.wantSubCAs) {
+				t.Errorf("the completed signer sub-CA names = %v, want %v", gotSubCANames, tt.wantSubCAs)
+
+			}
+		})
+	}
+}
+
+func Test_certificateChains_Complete(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name            string
+		testChains      *certificateChains
+		testClientPaths map[string]user.Info
+		testServerPaths map[string]sets.String
+		wantSigners     []string
+		wantErr         bool
+	}{
+		{
+			name: "general test",
+			testChains: NewCertificateChains(
+				NewCertificateSigner("test-signer1", filepath.Join(tmpDir, "test-signer1"), 1).
+					WithClientCertificates(&ClientCertificateSigningRequestInfo{
+						CertificateSigningRequestInfo: CertificateSigningRequestInfo{
+							Name:         "test-client1",
+							ValidityDays: 1,
+						},
+						UserInfo: &user.DefaultInfo{Name: "test-user", Groups: []string{"test-group1", "test-group2"}},
+					},
+						&ClientCertificateSigningRequestInfo{
+							CertificateSigningRequestInfo: CertificateSigningRequestInfo{
+								Name:         "test-client2",
+								ValidityDays: 1,
+							},
+							UserInfo: &user.DefaultInfo{Name: "test-user2"},
+						},
+					),
+				NewCertificateSigner("test-signer2", filepath.Join(tmpDir, "test-signer2"), 1).
+					WithServingCertificates(&ServingCertificateSigningRequestInfo{
+						CertificateSigningRequestInfo: CertificateSigningRequestInfo{
+							Name:         "test-server1",
+							ValidityDays: 1,
+						},
+						Hostnames: []string{"somewhere.over.the.rainbow", "bluebirds.fly"},
+					}),
+			),
+			wantSigners: []string{"test-signer1", "test-signer2"},
+			testClientPaths: map[string]user.Info{
+				"test-signer1/test-client1": &user.DefaultInfo{Name: "test-user", Groups: []string{"test-group1", "test-group2"}},
+				"test-signer1/test-client2": &user.DefaultInfo{Name: "test-user2"},
+				"test-signer1/test-client":  nil,
+			},
+			testServerPaths: map[string]sets.String{
+				"test-signer2/test-server1": sets.NewString("somewhere.over.the.rainbow", "bluebirds.fly"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := tt.testChains
+			got, err := cs.Complete()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("certificateChains.Complete() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotSignerNames := got.GetSignerNames(); !reflect.DeepEqual(gotSignerNames, tt.wantSigners) {
+				t.Errorf("certificateChains.Complete() = %v, want %v", gotSignerNames, tt.wantSigners)
+			}
+
+			for path, expectedInfo := range tt.testClientPaths {
+				gotPEM, _, err := got.GetCertKey(breakTestCertPath(path)...)
+
+				if expectedInfo == nil {
+					if err == nil {
+						t.Errorf("expected certificate to not be found at path %q, but got %s", path, gotPEM)
+					}
+					continue
+				} else {
+					require.NoError(t, err, "failed to retrieve cert/key pair from the certificate chains")
+				}
+
+				gotCert := pemToCert(t, gotPEM)
+
+				if cn := gotCert.Subject.CommonName; cn != expectedInfo.GetName() {
+					t.Errorf("expected certificate CN at path %q to be %q, but it is %q", path, expectedInfo.GetName(), cn)
+				}
+
+				if orgs := gotCert.Subject.Organization; !reflect.DeepEqual(orgs, expectedInfo.GetGroups()) {
+					t.Errorf("expected certificate O at path %q to be %v, but it is %v", path, expectedInfo.GetGroups(), orgs)
+				}
+			}
+
+			for path, expectedHostnames := range tt.testServerPaths {
+				gotPEM, _, err := got.GetCertKey(breakTestCertPath(path)...)
+
+				if expectedHostnames == nil {
+					if err == nil {
+						t.Errorf("expected certificate to not be found at path %q, but got %s", path, gotPEM)
+					}
+					continue
+				} else {
+					require.NoError(t, err, "failed to retrieve cert/key pair from the certificate chains")
+				}
+
+				gotCert := pemToCert(t, gotPEM)
+
+				if cn := gotCert.Subject.CommonName; cn != expectedHostnames.List()[0] {
+					t.Errorf("expected certificate CN at path %q to be %q, but it is %q", path, expectedHostnames.List()[0], cn)
+				}
+
+				expectedIPs, expectedDNSes := crypto.IPAddressesDNSNames(expectedHostnames.List())
+				if !equality.Semantic.DeepEqual(gotCert.IPAddresses, expectedIPs) || !equality.Semantic.DeepEqual(gotCert.DNSNames, expectedDNSes) {
+					t.Errorf("extected certificate at path %q to have IPs %v and DNS names %v, but got %v and %v", path, expectedIPs, expectedDNSes, gotCert.IPAddresses, gotCert.DNSNames)
+				}
+			}
+		})
+	}
+}
+
+func pemToCert(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+
+	pemBlock, _ := pem.Decode(certPEM)
+	require.NotNil(t, pemBlock, "failed to decode certificate PEM")
+
+	cert, err := x509.ParseCertificate(pemBlock.Bytes)
+	require.NoError(t, err, "failed to parse certificate PEM into a certificate")
+
+	return cert
+}
+
+func breakTestCertPath(testPath string) []string {
+	return strings.Split(testPath, "/")
+}


### PR DESCRIPTION
This PR adds a refactoring of the current certificate initialization code.

The new code allows describing certificate chains by Go structures, feeding them into a builder object, and then creating them all at once once the developer is happy with what they have.

The new structure currently only allows to retrieve leaf certificate certs/key PEMs in a path-like manner, but might be extensible to perform queries on *x509.Certificate objects in the future, so as to allow for checking expirations and could be thus fed to a controller that is capable of handling rotations over the structure.

/cc @ibihim 