### PR TITLE
Fix config params and tests

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -33,12 +33,21 @@ const (
 func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	flags := cmd.Flags()
 	// Read the config flag directly into the struct, so it's immediately available.
-	flags.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "File to read configuration from.")
+	flags.StringVar(&cfg.ConfigFile, "config", cfg.ConfigFile, "The file to read configuration from.")
 	cmd.MarkFlagFilename("config", "yaml", "yml")
 	// All other flags will be read after reading both config file and env vars.
-	flags.String("data-dir", cfg.DataDir, "Directory for storing runtime data.")
-	flags.String("audit-log-dir", cfg.AuditLogDir, "Directory for storing audit logs.")
-	flags.StringSlice("roles", cfg.Roles, "Roles of this MicroShift instance.")
+	flags.String("data-dir", cfg.DataDir, "The directory for storing runtime data.")
+	flags.String("audit-log-dir", cfg.AuditLogDir, "The directory for storing audit logs.")
+	flags.StringSlice("roles", cfg.Roles, "The roles of this MicroShift instance.")
+	flags.String("node-name", cfg.NodeName, "The hostname of the node.")
+	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
+	flags.String("url", cfg.Cluster.URL, "The URL of the API server.")
+	flags.String("cluster-cidr", cfg.Cluster.ClusterCIDR, "The IP range in CIDR notation for pods in the cluster.")
+	flags.String("service-cidr", cfg.Cluster.ServiceCIDR, "The IP range in CIDR notation for services in the cluster.")
+	flags.String("service-node-port-range", cfg.Cluster.ServiceNodePortRange, "The port range to reserve for services with NodePort visibility. This must not overlap with the ephemeral port range on nodes.")
+	flags.String("cluster-dns", cfg.Cluster.DNS, "Comma-separated list of DNS server IP address. This value is used for containers DNS server in case of Pods with \"dnsPolicy=ClusterFirst\".")
+	flags.String("cluster-domain", cfg.Cluster.Domain, "Domain for this cluster.")
+	flags.String("cluster-mtu", cfg.Cluster.MTU, "Network MTU for pods in the cluster.")
 	flags.Bool("debug.pprof", false, "Enable golang pprof debugging")
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,23 +213,51 @@ func (c *MicroshiftConfig) updateManifestList() {
 }
 
 func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
-	if dataDir, err := flags.GetString("data-dir"); err == nil && flags.Changed("data-dir") {
-		c.DataDir = dataDir
+	if s, err := flags.GetString("data-dir"); err == nil && flags.Changed("data-dir") {
+		c.DataDir = s
 		// if the defaults are present, rebuild based on the new data-dir
 		c.updateManifestList()
 	}
-	if auditLogDir, err := flags.GetString("audit-log-dir"); err == nil && flags.Changed("audit-log-dir") {
-		c.AuditLogDir = auditLogDir
+	if s, err := flags.GetString("audit-log-dir"); err == nil && flags.Changed("audit-log-dir") {
+		c.AuditLogDir = s
 	}
-	if vLevelFlag := flags.Lookup("v"); vLevelFlag != nil && flags.Changed("v") {
-		c.LogVLevel, _ = strconv.Atoi(vLevelFlag.Value.String())
+	if f := flags.Lookup("v"); f != nil && flags.Changed("v") {
+		c.LogVLevel, _ = strconv.Atoi(f.Value.String())
 	}
-	if roles, err := flags.GetStringSlice("roles"); err == nil && flags.Changed("roles") {
-		c.Roles = roles
+	if ss, err := flags.GetStringSlice("roles"); err == nil && flags.Changed("roles") {
+		c.Roles = ss
 	}
-	if pprofFlag, err := flags.GetBool("debug.pprof"); err == nil && flags.Changed("debug.pprof") {
-		c.Debug.Pprof = pprofFlag
+	if s, err := flags.GetString("node-name"); err == nil && flags.Changed("node-name") {
+		c.NodeName = s
 	}
+	if s, err := flags.GetString("node-ip"); err == nil && flags.Changed("node-ip") {
+		c.NodeIP = s
+	}
+	if s, err := flags.GetString("url"); err == nil && flags.Changed("url") {
+		c.Cluster.URL = s
+	}
+	if s, err := flags.GetString("cluster-cidr"); err == nil && flags.Changed("cluster-cidr") {
+		c.Cluster.ClusterCIDR = s
+	}
+	if s, err := flags.GetString("service-cidr"); err == nil && flags.Changed("service-cidr") {
+		c.Cluster.ServiceCIDR = s
+	}
+	if s, err := flags.GetString("service-node-port-range"); err == nil && flags.Changed("service-node-port-range") {
+		c.Cluster.ServiceNodePortRange = s
+	}
+	if s, err := flags.GetString("cluster-dns"); err == nil && flags.Changed("cluster-dns") {
+		c.Cluster.DNS = s
+	}
+	if s, err := flags.GetString("cluster-domain"); err == nil && flags.Changed("cluster-domain") {
+		c.Cluster.Domain = s
+	}
+	if s, err := flags.GetString("cluster-mtu"); err == nil && flags.Changed("cluster-mtu") {
+		c.Cluster.MTU = s
+	}
+	if b, err := flags.GetBool("debug.pprof"); err == nil && flags.Changed("debug.pprof") {
+		c.Debug.Pprof = b
+	}
+
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 	homedir "github.com/mitchellh/go-homedir"
@@ -31,8 +32,7 @@ const (
 )
 
 var (
-	defaultRoles = validRoles
-	validRoles   = []string{"controlplane", "node"}
+	validRoles = []string{"controlplane", "node"}
 )
 
 type ClusterConfig struct {
@@ -90,6 +90,8 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 
 	dataDir := findDataDir()
 
+	defaultRoles := make([]string, len(validRoles))
+	copy(defaultRoles, validRoles)
 	return &MicroshiftConfig{
 		ConfigFile:  findConfigFile(),
 		DataDir:     dataDir,
@@ -241,10 +243,9 @@ func (c *MicroshiftConfig) ReadAndValidate(flags *pflag.FlagSet) error {
 	if err := c.ReadFromCmdLine(flags); err != nil {
 		return err
 	}
-
 	for _, role := range c.Roles {
 		if !StringInList(role, validRoles) {
-			return fmt.Errorf("config error: '%s' is not a valid role, must be in ['controlplane','node']", role)
+			return fmt.Errorf("config error: '%s' is not a valid role, must be in {%s}", role, strings.Join(validRoles, ", "))
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,6 @@ func TestConfigFile(t *testing.T) {
 
 // test that MicroShift is able to properly read the config from the commandline
 func TestCommandLineConfig(t *testing.T) {
-	defaultConfig := NewMicroshiftConfig()
 
 	var ttests = []struct {
 		config *MicroshiftConfig
@@ -45,16 +44,16 @@ func TestCommandLineConfig(t *testing.T) {
 				AuditLogDir: "/tmp/microshift/logs",
 				LogVLevel:   4,
 				Roles:       []string{"controlplane", "node"},
-				NodeName:    defaultConfig.NodeName,
-				NodeIP:      defaultConfig.NodeIP,
+				NodeName:    "node1",
+				NodeIP:      "1.2.3.4",
 				Cluster: ClusterConfig{
-					URL:                  defaultConfig.Cluster.URL,
-					ClusterCIDR:          defaultConfig.Cluster.ClusterCIDR,
-					ServiceCIDR:          defaultConfig.Cluster.ServiceCIDR,
-					ServiceNodePortRange: defaultConfig.Cluster.ServiceNodePortRange,
-					DNS:                  defaultConfig.Cluster.DNS,
-					Domain:               defaultConfig.Cluster.Domain,
-					MTU:                  defaultConfig.Cluster.MTU,
+					URL:                  "https://1.2.3.4:6443",
+					ClusterCIDR:          "10.20.30.40/16",
+					ServiceCIDR:          "40.30.20.10/16",
+					ServiceNodePortRange: "1024-32767",
+					DNS:                  "cluster.dns",
+					Domain:               "cluster.local",
+					MTU:                  "1200",
 				},
 				Manifests: []string{defaultManifestDirLib, defaultManifestDirEtc, "/tmp/microshift/data/manifests"},
 				Debug: DebugConfig{
@@ -76,6 +75,15 @@ func TestCommandLineConfig(t *testing.T) {
 		flags.String("audit-log-dir", config.AuditLogDir, "")
 		flags.Int("v", config.LogVLevel, "")
 		flags.StringSlice("roles", config.Roles, "")
+		flags.String("node-name", config.NodeName, "")
+		flags.String("node-ip", config.NodeIP, "")
+		flags.String("url", config.Cluster.URL, "")
+		flags.String("cluster-cidr", config.Cluster.ClusterCIDR, "")
+		flags.String("service-cidr", config.Cluster.ServiceCIDR, "")
+		flags.String("service-node-port-range", config.Cluster.ServiceNodePortRange, "")
+		flags.String("cluster-dns", config.Cluster.DNS, "")
+		flags.String("cluster-domain", config.Cluster.Domain, "")
+		flags.String("cluster-mtu", config.Cluster.MTU, "")
 		flags.Bool("debug.pprof", false, "")
 
 		// parse the flags
@@ -86,6 +94,15 @@ func TestCommandLineConfig(t *testing.T) {
 			"--audit-log-dir=" + tt.config.AuditLogDir,
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
 			"--roles=" + strings.Join(tt.config.Roles, ","),
+			"--node-name=" + tt.config.NodeName,
+			"--node-ip=" + tt.config.NodeIP,
+			"--url=" + tt.config.Cluster.URL,
+			"--cluster-cidr=" + tt.config.Cluster.ClusterCIDR,
+			"--service-cidr=" + tt.config.Cluster.ServiceCIDR,
+			"--service-node-port-range=" + tt.config.Cluster.ServiceNodePortRange,
+			"--cluster-dns=" + tt.config.Cluster.DNS,
+			"--cluster-domain=" + tt.config.Cluster.Domain,
+			"--cluster-mtu=" + tt.config.Cluster.MTU,
 			"--debug.pprof=" + strconv.FormatBool(tt.config.Debug.Pprof),
 		})
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -238,12 +238,3 @@ func TestGlobalInitFlags(t *testing.T) {
 	// pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	pflag.Parse()
 }
-
-// tests that the default config file is being read
-func TestDefaultConfigFile(t *testing.T) {
-	os.Setenv("MICROSHIFT_CONFIG_FILE", "")
-	config := NewMicroshiftConfig()
-	if config.ConfigFile != "" {
-		t.Errorf("expected config file to be empty, got %s", config.ConfigFile)
-	}
-}

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -13,5 +13,7 @@ cluster:
   serviceCIDR: '40.30.20.10/16'
   dns: 'cluster.dns'
   domain: cluster.local
+  serviceNodePortRange: 30000-32767
+  mtu: "1400"
 manifests:
   - /etc/my-app/manifests


### PR DESCRIPTION
This PR fixes tests in pkg/config/config_tests.go that were either flaky in CI or not correctly testing the function under test.
Also, adds command line flags for parameters for which we already support configuration via config.file.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>

Closes [USHIFT-383](https://issues.redhat.com/browse/USHIFT-383)