### PR TITLE
API-1449: Enable kube-apiserver audit logging.

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -37,7 +37,6 @@ func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	cmd.MarkFlagFilename("config", "yaml", "yml")
 	// All other flags will be read after reading both config file and env vars.
 	flags.String("data-dir", cfg.DataDir, "The directory for storing runtime data.")
-	flags.String("audit-log-dir", cfg.AuditLogDir, "The directory for storing audit logs.")
 	flags.StringSlice("roles", cfg.Roles, "The roles of this MicroShift instance.")
 	flags.String("node-name", cfg.NodeName, "The hostname of the node.")
 	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
@@ -93,7 +92,6 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	}
 
 	os.MkdirAll(cfg.DataDir, 0700)
-	os.MkdirAll(cfg.AuditLogDir, 0700)
 
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
 	if _, err := os.Stat(filepath.Join(cfg.DataDir, "certs")); errors.Is(err, os.ErrNotExist) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,8 +56,7 @@ type MicroshiftConfig struct {
 	ConfigFile string `json:"configFile"`
 	DataDir    string `json:"dataDir"`
 
-	AuditLogDir string `json:"auditLogDir"`
-	LogVLevel   int    `json:"logVLevel"`
+	LogVLevel int `json:"logVLevel"`
 
 	Roles []string `json:"roles"`
 
@@ -101,13 +100,12 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	defaultRoles := make([]string, len(validRoles))
 	copy(defaultRoles, validRoles)
 	return &MicroshiftConfig{
-		ConfigFile:  findConfigFile(),
-		DataDir:     dataDir,
-		AuditLogDir: "",
-		LogVLevel:   0,
-		Roles:       defaultRoles,
-		NodeName:    nodeName,
-		NodeIP:      nodeIP,
+		ConfigFile: findConfigFile(),
+		DataDir:    dataDir,
+		LogVLevel:  0,
+		Roles:      defaultRoles,
+		NodeName:   nodeName,
+		NodeIP:     nodeIP,
 		Cluster: ClusterConfig{
 			URL:                  "https://127.0.0.1:6443",
 			ClusterCIDR:          "10.42.0.0/16",
@@ -220,9 +218,6 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 		c.DataDir = s
 		// if the defaults are present, rebuild based on the new data-dir
 		c.updateManifestList()
-	}
-	if s, err := flags.GetString("audit-log-dir"); err == nil && flags.Changed("audit-log-dir") {
-		c.AuditLogDir = s
 	}
 	if f := flags.Lookup("v"); f != nil && flags.Changed("v") {
 		c.LogVLevel, _ = strconv.Atoi(f.Value.String())

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,13 +39,12 @@ func TestCommandLineConfig(t *testing.T) {
 	}{
 		{
 			config: &MicroshiftConfig{
-				ConfigFile:  "/path/to/config.yaml",
-				DataDir:     "/tmp/microshift/data",
-				AuditLogDir: "/tmp/microshift/logs",
-				LogVLevel:   4,
-				Roles:       []string{"controlplane", "node"},
-				NodeName:    "node1",
-				NodeIP:      "1.2.3.4",
+				ConfigFile: "/path/to/config.yaml",
+				DataDir:    "/tmp/microshift/data",
+				LogVLevel:  4,
+				Roles:      []string{"controlplane", "node"},
+				NodeName:   "node1",
+				NodeIP:     "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://1.2.3.4:6443",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -72,7 +71,6 @@ func TestCommandLineConfig(t *testing.T) {
 		flags.StringVar(&config.ConfigFile, "config", config.ConfigFile, "File to read configuration from.")
 		// all other flags unbound (looked up by name) and defaulted
 		flags.String("data-dir", config.DataDir, "")
-		flags.String("audit-log-dir", config.AuditLogDir, "")
 		flags.Int("v", config.LogVLevel, "")
 		flags.StringSlice("roles", config.Roles, "")
 		flags.String("node-name", config.NodeName, "")
@@ -91,7 +89,6 @@ func TestCommandLineConfig(t *testing.T) {
 		err = flags.Parse([]string{
 			"--config=" + tt.config.ConfigFile,
 			"--data-dir=" + tt.config.DataDir,
-			"--audit-log-dir=" + tt.config.AuditLogDir,
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
 			"--roles=" + strings.Join(tt.config.Roles, ","),
 			"--node-name=" + tt.config.NodeName,
@@ -133,13 +130,12 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 	}{
 		{
 			desiredMicroShiftConfig: &MicroshiftConfig{
-				ConfigFile:  "/to/config/file",
-				DataDir:     "/tmp/microshift/data",
-				AuditLogDir: "/tmp/microshift/logs",
-				LogVLevel:   23,
-				Roles:       []string{"controlplane", "node"},
-				NodeName:    "node1",
-				NodeIP:      "1.2.3.4",
+				ConfigFile: "/to/config/file",
+				DataDir:    "/tmp/microshift/data",
+				LogVLevel:  23,
+				Roles:      []string{"controlplane", "node"},
+				NodeName:   "node1",
+				NodeIP:     "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://cluster.com:4343/endpoint",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -158,7 +154,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			}{
 				{"MICROSHIFT_CONFIGFILE", "/to/config/file"},
 				{"MICROSHIFT_DATADIR", "/tmp/microshift/data"},
-				{"MICROSHIFT_AUDITLOGDIR", "/tmp/microshift/logs"},
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
@@ -174,13 +169,12 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 		},
 		{
 			desiredMicroShiftConfig: &MicroshiftConfig{
-				ConfigFile:  "/to/config/file",
-				DataDir:     "/tmp/microshift/data",
-				AuditLogDir: "/tmp/microshift/logs",
-				LogVLevel:   23,
-				Roles:       []string{"controlplane", "node"},
-				NodeName:    "node1",
-				NodeIP:      "1.2.3.4",
+				ConfigFile: "/to/config/file",
+				DataDir:    "/tmp/microshift/data",
+				LogVLevel:  23,
+				Roles:      []string{"controlplane", "node"},
+				NodeName:   "node1",
+				NodeIP:     "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://cluster.com:4343/endpoint",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -199,7 +193,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			}{
 				{"MICROSHIFT_CONFIGFILE", "/to/config/file"},
 				{"MICROSHIFT_DATADIR", "/tmp/microshift/data"},
-				{"MICROSHIFT_AUDITLOGDIR", "/tmp/microshift/logs"},
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
@@ -237,7 +230,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.String("data-dir", "", "")
-	flags.String("audit-log-dir", "", "")
 	flags.Int("v", 0, "")
 	flags.StringSlice("roles", []string{}, "")
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -113,7 +113,6 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 	overrides := &kubecontrolplanev1.KubeAPIServerConfig{
 		APIServerArguments: map[string]kubecontrolplanev1.Arguments{
 			"advertise-address": {cfg.NodeIP},
-			"audit-log-path":    {cfg.AuditLogDir},
 			"audit-policy-file": {cfg.DataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
 			"client-ca-file":    {clientCABundlePath},
 			"etcd-cafile":       {ultimateTrustCACertFile},
@@ -318,6 +317,9 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 	if err != nil {
 		return err
 	}
+
+	// audit logs go here
+	os.MkdirAll("/var/log/kube-apiserver", 0700)
 
 	// Carrying a patch for NewAPIServerCommand to use cmd.Context().Done() as the stop channel
 	// instead of the channel returned by SetupSignalHandler, which expects to be called at most


### PR DESCRIPTION
Audit logs from kube-apiserver are used in virtually every support engagement with the API team, so they're useful to enable out-of-the-box. I've also removed the audit log path config field, instead using the same path used by OpenShift (under /var/log).