### PR TITLE
Change cadvisor port to not conflict with image-builder

### DIFF
--- a/ansible/roles/install-logging/templates/prometheus.yml.j2
+++ b/ansible/roles/install-logging/templates/prometheus.yml.j2
@@ -43,7 +43,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
-        - {{ hostvars[host].private_ip }}:8080
+        - {{ hostvars[host].private_ip }}:8081
 {% endfor %}
 
   - job_name: crio

--- a/ansible/roles/setup-microshift-host/templates/cadvisor.service.j2
+++ b/ansible/roles/setup-microshift-host/templates/cadvisor.service.j2
@@ -2,7 +2,7 @@
 Description=cAdvisor
 
 [Service]
-ExecStart=/usr/bin/cadvisor
+ExecStart=/usr/bin/cadvisor -port=8081
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
If cadvisor (default port 8080) is running on the microshift devenv node then the ostree server port is in use, and the image-builder is unable to run successfully due to port conflict.
Lets keep the image-builder defaults as they are and change the default cadvisor port in our configs instead.