### PR TITLE
Fix connectivity issue to NodePorts and router hostPort

### DIFF
--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -352,12 +352,13 @@ spec:
 
           gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
 
+          sysctl net.ipv4.ip_forward=1
+
           gw_interface_flag=
           # if br-ex1 is configured on the node, we want to use it for external gateway traffic
           if [ -d /sys/class/net/br-ex1 ]; then
             gw_interface_flag="--exgw-interface=br-ex1"
             # the functionality depends on ip_forwarding being enabled
-            sysctl net.ipv4.ip_forward=1
           fi
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3447,12 +3447,13 @@ spec:
 
           gateway_mode_flags="--gateway-mode local --gateway-interface br-ex"
 
+          sysctl net.ipv4.ip_forward=1
+
           gw_interface_flag=
           # if br-ex1 is configured on the node, we want to use it for external gateway traffic
           if [ -d /sys/class/net/br-ex1 ]; then
             gw_interface_flag="--exgw-interface=br-ex1"
             # the functionality depends on ip_forwarding being enabled
-            sysctl net.ipv4.ip_forward=1
           fi
 
           echo "I$(date "+%m%d %H:%M:%S.%N") - ovnkube-master - start ovnkube --init-master ${K8S_NODE} --init-node ${K8S_NODE}"
@@ -3598,7 +3599,7 @@ func assetsComponentsOvnMasterDaemonsetYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 15987, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
+	info := bindataFileInfo{name: "assets/components/ovn/master/daemonset.yaml", size: 15986, mode: os.FileMode(420), modTime: time.Unix(1664090284, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
The change to local gateway mode in ovnk needs the activation of ip forwarding for NodePorts and hostPorts to work.

It was only enabled conditionally when br-ex1 additional bridge was configured on the system.

Fixes-Issue: https://issues.redhat.com/browse/USHIFT-502

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
