### PR TITLE
USHIFT-529: fix(storage): correct lvmd file path

### DIFF
--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -66,7 +66,7 @@ func startCSIPlugin(cfg *config.MicroshiftConfig, kubeconfigPath string) error {
 
 	// the lvmd file should be located in the same directory as the microshift config to minimize coupling with the
 	// csi plugin.
-	lvmdCfg, err := lvmd.NewLvmdConfigFromFileOrDefault(filepath.Join(filepath.Dir(microshiftDataDir), "lvmd.yaml"))
+	lvmdCfg, err := lvmd.NewLvmdConfigFromFileOrDefault(filepath.Join(filepath.Dir(config.GetConfigFile()), "lvmd.yaml"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The lvmd file is expected to live in the same path with config file. Previous PR mistakenly changed it to manifests data directory. It's now changed it back to the correct config file directory.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
