### PR TITLE
AUTH-296: Cut off the root CA from the cluster-distributed client CA

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -210,9 +210,9 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		"service-account.crt", "service-account.key"); err != nil {
 		return nil, nil, err
 	}
-	if err := util.GenCerts("system:masters", filepath.Join(cfg.DataDir, "/certs/kube-apiserver/secrets/aggregator-client"),
+	if err := util.GenCerts("system:openshift-aggregator", filepath.Join(cfg.DataDir, "/certs/kube-apiserver/secrets/aggregator-client"),
 		"tls.crt", "tls.key",
-		[]string{"system:admin", "system:masters"}); err != nil {
+		[]string{"remove-this"}); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -16,7 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"net"
 	"path/filepath"
 
@@ -66,11 +65,6 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// FIXME: don't add the whole root CA to client CA bundle, get rid of a general trust by splitting the root CA
-	if err := cryptomaterial.AddToTotalClientCABundle(certsDir, clusterTrustBundlePEM); err != nil {
-		return nil, nil, fmt.Errorf("failed to add the root CA to the total client CA bundle: %w", err)
 	}
 
 	// based on https://github.com/openshift/cluster-etcd-operator/blob/master/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml#L19

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -90,7 +90,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 
 	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
 	kubeletClientDir := cryptomaterial.KubeAPIServerToKubeletClientCertDir(certsDir)
-	caCertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
+	ultimateTrustCACertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	clientCABundlePath := cryptomaterial.TotalClientCABundlePath(certsDir)
 	kasSecretsDir := filepath.Join(certsDir, "kube-apiserver", "secrets")
 	servingCertsDir := filepath.Join(kasSecretsDir, "service-network-serving-certkey")
@@ -114,19 +114,19 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"audit-log-path":    {cfg.AuditLogDir},
 			"audit-policy-file": {cfg.DataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
 			"client-ca-file":    {clientCABundlePath},
-			"etcd-cafile":       {caCertFile},
+			"etcd-cafile":       {ultimateTrustCACertFile},
 			"etcd-certfile":     {cfg.DataDir + "/resources/kube-apiserver/secrets/etcd-client/tls.crt"},
 			"etcd-keyfile":      {cfg.DataDir + "/resources/kube-apiserver/secrets/etcd-client/tls.key"},
 			"etcd-servers": {
 				"https://127.0.0.1:2379",
 			},
-			"kubelet-certificate-authority": {caCertFile},
+			"kubelet-certificate-authority": {ultimateTrustCACertFile},
 			"kubelet-client-certificate":    {cryptomaterial.ClientCertPath(kubeletClientDir)},
 			"kubelet-client-key":            {cryptomaterial.ClientKeyPath(kubeletClientDir)},
 
 			"proxy-client-cert-file":           {filepath.Join(kasSecretsDir, "aggregator-client", "tls.crt")},
 			"proxy-client-key-file":            {filepath.Join(kasSecretsDir, "aggregator-client", "tls.key")},
-			"requestheader-client-ca-file":     {clientCABundlePath},
+			"requestheader-client-ca-file":     {ultimateTrustCACertFile},
 			"service-account-signing-key-file": {cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key"},
 			"service-node-port-range":          {cfg.Cluster.ServiceNodePortRange},
 			"tls-cert-file":                    {filepath.Join(servingCertsDir, "tls.crt")},

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -52,6 +52,7 @@ func (s *KubeControllerManager) Dependencies() []string { return []string{"kube-
 func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
 	caCertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
+	csrSignerDir := cryptomaterial.CSRSignerCertDir(certsDir)
 	kubeconfig := cfg.KubeConfigPath(config.KubeControllerManager)
 	kubeadmConfig := cfg.KubeConfigPath(config.KubeAdmin)
 
@@ -70,13 +71,13 @@ func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 		"--cluster-cidr=" + cfg.Cluster.ClusterCIDR,
 		"--authorization-kubeconfig=" + kubeconfig,
 		"--authentication-kubeconfig=" + kubeconfig,
-		"--root-ca-file=" + caCertFile,
+		"--root-ca-file=" + caCertFile, // TODO: this should be service-account-token-ca.crt
 		"--bind-address=127.0.0.1",
 		"--secure-port=10257",
 		"--leader-elect=false",
 		"--use-service-account-credentials=true",
-		"--cluster-signing-cert-file=" + caCertFile,
-		"--cluster-signing-key-file=" + certsDir + "/ca-bundle/ca-bundle.key",
+		"--cluster-signing-cert-file=" + cryptomaterial.CACertPath(csrSignerDir),
+		"--cluster-signing-key-file=" + cryptomaterial.CAKeyPath(csrSignerDir),
 	}
 
 	// fake the kube-controller-manager cobra command to parse args into controllermanager options

--- a/pkg/util/cryptomaterial/signers.go
+++ b/pkg/util/cryptomaterial/signers.go
@@ -252,6 +252,16 @@ func (s *CertificateSigner) SignSubCA(signerInfo *certificateSigner) error {
 		return fmt.Errorf("failed to generate sub-CA %q: %w", signerInfo.signerName, err)
 	}
 
+	// lib-go automatically adds all the certs to the chain but KCM would not start
+	// if there were more than 1 certs in the file
+	subCAConfig.Certs = subCAConfig.Certs[:1]
+	if err := subCAConfig.WriteCertConfigFile(
+		CACertPath(signerInfo.signerDir),
+		CAKeyPath(signerInfo.signerDir),
+	); err != nil {
+		return fmt.Errorf("failed to write the %q cert/key pair files: %w", signerInfo.signerName, err)
+	}
+
 	signerInfo.signerConfig = &crypto.CA{
 		Config:          subCAConfig,
 		SerialGenerator: &crypto.RandomSerialGenerator{},


### PR DESCRIPTION
This PR makes the following changes:
- makes the KCM sign CSRs with the actual CSR signer certificate introduced in https://github.com/openshift/microshift/pull/898
- separates the root CA from the client-ca that is distributed by the KAS as the client cert trust