### PR TITLE
USHIFT-427: Disable clusterresourcequota and user informers

### DIFF
--- a/scripts/rebase_patches/0003-disable-clusterresourcequota-user-informers.patch
+++ b/scripts/rebase_patches/0003-disable-clusterresourcequota-user-informers.patch
@@ -1,0 +1,136 @@
+commit c75ed7eaad4f9ef8a39d1ca0b028c7c9d0e25aa2
+Author: Ricardo Noriega <rnoriega@redhat.com>
+Date:   Thu Sep 15 20:01:55 2022 +0200
+
+    Disabling informers for clusterresourcequota and user
+    
+    Signed-off-by: Ricardo Noriega <rnoriega@redhat.com>
+
+diff --git a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+index 046e20bc..ce254935 100644
+--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
++++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+@@ -6,33 +6,20 @@ import (
+ 
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
+-	"github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
+ 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
+ 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+ 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
+-	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
+-	quotainformer "github.com/openshift/client-go/quota/informers/externalversions"
+-	quotav1informer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
+ 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
+ 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+-	userclient "github.com/openshift/client-go/user/clientset/versioned"
+-	userinformer "github.com/openshift/client-go/user/informers/externalversions"
+ 	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
+ 	"github.com/openshift/library-go/pkg/apiserver/apiserverconfig"
+-	"github.com/openshift/library-go/pkg/quota/clusterquotamapping"
+ 	"k8s.io/apiserver/pkg/admission"
+-	"k8s.io/apiserver/pkg/quota/v1/generic"
+ 	genericapiserver "k8s.io/apiserver/pkg/server"
+ 	clientgoinformers "k8s.io/client-go/informers"
+-	corev1informers "k8s.io/client-go/informers/core/v1"
+ 	"k8s.io/client-go/rest"
+-	"k8s.io/client-go/tools/cache"
+-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
+-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
+-	"k8s.io/kubernetes/pkg/quota/v1/install"
+ 
+ 	// magnet to get authorizer package in hack/update-vendor.sh
+ 	_ "github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
+@@ -57,21 +44,10 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
+ 	genericConfig.LongRunningFunc = apiserverconfig.IsLongRunningRequest
+ 
+ 	// ADMISSION
+-	clusterQuotaMappingController := newClusterQuotaMappingController(kubeInformers.Core().V1().Namespaces(), openshiftInformers.OpenshiftQuotaInformers.Quota().V1().ClusterResourceQuotas())
+-	genericConfig.AddPostStartHookOrDie("quota.openshift.io-clusterquotamapping", func(context genericapiserver.PostStartHookContext) error {
+-		go clusterQuotaMappingController.Run(5, context.StopCh)
+-		return nil
+-	})
+ 
+ 	*pluginInitializers = append(*pluginInitializers,
+ 		imagepolicy.NewInitializer(imagereferencemutators.KubeImageMutators{}, enablement.OpenshiftConfig().ImagePolicyConfig.InternalRegistryHostname),
+-		restrictusers.NewInitializer(openshiftInformers.getOpenshiftUserInformers()),
+ 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
+-		clusterresourcequota.NewInitializer(
+-			openshiftInformers.getOpenshiftQuotaInformers().Quota().V1().ClusterResourceQuotas(),
+-			clusterQuotaMappingController.GetClusterQuotaMapper(),
+-			generic.NewRegistry(install.NewQuotaConfigurationForAdmission().Evaluators()),
+-		),
+ 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
+ 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
+ 		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
+@@ -118,19 +94,10 @@ func nodeFor() string {
+ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, error) {
+ 	// ClusterResourceQuota is served using CRD resource any status update must use JSON
+ 	jsonLoopbackClientConfig := makeJSONRESTConfig(loopbackClientConfig)
+-
+-	quotaClient, err := quotaclient.NewForConfig(jsonLoopbackClientConfig)
+-	if err != nil {
+-		return nil, err
+-	}
+ 	securityClient, err := securityv1client.NewForConfig(jsonLoopbackClientConfig)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	userClient, err := userclient.NewForConfig(loopbackClientConfig)
+-	if err != nil {
+-		return nil, err
+-	}
+ 	configClient, err := configclient.NewForConfig(loopbackClientConfig)
+ 	if err != nil {
+ 		return nil, err
+@@ -141,47 +108,26 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 	const defaultInformerResyncPeriod = 10 * time.Minute
+ 
+ 	ret := &kubeAPIServerInformers{
+-		OpenshiftQuotaInformers:    quotainformer.NewSharedInformerFactory(quotaClient, defaultInformerResyncPeriod),
+ 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
+-		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
+ 		OpenshiftConfigInformers:   configv1informer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
+ 	}
+-	if err := ret.OpenshiftUserInformers.User().V1().Groups().Informer().AddIndexers(cache.Indexers{
+-		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
+-	}); err != nil {
+-		return nil, err
+-	}
+ 
+ 	return ret, nil
+ }
+ 
+ type kubeAPIServerInformers struct {
+-	OpenshiftQuotaInformers    quotainformer.SharedInformerFactory
+ 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
+-	OpenshiftUserInformers     userinformer.SharedInformerFactory
+ 	OpenshiftConfigInformers   configv1informer.SharedInformerFactory
+ }
+ 
+-func (i *kubeAPIServerInformers) getOpenshiftQuotaInformers() quotainformer.SharedInformerFactory {
+-	return i.OpenshiftQuotaInformers
+-}
+ func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
+ 	return i.OpenshiftSecurityInformers
+ }
+-func (i *kubeAPIServerInformers) getOpenshiftUserInformers() userinformer.SharedInformerFactory {
+-	return i.OpenshiftUserInformers
+-}
+ func (i *kubeAPIServerInformers) getOpenshiftInfraInformers() configv1informer.SharedInformerFactory {
+ 	return i.OpenshiftConfigInformers
+ }
+ 
+ func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
+-	i.OpenshiftQuotaInformers.Start(stopCh)
+ 	i.OpenshiftSecurityInformers.Start(stopCh)
+-	i.OpenshiftUserInformers.Start(stopCh)
+ 	i.OpenshiftConfigInformers.Start(stopCh)
+ }
+-
+-func newClusterQuotaMappingController(nsInternalInformer corev1informers.NamespaceInformer, clusterQuotaInformer quotav1informer.ClusterResourceQuotaInformer) *clusterquotamapping.ClusterQuotaMappingController {
+-	return clusterquotamapping.NewClusterQuotaMappingController(nsInternalInformer, clusterQuotaInformer)
+-}

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -6,33 +6,20 @@ import (
 
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
-	"github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
-	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
-	quotainformer "github.com/openshift/client-go/quota/informers/externalversions"
-	quotav1informer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
-	userclient "github.com/openshift/client-go/user/clientset/versioned"
-	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
 	"github.com/openshift/library-go/pkg/apiserver/apiserverconfig"
-	"github.com/openshift/library-go/pkg/quota/clusterquotamapping"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/apiserver/pkg/quota/v1/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	clientgoinformers "k8s.io/client-go/informers"
-	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
-	"k8s.io/kubernetes/pkg/quota/v1/install"
 
 	// magnet to get authorizer package in hack/update-vendor.sh
 	_ "github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
@@ -57,21 +44,10 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 	genericConfig.LongRunningFunc = apiserverconfig.IsLongRunningRequest
 
 	// ADMISSION
-	clusterQuotaMappingController := newClusterQuotaMappingController(kubeInformers.Core().V1().Namespaces(), openshiftInformers.OpenshiftQuotaInformers.Quota().V1().ClusterResourceQuotas())
-	genericConfig.AddPostStartHookOrDie("quota.openshift.io-clusterquotamapping", func(context genericapiserver.PostStartHookContext) error {
-		go clusterQuotaMappingController.Run(5, context.StopCh)
-		return nil
-	})
 
 	*pluginInitializers = append(*pluginInitializers,
 		imagepolicy.NewInitializer(imagereferencemutators.KubeImageMutators{}, enablement.OpenshiftConfig().ImagePolicyConfig.InternalRegistryHostname),
-		restrictusers.NewInitializer(openshiftInformers.getOpenshiftUserInformers()),
 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
-		clusterresourcequota.NewInitializer(
-			openshiftInformers.getOpenshiftQuotaInformers().Quota().V1().ClusterResourceQuotas(),
-			clusterQuotaMappingController.GetClusterQuotaMapper(),
-			generic.NewRegistry(install.NewQuotaConfigurationForAdmission().Evaluators()),
-		),
 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
 		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
@@ -118,16 +94,7 @@ func nodeFor() string {
 func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, error) {
 	// ClusterResourceQuota is served using CRD resource any status update must use JSON
 	jsonLoopbackClientConfig := makeJSONRESTConfig(loopbackClientConfig)
-
-	quotaClient, err := quotaclient.NewForConfig(jsonLoopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
 	securityClient, err := securityv1client.NewForConfig(jsonLoopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
-	userClient, err := userclient.NewForConfig(loopbackClientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -141,47 +108,26 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 	const defaultInformerResyncPeriod = 10 * time.Minute
 
 	ret := &kubeAPIServerInformers{
-		OpenshiftQuotaInformers:    quotainformer.NewSharedInformerFactory(quotaClient, defaultInformerResyncPeriod),
 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
-		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
 		OpenshiftConfigInformers:   configv1informer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
-	}
-	if err := ret.OpenshiftUserInformers.User().V1().Groups().Informer().AddIndexers(cache.Indexers{
-		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
-	}); err != nil {
-		return nil, err
 	}
 
 	return ret, nil
 }
 
 type kubeAPIServerInformers struct {
-	OpenshiftQuotaInformers    quotainformer.SharedInformerFactory
 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
-	OpenshiftUserInformers     userinformer.SharedInformerFactory
 	OpenshiftConfigInformers   configv1informer.SharedInformerFactory
 }
 
-func (i *kubeAPIServerInformers) getOpenshiftQuotaInformers() quotainformer.SharedInformerFactory {
-	return i.OpenshiftQuotaInformers
-}
 func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
 	return i.OpenshiftSecurityInformers
-}
-func (i *kubeAPIServerInformers) getOpenshiftUserInformers() userinformer.SharedInformerFactory {
-	return i.OpenshiftUserInformers
 }
 func (i *kubeAPIServerInformers) getOpenshiftInfraInformers() configv1informer.SharedInformerFactory {
 	return i.OpenshiftConfigInformers
 }
 
 func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
-	i.OpenshiftQuotaInformers.Start(stopCh)
 	i.OpenshiftSecurityInformers.Start(stopCh)
-	i.OpenshiftUserInformers.Start(stopCh)
 	i.OpenshiftConfigInformers.Start(stopCh)
-}
-
-func newClusterQuotaMappingController(nsInternalInformer corev1informers.NamespaceInformer, clusterQuotaInformer quotav1informer.ClusterResourceQuotaInformer) *clusterquotamapping.ClusterQuotaMappingController {
-	return clusterquotamapping.NewClusterQuotaMappingController(nsInternalInformer, clusterQuotaInformer)
 }


### PR DESCRIPTION
These two APIs are not available in MicroShift, so informers are useless here.
