### PR TITLE
USHIFT-421: Update manifests to more closely align with OCP

### DIFF
--- a/assets/components/openshift-dns/dns/configmap.yaml
+++ b/assets/components/openshift-dns/dns/configmap.yaml
@@ -4,6 +4,9 @@ data:
     .:5353 {
         bufsize 512
         errors
+        log . {
+            class error
+        }
         health {
             lameduck 20s
         }
@@ -20,6 +23,9 @@ data:
             denial 9984 30
         }
         reload
+    }
+    hostname.bind:5353 {
+        chaos
     }
 kind: ConfigMap
 metadata:

--- a/assets/components/openshift-dns/dns/daemonset.yaml
+++ b/assets/components/openshift-dns/dns/daemonset.yaml
@@ -87,7 +87,8 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        - operator: Exists
+        - key: node-role.kubernetes.io/master
+          operator: Exists
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -102,3 +103,5 @@ spec:
 metadata:
   name: dns-default
   namespace: openshift-dns
+  labels:
+    dns.operator.openshift.io/owning-dns: default

--- a/assets/components/openshift-router/deployment.yaml
+++ b/assets/components/openshift-router/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - name: ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK
               value: "false"
             - name: ROUTER_LOAD_BALANCE_ALGORITHM
-              value: leastconn
+              value: random
             - name: ROUTER_METRICS_TYPE
               value: haproxy
             - name: ROUTER_SERVICE_NAME
@@ -55,6 +55,8 @@ spec:
               value: source
             - name: ROUTER_THREADS
               value: "4"
+            - name: ROUTER_USE_PROXY_PROTOCOL
+              value: "true"
             - name: SSL_MIN_VERSION
               value: TLSv1.2
           livenessProbe:

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -452,6 +452,7 @@ update_manifests() {
     # 2) Render operand manifest templates like the operator would
     #    Render the DNS DaemonSet
     yq -i '.metadata += {"name": "dns-default", "namespace": "openshift-dns"}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
+    yq -i '.metadata += {"labels": {"dns.operator.openshift.io/owning-dns": "default"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.selector = {"matchLabels": {"dns.operator.openshift.io/daemonset-dns": "default"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.metadata += {"labels": {"dns.operator.openshift.io/daemonset-dns": "default"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.containers[0].image = "REPLACE_COREDNS_IMAGE"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
@@ -459,7 +460,7 @@ update_manifests() {
     yq -i '.spec.template.spec.nodeSelector = {"kubernetes.io/os": "linux"}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.volumes[0].configMap.name = "dns-default"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.volumes[1] += {"secret": {"defaultMode": 420, "secretName": "dns-default-metrics-tls"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
-    yq -i '.spec.template.spec.tolerations = [{"operator": "Exists"}]' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
+    yq -i '.spec.template.spec.tolerations = [{"key": "node-role.kubernetes.io/master", "operator": "Exists"}]' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     #    Render the node-resolver script into the DaemonSet template
     export NODE_RESOLVER_SCRIPT="$(sed 's|^.|          &|' "${REPOROOT}"/assets/components/openshift-dns/node-resolver/update-node-resolver.sh)"
@@ -508,7 +509,7 @@ update_manifests() {
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CIPHERSUITES", "value": "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DISABLE_HTTP2", "value": "true"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", "value": "false"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_LOAD_BALANCE_ALGORITHM", "value": "leastconn"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_LOAD_BALANCE_ALGORITHM", "value": "random"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     # TODO: Generate and volume mount the metrics-certs secret
     # yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_METRICS_TLS_CERT_FILE", "value": "/etc/pki/tls/metrics-certs/tls.crt"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     # yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_METRICS_TLS_KEY_FILE", "value": "/etc/pki/tls/metrics-certs/tls.key"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
@@ -517,6 +518,7 @@ update_manifests() {
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_SET_FORWARDED_HEADERS", "value": "append"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_TCP_BALANCE_SCHEME", "value": "source"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_THREADS", "value": "4"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_USE_PROXY_PROTOCOL", "value": "true"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "SSL_MIN_VERSION", "value": "TLSv1.2"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     # TODO: Generate and volume mount the router-stats-default secret
     # yq -i '.spec.template.spec.containers[0].env += {"name": "STATS_PASSWORD_FILE", "value": "/var/lib/haproxy/conf/metrics-auth/statsPassword"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml


### PR DESCRIPTION
Small updates to the rebase script and the produced assets to more closely match OCP's deployments.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>

Closes [USHIFT-421](https://issues.redhat.com//browse/USHIFT-421)
