### PR TITLE
AUTH-296: split out the service-ca trust chain

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -87,6 +87,10 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	}
 
 	certChains, err := cryptomaterial.NewCertificateChains(
+		// ------------------------------
+		// CLIENT CERTIFICATE SIGNERS
+		// ------------------------------
+
 		// kube-control-plane-signer
 		cryptomaterial.NewCertificateSigner(
 			"kube-control-plane-signer",
@@ -152,6 +156,15 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 			},
 		).WithSubCAs(
 			cryptomaterial.NewCertificateSigner("kube-csr-signer", cryptomaterial.CSRSignerCertDir(certsDir), cryptomaterial.ClientCAValidityDays),
+		),
+
+		//------------------------------
+		// SERVING CERTIFICATE SIGNERS
+		//------------------------------
+		cryptomaterial.NewCertificateSigner(
+			"service-ca",
+			cryptomaterial.ServiceCADir(certsDir),
+			cryptomaterial.ServiceCAValidityDays,
 		),
 	).WithCABundle(
 		cryptomaterial.TotalClientCABundlePath(certsDir),
@@ -227,11 +240,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 			"kubernetes", "localhost"}); err != nil {
 		return nil, nil, err
 	}
-	if err := util.GenCerts("service-ca", filepath.Join(cfg.DataDir, "/resources/service-ca/secrets/service-ca"),
-		"tls.crt", "tls.key",
-		[]string{"localhost", cfg.NodeIP, "127.0.0.1", cfg.NodeName, apiServerServiceIP.String()}); err != nil {
-		return nil, nil, err
-	}
+
 	return clusterTrustBundlePEM, certChains, nil
 }
 

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -39,26 +39,24 @@ func startServiceCAController(cfg *config.MicroshiftConfig, kubeconfigPath strin
 		cmName     = "signing-cabundle"
 	)
 
-	caPath := cryptomaterial.UltimateTrustBundlePath(cryptomaterial.CertsDirectory(cfg.DataDir))
-	tlsCrtPath := cfg.DataDir + "/resources/service-ca/secrets/service-ca/tls.crt"
-	tlsKeyPath := cfg.DataDir + "/resources/service-ca/secrets/service-ca/tls.key"
+	serviceCADir := cryptomaterial.ServiceCADir(cryptomaterial.CertsDirectory(cfg.DataDir))
+	caCertPath := cryptomaterial.CACertPath(serviceCADir)
+	caKeyPath := cryptomaterial.CAKeyPath(serviceCADir)
+
 	cmData := map[string]string{}
 	secretData := map[string][]byte{}
-	cabundle, err := os.ReadFile(caPath)
+
+	caCertPEM, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return err
 	}
-	tlscrt, err := os.ReadFile(tlsCrtPath)
+	caKeyPEM, err := os.ReadFile(caKeyPath)
 	if err != nil {
 		return err
 	}
-	tlskey, err := os.ReadFile(tlsKeyPath)
-	if err != nil {
-		return err
-	}
-	cmData["ca-bundle.crt"] = string(cabundle)
-	secretData["tls.crt"] = tlscrt
-	secretData["tls.key"] = tlskey
+	cmData["ca-bundle.crt"] = string(caCertPEM)
+	secretData["tls.crt"] = caCertPEM
+	secretData["tls.key"] = caKeyPEM
 
 	if err := assets.ApplyNamespaces(ns, kubeconfigPath); err != nil {
 		klog.Warningf("Failed to apply ns %v: %v", ns, err)

--- a/pkg/util/cert.go
+++ b/pkg/util/cert.go
@@ -27,6 +27,7 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"math/big"
@@ -138,12 +139,10 @@ func GenCertsBuff(common string, svcName []string) ([]byte, []byte, error) {
 	return certBuff, keyBuff, nil
 }
 
-// GenCerts creates certs and keys
-// GenCerts("/var/lib/openshift/service-ca/key", "tls.crt", "tls.key", "example.com")
+// GenCerts creates certs and keys signed by the root CA
 func GenCerts(common, dir, certFilename, keyFilename string, svcName []string) error {
-	var err error
 	if rootCA == nil || rootKey == nil {
-		return err
+		return fmt.Errorf("the root CA cert/key pair was not yet generated")
 	}
 	os.MkdirAll(dir, 0700)
 	certBuff, keyBuff, err := GenCertsBuff(common, svcName)

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -16,6 +16,8 @@ const (
 	ClientCAValidityDays                  = 60
 	ClientCertValidityDays                = 30
 	AdminKubeconfigClientCertValidityDays = 365 * 10
+
+	ServiceCAValidityDays = 790
 )
 
 func CertsDirectory(dataPath string) string { return filepath.Join(dataPath, "certs") }
@@ -70,6 +72,10 @@ func CSRSignerCertDir(certsDir string) string {
 
 func KubeletClientCertDir(certsDir string) string {
 	return filepath.Join(KubeletCSRSignerSignerCertDir(certsDir), "kubelet-client")
+}
+
+func ServiceCADir(certsDir string) string {
+	return filepath.Join(certsDir, "service-ca")
 }
 
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers


### PR DESCRIPTION
This PR splits out service-ca trust chain from the root CA.

/hold
https://github.com/openshift/microshift/pull/939 should be merged first, I'm creating this PR just to see whether splitting out service-ca brings any issues.