### PR TITLE
disable ingress-ip controller as we are not allowing configuration of IngressIPNetworkCIDR

### DIFF
--- a/pkg/controllers/openshift-route-controller-manager.go
+++ b/pkg/controllers/openshift-route-controller-manager.go
@@ -81,8 +81,8 @@ func (s *OCPRouteControllerManager) writeConfig(cfg *config.MicroshiftConfig) *o
 			},
 		},
 		Controllers: []string{
-			"openshift.io/ingress-ip",
 			"openshift.io/ingress-to-route",
+			"-openshift.io/ingress-ip",
 		},
 	}
 


### PR DESCRIPTION
external IPs on services should be assigned manually and not automatically in microshift

followup to https://github.com/openshift/microshift/pull/1011#discussion_r1004232794 conversation