### PR TITLE
AUTH-296: generate kubelet certs properly

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -153,6 +153,14 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 					// userinfo per https://kubernetes.io/docs/reference/access-authn-authz/node/#overview
 					UserInfo: &user.DefaultInfo{Name: "system:node:" + cfg.NodeName, Groups: []string{"system:nodes"}},
 				},
+			).WithServingCertificates(
+				&cryptomaterial.ServingCertificateSigningRequestInfo{
+					CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
+						Name:         "kubelet-server",
+						ValidityDays: cryptomaterial.ServingCertValidityDays,
+					},
+					Hostnames: []string{cfg.NodeName, cfg.NodeIP},
+				},
 			),
 		),
 		cryptomaterial.NewCertificateSigner(
@@ -236,12 +244,6 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	}
 	if err := util.GenKeys(filepath.Join(cfg.DataDir, "/resources/kube-apiserver/secrets/service-account-key"),
 		"service-account.crt", "service-account.key"); err != nil {
-		return nil, nil, err
-	}
-
-	if err := util.GenCerts("kubelet", filepath.Join(cfg.DataDir, "/resources/kubelet/secrets/kubelet-server"),
-		"tls.crt", "tls.key",
-		[]string{"localhost", cfg.NodeIP, "127.0.0.1", cfg.NodeName}); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -97,7 +97,7 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
 	if _, err := os.Stat(filepath.Join(cfg.DataDir, "certs")); errors.Is(err, os.ErrNotExist) {
-		initAll(cfg)
+		util.Must(initAll(cfg))
 	} else {
 		err = loadCA(cfg)
 		if err != nil {

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -89,6 +89,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	s.verbosity = cfg.LogVLevel
 
 	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	kubeCSRSignerDir := cryptomaterial.CSRSignerCertDir(certsDir)
 	kubeletClientDir := cryptomaterial.KubeAPIServerToKubeletClientCertDir(certsDir)
 	ultimateTrustCACertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	clientCABundlePath := cryptomaterial.TotalClientCABundlePath(certsDir)
@@ -122,7 +123,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"etcd-servers": {
 				"https://127.0.0.1:2379",
 			},
-			"kubelet-certificate-authority": {ultimateTrustCACertFile},
+			"kubelet-certificate-authority": {cryptomaterial.CABundlePath(kubeCSRSignerDir)},
 			"kubelet-client-certificate":    {cryptomaterial.ClientCertPath(kubeletClientDir)},
 			"kubelet-client-key":            {cryptomaterial.ClientKeyPath(kubeletClientDir)},
 

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -92,6 +92,9 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 }
 
 func (s *KubeletServer) writeConfig(cfg *config.MicroshiftConfig) error {
+	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	servingCertDir := cryptomaterial.KubeletServingCertDir(certsDir)
+
 	data := []byte(`
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -100,8 +103,8 @@ authentication:
     clientCAFile: ` + cryptomaterial.KubeletClientCAPath(cryptomaterial.CertsDirectory(cfg.DataDir)) + `
   anonymous:
     enabled: false
-tlsCertFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-server/tls.crt
-tlsPrivateKeyFile: ` + cfg.DataDir + `/resources/kubelet/secrets/kubelet-server/tls.key
+tlsCertFile: ` + cryptomaterial.ServingCertPath(servingCertDir) + `
+tlsPrivateKeyFile: ` + cryptomaterial.ServingKeyPath(servingCertDir) + `
 cgroupDriver: "systemd"
 failSwapOn: false
 volumePluginDir: ` + cfg.DataDir + `/kubelet-plugins/volume/exec

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -81,7 +81,7 @@ func CSRSignerCertDir(certsDir string) string {
 }
 
 func KubeletClientCertDir(certsDir string) string {
-	return filepath.Join(KubeletCSRSignerSignerCertDir(certsDir), "kubelet-client")
+	return filepath.Join(CSRSignerCertDir(certsDir), "kubelet-client")
 }
 
 func ServiceCADir(certsDir string) string {

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -22,7 +22,8 @@ const (
 	KubeControllerManagerCSRSignerSignerCAValidityDays = 60
 	KubeControllerManagerCSRSignerCAValidityDays       = 30
 
-	ClientCertValidityDays = 30
+	ClientCertValidityDays  = 30
+	ServingCertValidityDays = 30
 
 	ServiceCAValidityDays            = 790
 	ServiceCAServingCertValidityDays = 730
@@ -82,6 +83,10 @@ func CSRSignerCertDir(certsDir string) string {
 
 func KubeletClientCertDir(certsDir string) string {
 	return filepath.Join(CSRSignerCertDir(certsDir), "kubelet-client")
+}
+
+func KubeletServingCertDir(certsDir string) string {
+	return filepath.Join(CSRSignerCertDir(certsDir), "kubelet-server")
 }
 
 func ServiceCADir(certsDir string) string {


### PR DESCRIPTION
This PR fixed cert generation for kubelet client cert to use the CSR signer instead of the root CA and uses this same signer to generate the serving cert for it.

/assign @oglok 