### PR TITLE
Add support for vnstat metrics to ansible playbooks & slight cleanup

### DIFF
--- a/ansible/roles/configure-firewall/defaults/main.yml
+++ b/ansible/roles/configure-firewall/defaults/main.yml
@@ -13,6 +13,7 @@ firewall_ports:
   - 5353/udp
   - 6443/tcp
   - 8080/tcp
+  - 8082/tcp
   - 9100/tcp
   - 9256/tcp
   - 9537/tcp

--- a/ansible/roles/install-logging-exporters/templates/cadvisor.service.j2
+++ b/ansible/roles/install-logging-exporters/templates/cadvisor.service.j2
@@ -2,7 +2,7 @@
 Description=cAdvisor
 
 [Service]
-ExecStart=/usr/bin/cadvisor -port=8081
+ExecStart=/usr/bin/cadvisor -port=8082
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/install-logging/defaults/main.yml
+++ b/ansible/roles/install-logging/defaults/main.yml
@@ -7,4 +7,4 @@ logging_packages:
 
 logging_services:
   - prometheus
-  - grafana-server
+  - grafana

--- a/ansible/roles/install-logging/tasks/main.yml
+++ b/ansible/roles/install-logging/tasks/main.yml
@@ -18,6 +18,7 @@
 
 - name: start and enable prometheus & grafana service(s)
   ansible.builtin.systemd:
-    name: "{{ logging_services }}"
+    name: "{{ item }}"
     state: restarted
     enabled: yes
+  loop: "{{ logging_services }}"

--- a/ansible/roles/install-logging/templates/prometheus.yml.j2
+++ b/ansible/roles/install-logging/templates/prometheus.yml.j2
@@ -43,7 +43,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
-        - {{ hostvars[host].private_ip }}:8081
+        - {{ hostvars[host].private_ip }}:8082
 {% endfor %}
 
   - job_name: crio

--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -8,8 +8,6 @@ microshift_dir: "{{ ansible_env.HOME }}/microshift"
 microshift_repo: https://github.com/openshift/microshift.git
 microshift_rpms: []
 
-remote_kubeconfig_path: /var/lib/microshift/resources/kubeadmin/kubeconfig
-
 du_dirs:
   - /
   - /var/
@@ -17,5 +15,3 @@ du_dirs:
   - /var/lib/containers/storage/
   - /usr/
   - /usr/bin/*
-
-sample_interval: 5

--- a/ansible/roles/microshift-start/defaults/main.yml
+++ b/ansible/roles/microshift-start/defaults/main.yml
@@ -10,3 +10,7 @@ du_dirs:
   - /var/lib/containers/storage/
   - /usr/
   - /usr/bin/*
+
+sample_interval: 5
+
+vnstat_db: /var/lib/vnstat/vnstat.db

--- a/ansible/roles/microshift-start/tasks/main.yml
+++ b/ansible/roles/microshift-start/tasks/main.yml
@@ -12,6 +12,26 @@
     state: stopped
     enabled: no
 
+- name: check for vnstat
+  ansible.builtin.command: rpm -q vnstat
+  register: vnstat_check
+  ignore_errors: true
+
+- name: vnstat cleanup
+  become: yes
+  block:
+  - name: stop & enable vnstat service
+    ansible.builtin.systemd:
+      name: vnstat
+      state: stopped
+      enabled: yes
+
+  - name: delete vnstat db
+    ansible.builtin.file:
+      path: "{{ vnstat_db }}"
+      state: absent
+  when: vnstat_check.rc == 0
+
 - name: create .kube home dir
   ansible.builtin.file:
     path: ~/.kube/
@@ -76,6 +96,7 @@
     enabled: no
 
 - name: restart cadvisor to pick up new containers
+  become: yes
   ansible.builtin.systemd:
     name: cadvisor
     state: restarted
@@ -143,6 +164,7 @@
 
   - name: source pbench-agent & move results
     ansible.builtin.shell: source /etc/profile.d/pbench-agent.sh && pbench-move-results
+    ignore_errors: yes
   when: install_pbench | bool
   environment:
     PBENCH_USER: microshift
@@ -152,3 +174,13 @@
     filename: disk2.txt
   include_tasks: roles/common/tasks/disk.yml
   loop: "{{ du_dirs }}"
+
+- name: get vnstat network usage
+  command: vnstat
+  register: vnstat
+
+- name: record network usage to file
+  local_action:
+    module: copy
+    content: "{{ vnstat.stdout }}"
+    dest: network.txt

--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -13,34 +13,7 @@ install_packages:
   - perf
   - rpm-build
   - selinux-policy-devel 
+  - vnstat
 
 vg_name: rhel
 lvm_disk: /dev/xvdb
-
-oc_archive_name: openshift-client-linux.tar.gz
-
-remote_kubeconfig_path: /var/lib/microshift/resources/kubeadmin/kubeconfig
-
-firewall_services:
-  - http
-  - https
-  - mdns
-
-firewall_ports:
-  - 80/tcp
-  - 443/tcp
-  - 2379/tcp
-  - 5353/udp
-  - 6443/tcp
-  - 8080/tcp
-  - 9100/tcp
-  - 9537/tcp
-  - 17001/tcp
-  - 30000-32767/tcp
-  - 30000-32767/udp
-
-firewall_trusted_cidr:
-  - 10.42.0.0/16
-  - 169.254.169.1/32
-
-root_bin_dir: /usr/bin

--- a/ansible/roles/setup-microshift-host/templates/cadvisor.service.j2
+++ b/ansible/roles/setup-microshift-host/templates/cadvisor.service.j2
@@ -1,8 +1,0 @@
-[Unit]
-Description=cAdvisor
-
-[Service]
-ExecStart=/usr/bin/cadvisor -port=8081
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
- `vnstat` gives us over the wire data metrics.
- `cadvisor` default port was already in use.
- As we split the roles into smaller pieces, some cruft needed to be removed.