### PR TITLE
packaging/systemd/configure-ovs.sh: Add tun device support

### DIFF
--- a/packaging/systemd/configure-ovs.sh
+++ b/packaging/systemd/configure-ovs.sh
@@ -196,6 +196,10 @@ convert_to_bridge() {
         clone_mac=0
       fi
     fi
+  elif [ $(nmcli --get-values connection.type conn show ${old_conn}) == "tun" ]; then
+    iface_type=tun
+    tun_mode=$(nmcli --get-values tun.mode -e no connection show ${old_conn})
+    extra_phys_args+=( tun.mode "${tun_mode}" )
   else
     iface_type=802-3-ethernet
   fi


### PR DESCRIPTION
In case VM is using tap/tun device for network connectivity, which is common for user mode networking then `configure-ovs` script fails because it doesn't have tun device support. This patch add supports for these type of device and able to create the bridge network.

Before running configure-ovs script
```
$ nmcli device status
DEVICE  TYPE      STATE      CONNECTION
tap0    tun       connected  tap0
lo      loopback  unmanaged  --
```

After running configure-ovs script
```
$ nmcli connection show
NAME            UUID                                  TYPE           DEVICE
ovs-if-br-ex    2a27fd37-e2b9-45c6-a552-3c5693a85ec0  ovs-interface  br-ex
br-ex           c454eb58-627a-49cb-9cad-d470f5c87b97  ovs-bridge     br-ex
ovs-if-phys0    9e3618f8-b7ac-45cc-bd90-717f03b64cfd  tun            tap0
ovs-port-br-ex  4afcb8f2-d5e4-456d-98d0-de252a13bca8  ovs-port       br-ex
ovs-port-phys0  ad9705cd-5a3d-4370-96ea-1852039601cc  ovs-port       tap0

$ ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: tap0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 4000 qdisc fq_codel master ovs-system state UNKNOWN group default qlen 1000
    link/ether 5a:94:ef:e4:0c:ee brd ff:ff:ff:ff:ff:ff
3: ovs-system: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether b6:dd:cc:00:c2:4e brd ff:ff:ff:ff:ff:ff
4: br-ex: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 4000 qdisc noqueue state UNKNOWN group default qlen 1000
    link/ether 5a:94:ef:e4:0c:ee brd ff:ff:ff:ff:ff:ff
    inet 192.168.127.2/24 brd 192.168.127.255 scope global noprefixroute br-ex
       valid_lft forever preferred_lft forever
    inet6 fe80::38f1:51da:39d:ff69/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
```

Fixes: [USHIFT-435](https://issues.redhat.com//browse/USHIFT-435)

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
