### PR TITLE
Fix microshift to be able to run on Mac

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -58,7 +58,7 @@ func NewRunMicroshiftCommand() *cobra.Command {
 
 func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	if err := cfg.ReadAndValidate("", flags); err != nil {
-		klog.Fatalf("Error in reading and validating flags", err)
+		klog.Fatalf("Error in reading and validating flags: %v", err)
 	}
 
 	// fail early if we don't have enough privileges

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,11 +188,11 @@ func StringInList(s string, list []string) bool {
 func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	contents, err := os.ReadFile(configFile)
 	if err != nil {
-		return fmt.Errorf("reading config file %s: %v", configFile, err)
+		return fmt.Errorf("reading config file %q: %v", configFile, err)
 	}
 
 	if err := yaml.Unmarshal(contents, c); err != nil {
-		return fmt.Errorf("decoding config file %s: %v", configFile, err)
+		return fmt.Errorf("decoding config file %q: %v", configFile, err)
 	}
 
 	return nil
@@ -245,6 +245,9 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 func (c *MicroshiftConfig) ReadAndValidate(configFile string, flags *pflag.FlagSet) error {
 	if configFile == "" {
 		configFile = findConfigFile()
+	}
+	if len(configFile) == 0 {
+		return fmt.Errorf("unable to find config file in %q or %q", defaultGlobalConfigFile, defaultUserConfigFile)
 	}
 	if err := c.ReadFromConfigFile(configFile); err != nil {
 		return err

--- a/pkg/release/release_arm64.go
+++ b/pkg/release/release_arm64.go
@@ -29,5 +29,12 @@ func init() {
 		"ovn_kubernetes_microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4678d1ccf812ef8bcbfd54cf59d5d01be05d1b08683c346e06c3e29d3f924824",
 		"pod":                       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9f9b6f1aa2770195c726ef4186306813b3c3c038cc488ff05aa5873297de94d0",
 		"service_ca_operator":       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:989a43840f16af130f846df494e61e484d42ed679d311db79a6b698d2399b92e",
+
+		// TODO: find the real images here, otherwise the run fails on infrastructure-service-controller
+		"odf_topolvm":             "quay.io/microshift/odf-topolvm-rhel8" + Base,
+		"ose_csi_ext_provisioner": "quay.io/microshift/ose-csi-external-provisioner" + Base,
+		"ose_csi_ext_resizer":     "quay.io/microshift/ose-csi-external-resizer" + Base,
+		"ose_csi_node_registrar":  "quay.io/microshift/ose-csi-node-driver-registrar" + Base,
+		"ose_csi_livenessprobe":   "quay.io/microshift/ose-csi-livenessprobe" + Base,
 	}
 }


### PR DESCRIPTION
These changes allow us to develop a microshift on M1 MacBook. Kubelet won't run and therefore is disabled with a big warning, but this allows at least testing without using an external Linux box or emulation. 

This is super low priority, but if somebody struggle to get microshift running on Mac, they can use this.