### PR TITLE
Some clean-ups for the rebase script

### DIFF
--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -573,6 +573,7 @@ rebase_to() {
     download_release "${release_image_amd64}" "${release_image_arm64}"
 
     rebase_branch=rebase-${release_image_amd64#*:}
+    rebase_branch=${rebase_branch%-x86_64}
     git branch -D "${rebase_branch}" || true
     git checkout -b "${rebase_branch}"
 

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -585,15 +585,7 @@ rebase_to() {
         git commit -m "update go.mod"
 
         title "## Updating vendor directory"
-        go mod vendor
-
-        if [ "$(ls -A scripts/rebase_patches)" ]; then
-            title "## Patching vendor directory"
-            git am scripts/rebase_patches/*.patch || true
-        fi
-
-        regenerate_openapi
-
+        make vendor
         if [[ -n "$(git status -s vendor)" ]]; then
             title "## Commiting changes to vendor directory"
             git add vendor


### PR DESCRIPTION
Drop the "-x86_64" suffix from the rebase branch's name.

Use "make vendor" instead of vendoring and patching manually.