### PR TITLE
Fix wait-for-pods command in performance test scripts 

### DIFF
--- a/ansible/roles/common/tasks/readinesscheck.yml
+++ b/ansible/roles/common/tasks/readinesscheck.yml
@@ -2,9 +2,8 @@
 # Wait for pods to be running
 
 - name: wait for pods running
-  ansible.builtin.shell: oc get po -A --no-headers | grep Running | wc -l
+  ansible.builtin.shell: oc get pods -A -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}' | grep -c False
   retries: 60
   delay: 5
   register: result
-  until: result.stdout == "8"
-
+  until: result.stdout == "0"


### PR DESCRIPTION
Fix wait-for-pods command in performance test scripts not to depend on the number of pods
Closes [USHIFT-294](https://issues.redhat.com//browse/USHIFT-294)
