### PR TITLE
AUTH-296: Certificate-related fixes

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -172,6 +172,17 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 			"service-ca",
 			cryptomaterial.ServiceCADir(certsDir),
 			cryptomaterial.ServiceCAValidityDays,
+		).WithServingCertificates(
+			&cryptomaterial.ServingCertificateSigningRequestInfo{
+				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
+					Name:         "openshift-controller-manager-serving",
+					ValidityDays: cryptomaterial.ServiceCAServingCertValidityDays,
+				},
+				Hostnames: []string{
+					"controller-manager.openshift-controller-manager.svc",
+					"controller-manager.openshift-controller-manager.svc.cluster.local",
+				},
+			},
 		),
 	).WithCABundle(
 		cryptomaterial.TotalClientCABundlePath(certsDir),
@@ -227,14 +238,6 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	if err := util.GenCerts("kubelet", filepath.Join(cfg.DataDir, "/resources/kubelet/secrets/kubelet-server"),
 		"tls.crt", "tls.key",
 		[]string{"localhost", cfg.NodeIP, "127.0.0.1", cfg.NodeName}); err != nil {
-		return nil, nil, err
-	}
-
-	// ocp
-	if err := util.GenCerts("openshift-controller-manager", filepath.Join(cfg.DataDir, "/resources/openshift-controller-manager/secrets"),
-		"tls.crt", "tls.key",
-		[]string{"openshift-controller-manager", cfg.NodeName, cfg.NodeIP, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default",
-			"kubernetes", "localhost"}); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -89,7 +89,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		cryptomaterial.NewCertificateSigner(
 			"kube-control-plane-signer",
 			cryptomaterial.KubeControlPlaneSignerCertDir(certsDir),
-			cryptomaterial.ClientCAValidityDays,
+			cryptomaterial.KubeControlPlaneSignerCAValidityDays,
 		).WithClientCertificates(
 			&cryptomaterial.ClientCertificateSigningRequestInfo{
 				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
@@ -110,7 +110,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		cryptomaterial.NewCertificateSigner(
 			"kube-apiserver-to-kubelet-signer",
 			cryptomaterial.KubeAPIServerToKubeletSignerCertDir(certsDir),
-			cryptomaterial.ClientCAValidityDays,
+			cryptomaterial.KubeAPIServerToKubeletCAValidityDays,
 		).WithClientCertificates(
 			&cryptomaterial.ClientCertificateSigningRequestInfo{
 				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
@@ -124,7 +124,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		cryptomaterial.NewCertificateSigner(
 			"admin-kubeconfig-signer",
 			cryptomaterial.AdminKubeconfigSignerDir(certsDir),
-			cryptomaterial.ClientCAValidityDays,
+			cryptomaterial.AdminKubeconfigCAValidityDays,
 		).WithClientCertificates(
 			&cryptomaterial.ClientCertificateSigningRequestInfo{
 				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
@@ -138,7 +138,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		cryptomaterial.NewCertificateSigner(
 			"kubelet-signer",
 			cryptomaterial.KubeletCSRSignerSignerCertDir(certsDir),
-			cryptomaterial.ClientCAValidityDays,
+			cryptomaterial.KubeControllerManagerCSRSignerSignerCAValidityDays,
 		).WithClientCertificates(
 			&cryptomaterial.ClientCertificateSigningRequestInfo{
 				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
@@ -149,12 +149,12 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 				UserInfo: &user.DefaultInfo{Name: "system:node:" + cfg.NodeName, Groups: []string{"system:nodes"}},
 			},
 		).WithSubCAs(
-			cryptomaterial.NewCertificateSigner("kube-csr-signer", cryptomaterial.CSRSignerCertDir(certsDir), cryptomaterial.ClientCAValidityDays),
+			cryptomaterial.NewCertificateSigner("kube-csr-signer", cryptomaterial.CSRSignerCertDir(certsDir), cryptomaterial.KubeControllerManagerCSRSignerCAValidityDays),
 		),
 		cryptomaterial.NewCertificateSigner(
 			"aggregator-signer",
 			cryptomaterial.AggregatorSignerDir(certsDir),
-			cryptomaterial.ClientCAValidityDays,
+			cryptomaterial.AggregatorFrontProxySignerCAValidityDays,
 		).WithClientCertificates(
 			&cryptomaterial.ClientCertificateSigningRequestInfo{
 				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{

--- a/pkg/controllers/openshift-controller-manager.go
+++ b/pkg/controllers/openshift-controller-manager.go
@@ -67,6 +67,8 @@ func (s *OCPControllerManager) configure(cfg *config.MicroshiftConfig) {
 }
 
 func (s *OCPControllerManager) writeConfig(cfg *config.MicroshiftConfig) error {
+	servingCertDir := cryptomaterial.OpenshiftControllerManagerServingCertDir(cryptomaterial.CertsDirectory(cfg.DataDir))
+
 	// OCM config contains a list of controllers to enable/disable.
 	// If no list is specified, all controllers are started (default).
 	// If a non-zero length list is specified, only controllers enabled in the list are started.  Unlisted controllers
@@ -81,8 +83,8 @@ kubeClientConfig:
     contentType: "application/json"
 servingInfo:
   bindAddress: "0.0.0.0:8445"
-  certFile: ` + cfg.DataDir + `/resources/openshift-controller-manager/secrets/tls.crt
-  keyFile:  ` + cfg.DataDir + `/resources/openshift-controller-manager/secrets/tls.key
+  certFile: ` + cryptomaterial.ServingCertPath(servingCertDir) + `
+  keyFile:  ` + cryptomaterial.ServingKeyPath(servingCertDir) + `
   clientCA: ` + cryptomaterial.TotalClientCABundlePath(cryptomaterial.CertsDirectory(cfg.DataDir)) + `
 controllers:
 - "openshift.io/ingress-ip"

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -14,11 +14,18 @@ const (
 	ClientCertFileName = "client.crt"
 	ClientKeyFileName  = "client.key"
 
-	ClientCAValidityDays                  = 60
-	ClientCertValidityDays                = 30
-	AdminKubeconfigClientCertValidityDays = 365 * 10
+	AdminKubeconfigCAValidityDays                      = 365 * 10
+	AdminKubeconfigClientCertValidityDays              = 365 * 10
+	AggregatorFrontProxySignerCAValidityDays           = 30
+	KubeAPIServerToKubeletCAValidityDays               = 365
+	KubeControlPlaneSignerCAValidityDays               = 365
+	KubeControllerManagerCSRSignerSignerCAValidityDays = 60
+	KubeControllerManagerCSRSignerCAValidityDays       = 30
 
-	ServiceCAValidityDays = 790
+	ClientCertValidityDays = 30
+
+	ServiceCAValidityDays            = 790
+	ServiceCAServingCertValidityDays = 730
 )
 
 func CertsDirectory(dataPath string) string { return filepath.Join(dataPath, "certs") }

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -7,6 +7,7 @@ import (
 const (
 	CACertFileName     = "ca.crt"
 	CAKeyFileName      = "ca.key"
+	CABundleFileName   = "ca-bundle.crt"
 	CASerialsFileName  = "serial.txt"
 	ServerCertFileName = "server.crt"
 	ServerKeyFileName  = "server.key"
@@ -25,6 +26,8 @@ func CertsDirectory(dataPath string) string { return filepath.Join(dataPath, "ce
 func CACertPath(dir string) string    { return filepath.Join(dir, CACertFileName) }
 func CAKeyPath(dir string) string     { return filepath.Join(dir, CAKeyFileName) }
 func CASerialsPath(dir string) string { return filepath.Join(dir, CASerialsFileName) }
+
+func CABundlePath(dir string) string { return filepath.Join(dir, CABundleFileName) }
 
 func ClientCertPath(dir string) string { return filepath.Join(dir, ClientCertFileName) }
 func ClientKeyPath(dir string) string  { return filepath.Join(dir, ClientKeyFileName) }
@@ -76,6 +79,10 @@ func KubeletClientCertDir(certsDir string) string {
 
 func ServiceCADir(certsDir string) string {
 	return filepath.Join(certsDir, "service-ca")
+}
+
+func OpenshiftControllerManagerServingCertDir(certsDir string) string {
+	return filepath.Join(ServiceCADir(certsDir), "openshift-controller-manager-serving")
 }
 
 func AggregatorSignerDir(certsDir string) string {


### PR DESCRIPTION
This PR introduces a couple of smaller fixes to the current code related to certificates.

Namely:
- actually use the serving CA to generate serving cert for the OCM
- don't generate new sub-CA certificates for the CSR signer with every restart
- fix the CA validity days to match OCP

/cc @oglok @ibihim 