### PR TITLE
Switch to ovnk local gateway mode

### DIFF
--- a/assets/components/ovn/configmap.yaml
+++ b/assets/components/ovn/configmap.yaml
@@ -27,7 +27,7 @@ data:
     enable-egress-qos=false
 
     [gateway]
-    mode=shared
+    mode=local
     nodeport=true
 
     [masterha]

--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -357,6 +357,12 @@ spec:
 
           gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
 
+          gw_interface_flag=
+          # if br-ex1 is configured on the node, we want to use it for external gateway traffic
+          if [ -d /sys/class/net/br-ex1 ]; then
+            gw_interface_flag="--exgw-interface=br-ex1"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \
@@ -364,6 +370,7 @@ spec:
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${gateway_mode_flags} \
+            ${gw_interface_flag} \
             --inactivity-probe="180000" \
             --nb-address "" \
             --sb-address "" \

--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -355,7 +355,7 @@ spec:
           ip6tables -t raw -A OUTPUT -p udp --dport 6081 -j NOTRACK
           echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
 
-          gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
           exec /usr/bin/ovnkube \

--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -361,6 +361,8 @@ spec:
           # if br-ex1 is configured on the node, we want to use it for external gateway traffic
           if [ -d /sys/class/net/br-ex1 ]; then
             gw_interface_flag="--exgw-interface=br-ex1"
+            # the functionality depends on ip_forwarding being enabled
+            sysctl net.ipv4.ip_forward=1
           fi
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3451,6 +3451,12 @@ spec:
 
           gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
 
+          gw_interface_flag=
+          # if br-ex1 is configured on the node, we want to use it for external gateway traffic
+          if [ -d /sys/class/net/br-ex1 ]; then
+            gw_interface_flag="--exgw-interface=br-ex1"
+          fi
+
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
           exec /usr/bin/ovnkube \
             --init-master "${K8S_NODE}" \
@@ -3458,6 +3464,7 @@ spec:
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
             ${gateway_mode_flags} \
+            ${gw_interface_flag} \
             --inactivity-probe="180000" \
             --nb-address "" \
             --sb-address "" \
@@ -3593,7 +3600,7 @@ func assetsComponentsOvnMasterDaemonsetYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 15886, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
+	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 16164, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3068,7 +3068,7 @@ data:
     enable-egress-qos=false
 
     [gateway]
-    mode=shared
+    mode=local
     nodeport=true
 
     [masterha]
@@ -3087,7 +3087,7 @@ func assetsComponentsOvnConfigmapYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/ovn/configmap.yaml", size: 848, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
+	info := bindataFileInfo{name: "assets/components/ovn/configmap.yaml", size: 847, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3449,7 +3449,7 @@ spec:
           ip6tables -t raw -A OUTPUT -p udp --dport 6081 -j NOTRACK
           echo "I$(date "+%m%d %H:%M:%S.%N") - starting ovnkube-node"
 
-          gateway_mode_flags="--gateway-mode shared --gateway-interface br-ex"
+          gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
           exec /usr/bin/ovnkube \
@@ -3593,7 +3593,7 @@ func assetsComponentsOvnMasterDaemonsetYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 15887, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
+	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 15886, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3455,6 +3455,8 @@ spec:
           # if br-ex1 is configured on the node, we want to use it for external gateway traffic
           if [ -d /sys/class/net/br-ex1 ]; then
             gw_interface_flag="--exgw-interface=br-ex1"
+            # the functionality depends on ip_forwarding being enabled
+            sysctl net.ipv4.ip_forward=1
           fi
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
@@ -3600,7 +3602,7 @@ func assetsComponentsOvnMasterDaemonsetYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 16164, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
+	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 16276, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
ovnk local gateway mode allows pod egress traffic to use system routes, also NodePorts will work over multiple interfaces.
