### PR TITLE
AUTH-296: Cut off the root CA from the cluster-distributed requestheader-client-ca

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -151,6 +151,19 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		).WithSubCAs(
 			cryptomaterial.NewCertificateSigner("kube-csr-signer", cryptomaterial.CSRSignerCertDir(certsDir), cryptomaterial.ClientCAValidityDays),
 		),
+		cryptomaterial.NewCertificateSigner(
+			"aggregator-signer",
+			cryptomaterial.AggregatorSignerDir(certsDir),
+			cryptomaterial.ClientCAValidityDays,
+		).WithClientCertificates(
+			&cryptomaterial.ClientCertificateSigningRequestInfo{
+				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
+					Name:         "aggregator-client",
+					ValidityDays: cryptomaterial.ClientCertValidityDays,
+				},
+				UserInfo: &user.DefaultInfo{Name: "system:openshift-aggregator"},
+			},
+		),
 
 		//------------------------------
 		// SERVING CERTIFICATE SIGNERS
@@ -208,11 +221,6 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	}
 	if err := util.GenKeys(filepath.Join(cfg.DataDir, "/resources/kube-apiserver/secrets/service-account-key"),
 		"service-account.crt", "service-account.key"); err != nil {
-		return nil, nil, err
-	}
-	if err := util.GenCerts("system:openshift-aggregator", filepath.Join(cfg.DataDir, "/certs/kube-apiserver/secrets/aggregator-client"),
-		"tls.crt", "tls.key",
-		[]string{"remove-this"}); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -92,6 +92,8 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	kubeletClientDir := cryptomaterial.KubeAPIServerToKubeletClientCertDir(certsDir)
 	ultimateTrustCACertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	clientCABundlePath := cryptomaterial.TotalClientCABundlePath(certsDir)
+	aggregatorCAPath := cryptomaterial.CACertPath(cryptomaterial.AggregatorSignerDir(certsDir))
+	aggregatorClientCertDir := cryptomaterial.AggregatorClientCertDir(certsDir)
 	kasSecretsDir := filepath.Join(certsDir, "kube-apiserver", "secrets")
 	servingCertsDir := filepath.Join(kasSecretsDir, "service-network-serving-certkey")
 
@@ -124,9 +126,9 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"kubelet-client-certificate":    {cryptomaterial.ClientCertPath(kubeletClientDir)},
 			"kubelet-client-key":            {cryptomaterial.ClientKeyPath(kubeletClientDir)},
 
-			"proxy-client-cert-file":           {filepath.Join(kasSecretsDir, "aggregator-client", "tls.crt")},
-			"proxy-client-key-file":            {filepath.Join(kasSecretsDir, "aggregator-client", "tls.key")},
-			"requestheader-client-ca-file":     {ultimateTrustCACertFile},
+			"proxy-client-cert-file":           {cryptomaterial.ClientCertPath(aggregatorClientCertDir)},
+			"proxy-client-key-file":            {cryptomaterial.ClientKeyPath(aggregatorClientCertDir)},
+			"requestheader-client-ca-file":     {aggregatorCAPath},
 			"service-account-signing-key-file": {cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key"},
 			"service-node-port-range":          {cfg.Cluster.ServiceNodePortRange},
 			"tls-cert-file":                    {filepath.Join(servingCertsDir, "tls.crt")},

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -78,6 +78,14 @@ func ServiceCADir(certsDir string) string {
 	return filepath.Join(certsDir, "service-ca")
 }
 
+func AggregatorSignerDir(certsDir string) string {
+	return filepath.Join(certsDir, "aggregator-signer")
+}
+
+func AggregatorClientCertDir(certsDir string) string {
+	return filepath.Join(AggregatorSignerDir(certsDir), "aggregator-client")
+}
+
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers
 func TotalClientCABundlePath(certsDir string) string {
 	return filepath.Join(certsDir, "ca-bundle", "client-ca.crt")


### PR DESCRIPTION
This PR narrows the trust for the requestheader-client-ca distributed in the cluster in the `kube-system/extension-apiserver-authentication` CM.

/cc @oglok @ibihim 
