### PR TITLE
USHIFT-607: Introduce a new config format for microshift config

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -10,48 +10,53 @@ The MicroShift configuration file must be located at `~/.microshift/config.yaml`
 The format of the `config.yaml` configuration file is as follows.
 
 ```yaml
-cluster:
-  clusterCIDR: ""
-  serviceCIDR: ""
-  serviceNodePortRange: ""
-  domain: ""
-  url: ""
-nodeIP: ""
-nodeName: ""
 subjectAltNames:
   - ""
-logVLevel: ""
+nodeName: ""
+nodeIP: ""
+url: ""
+clusterDomain: ""
+network:
+  clusterNetwork:
+    - cidr: ""
+  serviceNetwork:
+    - ""
+  serviceNodePortRange: ""
+debugging:
+  logLevel: ""
 ```
 
 The configuration settings alongside with the supported command line arguments and environment variables are presented below.
 
-| Field Name          | CLI Argument              | Environment Variable                    | Description |
-|---------------------|---------------------------|-----------------------------------------|-------------|
-| clusterCIDR         | --cluster-cidr            | MICROSHIFT_CLUSTER_CLUSTERCIDR          | A block of IP addresses from which Pod IP addresses are allocated
-| serviceCIDR         | --service-cidr            | MICROSHIFT_CLUSTER_SERVICECIDR          | A block of virtual IP addresses for Kubernetes services
-| serviceNodePortRange| --service-node-port-range | MICROSHIFT_CLUSTER_SERVICENODEPORTRANGE | The port range allowed for Kubernetes services of type NodePort (WARNING: see the dedicated section)
-| domain              | --cluster-domain          | MICROSHIFT_CLUSTER_DOMAIN               | Base DNS domain used to construct fully qualified pod and service domain names
-| url                 | --url                     | MICROSHIFT_CLUSTER_URL                  | URL of the API server for the cluster.
-| nodeIP              | --node-ip                 | MICROSHIFT_NODEIP                       | The IP address of the node, defaults to IP of the default route
-| nodeName            | --node-name               | MICROSHIFT_NODENAME                     | The name of the node, defaults to hostname
+| Field Name            | CLI Argument              | Environment Variable                    | Description |
+|-----------------------|---------------------------|-----------------------------------------|-------------|
+| cidr (clusterNetwork) | --cluster-cidr            | MICROSHIFT_CLUSTER_CLUSTERCIDR          | A block of IP addresses from which Pod IP addresses are allocated
+| serviceNetwork        | --service-cidr            | MICROSHIFT_CLUSTER_SERVICECIDR          | A block of virtual IP addresses for Kubernetes services
+| serviceNodePortRange  | --service-node-port-range | MICROSHIFT_CLUSTER_SERVICENODEPORTRANGE | The port range allowed for Kubernetes services of type NodePort
+| clusterDomain         | --cluster-domain          | MICROSHIFT_CLUSTER_DOMAIN               | Base DNS domain used to construct fully qualified pod and service domain names
+| url                   | --url                     | MICROSHIFT_CLUSTER_URL                  | URL of the API server for the cluster.
+| nodeIP                | --node-ip                 | MICROSHIFT_NODEIP                       | The IP address of the node, defaults to IP of the default route
+| nodeName              | --node-name               | MICROSHIFT_NODENAME                     | The name of the node, defaults to hostname
+| logLevel              | --v                       | MICROSHIFT_LOGVLEVEL                    | Log verbosity (Normal, Debug, Trace, TraceAll)
 | subjectAltNames     | --subject-alt-names       | MICROSHIFT_SUBJECTALTNAMES              | Subject Alternative Names for apiserver certificates
-| logVLevel           | --v                       | MICROSHIFT_LOGVLEVEL                    | Log verbosity (0-5)
 
 ## Default Settings
 
 In case `config.yaml` is not provided, the following default settings will be used.
 
 ```yaml
-cluster:
-  clusterCIDR: 10.42.0.0/16
-  serviceCIDR: 10.43.0.0/16
-  serviceNodePortRange: 30000-32767
-  domain: cluster.local
-  url: https://127.0.0.1:6443
-nodeIP: ""
 nodeName: ""
-subjectAltNames: nil
-logVLevel: 0
+nodeIP: ""
+url: https://127.0.0.1:6443
+clusterDomain: cluster.local
+network:
+  clusterNetwork:
+    - cidr: 10.42.0.0/16
+  serviceNetwork:
+    - 10.43.0.0/16
+  serviceNodePortRange: 30000-32767
+debugging:
+  logLevel: "Normal"
 ```
 
 ## Service NodePort range

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,6 +70,48 @@ type MicroshiftConfig struct {
 	Ingress IngressConfig `json:"-"`
 }
 
+// Top level config
+type Config struct {
+	NodeName        string    `json:"nodeName"`
+	NodeIP          string    `json:"nodeIP"`
+	URL             string    `json:"url"`
+	ClusterDomain   string    `json:"clusterDomain"`
+	Network         Network   `json:"network"`
+	Debugging       Debugging `json:"debugging"`
+	SubjectAltNames []string  `json:"subjectAltNames"`
+}
+
+type Network struct {
+	// IP address pool to use for pod IPs.
+	// This field is immutable after installation.
+	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
+
+	// IP address pool for services.
+	// Currently, we only support a single entry here.
+	// This field is immutable after installation.
+	ServiceNetwork []string `json:"serviceNetwork,omitempty"`
+
+	// The port range allowed for Services of type NodePort.
+	// If not specified, the default of 30000-32767 will be used.
+	// Such Services without a NodePort specified will have one
+	// automatically allocated from this range.
+	// This parameter can be updated after the cluster is
+	// installed.
+	// +kubebuilder:validation:Pattern=`^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$`
+	ServiceNodePortRange string `json:"serviceNodePortRange,omitempty"`
+}
+
+type ClusterNetworkEntry struct {
+	// The complete block for pod IPs.
+	CIDR string `json:"cidr,omitempty"`
+}
+
+type Debugging struct {
+	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+	// Defaults to "Normal".
+	LogLevel string `json:"logLevel"`
+}
+
 func GetConfigFile() string {
 	return configFile
 }
@@ -219,9 +261,36 @@ func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	if err != nil {
 		return fmt.Errorf("reading config file %q: %v", configFile, err)
 	}
+	var config Config
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		return fmt.Errorf("decoding config file %s: %v", configFile, err)
+	}
 
-	if err := yaml.Unmarshal(contents, c); err != nil {
-		return fmt.Errorf("decoding config file %q: %v", configFile, err)
+	// Wire new Config type to existing MicroshiftConfig
+	c.LogVLevel = config.GetVerbosity()
+	if config.NodeName != "" {
+		c.NodeName = config.NodeName
+	}
+	if config.NodeIP != "" {
+		c.NodeIP = config.NodeIP
+	}
+	if config.URL != "" {
+		c.Cluster.URL = config.URL
+	}
+	if len(config.Network.ClusterNetwork) != 0 {
+		c.Cluster.ClusterCIDR = config.Network.ClusterNetwork[0].CIDR
+	}
+	if len(config.Network.ServiceNetwork) != 0 {
+		c.Cluster.ServiceCIDR = config.Network.ServiceNetwork[0]
+	}
+	if config.Network.ServiceNodePortRange != "" {
+		c.Cluster.ServiceNodePortRange = config.Network.ServiceNodePortRange
+	}
+	if config.ClusterDomain != "" {
+		c.Cluster.Domain = config.ClusterDomain
+	}
+	if len(config.SubjectAltNames) > 0 {
+		c.SubjectAltNames = config.SubjectAltNames
 	}
 
 	return nil
@@ -382,4 +451,22 @@ func HideUnsupportedFlags(flags *pflag.FlagSet) {
 	})
 
 	flags.MarkHidden("version")
+}
+
+// GetVerbosity returns the numerical value for LogLevel which is an enum
+func (c *Config) GetVerbosity() int {
+	var verbosity int
+	switch c.Debugging.LogLevel {
+	case "Normal":
+		verbosity = 2
+	case "Debug":
+		verbosity = 4
+	case "Trace":
+		verbosity = 6
+	case "TraceAll":
+		verbosity = 8
+	default:
+		verbosity = 2
+	}
+	return verbosity
 }

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,12 +1,15 @@
 ---
-logVLevel: 4
 subjectAltNames:
   - '1.2.3.40'
 nodeName: node1
 nodeIP: '1.2.3.4'
-cluster:
-  url: https://127.0.0.1:6443
-  clusterCIDR: '10.20.30.40/16'
-  serviceCIDR: '40.30.20.10/16'
-  domain: cluster.local
+url: https://127.0.0.1:6443
+clusterDomain: 'cluster.local'
+network:
+  clusterNetwork:
+    - cidr: '10.20.30.40/16'
+  serviceNetwork:
+    - '40.30.20.10/16'
   serviceNodePortRange: 30000-32767
+debugging:
+  logLevel: 'Debug'


### PR DESCRIPTION
Separate component-specific config and microshift-specific config into 2 sections within top-level config. The components config is modelled after OpenShift config v1 API while microshift config contains fields that are specific to microshift usage.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
