### PR TITLE
Set UBI version to latest UBI minor version

### DIFF
--- a/hack/all-in-one/Dockerfile
+++ b/hack/all-in-one/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile should not be run directly. Instead, run ./build-aio-dev.sh
-ARG IMAGE_NAME=registry.access.redhat.com/ubi8/ubi-init:8.4
+ARG IMAGE_NAME=registry.access.redhat.com/ubi8/ubi-init:8.6
 FROM ${IMAGE_NAME}
 ARG ARCH
 ARG HOST=rhel8

--- a/hack/all-in-one/build-aio-dev.sh
+++ b/hack/all-in-one/build-aio-dev.sh
@@ -13,7 +13,7 @@ trap cleanup EXIT
 TAG="${TAG:-quay.io/microshift/microshift-aio:dev}"
 HOST="${HOST:-rhel8}"
 FROM_SOURCE="${FROM_SOURCE:-false}"
-IMAGE_NAME="${IMAGE_NAME:-registry.access.redhat.com/ubi8/ubi-init:8.4}"
+IMAGE_NAME="${IMAGE_NAME:-registry.access.redhat.com/ubi8/ubi-init:8.6}"
 cp ../../packaging/images/microshift-aio/unit ../../packaging/images/microshift-aio/crio-bridge.conf ../../packaging/images/microshift-aio/kubelet-cgroups.conf .
 
 ARCH=$(uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")

--- a/hack/all-in-one/build-images.sh
+++ b/hack/all-in-one/build-images.sh
@@ -8,7 +8,7 @@ cp ../../packaging/images/microshift-aio/unit ../../packaging/images/microshift-
 
 ARCH=$(uname -m |sed -e "s/x86_64/amd64/" |sed -e "s/aarch64/arm64/")
 TAG="${TAG:-quay.io/microshift/microshift-aio:$(date +%Y-%m-%d-%H-%M)}"
-for img in "registry.access.redhat.com/ubi8/ubi-init:8.4" "docker.io/nvidia/cuda:11.4.2-base-ubi8"; do
+for img in "registry.access.redhat.com/ubi8/ubi-init:8.6" "docker.io/nvidia/cuda:11.4.2-base-ubi8"; do
    echo "build microshift aio image using base image ""${img}"
    tag=$(echo ${img} |awk -F"/" '{print $NF}'| sed -e 's/:/-/g')
    echo "${tag}"

--- a/packaging/images/components/components/base-image/Dockerfile
+++ b/packaging/images/components/components/base-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 ARG TARGETARCH
 
 RUN microdnf -y install --nodocs --setopt=install_weak_deps=0 \

--- a/packaging/images/microshift-aio/Dockerfile
+++ b/packaging/images/microshift-aio/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME=registry.access.redhat.com/ubi8/ubi-init:8.4
+ARG IMAGE_NAME=registry.access.redhat.com/ubi8/ubi-init:8.6
 
 FROM registry.access.redhat.com/ubi8/go-toolset as builder
 

--- a/packaging/images/microshift/Dockerfile
+++ b/packaging/images/microshift/Dockerfile
@@ -24,7 +24,7 @@ RUN wget https://go.dev/dl/go1.18.1.linux-amd64.tar.gz && \
     make clean $MAKE_TARGET SOURCE_GIT_TAG=$SOURCE_GIT_TAG BIN_TIMESTAMP=$BIN_TIMESTAMP
 
 # RUN STAGE
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
 ARG ARCH=amd64
 


### PR DESCRIPTION
This will allow to get the latest 8.y.z security fixes, and bring some consistency in our build process.

We should bump 8.6 to 8.7 when 8.7 UBIs are released

The difference between building on top of 8.4 and 8.6 are highlighted on this security scan:
https://quay.io/repository/rhn_support_ekasprzy/microshift-aio?tab=tags

I manually tested the all in on build and things are working as expected (control plane and all infra pods as part of the cluster start and run successfully) Red Hat Enterprise Linux major releases have a stable API for kernel and glibc (https://access.redhat.com/articles/rhel8-abi-compatibility) so we shouldn't expect breakage anyway.

