### PR TITLE
scripts/image-builder/configure.sh: Add rpm-build to package list

### DIFF
--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -3,7 +3,7 @@ set -exo pipefail
 
 sudo dnf install -y git osbuild-composer composer-cli \
     cockpit-composer bash-completion podman genisoimage \
-    createrepo syslinux yum-utils selinux-policy-devel jq wget lorax
+    createrepo syslinux yum-utils selinux-policy-devel jq wget lorax rpm-build
 sudo systemctl enable osbuild-composer.socket --now
 sudo systemctl enable cockpit.socket --now
 sudo firewall-cmd -q --add-service=cockpit


### PR DESCRIPTION
rpm-build package provides the `rpmbuild` command and without it creating the local rpm fails which kind of break the flow for `docs/rhel4edge_iso.md` document.
