### PR TITLE
API-1437: Enable kube-apiserver option send-retry-after-while-not-ready-once

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -150,7 +150,8 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 				"quota.openshift.io/ClusterResourceQuota",
 				"quota.openshift.io/ValidateClusterResourceQuota",
 			},
-			"enable-admission-plugins": {},
+			"enable-admission-plugins":              {},
+			"send-retry-after-while-not-ready-once": {"true"},
 		},
 		GenericAPIServerConfig: configv1.GenericAPIServerConfig{
 			// from cluster-kube-apiserver-operator


### PR DESCRIPTION
Rebase of https://github.com/openshift/microshift/pull/924.