### PR TITLE
USHIFT-261: clean up path handling for kubeconfig files

### DIFF
--- a/pkg/assets/crd.go
+++ b/pkg/assets/crd.go
@@ -3,7 +3,6 @@ package assets
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -72,7 +71,7 @@ func isEstablished(cs *apiextclientv1.ApiextensionsV1Client, obj apiruntime.Obje
 }
 
 func WaitForCrdsEstablished(cfg *config.MicroshiftConfig) error {
-	restConfig, err := clientcmd.BuildConfigFromFlags("", filepath.Join(cfg.DataDir, "/resources/kubeadmin/kubeconfig"))
+	restConfig, err := clientcmd.BuildConfigFromFlags("", cfg.KubeConfigPath(config.KubeAdmin))
 	if err != nil {
 		return err
 	}
@@ -120,7 +119,7 @@ func ApplyCRDs(cfg *config.MicroshiftConfig) error {
 	lock.Lock()
 	defer lock.Unlock()
 
-	restConfig, err := clientcmd.BuildConfigFromFlags("", filepath.Join(cfg.DataDir, "/resources/kubeadmin/kubeconfig"))
+	restConfig, err := clientcmd.BuildConfigFromFlags("", cfg.KubeConfigPath(config.KubeAdmin))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -246,7 +246,7 @@ func initKubeconfig(
 		return err
 	}
 	if err := util.KubeConfigWithClientCerts(
-		filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig"),
+		cfg.KubeConfigPath(config.KubeAdmin),
 		cfg.Cluster.URL,
 		clusterTrustBundlePEM,
 		adminKubeconfigCertPEM,
@@ -260,7 +260,7 @@ func initKubeconfig(
 		return err
 	}
 	if err := util.KubeConfigWithClientCerts(
-		filepath.Join(cfg.DataDir, "resources", "kube-controller-manager", "kubeconfig"),
+		cfg.KubeConfigPath(config.KubeControllerManager),
 		cfg.Cluster.URL,
 		clusterTrustBundlePEM,
 		kcmCertPEM,
@@ -274,7 +274,7 @@ func initKubeconfig(
 		return err
 	}
 	if err := util.KubeConfigWithClientCerts(
-		filepath.Join(cfg.DataDir, "resources", "kube-scheduler", "kubeconfig"),
+		cfg.KubeConfigPath(config.KubeScheduler),
 		cfg.Cluster.URL,
 		clusterTrustBundlePEM,
 		schedulerCertPEM, schedulerKeyPEM,
@@ -287,7 +287,7 @@ func initKubeconfig(
 		return err
 	}
 	if err := util.KubeConfigWithClientCerts(
-		filepath.Join(cfg.DataDir, "resources", "kubelet", "kubeconfig"),
+		cfg.KubeConfigPath(config.Kubelet),
 		cfg.Cluster.URL,
 		clusterTrustBundlePEM,
 		kubeletCertPEM, kubeletKeyPEM,

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1,33 +1,33 @@
 package components
 
 import (
-	"path/filepath"
-
 	"github.com/openshift/microshift/pkg/config"
 	"k8s.io/klog/v2"
 )
 
 func StartComponents(cfg *config.MicroshiftConfig) error {
-	if err := startServiceCAController(cfg, filepath.Join(cfg.DataDir, "/resources/kubeadmin/kubeconfig")); err != nil {
+	kubeAdminConfig := cfg.KubeConfigPath(config.KubeAdmin)
+
+	if err := startServiceCAController(cfg, kubeAdminConfig); err != nil {
 		klog.Warningf("Failed to start service-ca controller: %v", err)
 		return err
 	}
 
-	if err := startCSIPLugin(cfg, cfg.DataDir+"/resources/kubeadmin/kubeconfig"); err != nil {
+	if err := startCSIPLugin(cfg, kubeAdminConfig); err != nil {
 		klog.Warningf("Failed to start csi plugin: %v", err)
 		return err
 	}
 
-	if err := startIngressController(cfg, filepath.Join(cfg.DataDir, "/resources/kubeadmin/kubeconfig")); err != nil {
+	if err := startIngressController(cfg, kubeAdminConfig); err != nil {
 		klog.Warningf("Failed to start ingress router controller: %v", err)
 		return err
 	}
-	if err := startDNSController(cfg, filepath.Join(cfg.DataDir, "/resources/kubeadmin/kubeconfig")); err != nil {
+	if err := startDNSController(cfg, kubeAdminConfig); err != nil {
 		klog.Warningf("Failed to start DNS controller: %v", err)
 		return err
 	}
 
-	if err := startOVNKubernetes(cfg, cfg.DataDir+"/resources/kubeadmin/kubeconfig"); err != nil {
+	if err := startOVNKubernetes(cfg, kubeAdminConfig); err != nil {
 		klog.Warningf("Failed to start OVNKubernetes: %v", err)
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,21 @@ type MicroshiftConfig struct {
 	Debug     DebugConfig `json:"debug"`
 }
 
+// KubeConfigID identifies the different kubeconfigs managed in the DataDir
+type KubeConfigID string
+
+const (
+	KubeAdmin             KubeConfigID = "kubeadmin"
+	KubeControllerManager KubeConfigID = "kube-controller-manager"
+	KubeScheduler         KubeConfigID = "kube-scheduler"
+	Kubelet               KubeConfigID = "kubelet"
+)
+
+// KubeConfigPath returns the path to the specified kubeconfig file.
+func (cfg *MicroshiftConfig) KubeConfigPath(id KubeConfigID) string {
+	return filepath.Join(cfg.DataDir, "resources", string(id), "kubeconfig")
+}
+
 func NewMicroshiftConfig() *MicroshiftConfig {
 	nodeName, err := os.Hostname()
 	if err != nil {

--- a/pkg/controllers/cluster-policy-controller.go
+++ b/pkg/controllers/cluster-policy-controller.go
@@ -15,7 +15,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	clusterpolicycontroller "github.com/openshift/cluster-policy-controller/pkg/cmd/cluster-policy-controller"
@@ -44,7 +43,7 @@ func (s *ClusterPolicyController) Name() string           { return "cluster-poli
 func (s *ClusterPolicyController) Dependencies() []string { return []string{"kube-apiserver"} }
 
 func (s *ClusterPolicyController) configure(cfg *config.MicroshiftConfig) error {
-	s.kubeconfig = filepath.Join(cfg.DataDir, "resources", "kube-controller-manager", "kubeconfig")
+	s.kubeconfig = cfg.KubeConfigPath(config.KubeControllerManager)
 
 	scheme := runtime.NewScheme()
 	openshiftcontrolplanev1.AddToScheme(scheme)

--- a/pkg/controllers/infra-services-controller.go
+++ b/pkg/controllers/infra-services-controller.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 
 	klog "k8s.io/klog/v2"
 
@@ -57,7 +56,7 @@ func (s *InfrastructureServicesManager) Run(ctx context.Context, ready chan<- st
 }
 
 func applyDefaultRBACs(cfg *config.MicroshiftConfig) error {
-	kubeconfigPath := filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
+	kubeconfigPath := cfg.KubeConfigPath(config.KubeAdmin)
 	var (
 		cr = []string{
 			"assets/core/csr_approver_clusterrole.yaml",

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -18,7 +18,6 @@ package controllers
 import (
 	"context"
 	"errors"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -53,8 +52,8 @@ func (s *KubeControllerManager) Dependencies() []string { return []string{"kube-
 func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
 	caCertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
-	kubeconfig := filepath.Join(cfg.DataDir, "resources", "kube-controller-manager", "kubeconfig")
-	kubeadmConfig := filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
+	kubeconfig := cfg.KubeConfigPath(config.KubeControllerManager)
+	kubeadmConfig := cfg.KubeConfigPath(config.KubeAdmin)
 
 	opts, err := kubecmoptions.NewKubeControllerManagerOptions()
 	if err != nil {

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -56,14 +56,14 @@ func (s *KubeScheduler) configure(cfg *config.MicroshiftConfig) {
 
 	s.options = schedulerOptions.NewOptions()
 	s.options.ConfigFile = cfg.DataDir + "/resources/kube-scheduler/config/config.yaml"
-	s.kubeconfig = filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
+	s.kubeconfig = cfg.KubeConfigPath(config.KubeAdmin)
 }
 
 func (s *KubeScheduler) writeConfig(cfg *config.MicroshiftConfig) error {
 	data := []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta3
 kind: KubeSchedulerConfiguration
 clientConnection:
-  kubeconfig: ` + cfg.DataDir + `/resources/kube-scheduler/kubeconfig
+  kubeconfig: ` + cfg.KubeConfigPath(config.KubeScheduler) + `
 leaderElection:
   leaderElect: false`)
 

--- a/pkg/controllers/openshift-controller-manager.go
+++ b/pkg/controllers/openshift-controller-manager.go
@@ -60,7 +60,7 @@ func (s *OCPControllerManager) configure(cfg *config.MicroshiftConfig) {
 	}
 
 	var configFilePath = cfg.DataDir + "/resources/openshift-controller-manager/config/config.yaml"
-	s.kubeconfig = filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig")
+	s.kubeconfig = cfg.KubeConfigPath(config.KubeAdmin)
 	s.ConfigFilePath = configFilePath
 	s.Output = os.Stdout
 }
@@ -75,7 +75,7 @@ func (s *OCPControllerManager) writeConfig(cfg *config.MicroshiftConfig) error {
 	data := []byte(`apiVersion: openshiftcontrolplane.config.openshift.io/v1
 kind: OpenShiftControllerManagerConfig
 kubeClientConfig:
-  kubeConfig: ` + cfg.DataDir + `/resources/kubeadmin/kubeconfig
+  kubeConfig: ` + cfg.KubeConfigPath(config.KubeAdmin) + `
   connectionOverrides:
     contentType: "application/json"
 servingInfo:

--- a/pkg/controllers/openshift-default-scc-manager.go
+++ b/pkg/controllers/openshift-default-scc-manager.go
@@ -52,7 +52,7 @@ func (s *OpenShiftDefaultSCCManager) Run(ctx context.Context, ready chan<- struc
 }
 
 func ApplyDefaultSCCs(cfg *config.MicroshiftConfig) error {
-	kubeconfigPath := cfg.DataDir + "/resources/kubeadmin/kubeconfig"
+	kubeconfigPath := cfg.KubeConfigPath(config.KubeAdmin)
 	var (
 		sccs = []string{
 			"assets/scc/0000_20_kube-apiserver-operator_00_scc-anyuid.yaml",

--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/openshift/microshift/pkg/assets"
 	"github.com/openshift/microshift/pkg/config"
@@ -54,7 +53,7 @@ func (s *VersionManager) Run(ctx context.Context, ready chan<- struct{}, stopped
 		"version": versionInfo.String(),
 	}
 
-	kubeConfigPath := filepath.Join(s.cfg.DataDir, "/resources/kubeadmin/kubeconfig")
+	kubeConfigPath := s.cfg.KubeConfigPath(config.KubeAdmin)
 	if err := assets.ApplyConfigMapWithData(cm, data, kubeConfigPath); err != nil {
 		klog.Warningf("Failed to apply configMap %v, %v", cm, err)
 		return err

--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -33,7 +33,7 @@ type Kustomizer struct {
 func NewKustomizer(cfg *config.MicroshiftConfig) *Kustomizer {
 	return &Kustomizer{
 		paths:      cfg.Manifests,
-		kubeconfig: filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig"),
+		kubeconfig: cfg.KubeConfigPath(config.KubeAdmin),
 	}
 }
 

--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -3,7 +3,6 @@ package mdns
 import (
 	"context"
 	"net"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -28,7 +27,7 @@ func NewMicroShiftmDNSController(cfg *config.MicroshiftConfig) *MicroShiftmDNSCo
 	return &MicroShiftmDNSController{
 		NodeIP:     cfg.NodeIP,
 		NodeName:   cfg.NodeName,
-		KubeConfig: filepath.Join(cfg.DataDir, "resources", "kubeadmin", "kubeconfig"),
+		KubeConfig: cfg.KubeConfigPath(config.KubeAdmin),
 		hostCount:  make(map[string]int),
 	}
 }

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -65,8 +65,8 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 	}
 
 	kubeletFlags := kubeletoptions.NewKubeletFlags()
-	kubeletFlags.BootstrapKubeconfig = cfg.DataDir + "/resources/kubelet/kubeconfig"
-	kubeletFlags.KubeConfig = cfg.DataDir + "/resources/kubelet/kubeconfig"
+	kubeletFlags.BootstrapKubeconfig = cfg.KubeConfigPath(config.Kubelet)
+	kubeletFlags.KubeConfig = cfg.KubeConfigPath(config.Kubelet)
 	kubeletFlags.RuntimeCgroups = "/system.slice/crio.service"
 	kubeletFlags.NodeIP = cfg.NodeIP
 	kubeletFlags.ContainerRuntime = "remote"


### PR DESCRIPTION
Provide a consistent way to calculate the path to a set of managed
kubeconfig files so we can avoid errors with path management
throughout the code.