### PR TITLE
USHIFT-399: update list of enabled APIs

### DIFF
--- a/docs/enable_apis.md
+++ b/docs/enable_apis.md
@@ -1,5 +1,7 @@
 # Enabled OpenShift APIs
-MicroShift supports the following sets of OpenShift API resources. 
+
+In addition to the standard Kubernetes APIs, MicroShift supports the
+following OpenShift API resources.
 
 | GroupVersion          | Kind  |
 |-----------------------|-------|
@@ -13,14 +15,4 @@ MicroShift supports the following sets of OpenShift API resources.
 
 | GroupVersion                  | Kind                      |
 |-------------------------------|---------------------------|
-| authorization.openshift.io/v1 | ClusterRoleBinding        |
-|                               | ClusterRole               |
-|                               | LocalResourceAccessReview |
-|                               | LocalSubjectAccessReview  |
-|                               | ResourceAccessReview      |
-|                               | RoleBindingRestriction    |
-|                               | RoleBinding               |
-|                               | Role                      |
-|                               | SelfSubjectRulesReview    |
-|                               | SubjectAccessReview       |
-|                               | SubjectRulesReview        |
+| authorization.openshift.io/v1 | RoleBindingRestriction    |


### PR DESCRIPTION
When we removed the openshift-apiserver dependency, most of the APIs
from the authorization.openshift.io group were removed. Update the
documentation to reflect that change.