### PR TITLE
AUTH-296: Finish the removal of the root CA

### DIFF
--- a/assets/components/openshift-router/service-internal.yaml
+++ b/assets/components/openshift-router/service-internal.yaml
@@ -25,4 +25,4 @@ metadata:
   name: router-internal-default
   namespace: openshift-ingress
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: router-certs-default
+    service.alpha.openshift.io/serving-cert-secret-name: router-metrics-certs-default

--- a/assets/components/openshift-router/serving-certificate.yaml
+++ b/assets/components/openshift-router/serving-certificate.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-ingress
+  name: router-certs-default

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -16,7 +16,9 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -31,43 +33,30 @@ var microshiftDataDir = config.GetDataDir()
 
 func initAll(cfg *config.MicroshiftConfig) error {
 	// create CA and keys
-	clusterTrustBundlePEM, certChains, err := initCerts(cfg)
+	certChains, err := initCerts(cfg)
 	if err != nil {
 		return err
 	}
 	// create kubeconfig for kube-scheduler, kubelet,controller-manager
-	if err := initKubeconfig(cfg, clusterTrustBundlePEM, certChains); err != nil {
+	if err := initKubeconfig(cfg, certChains); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func loadCA(cfg *config.MicroshiftConfig) error {
-	return util.LoadRootCA(filepath.Join(microshiftDataDir, "/certs/ca-bundle"), "ca-bundle.crt", "ca-bundle.key")
-}
-
-func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.CertificateChains, error) {
+func initCerts(cfg *config.MicroshiftConfig) (*cryptomaterial.CertificateChains, error) {
 	_, svcNet, err := net.ParseCIDR(cfg.Cluster.ServiceCIDR)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	_, apiServerServiceIP, err := ctrl.ServiceIPRange(*svcNet)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	certsDir := cryptomaterial.CertsDirectory(microshiftDataDir)
-	// store root CA for all
-	//TODO generate ca bundles for each component
-	clusterTrustBundlePEM, _, err := util.StoreRootCA("https://kubernetes.svc", filepath.Join(certsDir, "/ca-bundle"),
-		"ca-bundle.crt", "ca-bundle.key",
-		[]string{"https://kubernetes.svc"})
-
-	if err != nil {
-		return nil, nil, err
-	}
 
 	certChains, err := cryptomaterial.NewCertificateChains(
 		// ------------------------------
@@ -316,40 +305,43 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	).Complete()
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	csrSignerCAPEM, err := certChains.GetSigner("kubelet-signer", "kube-csr-signer").GetSignerCertPEM()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if err := cryptomaterial.AddToKubeletClientCABundle(certsDir, csrSignerCAPEM); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if err := cryptomaterial.AddToTotalClientCABundle(certsDir, csrSignerCAPEM); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if err := util.GenKeys(filepath.Join(microshiftDataDir, "/resources/kube-apiserver/secrets/service-account-key"),
 		"service-account.crt", "service-account.key"); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	cfg.Ingress.ServingCertificate, cfg.Ingress.ServingKey, err = certChains.GetCertKey("ingress-ca", "router-default-serving")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return clusterTrustBundlePEM, certChains, nil
+	return certChains, nil
 }
 
 func initKubeconfig(
 	cfg *config.MicroshiftConfig,
-	clusterTrustBundlePEM []byte,
 	certChains *cryptomaterial.CertificateChains,
 ) error {
+	inClusterTrustBundlePEM, err := os.ReadFile(cryptomaterial.ServiceAccountTokenCABundlePath(cryptomaterial.CertsDirectory(microshiftDataDir)))
+	if err != nil {
+		return fmt.Errorf("failed to load the in-cluster trust bundle: %v", err)
+	}
 
 	adminKubeconfigCertPEM, adminKubeconfigKeyPEM, err := certChains.GetCertKey("admin-kubeconfig-signer", "admin-kubeconfig-client")
 	if err != nil {
@@ -358,7 +350,7 @@ func initKubeconfig(
 	if err := util.KubeConfigWithClientCerts(
 		cfg.KubeConfigPath(config.KubeAdmin),
 		cfg.Cluster.URL,
-		clusterTrustBundlePEM,
+		inClusterTrustBundlePEM,
 		adminKubeconfigCertPEM,
 		adminKubeconfigKeyPEM,
 	); err != nil {
@@ -372,7 +364,7 @@ func initKubeconfig(
 	if err := util.KubeConfigWithClientCerts(
 		cfg.KubeConfigPath(config.KubeControllerManager),
 		cfg.Cluster.URL,
-		clusterTrustBundlePEM,
+		inClusterTrustBundlePEM,
 		kcmCertPEM,
 		kcmKeyPEM,
 	); err != nil {
@@ -386,7 +378,7 @@ func initKubeconfig(
 	if err := util.KubeConfigWithClientCerts(
 		cfg.KubeConfigPath(config.KubeScheduler),
 		cfg.Cluster.URL,
-		clusterTrustBundlePEM,
+		inClusterTrustBundlePEM,
 		schedulerCertPEM, schedulerKeyPEM,
 	); err != nil {
 		return err
@@ -399,7 +391,7 @@ func initKubeconfig(
 	if err := util.KubeConfigWithClientCerts(
 		cfg.KubeConfigPath(config.Kubelet),
 		cfg.Cluster.URL,
-		clusterTrustBundlePEM,
+		inClusterTrustBundlePEM,
 		kubeletCertPEM, kubeletKeyPEM,
 	); err != nil {
 		return err

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -86,17 +84,8 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	os.MkdirAll(microshiftDataDir, 0700)
 
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
-	if _, err := os.Stat(filepath.Join(microshiftDataDir, "certs")); errors.Is(err, os.ErrNotExist) {
-		util.Must(initAll(cfg))
-	} else {
-		err = loadCA(cfg)
-		if err != nil {
-			err := os.RemoveAll(filepath.Join(microshiftDataDir, "certs"))
-			if err != nil {
-				klog.Errorf("Removing old certs directory", err)
-			}
-			util.Must(initAll(cfg))
-		}
+	if err := initAll(cfg); err != nil {
+		klog.Fatalf("failed to retrieve the necessary certificates: %v", err)
 	}
 
 	m := servicemanager.NewServiceManager()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,11 @@ type ClusterConfig struct {
 	MTU                  string `json:"mtu"`
 }
 
+type IngressConfig struct {
+	ServingCertificate []byte
+	ServingKey         []byte
+}
+
 type MicroshiftConfig struct {
 	LogVLevel int `json:"logVLevel"`
 
@@ -59,6 +64,8 @@ type MicroshiftConfig struct {
 	NodeIP   string `json:"nodeIP"`
 
 	Cluster ClusterConfig `json:"cluster"`
+
+	Ingress IngressConfig `json:"ingress"`
 }
 
 func GetConfigFile() string {

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -51,7 +51,6 @@ func (s *KubeControllerManager) Dependencies() []string { return []string{"kube-
 
 func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 	certsDir := cryptomaterial.CertsDirectory(microshiftDataDir)
-	caCertFile := cryptomaterial.UltimateTrustBundlePath(certsDir)
 	csrSignerDir := cryptomaterial.CSRSignerCertDir(certsDir)
 	kubeconfig := cfg.KubeConfigPath(config.KubeControllerManager)
 	kubeadmConfig := cfg.KubeConfigPath(config.KubeAdmin)
@@ -71,7 +70,7 @@ func (s *KubeControllerManager) configure(cfg *config.MicroshiftConfig) {
 		"--cluster-cidr=" + cfg.Cluster.ClusterCIDR,
 		"--authorization-kubeconfig=" + kubeconfig,
 		"--authentication-kubeconfig=" + kubeconfig,
-		"--root-ca-file=" + caCertFile, // TODO: this should be service-account-token-ca.crt
+		"--root-ca-file=" + cryptomaterial.ServiceAccountTokenCABundlePath(certsDir),
 		"--bind-address=127.0.0.1",
 		"--secure-port=10257",
 		"--leader-elect=false",

--- a/pkg/util/cert.go
+++ b/pkg/util/cert.go
@@ -16,33 +16,16 @@ limitations under the License.
 package util
 
 import (
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/asn1"
-	"encoding/base64"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
-	"math"
-	"math/big"
-	"net"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-)
-
-var (
-	rootCA  *x509.Certificate
-	rootKey *rsa.PrivateKey
 )
 
 const (
@@ -56,105 +39,6 @@ const (
 	ValidityOneYear  = 365 * ValidityOneDay
 	ValidityTenYears = 10 * ValidityOneYear
 )
-
-func GenCA(common string, svcName []string, duration time.Duration) (*rsa.PrivateKey, *x509.Certificate, error) {
-	_, dns := IPAddressesDNSNames(svcName)
-	cfg := &CertCfg{
-		Validity:     duration,
-		IsCA:         true,
-		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		Subject:      pkix.Name{CommonName: common, Organization: dns},
-	}
-	key, ca, err := cfg.GenerateSelfSignedCertificate()
-	return key, ca, err
-}
-
-func LoadRootCA(dir, certFilename, keyFilename string) error {
-
-	key, err := ioutil.ReadFile(filepath.Join(dir, keyFilename))
-	if err != nil {
-		return errors.Wrap(err, "error reading CA key")
-	}
-
-	if rootKey, err = PemToPrivateKey(key); err != nil {
-		return errors.Wrap(err, "parsing CA key from PEM")
-	}
-
-	certPath := filepath.Join(dir, certFilename)
-	cert, err := ioutil.ReadFile(certPath)
-	if err != nil {
-		return errors.Wrap(err, "reading CA certificate")
-	}
-
-	if rootCA, err = PemToCertificate(cert); err != nil {
-		return errors.Wrap(err, "parsing CA certificate")
-	}
-
-	now := time.Now()
-
-	if now.After(rootCA.NotAfter) {
-		klog.Errorf("CA has expired: current time %s is after %s", now.Format(time.RFC3339), rootCA.NotAfter.Format(time.RFC3339), nil)
-	}
-
-	return nil
-}
-
-func StoreRootCA(common, dir, certFilename, keyFilename string, svcName []string) ([]byte, []byte, error) {
-	if rootCA == nil || rootKey == nil {
-		var err error
-		rootKey, rootCA, err = GenCA(common, svcName, defaultDuration)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	certBuff := CertToPem(rootCA)
-	keyBuff := PrivateKeyToPem(rootKey)
-	os.MkdirAll(dir, 0700)
-	certPath := filepath.Join(dir, certFilename)
-	keyPath := filepath.Join(dir, keyFilename)
-	ioutil.WriteFile(certPath, certBuff, 0644)
-	ioutil.WriteFile(keyPath, keyBuff, 0644)
-	return certBuff, keyBuff, nil
-}
-
-// GenCertsBuff create cert and key buff
-func GenCertsBuff(common string, svcName []string) ([]byte, []byte, error) {
-	ip, dns := IPAddressesDNSNames(svcName)
-	cfg := &CertCfg{
-		DNSNames:     dns,
-		IPAddresses:  ip,
-		Validity:     defaultDuration,
-		IsCA:         false,
-		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		Subject:      pkix.Name{CommonName: common, Organization: dns},
-	}
-	key, ca, err := cfg.GenerateSignedCertificate(rootKey, rootCA)
-	if err != nil {
-		return nil, nil, err
-	}
-	certBuff := CertToPem(ca)
-	keyBuff := PrivateKeyToPem(key)
-	return certBuff, keyBuff, nil
-}
-
-// GenCerts creates certs and keys signed by the root CA
-func GenCerts(common, dir, certFilename, keyFilename string, svcName []string) error {
-	if rootCA == nil || rootKey == nil {
-		return fmt.Errorf("the root CA cert/key pair was not yet generated")
-	}
-	os.MkdirAll(dir, 0700)
-	certBuff, keyBuff, err := GenCertsBuff(common, svcName)
-	if err != nil {
-		return err
-	}
-	certPath := filepath.Join(dir, certFilename)
-	keyPath := filepath.Join(dir, keyFilename)
-	ioutil.WriteFile(certPath, certBuff, 0644)
-	ioutil.WriteFile(keyPath, keyBuff, 0644)
-	return err
-}
 
 // GenKeys generates and save rsa keys
 func GenKeys(dir, pubFilename, keyFilename string) error {
@@ -177,75 +61,6 @@ func GenKeys(dir, pubFilename, keyFilename string) error {
 
 }
 
-// based on github.com/hypershift/certs/tls.go
-
-// CertCfg contains all needed fields to configure a new certificate
-type CertCfg struct {
-	DNSNames     []string
-	ExtKeyUsages []x509.ExtKeyUsage
-	IPAddresses  []net.IP
-	KeyUsages    x509.KeyUsage
-	Subject      pkix.Name
-	Validity     time.Duration
-	IsCA         bool
-}
-
-// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
-type rsaPublicKey struct {
-	N *big.Int
-	E int
-}
-
-// GenerateSelfSignedCertificate generates a key/cert pair defined by CertCfg.
-func (cfg *CertCfg) GenerateSelfSignedCertificate() (*rsa.PrivateKey, *x509.Certificate, error) {
-	key, err := PrivateKey()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to generate private key")
-	}
-
-	crt, err := cfg.SelfSignedCertificate(key)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create self-signed certificate")
-	}
-	return key, crt, nil
-}
-
-// GenerateSignedCertificate generate a key and cert defined by CertCfg and signed by CA.
-func (cfg *CertCfg) GenerateSignedCertificate(caKey *rsa.PrivateKey, caCert *x509.Certificate) (*rsa.PrivateKey, *x509.Certificate, error) {
-
-	if caCert == nil {
-		return nil, nil, errors.New("Unable to GenerateSignedCertificate with (nil) caCert")
-	}
-
-	if caKey == nil {
-		return nil, nil, errors.New("Unable to GenerateSignedCertificate with (nil) caKey")
-	}
-
-	// create a private key
-	key, err := PrivateKey()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to generate private key")
-	}
-
-	// create a CSR
-	csrTmpl := x509.CertificateRequest{Subject: cfg.Subject, DNSNames: cfg.DNSNames, IPAddresses: cfg.IPAddresses}
-	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTmpl, key)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create certificate request")
-	}
-	csr, err := x509.ParseCertificateRequest(csrBytes)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error parsing x509 certificate request")
-	}
-
-	// create a cert
-	cert, err := cfg.SignedCertificate(csr, key, caCert, caKey)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create a signed certificate")
-	}
-	return key, cert, nil
-}
-
 // PrivateKey generates an RSA Private key and returns the value
 func PrivateKey() (*rsa.PrivateKey, error) {
 	rsaKey, err := rsa.GenerateKey(rand.Reader, keySize)
@@ -254,95 +69,6 @@ func PrivateKey() (*rsa.PrivateKey, error) {
 	}
 
 	return rsaKey, nil
-}
-
-// SelfSignedCertificate creates a self signed certificate
-func (cfg *CertCfg) SelfSignedCertificate(key *rsa.PrivateKey) (*x509.Certificate, error) {
-	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
-	if err != nil {
-		return nil, err
-	}
-	cert := x509.Certificate{
-		BasicConstraintsValid: true,
-		IsCA:                  cfg.IsCA,
-		KeyUsage:              cfg.KeyUsages,
-		NotAfter:              time.Now().Add(cfg.Validity),
-		NotBefore:             time.Now(),
-		SerialNumber:          serial,
-		Subject:               cfg.Subject,
-	}
-	// verifies that the CN and/or OU for the cert is set
-	if len(cfg.Subject.CommonName) == 0 {
-		return nil, errors.Errorf("certification's subject is not set, or invalid")
-	}
-	pub := key.Public()
-	cert.SubjectKeyId, err = generateSubjectKeyID(pub)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to set subject key identifier")
-	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, &cert, &cert, key.Public(), key)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create certificate")
-	}
-	return x509.ParseCertificate(certBytes)
-}
-
-// SignedCertificate creates a new X.509 certificate based on a template.
-func (cfg *CertCfg) SignedCertificate(
-	csr *x509.CertificateRequest,
-	key *rsa.PrivateKey,
-	caCert *x509.Certificate,
-	caKey *rsa.PrivateKey,
-) (*x509.Certificate, error) {
-	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
-	if err != nil {
-		return nil, err
-	}
-
-	certTmpl := x509.Certificate{
-		DNSNames:              csr.DNSNames,
-		ExtKeyUsage:           cfg.ExtKeyUsages,
-		IPAddresses:           csr.IPAddresses,
-		KeyUsage:              cfg.KeyUsages,
-		NotAfter:              time.Now().Add(cfg.Validity),
-		NotBefore:             caCert.NotBefore,
-		SerialNumber:          serial,
-		Subject:               csr.Subject,
-		IsCA:                  cfg.IsCA,
-		Version:               3,
-		BasicConstraintsValid: true,
-	}
-	pub := caCert.PublicKey.(*rsa.PublicKey)
-	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to set subject key identifier")
-	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, key.Public(), caKey)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create x509 certificate")
-	}
-	return x509.ParseCertificate(certBytes)
-}
-
-// generateSubjectKeyID generates a SHA-1 hash of the subject public key.
-func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
-	var publicKeyBytes []byte
-	var err error
-
-	switch pub := pub.(type) {
-	case *rsa.PublicKey:
-		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{N: pub.N, E: pub.E})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to Marshal ans1 public key")
-		}
-	case *ecdsa.PublicKey:
-		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
-	default:
-		return nil, errors.New("only RSA and ECDSA public keys supported")
-	}
-
-	hash := sha1.Sum(publicKeyBytes)
-	return hash[:], nil
 }
 
 // PrivateKeyToPem converts an rsa.PrivateKey object to pem string
@@ -355,28 +81,6 @@ func PrivateKeyToPem(key *rsa.PrivateKey) []byte {
 		},
 	)
 	return keyinPem
-}
-
-// CertToPem converts an x509.Certificate object to a pem string
-func CertToPem(cert *x509.Certificate) []byte {
-	certInPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: cert.Raw,
-		},
-	)
-	return certInPem
-}
-
-// CSRToPem converts an x509.CertificateRequest to a pem string
-func CSRToPem(cert *x509.CertificateRequest) []byte {
-	certInPem := pem.EncodeToMemory(
-		&pem.Block{
-			Type:  "CERTIFICATE REQUEST",
-			Bytes: cert.Raw,
-		},
-	)
-	return certInPem
 }
 
 // PublicKeyToPem converts an rsa.PublicKey object to pem string
@@ -392,47 +96,4 @@ func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
 		},
 	)
 	return keyinPem, nil
-}
-
-// PemToPrivateKey converts a data block to rsa.PrivateKey.
-func PemToPrivateKey(data []byte) (*rsa.PrivateKey, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, errors.Errorf("could not find a PEM block in the private key")
-	}
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
-}
-
-// PemToCertificate converts a data block to x509.Certificate.
-func PemToCertificate(data []byte) (*x509.Certificate, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, errors.Errorf("could not find a PEM block in the certificate")
-	}
-	return x509.ParseCertificate(block.Bytes)
-}
-
-// per https://github.com/openshift/library-go/blob/e555322cb70844f90b003cbdfe7ce002d7c61810/pkg/crypto/crypto.go#L989
-func IPAddressesDNSNames(hosts []string) ([]net.IP, []string) {
-	ips := []net.IP{}
-	dns := []string{}
-	for _, host := range hosts {
-		if ip := net.ParseIP(host); ip != nil {
-			ips = append(ips, ip)
-		} else {
-			dns = append(dns, host)
-		}
-	}
-
-	// Include IP addresses as DNS subjectAltNames in the cert as well, for the sake of Python, Windows (< 10), and unnamed other libraries
-	// Ensure these technically invalid DNS subjectAltNames occur after the valid ones, to avoid triggering cert errors in Firefox
-	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1148766
-	for _, ip := range ips {
-		dns = append(dns, ip.String())
-	}
-
-	return ips, dns
-}
-func Base64(data []byte) string {
-	return base64.StdEncoding.EncodeToString(data)
 }

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -33,6 +33,9 @@ const (
 
 	KubeAPIServerServingSignerCAValidityDays = 365 * 10
 	KubeAPIServerServingCertValidityDays     = 365
+
+	IngressSignerCAValidityDays    = 365 * 2
+	IngressServingCertValidityDays = 365
 )
 
 func CertsDirectory(dataPath string) string { return filepath.Join(dataPath, "certs") }
@@ -104,6 +107,10 @@ func ServiceCADir(certsDir string) string {
 
 func RouteControllerManagerServingCertDir(certsDir string) string {
 	return filepath.Join(ServiceCADir(certsDir), "route-controller-manager-serving")
+}
+
+func IngressCADir(certsDir string) string {
+	return filepath.Join(certsDir, "ingress-ca")
 }
 
 func AggregatorSignerDir(certsDir string) string {

--- a/pkg/util/cryptomaterial/certpaths.go
+++ b/pkg/util/cryptomaterial/certpaths.go
@@ -30,6 +30,9 @@ const (
 
 	ServiceCAValidityDays            = 790
 	ServiceCAServingCertValidityDays = 730
+
+	KubeAPIServerServingSignerCAValidityDays = 365 * 10
+	KubeAPIServerServingCertValidityDays     = 365
 )
 
 func CertsDirectory(dataPath string) string { return filepath.Join(dataPath, "certs") }
@@ -127,6 +130,30 @@ func EtcdServingCertDir(certsDir string) string {
 	return filepath.Join(EtcdSignerDir(certsDir), "etcd-serving")
 }
 
+func KubeAPIServerExternalSigner(certsDir string) string {
+	return filepath.Join(certsDir, "kube-apiserver-external-signer")
+}
+
+func KubeAPIServerExternalServingCertDir(certsDir string) string {
+	return filepath.Join(KubeAPIServerExternalSigner(certsDir), "kube-external-serving")
+}
+
+func KubeAPIServerLocalhostSigner(certsDir string) string {
+	return filepath.Join(certsDir, "kube-apiserver-localhost-signer")
+}
+
+func KubeAPIServerLocalhostServingCertDir(certsDir string) string {
+	return filepath.Join(KubeAPIServerLocalhostSigner(certsDir), "kube-apiserver-localhost-serving")
+}
+
+func KubeAPIServerServiceNetworkSigner(certsDir string) string {
+	return filepath.Join(certsDir, "kube-apiserver-service-network-signer")
+}
+
+func KubeAPIServerServiceNetworkServingCertDir(certsDir string) string {
+	return filepath.Join(KubeAPIServerServiceNetworkSigner(certsDir), "kube-apiserver-service-network-serving")
+}
+
 // TotalClientCABundlePath returns the path to the cert bundle with all client certificate signers
 func TotalClientCABundlePath(certsDir string) string {
 	return filepath.Join(certsDir, "ca-bundle", "client-ca.crt")
@@ -140,4 +167,8 @@ func UltimateTrustBundlePath(certsDir string) string {
 // KubeletClientCAPath returns the path to the cert bundle with all client certificate signers that kubelet should respect
 func KubeletClientCAPath(certsDir string) string {
 	return filepath.Join(certsDir, "ca-bundle", "kubelet-ca.crt")
+}
+
+func ServiceAccountTokenCABundlePath(certsDir string) string {
+	return filepath.Join(certsDir, "ca-bundle", "service-account-token-ca.crt")
 }

--- a/pkg/util/cryptomaterial/trustupdates.go
+++ b/pkg/util/cryptomaterial/trustupdates.go
@@ -3,6 +3,7 @@ package cryptomaterial
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func AddToTotalClientCABundle(certsDir string, cacerts ...[]byte) error {
@@ -14,6 +15,11 @@ func AddToKubeletClientCABundle(certsDir string, cacerts ...[]byte) error {
 }
 
 func appendCertsToFile(bundlePath string, certs ...[]byte) error {
+	// ensure parent dir
+	if err := os.MkdirAll(filepath.Dir(bundlePath), os.FileMode(0755)); err != nil {
+		return err
+	}
+
 	f, err := os.OpenFile(bundlePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open %q for writing: %w", bundlePath, err)

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -531,7 +531,6 @@ update_manifests() {
     yq -i '.spec.template.spec.serviceAccount = "router"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.securityContext = {}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.schedulerName = "default-scheduler"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.volumes[0].secret.secretName = "router-certs-default"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     sed -i '/#.*at runtime/d' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     sed -i '/#.*at run-time/d' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.metadata.labels += {"ingresscontroller.operator.openshift.io/owning-ingresscontroller": "default"}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
@@ -546,8 +545,6 @@ update_manifests() {
     # 3) Make MicroShift-specific changes
     #    Set replica count to 1, as we're single-node.
     yq -i '.spec.replicas = 1' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    #    Use router-certs-default instead of the router-metrics-certs-default that the CIO sets
-    yq -i '.metadata += {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "router-certs-default"}}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
     #    Add hostPorts for routes and metrics (needed as long as there is no load balancer)
     yq -i '.spec.template.spec.containers[0].ports[0].hostPort = 80' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].ports[1].hostPort = 443' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml


### PR DESCRIPTION
This PR does a couple of things in order to be able to finally remove the root CA:
1. generates serving certificates for the KAS
2. fixes the trust for ingress CA which caused the default router cert to be signed by the service-ca
3. removes the root CA and most of the original crypto code as that becomes unused

-----

depends on:
- https://github.com/openshift/microshift/pull/975
- https://github.com/openshift/microshift/pull/981