### PR TITLE
USHIFT-401: Carried out patch to disable APIrequestcount controller

### DIFF
--- a/scripts/rebase_patches/0002-disable-APIrequestcount-controller.patch
+++ b/scripts/rebase_patches/0002-disable-APIrequestcount-controller.patch
@@ -1,0 +1,47 @@
+diff --git a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+index fb66eece..046e20bc 100644
+--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
++++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+@@ -8,7 +8,6 @@ import (
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
+ 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
+-	apiclientv1 "github.com/openshift/client-go/apiserver/clientset/versioned/typed/apiserver/v1"
+ 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+ 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
+ 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
+@@ -33,7 +32,6 @@ import (
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
+-	"k8s.io/kubernetes/openshift-kube-apiserver/filters/deprecatedapirequest"
+ 	"k8s.io/kubernetes/pkg/quota/v1/install"
+ 
+ 	// magnet to get authorizer package in hack/update-vendor.sh
+@@ -80,26 +78,6 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
+ 	)
+ 	// END ADMISSION
+ 
+-	// HANDLER CHAIN (with oauth server and web console)
+-	deprecatedAPIClient, err := apiclientv1.NewForConfig(makeJSONRESTConfig(genericConfig.LoopbackClientConfig))
+-	if err != nil {
+-		return err
+-	}
+-	deprecatedAPIRequestController := deprecatedapirequest.NewController(deprecatedAPIClient.APIRequestCounts(), nodeFor())
+-	genericConfig.AddPostStartHook("openshift.io-deprecated-api-requests-filter", func(context genericapiserver.PostStartHookContext) error {
+-		go deprecatedAPIRequestController.Start(context.StopCh)
+-		return nil
+-	})
+-	genericConfig.BuildHandlerChainFunc, err = BuildHandlerChain(
+-		enablement.OpenshiftConfig().ConsolePublicURL,
+-		enablement.OpenshiftConfig().AuthConfig.OAuthMetadataFile,
+-		deprecatedAPIRequestController,
+-	)
+-	if err != nil {
+-		return err
+-	}
+-	// END HANDLER CHAIN
+-
+ 	openshiftAPIServiceReachabilityCheck := newOpenshiftAPIServiceReachabilityCheck()
+ 	oauthAPIServiceReachabilityCheck := newOAuthPIServiceReachabilityCheck()
+ 	genericConfig.ReadyzChecks = append(genericConfig.ReadyzChecks, openshiftAPIServiceReachabilityCheck, oauthAPIServiceReachabilityCheck)

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
 	"github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
-	apiclientv1 "github.com/openshift/client-go/apiserver/clientset/versioned/typed/apiserver/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
@@ -33,7 +32,6 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
-	"k8s.io/kubernetes/openshift-kube-apiserver/filters/deprecatedapirequest"
 	"k8s.io/kubernetes/pkg/quota/v1/install"
 
 	// magnet to get authorizer package in hack/update-vendor.sh
@@ -79,26 +77,6 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
 	)
 	// END ADMISSION
-
-	// HANDLER CHAIN (with oauth server and web console)
-	deprecatedAPIClient, err := apiclientv1.NewForConfig(makeJSONRESTConfig(genericConfig.LoopbackClientConfig))
-	if err != nil {
-		return err
-	}
-	deprecatedAPIRequestController := deprecatedapirequest.NewController(deprecatedAPIClient.APIRequestCounts(), nodeFor())
-	genericConfig.AddPostStartHook("openshift.io-deprecated-api-requests-filter", func(context genericapiserver.PostStartHookContext) error {
-		go deprecatedAPIRequestController.Start(context.StopCh)
-		return nil
-	})
-	genericConfig.BuildHandlerChainFunc, err = BuildHandlerChain(
-		enablement.OpenshiftConfig().ConsolePublicURL,
-		enablement.OpenshiftConfig().AuthConfig.OAuthMetadataFile,
-		deprecatedAPIRequestController,
-	)
-	if err != nil {
-		return err
-	}
-	// END HANDLER CHAIN
 
 	openshiftAPIServiceReachabilityCheck := newOpenshiftAPIServiceReachabilityCheck()
 	oauthAPIServiceReachabilityCheck := newOAuthPIServiceReachabilityCheck()


### PR DESCRIPTION
Signed-off-by: Ricardo Noriega <rnoriega@redhat.com>

The APIrequestcount controller cannot be disabled via configuration param in the OpenShift KAS. This carried out patch disables it and avoids recurrent calls to this non-existing API.

