### PR TITLE
USHIFT-362: Fix output directories for container RPM builds

### DIFF
--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -109,7 +109,7 @@ $ sudo vgdisplay -s
   "rhel" <19.00 GiB [8.00 GiB  used / <11.00 GiB free]
 ```
 
-> Unallocated disk space of 14GB size remains in the `rhel` volume group to be used by the CSI driver.
+> Unallocated disk space of 11GB size remains in the `rhel` volume group to be used by the CSI driver.
 
 ### Offline Containers
 The `scripts/image-builder/build.sh` script supports a special mode for including user-specific RPM files into the generated ISO. The remainder of this section demonstrates how to generate container image RPMs for MicroShift and include them in the installation ISO.
@@ -143,14 +143,14 @@ Run the script in the `rpm` mode to pull the images required by MicroShift and g
 
 If the procedure runs successfully, the RPM artifacts can be found in the `paack-result` directory.
 ```bash
-$ find ~/microshift/paack-result -name microshift-containers-\*.rpm
-/home/microshift/microshift/paack-result/microshift-containers-4.10.18-1.x86_64.rpm
-/home/microshift/microshift/paack-result/microshift-containers-4.10.18-1.src.rpm
+$ find ~/microshift/_output/paack-result -name microshift-containers-\*.rpm
+/home/microshift/microshift/_output/paack-result/microshift-containers-4.10.18-1.x86_64.rpm
+/home/microshift/microshift/_output/paack-result/microshift-containers-4.10.18-1.src.rpm
 ```
 
 Finally, run the build script with the `-custom_rpms` argument to include the specified container image RPMs into the generated ISO.
 ```bash
-CONTAINERS_RPM=$(find ~/microshift/paack-result -name microshift-containers-\*.$(uname -i).rpm)
+CONTAINERS_RPM=$(find ~/microshift/_output/paack-result -name microshift-containers-\*.$(uname -i).rpm)
 ~/microshift/scripts/image-builder/build.sh -pull_secret_file ~/.pull-secret.json -custom_rpms $CONTAINERS_RPM
 ```
 > If user-specific container images need to be included into the ISO, multiple comma-separated RPM files can be specified as the `-custom_rpms` argument value.
@@ -162,7 +162,7 @@ Log into the host machine using your user credentials. The remainder of this sec
 
 Start by copying the installer image from the development virtual machine to the host file system.
 ```bash
-sudo scp microshift@microshift-dev:/home/microshift/microshift/scripts/image-builder/_builds/microshift-installer-*.$(uname -i).iso /var/lib/libvirt/images/
+sudo scp microshift@microshift-dev:/home/microshift/microshift/_output/image-builder/microshift-installer-*.$(uname -i).iso /var/lib/libvirt/images/
 ```
 
 Run the following commands to create a virtual machine using the installer image.

--- a/packaging/rpm/make-microshift-images-rpm.sh
+++ b/packaging/rpm/make-microshift-images-rpm.sh
@@ -4,7 +4,7 @@ set -e -o pipefail
 # generated from other info
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BASE_VERSION="$(${SCRIPT_DIR}/../../pkg/release/get.sh base)"
-RPMBUILD_DIR="${SCRIPT_DIR}/_rpmbuild/"
+RPMBUILD_DIR="${SCRIPT_DIR}/../../_output/image-rpmbuild/"
 RELEASE=${RELEASE:-1}
 
 build() {

--- a/packaging/rpm/paack.py
+++ b/packaging/rpm/paack.py
@@ -503,6 +503,6 @@ elif args.command == "rpm":
     _report_generated_files(files)
     print("")
     print(GREEN + "Building via mock for the target platform: %s" % args.target + CLEAR)
-    system("mock --resultdir ./paack-result -r %s %s" % (args.target, ' '.join(files)))
+    system("mock --resultdir ./_output/paack-result -r %s %s" % (args.target, ' '.join(files)))
 
-    print(GREEN + "your output files can be found in ./paack-result" + CLEAR)
+    print(GREEN + "your output files can be found in ./_output/paack-result" + CLEAR)


### PR DESCRIPTION
Closes [USHIFT-362](https://issues.redhat.com//browse/USHIFT-362)
