### PR TITLE
update create-vm.sh to support shared systems

### DIFF
--- a/scripts/devenv-builder/create-vm.sh
+++ b/scripts/devenv-builder/create-vm.sh
@@ -42,7 +42,7 @@ SYSROOTSIZE=$(( ${SYSROOTSIZE} * 1024 ))
 # Swap size is expected in MB
 SWAPSIZE=$(( ${SWAPSIZE} * 1024 ))
 
-KICKSTART_FILE=/tmp/devenv-kickstart.ks
+KICKSTART_FILE=/tmp/${VMNAME}-kickstart.ks
 cat ${ROOTDIR}/config/kickstart.ks.template | \
     sed "s;REPLACE_HOST_NAME;${VMNAME};" | \
     sed "s;REPLACE_SWAP_SIZE;${SWAPSIZE};" | \


### PR DESCRIPTION
Update the kickstart filename to include the VM name to ensure it is
unique. This lets the script work better when multiple developers may
be sharing a server.

/assign @ggigaush
/assign @jcope