### PR TITLE
USHIFT-205: Clean osbuild-composer cache when switching versions

### DIFF
--- a/hack/osbuild2copr.sh
+++ b/hack/osbuild2copr.sh
@@ -21,6 +21,10 @@ echo "Removing the existing 'osbuild' packages..."
 LIST2REMOVE=$(rpm -qa | egrep 'osbuild|cockpit-composer|rpm-ostree' || true)
 [ ! -z "${LIST2REMOVE}" ] && sudo rpm -e ${LIST2REMOVE}
 
+# Clean-up the old osbuild jobs and state to avoid incompatibilities between versions
+sudo rm -rf /var/lib/osbuild-composer || true
+sudo rm -rf /var/cache/{osbuild-composer,osbuild-worker} || true
+
 echo "Configuring the 'copr' repositories..."
 sudo dnf copr -y $REPO_MODE @osbuild/osbuild
 sudo dnf copr -y $REPO_MODE @osbuild/osbuild-composer

--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -3,10 +3,9 @@ set -exo pipefail
 
 sudo dnf install -y git osbuild-composer composer-cli ostree rpm-ostree \
     cockpit-composer bash-completion podman genisoimage \
-    createrepo syslinux yum-utils selinux-policy-devel jq wget lorax rpm-build
+    createrepo yum-utils selinux-policy-devel jq wget lorax rpm-build
 sudo systemctl enable osbuild-composer.socket --now
 sudo systemctl enable cockpit.socket --now
-sudo firewall-cmd -q --add-service=cockpit
 sudo firewall-cmd -q --add-service=cockpit --permanent
 
 # The mock utility comes from the EPEL repository


### PR DESCRIPTION
More fixes for [USHIFT-205](https://issues.redhat.com//browse/USHIFT-205)
