### PR TITLE
AUTH-296: work out etcd certificates

### DIFF
--- a/pkg/controllers/etcd.go
+++ b/pkg/controllers/etcd.go
@@ -82,14 +82,10 @@ func (s *EtcdService) configure(cfg *config.MicroshiftConfig) {
 	s.etcdCfg.ClientTLSInfo.CertFile = cryptomaterial.PeerCertPath(etcdServingCertDir)
 	s.etcdCfg.ClientTLSInfo.KeyFile = cryptomaterial.PeerKeyPath(etcdServingCertDir)
 	s.etcdCfg.ClientTLSInfo.TrustedCAFile = etcdSignerCertPath
-	s.etcdCfg.ClientTLSInfo.ClientCertAuth = false
-	s.etcdCfg.ClientTLSInfo.InsecureSkipVerify = true //TODO after fix GenCert to generate client cert
 
 	s.etcdCfg.PeerTLSInfo.CertFile = cryptomaterial.PeerCertPath(etcdPeerCertDir)
 	s.etcdCfg.PeerTLSInfo.KeyFile = cryptomaterial.PeerKeyPath(etcdPeerCertDir)
 	s.etcdCfg.PeerTLSInfo.TrustedCAFile = etcdSignerCertPath
-	s.etcdCfg.PeerTLSInfo.ClientCertAuth = false
-	s.etcdCfg.PeerTLSInfo.InsecureSkipVerify = true //TODO after fix GenCert to generate client cert
 }
 
 func (s *EtcdService) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -91,10 +91,10 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
 	kubeCSRSignerDir := cryptomaterial.CSRSignerCertDir(certsDir)
 	kubeletClientDir := cryptomaterial.KubeAPIServerToKubeletClientCertDir(certsDir)
-	ultimateTrustCACertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	clientCABundlePath := cryptomaterial.TotalClientCABundlePath(certsDir)
 	aggregatorCAPath := cryptomaterial.CACertPath(cryptomaterial.AggregatorSignerDir(certsDir))
 	aggregatorClientCertDir := cryptomaterial.AggregatorClientCertDir(certsDir)
+	etcdClientCertDir := cryptomaterial.EtcdAPIServerClientCertDir(certsDir)
 	kasSecretsDir := filepath.Join(certsDir, "kube-apiserver", "secrets")
 	servingCertsDir := filepath.Join(kasSecretsDir, "service-network-serving-certkey")
 
@@ -117,9 +117,9 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"audit-log-path":    {cfg.AuditLogDir},
 			"audit-policy-file": {cfg.DataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
 			"client-ca-file":    {clientCABundlePath},
-			"etcd-cafile":       {ultimateTrustCACertFile},
-			"etcd-certfile":     {cfg.DataDir + "/resources/kube-apiserver/secrets/etcd-client/tls.crt"},
-			"etcd-keyfile":      {cfg.DataDir + "/resources/kube-apiserver/secrets/etcd-client/tls.key"},
+			"etcd-cafile":       {cryptomaterial.CACertPath(cryptomaterial.EtcdSignerDir(certsDir))},
+			"etcd-certfile":     {cryptomaterial.ClientCertPath(etcdClientCertDir)},
+			"etcd-keyfile":      {cryptomaterial.ClientKeyPath(etcdClientCertDir)},
 			"etcd-servers": {
 				"https://127.0.0.1:2379",
 			},

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -13,6 +13,8 @@ const (
 	ServerKeyFileName  = "server.key"
 	ClientCertFileName = "client.crt"
 	ClientKeyFileName  = "client.key"
+	PeerCertFileName   = "peer.crt"
+	PeerKeyFileName    = "peer.key"
 
 	AdminKubeconfigCAValidityDays                      = 365 * 10
 	AdminKubeconfigClientCertValidityDays              = 365 * 10
@@ -21,6 +23,7 @@ const (
 	KubeControlPlaneSignerCAValidityDays               = 365
 	KubeControllerManagerCSRSignerSignerCAValidityDays = 60
 	KubeControllerManagerCSRSignerCAValidityDays       = 30
+	EtcdSignerCAValidityDays                           = 365 * 10
 
 	ClientCertValidityDays  = 30
 	ServingCertValidityDays = 30
@@ -42,6 +45,9 @@ func ClientKeyPath(dir string) string  { return filepath.Join(dir, ClientKeyFile
 
 func ServingCertPath(dir string) string { return filepath.Join(dir, ServerCertFileName) }
 func ServingKeyPath(dir string) string  { return filepath.Join(dir, ServerKeyFileName) }
+
+func PeerCertPath(dir string) string { return filepath.Join(dir, PeerCertFileName) }
+func PeerKeyPath(dir string) string  { return filepath.Join(dir, PeerKeyFileName) }
 
 func KubeControlPlaneSignerCertDir(certsDir string) string {
 	return filepath.Join(certsDir, "kube-control-plane-signer")
@@ -103,6 +109,22 @@ func AggregatorSignerDir(certsDir string) string {
 
 func AggregatorClientCertDir(certsDir string) string {
 	return filepath.Join(AggregatorSignerDir(certsDir), "aggregator-client")
+}
+
+func EtcdSignerDir(certsDir string) string {
+	return filepath.Join(certsDir, "etcd-signer")
+}
+
+func EtcdPeerCertDir(certsDir string) string {
+	return filepath.Join(EtcdSignerDir(certsDir), "etcd-peer")
+}
+
+func EtcdAPIServerClientCertDir(certsDir string) string {
+	return filepath.Join(EtcdSignerDir(certsDir), "apiserver-etcd-client")
+}
+
+func EtcdServingCertDir(certsDir string) string {
+	return filepath.Join(EtcdSignerDir(certsDir), "etcd-serving")
 }
 
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers


### PR DESCRIPTION
I was not yet able to learn what's important for etcd serving/peer certs so I'm going with minimal config where client certificates only follow the kube CN and O schemes, and serving certificates get their hostnames in DNS/IPs SANs.

The PR is rebased on top of https://github.com/openshift/microshift/pull/970 and can only merge once this one merges.

It's very likely that we may not see any failures in etcd because no peer communication is likely to happen with just one etcd instance. I'll need to test the cert setup with at least 2 etcds or ask someone with the necessary knowledge about how the peer certs should look like.