### PR TITLE
ETCD-319: adding transient systemd unit for etcd

### DIFF
--- a/etcd/cmd/microshift-etcd/run.go
+++ b/etcd/cmd/microshift-etcd/run.go
@@ -97,6 +97,7 @@ func (s *EtcdService) Run() error {
 	}
 	<-e.Server.ReadyNotify()
 
+	// Wait to be stopped.
 	sigTerm := make(chan os.Signal, 1)
 	signal.Notify(sigTerm, os.Interrupt, syscall.SIGTERM)
 	sig := <-sigTerm

--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -18,6 +18,9 @@ sudo bash -c "
     systemctl disable microshift 2>/dev/null
     pkill -9 microshift
 
+    systemctl stop --now microshift-etcd 2>/dev/null
+    systemctl reset-failed microshift-etcd 2>/dev/null
+
     echo Removing crio container and image storage
     crio wipe -f &>/dev/null || true
     systemctl restart crio


### PR DESCRIPTION
This is the first step to get etcd running un-bundled from MicroShift; this change makes etcd run in a transient systemd unit whose lifetime is bound to the MicroShift execution. Also, as a temporary measure, I added a subcommand to MicroShift that just runs the bundled etcd; this is so we can test etcd's execution with the systemd unit and this will be removed and replaced by an invocation of the etcd binary that will be laid down by an rpm.

The end goal, as described in this [Microshift Enhancement](https://github.com/openshift/enhancements/pull/1242) is to remove the current embedded etcd service and replace it with a service that launches etcd in a transient systemd unit.