### PR TITLE
USHIFT-500: Remove ConfigFile, DataDir and Manifests fields off MicroShift config

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -5,7 +5,7 @@ MicroShift can be configured in the following ways, in order of precedence:
 * Environment variables
 * Configuration file
 
-The MicroShift configuration file may be located at `~/.microshift/config.yaml` (user-specific) and `/etc/microshift/config.yaml` (system-wide), while the former takes precedence if it exists. Use the `--config` command line argument or `MICROSHIFT_CONFIGFILE` environment variable to specify a custom location of the configuration file.
+The MicroShift configuration file must be located at `~/.microshift/config.yaml` (user-specific) and `/etc/microshift/config.yaml` (system-wide), while the former takes precedence if it exists.
 
 The format of the `config.yaml` configuration file is as follows.
 
@@ -20,9 +20,7 @@ cluster:
   mtu: ""
 nodeIP: ""
 nodeName: ""
-dataDir: ""
 logVLevel: ""
-manifests: []
 ```
 
 The configuration settings alongside with the supported command line arguments and environment variables are presented below.
@@ -38,9 +36,7 @@ The configuration settings alongside with the supported command line arguments a
 | mtu                 | --cluster-mtu             | MICROSHIFT_CLUSTER_MTU                  | The maximum transmission unit for the Generic Network Virtualization Encapsulation overlay network
 | nodeIP              | --node-ip                 | MICROSHIFT_NODEIP                       | The IP address of the node, defaults to IP of the default route
 | nodeName            | --node-name               | MICROSHIFT_NODENAME                     | The name of the node, defaults to hostname
-| dataDir             | --data-dir                | MICROSHIFT_DATADIR                      | Location for data created by MicroShift
 | logVLevel           | --v                       | MICROSHIFT_LOGVLEVEL                    | Log verbosity (0-5)
-| manifests           | n/a                       | n/a                                     | Locations to scan for manifests to be loaded on startup
 
 ## Default Settings
 
@@ -57,11 +53,7 @@ cluster:
   mtu: "1400"
 nodeIP: ""
 nodeName: ""
-dataDir: /var/lib/microshift
 logVLevel: 0
-manifests:
-  - /usr/lib/microshift/manifests
-  - /etc/microshift/manifests
 ```
 
 # Auto-applying Manifests
@@ -74,8 +66,6 @@ The reason for providing multiple directories is to allow a flexible method to m
 |-------------------------------|--------|
 | /etc/microshift/manifests     | Read-write location for configuration management systems or development
 | /usr/lib/microshift/manifests | Read-only location for embedding configuration manifests on ostree based systems
-
-The list of manifest locations can be customized via configuration using the above-mentioned `manifests` section of the `config.yaml` file or via the `MICROSHIFT_MANIFESTS` environment variable as comma separated directories.
 
 ## Manifest Example
 

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -27,6 +27,8 @@ import (
 	"github.com/openshift/microshift/pkg/util/cryptomaterial"
 )
 
+var microshiftDataDir = config.GetDataDir()
+
 func initAll(cfg *config.MicroshiftConfig) error {
 	// create CA and keys
 	clusterTrustBundlePEM, certChains, err := initCerts(cfg)
@@ -42,7 +44,7 @@ func initAll(cfg *config.MicroshiftConfig) error {
 }
 
 func loadCA(cfg *config.MicroshiftConfig) error {
-	return util.LoadRootCA(filepath.Join(cfg.DataDir, "/certs/ca-bundle"), "ca-bundle.crt", "ca-bundle.key")
+	return util.LoadRootCA(filepath.Join(microshiftDataDir, "/certs/ca-bundle"), "ca-bundle.crt", "ca-bundle.key")
 }
 
 func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.CertificateChains, error) {
@@ -56,7 +58,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 		return nil, nil, err
 	}
 
-	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	certsDir := cryptomaterial.CertsDirectory(microshiftDataDir)
 	// store root CA for all
 	//TODO generate ca bundles for each component
 	clusterTrustBundlePEM, _, err := util.StoreRootCA("https://kubernetes.svc", filepath.Join(certsDir, "/ca-bundle"),
@@ -251,14 +253,14 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	}
 
 	// kube-apiserver
-	if err := util.GenCerts("kube-apiserver", filepath.Join(cfg.DataDir, "/certs/kube-apiserver/secrets/service-network-serving-certkey"),
+	if err := util.GenCerts("kube-apiserver", filepath.Join(microshiftDataDir, "/certs/kube-apiserver/secrets/service-network-serving-certkey"),
 		"tls.crt", "tls.key",
 		[]string{"kube-apiserver", cfg.NodeIP, cfg.NodeName, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes",
 			"localhost",
 			apiServerServiceIP.String()}); err != nil {
 		return nil, nil, err
 	}
-	if err := util.GenKeys(filepath.Join(cfg.DataDir, "/resources/kube-apiserver/secrets/service-account-key"),
+	if err := util.GenKeys(filepath.Join(microshiftDataDir, "/resources/kube-apiserver/secrets/service-account-key"),
 		"service-account.crt", "service-account.key"); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -30,14 +30,11 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 
 			switch opts.Mode {
 			case "default":
-				// Override a few settings to always use the global locations
-				cfg.DataDir = config.DefaultGlobalDataDir
-				cfg.Manifests = cfg.Manifests[:len(cfg.Manifests)-1]
 				cfg.NodeIP = ""
 				cfg.NodeName = ""
 			case "effective":
 				// Load the current configuration
-				if err := cfg.ReadAndValidate(cmd.Flags()); err != nil {
+				if err := cfg.ReadAndValidate("", cmd.Flags()); err != nil {
 					cmdutil.CheckErr(err)
 				}
 			default:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -5,6 +5,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var microshiftDataDir = config.GetDataDir()
+
 func StartComponents(cfg *config.MicroshiftConfig) error {
 	kubeAdminConfig := cfg.KubeConfigPath(config.KubeAdmin)
 

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -39,7 +39,7 @@ func startServiceCAController(cfg *config.MicroshiftConfig, kubeconfigPath strin
 		cmName     = "signing-cabundle"
 	)
 
-	serviceCADir := cryptomaterial.ServiceCADir(cryptomaterial.CertsDirectory(cfg.DataDir))
+	serviceCADir := cryptomaterial.ServiceCADir(cryptomaterial.CertsDirectory(microshiftDataDir))
 	caCertPath := cryptomaterial.CACertPath(serviceCADir)
 	caKeyPath := cryptomaterial.CAKeyPath(serviceCADir)
 

--- a/pkg/components/networking.go
+++ b/pkg/components/networking.go
@@ -64,7 +64,7 @@ func startOVNKubernetes(cfg *config.MicroshiftConfig, kubeconfigPath string) err
 	}
 	extraParams := assets.RenderParams{
 		"KubeconfigPath": kubeconfigPath,
-		"KubeconfigDir":  filepath.Join(cfg.DataDir, "/resources/kubeadmin"),
+		"KubeconfigDir":  filepath.Join(microshiftDataDir, "/resources/kubeadmin"),
 	}
 	if err := assets.ApplyConfigMaps(cm, renderTemplate, renderParamsFromConfig(cfg, extraParams), kubeconfigPath); err != nil {
 		klog.Warningf("Failed to apply configMap %v %v", cm, err)

--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -66,7 +66,7 @@ func startCSIPlugin(cfg *config.MicroshiftConfig, kubeconfigPath string) error {
 
 	// the lvmd file should be located in the same directory as the microshift config to minimize coupling with the
 	// csi plugin.
-	lvmdCfg, err := lvmd.NewLvmdConfigFromFileOrDefault(filepath.Join(filepath.Dir(cfg.ConfigFile), "lvmd.yaml"))
+	lvmdCfg, err := lvmd.NewLvmdConfigFromFileOrDefault(filepath.Join(filepath.Dir(microshiftDataDir), "lvmd.yaml"))
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/etcd.go
+++ b/pkg/controllers/etcd.go
@@ -36,6 +36,7 @@ var (
 		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
 	}
+	microshiftDataDir = config.GetDataDir()
 )
 
 const (
@@ -56,12 +57,12 @@ func (s *EtcdService) Name() string           { return "etcd" }
 func (s *EtcdService) Dependencies() []string { return []string{} }
 
 func (s *EtcdService) configure(cfg *config.MicroshiftConfig) {
-	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	certsDir := cryptomaterial.CertsDirectory(microshiftDataDir)
 
 	etcdServingCertDir := cryptomaterial.EtcdServingCertDir(certsDir)
 	etcdPeerCertDir := cryptomaterial.EtcdPeerCertDir(certsDir)
 	etcdSignerCertPath := cryptomaterial.CACertPath(cryptomaterial.EtcdSignerDir(certsDir))
-	dataDir := filepath.Join(cfg.DataDir, s.Name())
+	dataDir := filepath.Join(microshiftDataDir, s.Name())
 
 	// based on https://github.com/openshift/cluster-etcd-operator/blob/master/bindata/bootkube/bootstrap-manifests/etcd-member-pod.yaml#L19
 	s.etcdCfg = etcd.NewConfig()

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -88,7 +88,7 @@ func (s *KubeAPIServer) Dependencies() []string { return []string{"etcd"} }
 func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	s.verbosity = cfg.LogVLevel
 
-	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	certsDir := cryptomaterial.CertsDirectory(microshiftDataDir)
 	kubeCSRSignerDir := cryptomaterial.CSRSignerCertDir(certsDir)
 	kubeletClientDir := cryptomaterial.KubeAPIServerToKubeletClientCertDir(certsDir)
 	clientCABundlePath := cryptomaterial.TotalClientCABundlePath(certsDir)
@@ -114,7 +114,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	overrides := &kubecontrolplanev1.KubeAPIServerConfig{
 		APIServerArguments: map[string]kubecontrolplanev1.Arguments{
 			"advertise-address": {cfg.NodeIP},
-			"audit-policy-file": {cfg.DataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
+			"audit-policy-file": {microshiftDataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
 			"client-ca-file":    {clientCABundlePath},
 			"etcd-cafile":       {cryptomaterial.CACertPath(cryptomaterial.EtcdSignerDir(certsDir))},
 			"etcd-certfile":     {cryptomaterial.ClientCertPath(etcdClientCertDir)},
@@ -129,7 +129,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"proxy-client-cert-file":           {cryptomaterial.ClientCertPath(aggregatorClientCertDir)},
 			"proxy-client-key-file":            {cryptomaterial.ClientKeyPath(aggregatorClientCertDir)},
 			"requestheader-client-ca-file":     {aggregatorCAPath},
-			"service-account-signing-key-file": {cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key"},
+			"service-account-signing-key-file": {microshiftDataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key"},
 			"service-node-port-range":          {cfg.Cluster.ServiceNodePortRange},
 			"tls-cert-file":                    {filepath.Join(servingCertsDir, "tls.crt")},
 			"tls-private-key-file":             {filepath.Join(servingCertsDir, "tls.key")},
@@ -168,7 +168,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			},
 		},
 		ServiceAccountPublicKeyFiles: []string{
-			cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.crt",
+			microshiftDataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.crt",
 		},
 		ServicesSubnet:        cfg.Cluster.ServiceCIDR,
 		ServicesNodePortRange: cfg.Cluster.ServiceNodePortRange,
@@ -246,7 +246,7 @@ rules:
   omitStages:
   - "RequestReceived"`)
 
-	path := filepath.Join(cfg.DataDir, "resources", "kube-apiserver-audit-policies", "default.yaml")
+	path := filepath.Join(microshiftDataDir, "resources", "kube-apiserver-audit-policies", "default.yaml")
 	os.MkdirAll(filepath.Dir(path), os.FileMode(0700))
 	return os.WriteFile(path, data, 0644)
 }

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -50,7 +50,7 @@ func (s *KubeControllerManager) Name() string           { return "kube-controlle
 func (s *KubeControllerManager) Dependencies() []string { return []string{"kube-apiserver"} }
 
 func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
-	certsDir := cryptomaterial.CertsDirectory(cfg.DataDir)
+	certsDir := cryptomaterial.CertsDirectory(microshiftDataDir)
 	caCertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	csrSignerDir := cryptomaterial.CSRSignerCertDir(certsDir)
 	kubeconfig := cfg.KubeConfigPath(config.KubeControllerManager)
@@ -66,7 +66,7 @@ func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 
 	args := []string{
 		"--kubeconfig=" + kubeconfig,
-		"--service-account-private-key-file=" + cfg.DataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
+		"--service-account-private-key-file=" + microshiftDataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.key",
 		"--allocate-node-cidrs=true",
 		"--cluster-cidr=" + cfg.Cluster.ClusterCIDR,
 		"--authorization-kubeconfig=" + kubeconfig,

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -55,7 +55,7 @@ func (s *KubeScheduler) configure(cfg *config.MicroshiftConfig) {
 	}
 
 	s.options = schedulerOptions.NewOptions()
-	s.options.ConfigFile = cfg.DataDir + "/resources/kube-scheduler/config/config.yaml"
+	s.options.ConfigFile = microshiftDataDir + "/resources/kube-scheduler/config/config.yaml"
 	s.kubeconfig = cfg.KubeConfigPath(config.KubeAdmin)
 }
 
@@ -67,7 +67,7 @@ clientConnection:
 leaderElection:
   leaderElect: false`)
 
-	path := filepath.Join(cfg.DataDir, "resources", "kube-scheduler", "config", "config.yaml")
+	path := filepath.Join(microshiftDataDir, "resources", "kube-scheduler", "config", "config.yaml")
 	os.MkdirAll(filepath.Dir(path), os.FileMode(0700))
 	return ioutil.WriteFile(path, data, 0644)
 }

--- a/pkg/controllers/openshift-route-controller-manager.go
+++ b/pkg/controllers/openshift-route-controller-manager.go
@@ -60,7 +60,7 @@ func (s *OCPRouteControllerManager) configure(cfg *config.MicroshiftConfig) {
 }
 
 func (s *OCPRouteControllerManager) writeConfig(cfg *config.MicroshiftConfig) *openshiftcontrolplanev1.OpenShiftControllerManagerConfig {
-	servingCertDir := cryptomaterial.RouteControllerManagerServingCertDir(cryptomaterial.CertsDirectory(cfg.DataDir))
+	servingCertDir := cryptomaterial.RouteControllerManagerServingCertDir(cryptomaterial.CertsDirectory(microshiftDataDir))
 
 	c := &openshiftcontrolplanev1.OpenShiftControllerManagerConfig{
 		KubeClientConfig: configv1.KubeClientConfig{
@@ -77,7 +77,7 @@ func (s *OCPRouteControllerManager) writeConfig(cfg *config.MicroshiftConfig) *o
 					CertFile: cryptomaterial.ServingCertPath(servingCertDir),
 					KeyFile:  cryptomaterial.ServingKeyPath(servingCertDir),
 				},
-				ClientCA: cryptomaterial.TotalClientCABundlePath(cryptomaterial.CertsDirectory(cfg.DataDir)),
+				ClientCA: cryptomaterial.TotalClientCABundlePath(cryptomaterial.CertsDirectory(microshiftDataDir)),
 			},
 		},
 		Controllers: []string{

--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -23,6 +23,8 @@ const (
 	retryTimeout  = 1 * time.Minute
 )
 
+var microshiftManifestsDir = config.GetManifestsDir()
+
 type Kustomizer struct {
 	paths      []string
 	kubeconfig string
@@ -30,7 +32,7 @@ type Kustomizer struct {
 
 func NewKustomizer(cfg *config.MicroshiftConfig) *Kustomizer {
 	return &Kustomizer{
-		paths:      cfg.Manifests,
+		paths:      microshiftManifestsDir,
 		kubeconfig: cfg.KubeConfigPath(config.KubeAdmin),
 	}
 }

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,5 +1,4 @@
---- 
-dataDir: /tmp/microshift/data
+---
 logVLevel: 4
 roles:
   - role1
@@ -14,5 +13,3 @@ cluster:
   domain: cluster.local
   serviceNodePortRange: 30000-32767
   mtu: "1400"
-manifests:
-  - /etc/my-app/manifests


### PR DESCRIPTION
The three fields ConfigFile, DataDir and Manifests don't need to be user-configurable. Those values should be set to be default values at all time. As a result, those fields can be removed off microshift config to avoid supporting these user-facing configuration in the future.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
