### PR TITLE
USHIFT-494: go1.18

### DIFF
--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -5,7 +5,7 @@ install_packages:
   - bash-completion
   - firewalld
   - git
-  - golang
+  - gcc
   - lvm2
   - make
   - openshift-clients

--- a/ansible/roles/setup-microshift-host/tasks/main.yml
+++ b/ansible/roles/setup-microshift-host/tasks/main.yml
@@ -7,6 +7,17 @@
     state: present
     update_cache: true
 
+- name: install golang
+  ansible.builtin.shell: |
+    export GO_VER=1.18.7
+    curl -L -o go${GO_VER}.linux-amd64.tar.gz https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz &&
+        sudo rm -rf /usr/local/go${GO_VER} && \
+        sudo mkdir -p /usr/local/go${GO_VER} && \
+        sudo tar -C /usr/local/go${GO_VER} -xzf go${GO_VER}.linux-amd64.tar.gz --strip-components 1 && \
+        sudo rm -rfv /usr/local/bin/{go,gofmt}
+        sudo ln --symbolic /usr/local/go1.18.7/bin/go /usr/local/go1.18.7/bin/gofmt /usr/local/bin/ && \
+        rm -rfv go${GO_VER}.linux-amd64.tar.gz
+
 - name: start and enable firewalld
   ansible.builtin.systemd:
     name: firewalld

--- a/docs/devenv_rhel8.md
+++ b/docs/devenv_rhel8.md
@@ -55,8 +55,15 @@ Run the following commands to configure SUDO, upgrade the system, install basic 
 ```bash
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift
 sudo dnf update -y
-sudo dnf install -y git cockpit make golang selinux-policy-devel rpm-build bash-completion
+sudo dnf install -y git cockpit make gcc selinux-policy-devel rpm-build bash-completion
 sudo systemctl enable --now cockpit.socket
+export GO_VER=1.18.7; curl -L -o go${GO_VER}.linux-amd64.tar.gz https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz &&
+    sudo rm -rf /usr/local/go${GO_VER} && \
+    sudo mkdir -p /usr/local/go${GO_VER} && \
+    sudo tar -C /usr/local/go${GO_VER} -xzf go${GO_VER}.linux-amd64.tar.gz --strip-components 1 && \
+    sudo rm -rfv /usr/local/bin/{go,gofmt}
+    sudo ln --symbolic /usr/local/go1.18.7/bin/go /usr/local/go1.18.7/bin/gofmt /usr/local/bin/ && \
+    rm -rfv go${GO_VER}.linux-amd64.tar.gz
 ```
 You should now be able to access the VM Cockpit console using `https://<vm_ip>:9090` URL.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/microshift
 
-go 1.17
+go 1.18
 
 require (
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // route-controller-manager

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -51,7 +51,7 @@ Source0: https://github.com/openshift/microshift/archive/%{git_commit}/microshif
 ExclusiveArch: x86_64 aarch64
 
 BuildRequires: gcc
-BuildRequires: golang >= %{golang_version}
+# BuildRequires: golang >= %{golang_version} Temporarily disabled until go1.18 is available in RHEL8 repositories
 BuildRequires: make
 BuildRequires: policycoreutils
 BuildRequires: systemd

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -50,8 +50,15 @@ fi
 # https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#configuring-vm
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift
 sudo dnf update -y
-sudo dnf install -y git cockpit make golang selinux-policy-devel rpm-build bash-completion
+sudo dnf install -y git cockpit make gcc selinux-policy-devel rpm-build bash-completion
 sudo systemctl enable --now cockpit.socket
+export GO_VER=1.18.7; curl -L -o go${GO_VER}.linux-amd64.tar.gz https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz &&
+    sudo rm -rf /usr/local/go${GO_VER} && \
+    sudo mkdir -p /usr/local/go${GO_VER} && \
+    sudo tar -C /usr/local/go${GO_VER} -xzf go${GO_VER}.linux-amd64.tar.gz --strip-components 1 && \
+    sudo rm -rfv /usr/local/bin/{go,gofmt}
+    sudo ln --symbolic /usr/local/go1.18.7/bin/go /usr/local/go1.18.7/bin/gofmt /usr/local/bin/ && \
+    rm -rfv go${GO_VER}.linux-amd64.tar.gz
 
 # Build MicroShift
 # https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#build-microshift
@@ -62,7 +69,7 @@ cd ~/microshift
 
 # Build MicroShift > RPM Packages
 # https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#rpm-packages
-make rpm 
+make rpm
 make srpm
 
 # Run MicroShift Executable > Runtime Prerequisites

--- a/scripts/devenv-builder/create-vm.sh
+++ b/scripts/devenv-builder/create-vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script automates the VM creation steps described in the "MicroShift Development Environment on RHEL 8" document.
-# See https://github.com/ggiguash/microshift/blob/main/docs/devenv_rhel8.md#creating-vm
+# See https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#creating-vm
 #
 set -eo pipefail
 ROOTDIR=$(git rev-parse --show-toplevel)/scripts/devenv-builder


### PR DESCRIPTION
- updates go version `go.mod`
- makes necessary changes to dev-env doc & scripts and ansible playbook to work around rhel8.6 not having go1.18 in repos - **these should be reverted when we start using RHEL 8.7**