### PR TITLE
USHIFT-457: use cli.Run for executing boilerplate and initializing logs

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -1,33 +1,21 @@
 package main
 
 import (
-	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/component-base/logs"
+	"k8s.io/component-base/cli"
 
 	cmds "github.com/openshift/microshift/pkg/cmd"
 	"github.com/openshift/microshift/pkg/config"
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	config.InitGlobalFlags()
-
-	logs.InitLogs()
-	defer logs.FlushLogs()
-
 	command := newCommand()
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
+	code := cli.Run(command)
+	os.Exit(code)
 }
 
 func newCommand() *cobra.Command {
@@ -39,6 +27,11 @@ func newCommand() *cobra.Command {
 			os.Exit(1)
 		},
 	}
+	originalHelpFunc := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		config.HideUnsupportedFlags(command.Flags())
+		originalHelpFunc(command, strings)
+	})
 
 	ioStreams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -247,8 +247,26 @@ func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 }
 
 // tests that the global flags have been initialized
-func TestGlobalInitFlags(t *testing.T) {
-	InitGlobalFlags()
-	// pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
-	pflag.Parse()
+func TestHideUnsupportedFlags(t *testing.T) {
+	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+
+	flags.String("url", "", "version usage")
+	flags.String("v", "10", "v usage")
+	flags.String("log_dir", "/tmp", "log_dir usage")
+	flags.String("version", "", "version usage")
+
+	HideUnsupportedFlags(flags)
+
+	if flags.Lookup("url").Hidden {
+		t.Errorf("v should not be hidden")
+	}
+	if flags.Lookup("v").Hidden {
+		t.Errorf("v should not be hidden")
+	}
+	if !flags.Lookup("version").Hidden {
+		t.Errorf("version should be hidden")
+	}
+	if !flags.Lookup("log_dir").Hidden {
+		t.Errorf("log_dir should be hidden")
+	}
 }

--- a/vendor/k8s.io/component-base/cli/OWNERS
+++ b/vendor/k8s.io/component-base/cli/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned cli to sig-cli since:
+# (a) its literally named "cli"
+# (b) flags are the bread-and-butter of cli tools.
+
+approvers:
+  - sig-cli-maintainers
+reviewers:
+  - sig-cli-reviewers
+labels:
+  - sig/cli

--- a/vendor/k8s.io/component-base/cli/run.go
+++ b/vendor/k8s.io/component-base/cli/run.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+)
+
+// Run provides the common boilerplate code around executing a cobra command.
+// For example, it ensures that logging is set up properly. Logging
+// flags get added to the command line if not added already. Flags get normalized
+// so that help texts show them with hyphens. Underscores are accepted
+// as alternative for the command parameters.
+//
+// Run tries to be smart about how to print errors that are returned by the
+// command: before logging is known to be set up, it prints them as plain text
+// to stderr. This covers command line flag parse errors and unknown commands.
+// Afterwards it logs them. This covers runtime errors.
+//
+// Commands like kubectl where logging is not normally part of the runtime output
+// should use RunNoErrOutput instead and deal with the returned error themselves.
+func Run(cmd *cobra.Command) int {
+	if logsInitialized, err := run(cmd); err != nil {
+		// If the error is about flag parsing, then printing that error
+		// with the decoration that klog would add ("E0923
+		// 23:02:03.219216 4168816 run.go:61] unknown shorthand flag")
+		// is less readable. Using klog.Fatal is even worse because it
+		// dumps a stack trace that isn't about the error.
+		//
+		// But if it is some other error encountered at runtime, then
+		// we want to log it as error, at least in most commands because
+		// their output is a log event stream.
+		//
+		// We can distinguish these two cases depending on whether
+		// we got to logs.InitLogs() above.
+		//
+		// This heuristic might be problematic for command line
+		// tools like kubectl where the output is carefully controlled
+		// and not a log by default. They should use RunNoErrOutput
+		// instead.
+		//
+		// The usage of klog is problematic also because we don't know
+		// whether the command has managed to configure it. This cannot
+		// be checked right now, but may become possible when the early
+		// logging proposal from
+		// https://github.com/kubernetes/enhancements/pull/3078
+		// ("contextual logging") is implemented.
+		if !logsInitialized {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		} else {
+			klog.ErrorS(err, "command failed")
+		}
+		return 1
+	}
+	return 0
+}
+
+// RunNoErrOutput is a version of Run which returns the cobra command error
+// instead of printing it.
+func RunNoErrOutput(cmd *cobra.Command) error {
+	_, err := run(cmd)
+	return err
+}
+
+func run(cmd *cobra.Command) (logsInitialized bool, err error) {
+	rand.Seed(time.Now().UnixNano())
+	defer logs.FlushLogs()
+
+	cmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
+
+	// When error printing is enabled for the Cobra command, a flag parse
+	// error gets printed first, then optionally the often long usage
+	// text. This is very unreadable in a console because the last few
+	// lines that will be visible on screen don't include the error.
+	//
+	// The recommendation from #sig-cli was to print the usage text, then
+	// the error. We implement this consistently for all commands here.
+	// However, we don't want to print the usage text when command
+	// execution fails for other reasons than parsing. We detect this via
+	// the FlagParseError callback.
+	//
+	// Some commands, like kubectl, already deal with this themselves.
+	// We don't change the behavior for those.
+	if !cmd.SilenceUsage {
+		cmd.SilenceUsage = true
+		cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+			// Re-enable usage printing.
+			c.SilenceUsage = false
+			return err
+		})
+	}
+
+	// In all cases error printing is done below.
+	cmd.SilenceErrors = true
+
+	// This is idempotent.
+	logs.AddFlags(cmd.PersistentFlags())
+
+	// Inject logs.InitLogs after command line parsing into one of the
+	// PersistentPre* functions.
+	switch {
+	case cmd.PersistentPreRun != nil:
+		pre := cmd.PersistentPreRun
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			logs.InitLogs()
+			logsInitialized = true
+			pre(cmd, args)
+		}
+	case cmd.PersistentPreRunE != nil:
+		pre := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			logs.InitLogs()
+			logsInitialized = true
+			return pre(cmd, args)
+		}
+	default:
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			logs.InitLogs()
+			logsInitialized = true
+		}
+	}
+
+	err = cmd.Execute()
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2280,6 +2280,7 @@ k8s.io/cluster-bootstrap/util/secrets
 k8s.io/cluster-bootstrap/util/tokens
 # k8s.io/component-base v0.25.0 => github.com/openshift/kubernetes/staging/src/k8s.io/component-base v0.0.0-20220920132840-8c7c96729e60
 ## explicit; go 1.16
+k8s.io/component-base/cli
 k8s.io/component-base/cli/flag
 k8s.io/component-base/cli/globalflag
 k8s.io/component-base/codec


### PR DESCRIPTION
- fixes -v flag
- hide unsupported flags in help

this is reaction to https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components. Similar change discussed in https://coreos.slack.com/archives/CB48XQ4KZ/p1662394269749719?thread_ts=1661425151.276079&cid=CB48XQ4KZ 
