### PR TITLE
USHIFT-247: Add images command

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -38,5 +38,6 @@ func newCommand() *cobra.Command {
 	cmd.AddCommand(cmds.NewRunMicroshiftCommand())
 	cmd.AddCommand(cmds.NewVersionCommand(ioStreams))
 	cmd.AddCommand(cmds.NewShowConfigCommand(ioStreams))
+	cmd.AddCommand(cmds.NewImagesCommand(ioStreams))
 	return cmd
 }

--- a/pkg/cmd/images.go
+++ b/pkg/cmd/images.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift/microshift/pkg/release"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type imagesOptions struct {
+	Output string
+}
+
+func NewImagesCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	opts := imagesOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Print container images used by this MicroShift version",
+		Run: func(cmd *cobra.Command, args []string) {
+			var marshalled []byte
+			var err error
+
+			switch opts.Output {
+			case "":
+				separator := ""
+				for _, v := range release.Image {
+					fmt.Fprintf(ioStreams.Out, "%s%s", separator, v)
+					separator = " "
+				}
+			case "json":
+				marshalled, err = json.MarshalIndent(&release.Image, "", "  ")
+				if err != nil {
+					cmdutil.CheckErr(err)
+				}
+				fmt.Fprintf(ioStreams.Out, "%s\n", string(marshalled))
+			case "yaml":
+				marshalled, err = yaml.Marshal(&release.Image)
+				if err != nil {
+					cmdutil.CheckErr(err)
+				}
+				fmt.Fprintf(ioStreams.Out, "%s", string(marshalled))
+			case "toml":
+				for _, v := range release.Image {
+					fmt.Fprintf(ioStreams.Out, "[[containers]]\nsource = \"%v\"\n\n", v)
+				}
+			default:
+				cmdutil.CheckErr(fmt.Errorf("Unknown output format %q", opts.Output))
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.Output, "output", "o", opts.Output, "One of 'json', 'yaml' or 'toml'.")
+	return cmd
+}


### PR DESCRIPTION
Adds a "microshift images" command that prints the embedded image references. By default, prints them space-separated (e.g. for use in "podman pull"). The output format can be changed to json, yaml, or toml. The latter format can be used in ImageBuilder blueprints.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>

Closes [USHIFT-247](https://issues.redhat.com//browse/USHIFT-247)
