### PR TITLE
Remove NodeIP configurable option from microshift config

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -18,7 +18,6 @@ cluster:
   domain: ""
   url: ""
   mtu: ""
-nodeIP: ""
 nodeName: ""
 logVLevel: ""
 ```
@@ -34,7 +33,6 @@ The configuration settings alongside with the supported command line arguments a
 | domain              | --cluster-domain          | MICROSHIFT_CLUSTER_DOMAIN               | Base DNS domain used to construct fully qualified pod and service domain names
 | url                 | --url                     | MICROSHIFT_CLUSTER_URL                  | URL of the API server for the cluster.
 | mtu                 | --cluster-mtu             | MICROSHIFT_CLUSTER_MTU                  | The maximum transmission unit for the Generic Network Virtualization Encapsulation overlay network
-| nodeIP              | --node-ip                 | MICROSHIFT_NODEIP                       | The IP address of the node, defaults to IP of the default route
 | nodeName            | --node-name               | MICROSHIFT_NODENAME                     | The name of the node, defaults to hostname
 | logVLevel           | --v                       | MICROSHIFT_LOGVLEVEL                    | Log verbosity (0-5)
 
@@ -51,7 +49,6 @@ cluster:
   domain: cluster.local
   url: https://127.0.0.1:6443
   mtu: "1400"
-nodeIP: ""
 nodeName: ""
 logVLevel: 0
 ```

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -22,19 +22,8 @@ cluster:
   # MTU for CNI
   #mtu: "1400"
 
-# Location for data created by MicroShift
-#dataDir: /var/lib/microshift
-
 # Log verbosity (0-5)
 #logVLevel: 0
-
-# Locations to scan for manifests to load on startup
-#manifests:
-#- /usr/lib/microshift/manifests
-#- /etc/microshift/manifests
-
-# The IP of the node (defaults to IP of default route)
-#nodeIP: ""
 
 # The name of the node (defaults to hostname)
 #nodeName: ""

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -27,7 +27,10 @@ import (
 	"github.com/openshift/microshift/pkg/util/cryptomaterial"
 )
 
-var microshiftDataDir = config.GetDataDir()
+var (
+	microshiftDataDir = config.GetDataDir()
+	nodeIP            = config.GetNodeIP()
+)
 
 func initAll(cfg *config.MicroshiftConfig) error {
 	// create CA and keys
@@ -148,7 +151,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 						Name:         "kubelet-server",
 						ValidityDays: cryptomaterial.ServingCertValidityDays,
 					},
-					Hostnames: []string{cfg.NodeName, cfg.NodeIP},
+					Hostnames: []string{cfg.NodeName, nodeIP},
 				},
 			),
 		),
@@ -208,7 +211,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 					ValidityDays: 3 * 365,
 				},
 				UserInfo:  &user.DefaultInfo{Name: "system:etcd-peer:etcd-client", Groups: []string{"system:etcd-peers"}},
-				Hostnames: []string{"localhost", cfg.NodeIP, "127.0.0.1", cfg.NodeName},
+				Hostnames: []string{"localhost", nodeIP, "127.0.0.1", cfg.NodeName},
 			},
 			&cryptomaterial.PeerCertificateSigningRequestInfo{
 				CertificateSigningRequestInfo: cryptomaterial.CertificateSigningRequestInfo{
@@ -216,7 +219,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 					ValidityDays: 3 * 365,
 				},
 				UserInfo:  &user.DefaultInfo{Name: "system:etcd-server:etcd-client", Groups: []string{"system:etcd-servers"}},
-				Hostnames: []string{"localhost", "127.0.0.1", cfg.NodeIP, cfg.NodeName},
+				Hostnames: []string{"localhost", "127.0.0.1", nodeIP, cfg.NodeName},
 			},
 		),
 	).WithCABundle(
@@ -255,7 +258,7 @@ func initCerts(cfg *config.MicroshiftConfig) ([]byte, *cryptomaterial.Certificat
 	// kube-apiserver
 	if err := util.GenCerts("kube-apiserver", filepath.Join(microshiftDataDir, "/certs/kube-apiserver/secrets/service-network-serving-certkey"),
 		"tls.crt", "tls.key",
-		[]string{"kube-apiserver", cfg.NodeIP, cfg.NodeName, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes",
+		[]string{"kube-apiserver", nodeIP, cfg.NodeName, "127.0.0.1", "kubernetes.default.svc", "kubernetes.default", "kubernetes",
 			"localhost",
 			apiServerServiceIP.String()}); err != nil {
 		return nil, nil, err

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -35,7 +35,6 @@ func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	// All other flags will be read after reading both config file and env vars.
 	flags.StringSlice("roles", cfg.Roles, "The roles of this MicroShift instance.")
 	flags.String("node-name", cfg.NodeName, "The hostname of the node.")
-	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
 	flags.String("url", cfg.Cluster.URL, "The URL of the API server.")
 	flags.String("cluster-cidr", cfg.Cluster.ClusterCIDR, "The IP range in CIDR notation for pods in the cluster.")
 	flags.String("service-cidr", cfg.Cluster.ServiceCIDR, "The IP range in CIDR notation for services in the cluster.")
@@ -77,7 +76,6 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	//        see https://github.com/openshift/microshift/pull/471
 
 	if err := util.AddToNoProxyEnv(
-		cfg.NodeIP,
 		cfg.NodeName,
 		cfg.Cluster.ClusterCIDR,
 		cfg.Cluster.ServiceCIDR,
@@ -155,7 +153,7 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 		go func() {
 			var server *http.Server
 			server = &http.Server{
-				Addr:    cfg.NodeIP + ":29500",
+				Addr:    nodeIP + ":29500",
 				Handler: mux,
 			}
 			err := server.ListenAndServe()

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -30,7 +30,6 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 
 			switch opts.Mode {
 			case "default":
-				cfg.NodeIP = ""
 				cfg.NodeName = ""
 			case "effective":
 				// Load the current configuration

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -5,7 +5,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var microshiftDataDir = config.GetDataDir()
+var (
+	microshiftDataDir = config.GetDataDir()
+	nodeIP            = config.GetNodeIP()
+)
 
 func StartComponents(cfg *config.MicroshiftConfig) error {
 	kubeAdminConfig := cfg.KubeConfigPath(config.KubeAdmin)

--- a/pkg/components/render.go
+++ b/pkg/components/render.go
@@ -24,7 +24,7 @@ func renderParamsFromConfig(cfg *config.MicroshiftConfig, extra assets.RenderPar
 	params := map[string]interface{}{
 		"ReleaseImage":  release.Image,
 		"NodeName":      cfg.NodeName,
-		"NodeIP":        cfg.NodeIP,
+		"NodeIP":        nodeIP,
 		"ClusterCIDR":   cfg.Cluster.ClusterCIDR,
 		"ServiceCIDR":   cfg.Cluster.ServiceCIDR,
 		"ClusterDNS":    cfg.Cluster.DNS,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,7 +45,6 @@ func TestCommandLineConfig(t *testing.T) {
 				LogVLevel: 4,
 				Roles:     []string{"controlplane", "node"},
 				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://1.2.3.4:6443",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -71,7 +70,6 @@ func TestCommandLineConfig(t *testing.T) {
 		flags.Int("v", config.LogVLevel, "")
 		flags.StringSlice("roles", config.Roles, "")
 		flags.String("node-name", config.NodeName, "")
-		flags.String("node-ip", config.NodeIP, "")
 		flags.String("url", config.Cluster.URL, "")
 		flags.String("cluster-cidr", config.Cluster.ClusterCIDR, "")
 		flags.String("service-cidr", config.Cluster.ServiceCIDR, "")
@@ -87,7 +85,6 @@ func TestCommandLineConfig(t *testing.T) {
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
 			"--roles=" + strings.Join(tt.config.Roles, ","),
 			"--node-name=" + tt.config.NodeName,
-			"--node-ip=" + tt.config.NodeIP,
 			"--url=" + tt.config.Cluster.URL,
 			"--cluster-cidr=" + tt.config.Cluster.ClusterCIDR,
 			"--service-cidr=" + tt.config.Cluster.ServiceCIDR,
@@ -128,7 +125,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				LogVLevel: 23,
 				Roles:     []string{"controlplane", "node"},
 				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://cluster.com:4343/endpoint",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -147,7 +143,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
-				{"MICROSHIFT_NODEIP", "1.2.3.4"},
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
 				{"MICROSHIFT_CLUSTER_CLUSTERCIDR", "10.20.30.40/16"},
 				{"MICROSHIFT_CLUSTER_SERVICECIDR", "40.30.20.10/16"},
@@ -162,7 +157,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				LogVLevel: 23,
 				Roles:     []string{"controlplane", "node"},
 				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://cluster.com:4343/endpoint",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -181,7 +175,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
-				{"MICROSHIFT_NODEIP", "1.2.3.4"},
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
 				{"MICROSHIFT_CLUSTER_CLUSTERCIDR", "10.20.30.40/16"},
 				{"MICROSHIFT_CLUSTER_SERVICECIDR", "40.30.20.10/16"},

--- a/pkg/controllers/etcd.go
+++ b/pkg/controllers/etcd.go
@@ -37,6 +37,7 @@ var (
 		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
 	}
 	microshiftDataDir = config.GetDataDir()
+	nodeIP            = config.GetNodeIP()
 )
 
 const (
@@ -70,14 +71,14 @@ func (s *EtcdService) configure(cfg *config.MicroshiftConfig) {
 	//s.etcdCfg.ForceNewCluster = true //TODO
 	s.etcdCfg.Logger = "zap"
 	s.etcdCfg.Dir = dataDir
-	s.etcdCfg.APUrls = setURL([]string{cfg.NodeIP}, ":2380")
-	s.etcdCfg.LPUrls = setURL([]string{cfg.NodeIP}, ":2380")
-	s.etcdCfg.ACUrls = setURL([]string{cfg.NodeIP}, ":2379")
-	s.etcdCfg.LCUrls = setURL([]string{"127.0.0.1", cfg.NodeIP}, ":2379")
+	s.etcdCfg.APUrls = setURL([]string{nodeIP}, ":2380")
+	s.etcdCfg.LPUrls = setURL([]string{nodeIP}, ":2380")
+	s.etcdCfg.ACUrls = setURL([]string{nodeIP}, ":2379")
+	s.etcdCfg.LCUrls = setURL([]string{"127.0.0.1", nodeIP}, ":2379")
 	s.etcdCfg.ListenMetricsUrls = setURL([]string{"127.0.0.1"}, ":2381")
 
 	s.etcdCfg.Name = cfg.NodeName
-	s.etcdCfg.InitialCluster = fmt.Sprintf("%s=https://%s:2380", cfg.NodeName, cfg.NodeIP)
+	s.etcdCfg.InitialCluster = fmt.Sprintf("%s=https://%s:2380", cfg.NodeName, nodeIP)
 
 	s.etcdCfg.CipherSuites = tlsCipherSuites
 	s.etcdCfg.ClientTLSInfo.CertFile = cryptomaterial.PeerCertPath(etcdServingCertDir)

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -113,7 +113,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 
 	overrides := &kubecontrolplanev1.KubeAPIServerConfig{
 		APIServerArguments: map[string]kubecontrolplanev1.Arguments{
-			"advertise-address": {cfg.NodeIP},
+			"advertise-address": {nodeIP},
 			"audit-policy-file": {microshiftDataDir + "/resources/kube-apiserver-audit-policies/default.yaml"},
 			"client-ca-file":    {clientCABundlePath},
 			"etcd-cafile":       {cryptomaterial.CACertPath(cryptomaterial.EtcdSignerDir(certsDir))},

--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -25,7 +25,7 @@ type MicroShiftmDNSController struct {
 
 func NewMicroShiftmDNSController(cfg *config.MicroshiftConfig) *MicroShiftmDNSController {
 	return &MicroShiftmDNSController{
-		NodeIP:     cfg.NodeIP,
+		NodeIP:     config.GetNodeIP(),
 		NodeName:   cfg.NodeName,
 		KubeConfig: cfg.KubeConfigPath(config.KubeAdmin),
 		hostCount:  make(map[string]int),

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -70,7 +70,7 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 	kubeletFlags.BootstrapKubeconfig = cfg.KubeConfigPath(config.Kubelet)
 	kubeletFlags.KubeConfig = cfg.KubeConfigPath(config.Kubelet)
 	kubeletFlags.RuntimeCgroups = "/system.slice/crio.service"
-	kubeletFlags.NodeIP = cfg.NodeIP
+	kubeletFlags.NodeIP = config.GetNodeIP()
 	kubeletFlags.ContainerRuntime = "remote"
 	kubeletFlags.RemoteRuntimeEndpoint = "unix:///var/run/crio/crio.sock"
 	for _, role := range cfg.Roles {

--- a/pkg/sysconfwatch/sysconfwatch_linux.go
+++ b/pkg/sysconfwatch/sysconfwatch_linux.go
@@ -55,7 +55,7 @@ func NewSysConfWatchController(cfg *config.MicroshiftConfig) *SysConfWatchContro
 	}
 
 	return &SysConfWatchController{
-		NodeIP:  cfg.NodeIP,
+		NodeIP:  config.GetNodeIP(),
 		timerFd: fd,
 	}
 }

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,7 +4,6 @@ roles:
   - role1
   - role2
 nodeName: node1
-nodeIP: '1.2.3.4'
 cluster:
   url: https://1.2.3.4:6443
   clusterCIDR: '10.20.30.40/16'


### PR DESCRIPTION
The NodeIP is always the host IP.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
