### PR TITLE
USHIFT-533: Remove role (controlplane/node) config.

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -73,10 +73,6 @@ When deciding between different design options, we follow the following principl
   * Reduces resource footprint by downloading and running "less stuff".
 * MicroShift provides a small, optional set of infrastructure services to support common use cases and reuses OpenShift's container images for these:
   * openshift-dns, openshift-router, service-ca, local storage provider
-* MicroShift instances (processes) run directly on the host or containerized on Podman. They can take on the roles of Control Plane, Node, or both:
-  * Instances with Control Plane role run etcd and the Kubernetes and OpenShift control plane services. As these services don't require a kubelet, pure Control Plane instances are not nodes in the Kubernetes sense and require fewer system privileges.
-  * Instances with Node role run a kubelet (and thus register as node) and interface with CRI-O for running workloads. They may thus require higher system privileges.
-* While it's possible to run a single MicroShift instance with both Control Plane and Node roles, there may be reasons to run two instances - one Control Plane and one Node - on the same host, e.g. to run the Control Plane with fewer privileges for security reasons. Implementation decisions should consider this.
 * MicroShift does not bundle any OS user space! Bundling makes maintenance and security hard, breaks compliance. Instead, user space is provided by the host OS, the container image base layer or a sidecar container.
 
 ### Supported APIs

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -31,7 +31,6 @@ const (
 func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	flags := cmd.Flags()
 	// All other flags will be read after reading both config file and env vars.
-	flags.StringSlice("roles", cfg.Roles, "The roles of this MicroShift instance.")
 	flags.String("node-name", cfg.NodeName, "The hostname of the node.")
 	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
 	flags.String("url", cfg.Cluster.URL, "The URL of the API server.")
@@ -65,8 +64,8 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	}
 
 	// fail early if we don't have enough privileges
-	if config.StringInList("node", cfg.Roles) && os.Geteuid() > 0 {
-		klog.Fatalf("MicroShift must be run privileged for role 'node'")
+	if os.Geteuid() > 0 {
+		klog.Fatalf("MicroShift must be run privileged")
 	}
 
 	// TO-DO: When multi-node is ready, we need to add the controller host-name/mDNS hostname
@@ -100,28 +99,20 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	}
 
 	m := servicemanager.NewServiceManager()
-	if config.StringInList("controlplane", cfg.Roles) {
-		util.Must(m.AddService(controllers.NewEtcd(cfg)))
-		util.Must(m.AddService(sysconfwatch.NewSysConfWatchController(cfg)))
-		util.Must(m.AddService(controllers.NewKubeAPIServer(cfg)))
-		util.Must(m.AddService(controllers.NewKubeScheduler(cfg)))
-		util.Must(m.AddService(controllers.NewKubeControllerManager(cfg)))
-		util.Must(m.AddService(controllers.NewOpenShiftCRDManager(cfg)))
-		util.Must(m.AddService(controllers.NewRouteControllerManager(cfg)))
-		util.Must(m.AddService(controllers.NewClusterPolicyController(cfg)))
-		util.Must(m.AddService(controllers.NewOpenShiftDefaultSCCManager(cfg)))
-		util.Must(m.AddService(mdns.NewMicroShiftmDNSController(cfg)))
-		util.Must(m.AddService(controllers.NewInfrastructureServices(cfg)))
-		util.Must(m.AddService((controllers.NewVersionManager((cfg)))))
-		util.Must(m.AddService(kustomize.NewKustomizer(cfg)))
-	}
-
-	if config.StringInList("node", cfg.Roles) {
-		if len(cfg.Roles) == 1 {
-			util.Must(m.AddService(sysconfwatch.NewSysConfWatchController(cfg)))
-		}
-		util.Must(m.AddService(node.NewKubeletServer(cfg)))
-	}
+	util.Must(m.AddService(controllers.NewEtcd(cfg)))
+	util.Must(m.AddService(sysconfwatch.NewSysConfWatchController(cfg)))
+	util.Must(m.AddService(controllers.NewKubeAPIServer(cfg)))
+	util.Must(m.AddService(controllers.NewKubeScheduler(cfg)))
+	util.Must(m.AddService(controllers.NewKubeControllerManager(cfg)))
+	util.Must(m.AddService(controllers.NewOpenShiftCRDManager(cfg)))
+	util.Must(m.AddService(controllers.NewRouteControllerManager(cfg)))
+	util.Must(m.AddService(controllers.NewClusterPolicyController(cfg)))
+	util.Must(m.AddService(controllers.NewOpenShiftDefaultSCCManager(cfg)))
+	util.Must(m.AddService(mdns.NewMicroShiftmDNSController(cfg)))
+	util.Must(m.AddService(controllers.NewInfrastructureServices(cfg)))
+	util.Must(m.AddService((controllers.NewVersionManager((cfg)))))
+	util.Must(m.AddService(kustomize.NewKustomizer(cfg)))
+	util.Must(m.AddService(node.NewKubeletServer(cfg)))
 
 	// Storing and clearing the env, so other components don't send the READY=1 until MicroShift is fully ready
 	notifySocket := os.Getenv("NOTIFY_SOCKET")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/mitchellh/go-homedir"
@@ -33,7 +32,6 @@ const (
 )
 
 var (
-	validRoles   = []string{"controlplane", "node"}
 	configFile   = findConfigFile()
 	dataDir      = findDataDir()
 	manifestsDir = findManifestsDir()
@@ -52,8 +50,6 @@ type ClusterConfig struct {
 
 type MicroshiftConfig struct {
 	LogVLevel int `json:"logVLevel"`
-
-	Roles []string `json:"roles"`
 
 	NodeName string `json:"nodeName"`
 	NodeIP   string `json:"nodeIP"`
@@ -98,11 +94,8 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 		klog.Fatalf("failed to get host IP: %v", err)
 	}
 
-	defaultRoles := make([]string, len(validRoles))
-	copy(defaultRoles, validRoles)
 	return &MicroshiftConfig{
 		LogVLevel: 0,
-		Roles:     defaultRoles,
 		NodeName:  nodeName,
 		NodeIP:    nodeIP,
 		Cluster: ClusterConfig{
@@ -209,9 +202,6 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 	if f := flags.Lookup("v"); f != nil && flags.Changed("v") {
 		c.LogVLevel, _ = strconv.Atoi(f.Value.String())
 	}
-	if ss, err := flags.GetStringSlice("roles"); err == nil && flags.Changed("roles") {
-		c.Roles = ss
-	}
 	if s, err := flags.GetString("node-name"); err == nil && flags.Changed("node-name") {
 		c.NodeName = s
 	}
@@ -257,11 +247,6 @@ func (c *MicroshiftConfig) ReadAndValidate(configFile string, flags *pflag.FlagS
 	}
 	if err := c.ReadFromCmdLine(flags); err != nil {
 		return err
-	}
-	for _, role := range c.Roles {
-		if !StringInList(role, validRoles) {
-			return fmt.Errorf("config error: '%s' is not a valid role, must be in {%s}", role, strings.Join(validRoles, ", "))
-		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -43,7 +42,6 @@ func TestCommandLineConfig(t *testing.T) {
 		{
 			config: &MicroshiftConfig{
 				LogVLevel: 4,
-				Roles:     []string{"controlplane", "node"},
 				NodeName:  "node1",
 				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
@@ -66,7 +64,6 @@ func TestCommandLineConfig(t *testing.T) {
 		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 		// all other flags unbound (looked up by name) and defaulted
 		flags.Int("v", config.LogVLevel, "")
-		flags.StringSlice("roles", config.Roles, "")
 		flags.String("node-name", config.NodeName, "")
 		flags.String("node-ip", config.NodeIP, "")
 		flags.String("url", config.Cluster.URL, "")
@@ -81,7 +78,6 @@ func TestCommandLineConfig(t *testing.T) {
 		var err error
 		err = flags.Parse([]string{
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
-			"--roles=" + strings.Join(tt.config.Roles, ","),
 			"--node-name=" + tt.config.NodeName,
 			"--node-ip=" + tt.config.NodeIP,
 			"--url=" + tt.config.Cluster.URL,
@@ -121,7 +117,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 		{
 			desiredMicroShiftConfig: &MicroshiftConfig{
 				LogVLevel: 23,
-				Roles:     []string{"controlplane", "node"},
 				NodeName:  "node1",
 				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
@@ -140,7 +135,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				value   string
 			}{
 				{"MICROSHIFT_LOGVLEVEL", "23"},
-				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
 				{"MICROSHIFT_NODEIP", "1.2.3.4"},
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
@@ -155,7 +149,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 		{
 			desiredMicroShiftConfig: &MicroshiftConfig{
 				LogVLevel: 23,
-				Roles:     []string{"controlplane", "node"},
 				NodeName:  "node1",
 				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
@@ -174,7 +167,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 				value   string
 			}{
 				{"MICROSHIFT_LOGVLEVEL", "23"},
-				{"MICROSHIFT_ROLES", "controlplane,node"},
 				{"MICROSHIFT_NODENAME", "node1"},
 				{"MICROSHIFT_NODEIP", "1.2.3.4"},
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
@@ -209,7 +201,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	flags.Int("v", 0, "")
-	flags.StringSlice("roles", []string{}, "")
 
 	c := NewMicroshiftConfig()
 

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -73,15 +73,9 @@ func (s *KubeletServer) configure(cfg *config.MicroshiftConfig) {
 	kubeletFlags.NodeIP = cfg.NodeIP
 	kubeletFlags.ContainerRuntime = "remote"
 	kubeletFlags.RemoteRuntimeEndpoint = "unix:///var/run/crio/crio.sock"
-	for _, role := range cfg.Roles {
-		if role == "controlplane" {
-			kubeletFlags.NodeLabels["node-role.kubernetes.io/control-plane"] = ""
-			kubeletFlags.NodeLabels["node-role.kubernetes.io/master"] = ""
-		}
-		if role == "node" {
-			kubeletFlags.NodeLabels["node-role.kubernetes.io/worker"] = ""
-		}
-	}
+	kubeletFlags.NodeLabels["node-role.kubernetes.io/control-plane"] = ""
+	kubeletFlags.NodeLabels["node-role.kubernetes.io/master"] = ""
+	kubeletFlags.NodeLabels["node-role.kubernetes.io/worker"] = ""
 
 	kubeletConfig, err := loadConfigFile(microshiftDataDir + "/resources/kubelet/config/config.yaml")
 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,8 +1,5 @@
 ---
 logVLevel: 4
-roles:
-  - role1
-  - role2
 nodeName: node1
 nodeIP: '1.2.3.4'
 cluster:


### PR DESCRIPTION
Following earlier discussion (https://github.com/openshift/microshift/pull/1011#discussion_r991640607), let's wait to define the configuration surface until split role support arrives.