### PR TITLE
Update pause image to registry.k8s.io

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -126,7 +126,7 @@ resources:
   - busybox.yaml
 images:
   - name: BUSYBOX_IMAGE
-    newName: k8s.gcr.io/busybox
+    newName: registry.k8s.io/busybox
 EOF
 ```
 

--- a/pkg/release/release_amd64.go
+++ b/pkg/release/release_amd64.go
@@ -32,7 +32,7 @@ func init() {
 		"ose_csi_node_registrar":    "registry.redhat.io/openshift4/ose-csi-node-driver-registrar@sha256:3babcf219371017d92f8bc3301de6c63681fcfaa8c344ec7891c8e84f31420eb",
 		"ose_csi_livenessprobe":     "registry.redhat.io/openshift4/ose-csi-livenessprobe@sha256:e4b0f6c89a12d26babdc2feae7d13d3f281ac4d38c24614c13c230b4a29ec56e",
 		"ovn_kubernetes_microshift": "quay.io/microshift/ovn-kubernetes-singlenode@sha256:e97d6035754fad1660b522b8afa4dea2502d5189c8490832e762ae2afb4cf142",
-		"pause":                     "k8s.gcr.io/pause:3.6",
+		"pause":                     "registry.k8s.io/pause:3.6",
 		"service_ca_operator":       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:afcc1f59015b394e6da7d73eba32de407807da45018e3c4ecc25e5741aaae2dd",
 	}
 }

--- a/pkg/release/release_arm64.go
+++ b/pkg/release/release_arm64.go
@@ -27,7 +27,7 @@ func init() {
 		"kube_rbac_proxy":           "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c19226019fe605b5ab10496fb0b7cb4712cb694a7ee1e26642d63d515ca6b7cc",
 		"openssl":                   "registry.access.redhat.com/ubi8/openssl@sha256:3f781a07e59d164eba065dba7d8e7661ab2494b21199c379b65b0ff514a1b8d0",
 		"ovn_kubernetes_microshift": "quay.io/microshift/ovn-kubernetes-singlenode@sha256:012e743363b5f15f442c238099d35a0c70343fd1d4dc15b0a57a7340a338ffdb",
-		"pause":                     "k8s.gcr.io/pause:3.6",
+		"pause":                     "registry.k8s.io/pause:3.6",
 		"service_ca_operator":       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2fe468f25881e7b5ae8118c7d54b41a7fbb132a186f0156bbe46df0fd6a2f1f8",
 	}
 }


### PR DESCRIPTION
Kubernetes moved from k8s.gcr.io to registry.k8s.io in 1.15 via: https://github.com/kubernetes/kubernetes/pull/109938

With old k8s.grc.io, pods failed to start in offline mode since it cannot resolve registry.k8s.io or download the new pause image:

  Warning  FailedCreatePodSandBox  10s (x7 over 92s)  kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = error creating pod sandbox with name "k8s_ovnkube-master-84dtp_openshift-ovn-kubernetes_cb245daf-ef1d-4610-9f9b-77f7d0af8dc7_0": initializing source docker://registry.k8s.io/pause:3.6: pinging container registry registry.k8s.io: Get "https://registry.k8s.io/v2/": dial tcp: lookup registry.k8s.io on 192.168.100.1:53: server misbehaving
