### PR TITLE
WIP: add microshift inspect command

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -10,6 +10,7 @@ import (
 
 	cmds "github.com/openshift/microshift/pkg/cmd"
 	"github.com/openshift/microshift/pkg/config"
+	"github.com/openshift/microshift/pkg/inspect"
 )
 
 func main() {
@@ -38,5 +39,6 @@ func newCommand() *cobra.Command {
 	cmd.AddCommand(cmds.NewRunMicroshiftCommand())
 	cmd.AddCommand(cmds.NewVersionCommand(ioStreams))
 	cmd.AddCommand(cmds.NewShowConfigCommand(ioStreams))
+	cmd.AddCommand(inspect.NewCmdInspect(ioStreams))
 	return cmd
 }

--- a/pkg/inspect/event_filter_html.go
+++ b/pkg/inspect/event_filter_html.go
@@ -1,0 +1,93 @@
+package inspect
+
+const eventHTMLPage = `
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+	<link href="https://unpkg.com/bootstrap-table@1.17.1/dist/bootstrap-table.min.css" rel="stylesheet">
+
+    <title>Events</title>
+	<style type="text/css">
+      body * {
+       font-size: 12px!important;
+      }
+	  .text-overflow() {
+       overflow: hidden;
+	   text-overflow: ellipsis;
+	   white-space: nowrap;
+	  }
+      .truncated {
+        display: inline-block;
+        max-width: 200px;
+        .text-overflow();
+      }
+    </style>
+  </head>
+  <body>
+
+<table
+  id="events"
+  class="table table-bordered table-hover table-sm"
+  data-toggle="table"
+  data-search="true"
+  data-show-search-clear-button="true"
+  data-filter-control="true"
+  data-advanced-search="true"
+  data-id-table="advancedTable"
+  data-pagination="true"
+  data-page-size="100"
+  data-show-columns-toggle-all="true"
+  data-show-pagination-switch="true"
+  data-show-columns="true">
+  <thead>
+    <tr>
+      <th data-width="100" data-field="time" data-filter-control="input" data-sortable="true">Time</th>
+      <th data-width="200" data-field="namespace" data-filter-control="input" data-sortable="true">Namespace</th>
+      <th data-width="200" data-field="component" data-filter-control="input" data-sortable="true">Component</th>
+      <th data-width="200" data-field="relatedobject" data-filter-control="input" data-sortable="true">RelatedObject</th>
+      <th data-field="reason" data-filter-control="input">Reason</th>
+      <th data-field="message" data-filter-control="input" data-escape="true">Message</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{range .Items}}
+    <tr>
+      <td>{{formatTime .ObjectMeta.CreationTimestamp .FirstTimestamp .LastTimestamp .Count}}</td>
+      <td><p class="truncated">{{.Namespace}}</p></td>
+      <td><p class="truncated">{{.Source.Component}}</p></td>
+      <td><p class="truncated">{{.InvolvedObject.Name}}</p></td>
+      <td>{{formatReason .Reason}}</td>
+      <td data-formatter="messageFormatter">{{.Message}}</td>
+    </tr>
+    {{end}}
+  </tbody>
+</table>
+
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+
+    <script src="https://unpkg.com/bootstrap-table@1.17.1/dist/bootstrap-table.min.js" crossorigin="anonymous"></script>
+	<script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/toolbar/bootstrap-table-toolbar.min.js" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.17.1/dist/extensions/filter-control/bootstrap-table-filter-control.min.js" crossorigin="anonymous"></script>
+
+	<script>
+	function messageFormatter(value, row) {
+    	return '<code>'+value+'</code>'
+  	}
+    $(function() {
+      $('#events').bootstrapTable()
+    })
+	</script>
+  </body>
+</html>
+`

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -1,0 +1,416 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+var (
+	inspectLong = templates.LongDesc(`
+		Gather debugging information for a resource.
+
+		This command downloads the specified resource and any related
+		resources for the purpose of gathering debugging information.
+
+		Experimental: This command is under active development and may change without notice.
+	`)
+
+	inspectExample = templates.Examples(`
+		# Collect debugging data for the "openshift-apiserver" clusteroperator
+		oc adm inspect clusteroperator/openshift-apiserver
+
+		# Collect debugging data for the "openshift-apiserver" and "kube-apiserver" clusteroperator
+		oc adm inspect clusteroperator/openshift-apiserver clusteroperator/kube-apiserver
+
+		# Collect debugging data for all clusteroperators
+		oc adm inspect clusteroperator
+
+		# Collect debugging data for all clusteroperator and clusterversions
+		oc adm inspect clusteroperators,clusterversions
+	`)
+)
+
+type InspectOptions struct {
+	printFlags  *genericclioptions.PrintFlags
+	configFlags *genericclioptions.ConfigFlags
+
+	restConfig      *rest.Config
+	kubeClient      kubernetes.Interface
+	discoveryClient discovery.CachedDiscoveryInterface
+	dynamicClient   dynamic.Interface
+
+	podUrlGetter *PortForwardURLGetter
+
+	fileWriter     *MultiSourceFileWriter
+	builder        *resource.Builder
+	since          time.Duration
+	args           []string
+	namespace      string
+	sinceTime      string
+	allNamespaces  bool
+	sinceInt       int64
+	sinceTimestamp metav1.Time
+
+	// directory where all gathered data will be stored
+	destDir string
+	// whether or not to allow writes to an existing and populated base directory
+	overwrite bool
+
+	genericclioptions.IOStreams
+	eventFile string
+}
+
+func NewInspectOptions(streams genericclioptions.IOStreams) *InspectOptions {
+	return &InspectOptions{
+		printFlags:  genericclioptions.NewPrintFlags("gathered").WithDefaultOutput("yaml").WithTypeSetter(scheme.Scheme),
+		configFlags: genericclioptions.NewConfigFlags(true),
+		overwrite:   true,
+		IOStreams:   streams,
+	}
+}
+
+func NewCmdInspect(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewInspectOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "inspect (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME ...) [flags]",
+		Short:   "Collect debugging data for a given resource",
+		Long:    inspectLong,
+		Example: inspectExample,
+		Run: func(c *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(c, args))
+			kcmdutil.CheckErr(o.Validate())
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+
+	cmd.Flags().StringVar(&o.destDir, "dest-dir", o.destDir, "Root directory used for storing all gathered cluster operator data. Defaults to $(PWD)/inspect.local.<rand>")
+	cmd.Flags().StringVar(&o.eventFile, "events-file", o.eventFile, "A path to an events.json file to create a HTML page from")
+	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().StringVar(&o.sinceTime, "since-time", o.sinceTime, "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.")
+	cmd.Flags().DurationVar(&o.since, "since", o.since, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.")
+
+	o.configFlags.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (o *InspectOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+
+	if len(o.eventFile) > 0 {
+		return nil
+	}
+
+	var err error
+	o.restConfig, err = o.configFlags.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+	// we make lots and lots of client calls, don't slow down artificially.
+	o.restConfig.QPS = 999999
+	o.restConfig.Burst = 999999
+
+	o.kubeClient, err = kubernetes.NewForConfig(o.restConfig)
+	if err != nil {
+		return err
+	}
+
+	o.dynamicClient, err = dynamic.NewForConfig(o.restConfig)
+	if err != nil {
+		return err
+	}
+
+	o.discoveryClient, err = o.configFlags.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+
+	o.namespace, _, err = o.configFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	if o.since != 0 {
+		o.sinceInt = (int64(o.since.Round(time.Second).Seconds()))
+	}
+	if len(o.sinceTime) > 0 {
+		o.sinceTimestamp, err = util.ParseRFC3339(o.sinceTime, metav1.Now)
+		if err != nil {
+			return err
+		}
+	}
+
+	printer, err := o.printFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	o.fileWriter = NewMultiSourceWriter(printer)
+	o.podUrlGetter = &PortForwardURLGetter{
+		Protocol:  "https",
+		Host:      "localhost",
+		LocalPort: "37587",
+	}
+
+	o.builder = resource.NewBuilder(o.configFlags)
+
+	if len(o.destDir) == 0 {
+		o.destDir = fmt.Sprintf("inspect.local.%06d", rand.Int63())
+	}
+	return nil
+}
+
+func (o *InspectOptions) Validate() error {
+	if len(o.destDir) == 0 {
+		return fmt.Errorf("--dest-dir must not be empty")
+	}
+	if len(o.sinceTime) > 0 && o.since != 0 {
+		return fmt.Errorf("at most one of `sinceTime` or `since` may be specified")
+	}
+	return nil
+}
+
+func (o *InspectOptions) Run() error {
+	if len(o.eventFile) > 0 {
+		return createEventFilterPageFromFile(o.eventFile, o.destDir)
+	}
+	r := o.builder.
+		Unstructured().
+		NamespaceParam(o.namespace).DefaultNamespace().AllNamespaces(o.allNamespaces).
+		ResourceTypeOrNameArgs(true, o.args...).
+		Flatten().
+		Latest().Do()
+
+	infos, err := r.Infos()
+	if err != nil {
+		return err
+	}
+
+	// ensure we're able to proceed writing data to specified destination
+	if err := o.ensureDirectoryViable(); err != nil {
+		return err
+	}
+
+	// ensure destination path exists
+	if err := os.MkdirAll(o.destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := o.logTimestamp(); err != nil {
+		return err
+	}
+	defer o.logTimestamp()
+
+	// finally, gather polymorphic resources specified by the user
+	allErrs := []error{}
+	ctx := NewResourceContext()
+	for _, info := range infos {
+		err := InspectResource(info, ctx, o)
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	// now gather all the events into a single file and produce a unified file
+	if err := CreateEventFilterPage(o.destDir); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	fmt.Fprintf(o.Out, "Wrote inspect data to %s.\n", o.destDir)
+	if len(allErrs) > 0 {
+		return fmt.Errorf("errors ocurred while gathering data:\n    %v", errors.NewAggregate(allErrs))
+	}
+
+	return nil
+}
+
+// gatherConfigResourceData gathers all config.openshift.io resources
+func (o *InspectOptions) gatherConfigResourceData(destDir string, ctx *resourceContext) error {
+	// determine if we've already collected configResourceData
+	if ctx.visited.Has(configResourceDataKey) {
+		klog.V(1).Infof("Skipping previously-collected config.openshift.io resource data")
+		return nil
+	}
+	ctx.visited.Insert(configResourceDataKey)
+
+	klog.V(1).Infof("Gathering config.openshift.io resource data...\n")
+
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	resources, err := retrieveAPIGroupVersionResourceNames(o.discoveryClient, configv1.GroupName)
+	if err != nil {
+		return err
+	}
+
+	errs := []error{}
+	for _, resource := range resources {
+		resourceList, err := o.dynamicClient.Resource(resource).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		objToPrint := runtime.Object(resourceList)
+		filename := fmt.Sprintf("%s.yaml", resource.Resource)
+		if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), objToPrint); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors ocurred while gathering config.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
+	}
+	return nil
+}
+
+// gatherOperatorResourceData gathers all kubeapiserver.operator.openshift.io resources
+func (o *InspectOptions) gatherOperatorResourceData(destDir string, ctx *resourceContext) error {
+	// determine if we've already collected operatorResourceData
+	if ctx.visited.Has(operatorResourceDataKey) {
+		klog.V(1).Infof("Skipping previously-collected operator.openshift.io resource data")
+		return nil
+	}
+	ctx.visited.Insert(operatorResourceDataKey)
+
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	resources, err := retrieveAPIGroupVersionResourceNames(o.discoveryClient, "kubeapiserver.operator.openshift.io")
+	if err != nil {
+		return err
+	}
+
+	errs := []error{}
+	for _, resource := range resources {
+		resourceList, err := o.dynamicClient.Resource(resource).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		objToPrint := runtime.Object(resourceList)
+		filename := fmt.Sprintf("%s.yaml", resource.Resource)
+		if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), objToPrint); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors ocurred while gathering operator.openshift.io resource data:\n\n    %v", errors.NewAggregate(errs))
+	}
+	return nil
+}
+
+// ensureDirectoryViable returns an error if destDir:
+// 1. already exists AND is a file (not a directory)
+// 2. already exists AND is NOT empty, unless overwrite was passed
+// 3. an IO error occurs
+func (o *InspectOptions) ensureDirectoryViable() error {
+	baseDirInfo, err := os.Stat(o.destDir)
+	if err != nil && os.IsNotExist(err) {
+		// no error, directory simply does not exist yet
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !baseDirInfo.IsDir() {
+		return fmt.Errorf("%q exists and is a file", o.destDir)
+	}
+	files, err := ioutil.ReadDir(o.destDir)
+	if err != nil {
+		return err
+	}
+	if len(files) > 0 && !o.overwrite {
+		return fmt.Errorf("%q exists and is not empty. Pass --overwrite to allow data overwrites", o.destDir)
+	}
+	return nil
+}
+
+func (o *InspectOptions) logTimestamp() error {
+	f, err := os.OpenFile(path.Join(o.destDir, "timestamp"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(fmt.Sprintf("%v\n", time.Now()))
+	return err
+}
+
+// supportedResourceFinder provides a way to discover supported resources by the server.
+// it exists to allow for easier testability.
+type supportedResourceFinder interface {
+	ServerPreferredResources() ([]*metav1.APIResourceList, error)
+}
+
+func retrieveAPIGroupVersionResourceNames(discoveryClient supportedResourceFinder, apiGroup string) ([]schema.GroupVersionResource, error) {
+	lists, discoveryErr := discoveryClient.ServerPreferredResources()
+
+	foundResources := sets.String{}
+	resources := []schema.GroupVersionResource{}
+	for _, list := range lists {
+		if len(list.APIResources) == 0 {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(list.GroupVersion)
+		if err != nil {
+			/// something went seriously wrong
+			return nil, err
+		}
+		for _, resource := range list.APIResources {
+			// filter groups outside of the provided apiGroup
+			if !strings.HasSuffix(gv.Group, apiGroup) {
+				continue
+			}
+			verbs := sets.NewString(([]string(resource.Verbs))...)
+			if !verbs.Has("list") {
+				continue
+			}
+			// if we've already seen this resource in another version, don't add it again
+			if foundResources.Has(resource.Name) {
+				continue
+			}
+
+			foundResources.Insert(resource.Name)
+			resources = append(resources, schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: resource.Name})
+		}
+	}
+	// we only care about discovery errors if we don't find what we want
+	if len(resources) == 0 {
+		return nil, discoveryErr
+	}
+
+	return resources, nil
+}

--- a/pkg/inspect/inspect_test.go
+++ b/pkg/inspect/inspect_test.go
@@ -1,0 +1,238 @@
+package inspect
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestDirectoryViable(t *testing.T) {
+	tc := []struct {
+		name          string
+		dirName       func() (string, error)
+		teardown      func(string) error
+		allowOverride bool
+		expectedErr   error
+	}{
+		{
+			name:    "ensure non-existent directory is viable",
+			dirName: func() (string, error) { return "/foo/bar/baz", nil },
+		},
+		{
+			name: "ensure empty directory is viable",
+			dirName: func() (string, error) {
+				tmpDir, err := ioutil.TempDir(os.TempDir(), "must-gather-inspect-")
+				if err != nil {
+					return "", err
+				}
+				return tmpDir, nil
+			},
+			teardown: defaultTempDirTeardown,
+		},
+		{
+			name: "ensure non-empty directory not viable",
+			dirName: func() (string, error) {
+				tmpDir, err := ioutil.TempDir(os.TempDir(), "must-gather-inspect-")
+				if err != nil {
+					return "", err
+				}
+				_, err = ioutil.TempFile(tmpDir, "must-gather-inspect-file-")
+				return tmpDir, err
+			},
+			expectedErr: fmt.Errorf("exists and is not empty"),
+			teardown:    defaultTempDirTeardown,
+		},
+		{
+			name: "ensure non-empty directory viable with data override",
+			dirName: func() (string, error) {
+				tmpDir, err := ioutil.TempDir(os.TempDir(), "must-gather-inspect-")
+				if err != nil {
+					return "", err
+				}
+				_, err = ioutil.TempFile(tmpDir, "must-gather-inspect-file-")
+				return tmpDir, err
+			},
+			allowOverride: true,
+			teardown:      defaultTempDirTeardown,
+		},
+	}
+
+	for _, test := range tc {
+		t.Run(test.name, func(t *testing.T) {
+			dirName, err := test.dirName()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if test.teardown != nil {
+				defer test.teardown(dirName)
+			}
+
+			o := InspectOptions{destDir: dirName, overwrite: test.allowOverride}
+			err = o.ensureDirectoryViable()
+			if !errorFuzzyEquals(err, test.expectedErr) {
+				t.Fatalf("unexpected error: expecting %v, but got %v", test.expectedErr, err)
+			}
+		})
+	}
+}
+
+// fakeSupportedResourceFinder implements supportedResourceFinder
+type fakeSupportedResourceFinder struct {
+	withError          error
+	supportedResources []*metav1.APIResourceList
+}
+
+func (f *fakeSupportedResourceFinder) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return f.supportedResources, f.withError
+}
+
+func TestAPIGroupVersionRetrieval(t *testing.T) {
+	tc := []struct {
+		name              string
+		resourceFinder    supportedResourceFinder
+		apiGroup          string
+		expectedResources []schema.GroupVersionResource
+		expectedErr       error
+	}{
+		{
+			name: "ensure unknown apiGroup returns no results",
+			resourceFinder: &fakeSupportedResourceFinder{
+				supportedResources: fakeAPIResourceList(),
+			},
+			apiGroup: "unknown",
+		},
+		{
+			name: "ensure known apiGroup returns expected results",
+			resourceFinder: &fakeSupportedResourceFinder{
+				supportedResources: fakeAPIResourceList(),
+			},
+			apiGroup:          "test.group.io",
+			expectedResources: []schema.GroupVersionResource{{Group: "test.group.io", Version: "v1", Resource: "testresources"}},
+		},
+		{
+			name: "ensure different, but known apiGroup returns expected results",
+			resourceFinder: &fakeSupportedResourceFinder{
+				supportedResources: fakeAPIResourceList(),
+			},
+			apiGroup:          "foo.group.io",
+			expectedResources: []schema.GroupVersionResource{{Group: "foo.group.io", Version: "v1", Resource: "foos"}},
+		},
+		{
+			name: "ensure known apiGroup with NO `list` verb is omitted from results",
+			resourceFinder: &fakeSupportedResourceFinder{
+				supportedResources: []*metav1.APIResourceList{
+					{
+						TypeMeta:     metav1.TypeMeta{Kind: "test", APIVersion: "v1"},
+						GroupVersion: schema.GroupVersion{Group: "test.group.io", Version: "v1"}.String(),
+						APIResources: []metav1.APIResource{
+							{
+								Name:         "testresources",
+								SingularName: "testresource",
+								Group:        "test.group.io",
+								Version:      "v1",
+								Kind:         "test",
+								Verbs:        []string{"get"},
+							},
+						},
+					},
+				},
+			},
+			apiGroup: "test.group.io",
+		},
+		{
+			name:           "ensure only discovery errors are returned when no resources are found",
+			resourceFinder: &fakeSupportedResourceFinder{withError: fmt.Errorf("test")},
+			apiGroup:       "foo",
+			expectedErr:    fmt.Errorf("test"),
+		},
+	}
+
+	for _, test := range tc {
+		t.Run(test.name, func(t *testing.T) {
+			resources, err := retrieveAPIGroupVersionResourceNames(test.resourceFinder, test.apiGroup)
+			if !errorFuzzyEquals(err, test.expectedErr) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !resourceListsEqual(resources, test.expectedResources) {
+				t.Fatalf("unexpected result; expected %#v, but got %#v", test.expectedResources, resources)
+			}
+		})
+	}
+}
+
+func resourceListsEqual(a, b []schema.GroupVersionResource) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 1 {
+		return a[0].String() == b[0].String()
+	}
+
+	for idxA := range a {
+		for idxB := range b {
+			if a[idxA].String() != b[idxB].String() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func fakeAPIResourceList() []*metav1.APIResourceList {
+	return []*metav1.APIResourceList{
+		{
+			TypeMeta:     metav1.TypeMeta{Kind: "test", APIVersion: "v1"},
+			GroupVersion: schema.GroupVersion{Group: "test.group.io", Version: "v1"}.String(),
+			APIResources: []metav1.APIResource{
+				{
+					Name:         "testresources",
+					SingularName: "testresource",
+					Group:        "test.group.io",
+					Version:      "v1",
+					Kind:         "test",
+					Verbs:        []string{"list"},
+				},
+			},
+		},
+		{
+			TypeMeta:     metav1.TypeMeta{Kind: "foo", APIVersion: "v1"},
+			GroupVersion: schema.GroupVersion{Group: "foo.group.io", Version: "v1"}.String(),
+			APIResources: []metav1.APIResource{
+				{
+					Name:         "foos",
+					SingularName: "foo",
+					Group:        "foo.group.io",
+					Version:      "v1",
+					Kind:         "foo",
+					Verbs:        []string{"list"},
+				},
+			},
+		},
+	}
+}
+
+func defaultTempDirTeardown(dirName string) error {
+	if len(dirName) == 0 {
+		return nil
+	}
+	return os.RemoveAll(dirName)
+}
+
+func errorFuzzyEquals(a, b error) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return strings.Contains(a.Error(), b.Error())
+}

--- a/pkg/inspect/namespace.go
+++ b/pkg/inspect/namespace.go
@@ -1,0 +1,87 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+)
+
+// TODO someone may later choose to use discovery information to determine what to collect
+func namespaceResourcesToCollect() []schema.GroupResource {
+	return []schema.GroupResource{
+		// this is actually a group which collects most useful things
+		{Resource: "all"},
+		{Resource: "configmaps"},
+		{Resource: "events"},
+		{Resource: "endpoints"},
+		{Resource: "endpointslices"},
+		{Resource: "persistentvolumeclaims"},
+		{Resource: "secrets"},
+	}
+}
+
+func (o *InspectOptions) gatherNamespaceData(baseDir, namespace string) error {
+	fmt.Fprintf(o.Out, "Gathering data for ns/%s...\n", namespace)
+
+	destDir := path.Join(baseDir, namespaceResourcesDirname, namespace)
+
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	ns, err := o.kubeClient.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+	if err != nil { // If we can't get the namespace we need to exit out
+		return err
+	}
+	ns.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+
+	errs := []error{}
+	// write namespace.yaml file
+	filename := fmt.Sprintf("%s.yaml", namespace)
+	if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), ns); err != nil {
+		errs = append(errs, err)
+	}
+
+	klog.V(1).Infof("    Collecting resources for namespace %q...\n", namespace)
+
+	resourcesTypesToStore := map[schema.GroupVersionResource]bool{
+		corev1.SchemeGroupVersion.WithResource("pods"): true,
+	}
+	resourcesToStore := map[schema.GroupVersionResource]runtime.Object{}
+
+	// collect specific resource information for namespace
+	for gvr := range resourcesTypesToStore {
+		list, err := o.dynamicClient.Resource(gvr).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			errs = append(errs, err)
+		}
+		resourcesToStore[gvr] = list
+	}
+
+	klog.V(1).Infof("    Gathering pod data for namespace %q...\n", namespace)
+	// gather specific pod data
+	for _, pod := range resourcesToStore[corev1.SchemeGroupVersion.WithResource("pods")].(*unstructured.UnstructuredList).Items {
+		klog.V(1).Infof("        Gathering data for pod %q\n", pod.GetName())
+		structuredPod := &corev1.Pod{}
+		runtime.DefaultUnstructuredConverter.FromUnstructured(pod.Object, structuredPod)
+		if err := o.gatherPodData(path.Join(destDir, "/pods/"+pod.GetName()), namespace, structuredPod); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors ocurred while gathering pod-specific data for namespace: %s\n\n    %v", namespace, errors.NewAggregate(errs))
+	}
+	return nil
+}

--- a/pkg/inspect/pod.go
+++ b/pkg/inspect/pod.go
@@ -1,0 +1,362 @@
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+func (o *InspectOptions) gatherPodData(destDir, namespace string, pod *corev1.Pod) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf("%s.yaml", pod.Name)
+	if err := o.fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), pod); err != nil {
+		return err
+	}
+
+	errs := []error{}
+
+	// gather data for each container in the given pod
+	for _, container := range pod.Spec.Containers {
+		if err := o.gatherContainerInfo(path.Join(destDir, "/"+container.Name), pod, container); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+	for _, container := range pod.Spec.InitContainers {
+		if err := o.gatherContainerInfo(path.Join(destDir, "/"+container.Name), pod, container); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("one or more errors ocurred while gathering container data for pod %s:\n\n    %v", pod.Name, utilerrors.NewAggregate(errs))
+	}
+	return nil
+}
+
+func (o *InspectOptions) gatherContainerInfo(destDir string, pod *corev1.Pod, container corev1.Container) error {
+	if err := o.gatherContainerAllLogs(path.Join(destDir, "/"+container.Name), pod, &container); err != nil {
+		return err
+	}
+	if len(o.restConfig.BearerToken) > 0 {
+		// token authentication is vulnerable to replays if the token is sent to a potentially untrustworthy source.
+		klog.V(1).Infof("        Skipping container endpoint collection for pod %q container %q: Using token authentication\n", pod.Name, container.Name)
+		return nil
+	}
+	if len(container.Ports) == 0 {
+		klog.V(1).Infof("        Skipping container endpoint collection for pod %q container %q: No ports\n", pod.Name, container.Name)
+		return nil
+	}
+	port := &RemoteContainerPort{
+		Protocol: "https",
+		Port:     container.Ports[0].ContainerPort,
+	}
+
+	if err := o.gatherContainerEndpoints(path.Join(destDir, "/"+container.Name), pod, port); err != nil {
+		klog.V(1).Infof("        Skipping one or more container endpoint collection for pod %q container %q: %v\n", pod.Name, container.Name, err)
+	}
+
+	return nil
+}
+
+func (o *InspectOptions) gatherContainerAllLogs(destDir string, pod *corev1.Pod, container *corev1.Container) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	errs := []error{}
+	if err := o.gatherContainerLogs(path.Join(destDir, "/logs"), pod, container); err != nil {
+		errs = append(errs, filterContainerLogsErrors(err))
+	}
+
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+	return nil
+}
+
+func (o *InspectOptions) gatherContainerEndpoints(destDir string, pod *corev1.Pod, metricsPort *RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	errs := []error{}
+	if err := o.gatherContainerHealthz(path.Join(destDir, "/healthz"), pod, metricsPort); err != nil {
+		errs = append(errs, fmt.Errorf("unable to gather container /healthz: %v", err))
+	}
+	if err := o.gatherContainerVersion(destDir, pod, metricsPort); err != nil {
+		errs = append(errs, fmt.Errorf("unable to gather container /version: %v", err))
+	}
+	if err := o.gatherContainerMetrics(destDir, pod, metricsPort); err != nil {
+		errs = append(errs, fmt.Errorf("unable to gather container /metrics: %v", err))
+	}
+	if err := o.gatherContainerDebug(destDir, pod, metricsPort); err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("unable to gather container /debug : %v", err))
+	}
+
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+	return nil
+}
+
+func filterContainerLogsErrors(err error) error {
+	if strings.Contains(err.Error(), "previous terminated container") && strings.HasSuffix(err.Error(), "not found") {
+		klog.V(1).Infof("        Unable to gather previous container logs: %v\n", err)
+		return nil
+	}
+	return err
+}
+
+func (o *InspectOptions) gatherContainerVersion(destDir string, pod *corev1.Pod, metricsPort *RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	hasVersionPath := false
+
+	// determine if a /version endpoint exists
+	paths, err := getAvailablePodEndpoints(o.podUrlGetter, pod, o.restConfig, metricsPort)
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		if p != "/version" {
+			continue
+		}
+		hasVersionPath = true
+		break
+	}
+	if !hasVersionPath {
+		klog.V(1).Infof("        Skipping /version info gathering for pod %q. Endpoint not found...\n", pod.Name)
+		return nil
+	}
+
+	result, err := o.podUrlGetter.Get("/version", pod, o.restConfig, metricsPort)
+
+	return o.fileWriter.WriteFromSource(path.Join(destDir, "version.json"), &TextWriterSource{Text: result})
+}
+
+// gatherContainerDebug invokes an asynchronous network call to gather pprof profile and heap
+func (o *InspectOptions) gatherContainerDebug(destDir string, pod *corev1.Pod, debugPort *RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+	endpoints := []string{"heap", "profile", "trace"}
+
+	for _, endpoint := range endpoints {
+		// we need a token in order to access the /debug endpoint
+		result, err := o.podUrlGetter.Get("/debug/pprof/"+endpoint, pod, o.restConfig, debugPort)
+		if err != nil {
+			return err
+		}
+		if err := o.fileWriter.WriteFromSource(path.Join(destDir, endpoint), &TextWriterSource{Text: result}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// gatherContainerMetrics invokes an asynchronous network call
+func (o *InspectOptions) gatherContainerMetrics(destDir string, pod *corev1.Pod, metricsPort *RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	// we need a token in order to access the /metrics endpoint
+	result, err := o.podUrlGetter.Get("/metrics", pod, o.restConfig, metricsPort)
+	if err != nil {
+		return err
+	}
+
+	return o.fileWriter.WriteFromSource(path.Join(destDir, "metrics.json"), &TextWriterSource{Text: result})
+}
+
+func (o *InspectOptions) gatherContainerHealthz(destDir string, pod *corev1.Pod, metricsPort *RemoteContainerPort) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	paths, err := getAvailablePodEndpoints(o.podUrlGetter, pod, o.restConfig, metricsPort)
+	if err != nil {
+		return err
+	}
+
+	healthzSeparator := "/healthz"
+	healthzPaths := []string{}
+	for _, p := range paths {
+		if !strings.HasPrefix(p, healthzSeparator) {
+			continue
+		}
+		healthzPaths = append(healthzPaths, p)
+	}
+	if len(healthzPaths) == 0 {
+		return fmt.Errorf("unable to find any available /healthz paths hosted in pod %q", pod.Name)
+	}
+
+	err = o.podUrlGetter.ForwardRequests(pod, o.restConfig, metricsPort, func(restClient rest.Interface) error {
+		for _, healthzPath := range healthzPaths {
+			ioCloser, err := restClient.Get().RequestURI(path.Join("/", healthzPath)).Stream(context.TODO())
+			if err != nil {
+				return err
+			}
+			defer ioCloser.Close()
+
+			data := bytes.NewBuffer(nil)
+			if _, err := io.Copy(data, ioCloser); err != nil {
+				return err
+			}
+
+			if len(healthzSeparator) > len(healthzPath) {
+				continue
+			}
+			filename := healthzPath[len(healthzSeparator):]
+			if len(filename) == 0 {
+				filename = "index"
+			} else {
+				filename = strings.TrimPrefix(filename, "/")
+			}
+
+			filenameSegs := strings.Split(filename, "/")
+			if len(filenameSegs) > 1 {
+				// ensure directory structure for nested paths exists
+				filenameSegs = filenameSegs[:len(filenameSegs)-1]
+				if err := os.MkdirAll(path.Join(destDir, "/"+strings.Join(filenameSegs, "/")), os.ModePerm); err != nil {
+					return err
+				}
+			}
+
+			if err := o.fileWriter.WriteFromSource(path.Join(destDir, filename), &TextWriterSource{Text: data.String()}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getAvailablePodEndpoints(urlGetter *PortForwardURLGetter, pod *corev1.Pod, config *rest.Config, port *RemoteContainerPort) ([]string, error) {
+	result, err := urlGetter.Get("/", pod, config, port)
+	if err != nil {
+		return nil, err
+	}
+
+	resultBuffer := bytes.NewBuffer([]byte(result))
+	pathInfo := map[string][]string{}
+
+	// first, unmarshal result into json object and obtain all available /healthz endpoints
+	if err := json.Unmarshal(resultBuffer.Bytes(), &pathInfo); err != nil {
+		return nil, err
+	}
+	paths, ok := pathInfo["paths"]
+	if !ok {
+		return nil, fmt.Errorf("unable to extract path information for pod %q", pod.Name)
+	}
+
+	return paths, nil
+}
+
+func (o *InspectOptions) gatherContainerLogs(destDir string, pod *corev1.Pod, container *corev1.Container) error {
+	// ensure destination path exists
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+	errs := []error{}
+	wg := sync.WaitGroup{}
+	errLock := sync.Mutex{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		innerErrs := []error{}
+		logOptions := &corev1.PodLogOptions{
+			Container:  container.Name,
+			Follow:     false,
+			Previous:   false,
+			Timestamps: true,
+		}
+		if len(o.sinceTime) > 0 {
+			logOptions.SinceTime = &o.sinceTimestamp
+		}
+		if o.since != 0 {
+			logOptions.SinceSeconds = &o.sinceInt
+		}
+		filename := "current.log"
+		logsReq := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+		if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {
+			innerErrs = append(innerErrs, err)
+
+			// if we had an error, we will try again with an insecure backendproxy flag set
+			logOptions.InsecureSkipTLSVerifyBackend = true
+			logsReq = o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+			filename = "current.insecure.log"
+			if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {
+				innerErrs = append(innerErrs, err)
+			}
+		}
+
+		errLock.Lock()
+		defer errLock.Unlock()
+		errs = append(errs, innerErrs...)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		innerErrs := []error{}
+		logOptions := &corev1.PodLogOptions{
+			Container:  container.Name,
+			Follow:     false,
+			Previous:   true,
+			Timestamps: true,
+		}
+		logsReq := o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+		filename := "previous.log"
+		if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {
+			innerErrs = append(innerErrs, err)
+
+			// if we had an error, we will try again with an insecure backendproxy flag set
+			logOptions.InsecureSkipTLSVerifyBackend = true
+			logsReq = o.kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, logOptions)
+			filename = "previous.insecure.log"
+			if err := o.fileWriter.WriteFromSource(path.Join(destDir, "/"+filename), logsReq); err != nil {
+				innerErrs = append(innerErrs, err)
+			}
+		}
+
+		errLock.Lock()
+		defer errLock.Unlock()
+		errs = append(errs, innerErrs...)
+	}()
+	wg.Wait()
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/inspect/pod_readiness.go
+++ b/pkg/inspect/pod_readiness.go
@@ -1,0 +1,80 @@
+package inspect
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// PodRunningReady checks whether pod p's phase is running and it has a ready
+// condition of status true.
+func PodRunningReady(p *v1.Pod) (bool, error) {
+	if !hasReadyCondition(p) {
+		return false, nil
+	}
+
+	// Check the phase is running.
+	if p.Status.Phase != v1.PodRunning {
+		return false, fmt.Errorf("want pod '%s' on '%s' to be '%v' but was '%v'",
+			p.ObjectMeta.Name, p.Spec.NodeName, v1.PodRunning, p.Status.Phase)
+	}
+	// Check the ready condition is true.
+	if !IsPodReady(p) {
+		return false, fmt.Errorf("pod '%s' on '%s' didn't have condition {%v %v}; conditions: %v",
+			p.ObjectMeta.Name, p.Spec.NodeName, v1.PodReady, v1.ConditionTrue, p.Status.Conditions)
+	}
+	return true, nil
+}
+
+func hasReadyCondition(pod *v1.Pod) bool {
+	conditionReady := true
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type != v1.PodReady {
+			continue
+		}
+		conditionReady = cond.Status == v1.ConditionTrue
+		break
+	}
+	return conditionReady
+}
+
+// IsPodReady returns true if a pod is ready; false otherwise.
+func IsPodReady(pod *v1.Pod) bool {
+	return IsPodReadyConditionTrue(pod.Status)
+}
+
+// IsPodReady returns true if a pod is ready; false otherwise.
+func IsPodReadyConditionTrue(status v1.PodStatus) bool {
+	condition := GetPodReadyCondition(status)
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
+// Extracts the pod ready condition from the given status and returns that.
+// Returns nil if the condition is not present.
+func GetPodReadyCondition(status v1.PodStatus) *v1.PodCondition {
+	_, condition := GetPodCondition(&status, v1.PodReady)
+	return condition
+}
+
+// GetPodCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func GetPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	return GetPodConditionFromList(status.Conditions, conditionType)
+}
+
+// GetPodConditionFromList extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func GetPodConditionFromList(conditions []v1.PodCondition, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if conditions == nil {
+		return -1, nil
+	}
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return i, &conditions[i]
+		}
+	}
+	return -1, nil
+}

--- a/pkg/inspect/port_forward.go
+++ b/pkg/inspect/port_forward.go
@@ -1,0 +1,157 @@
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+type defaultPortForwarder struct {
+	restConfig *rest.Config
+
+	StopChannel  chan struct{}
+	ReadyChannel chan struct{}
+}
+
+func NewDefaultPortForwarder(adminConfig *rest.Config) *defaultPortForwarder {
+	return &defaultPortForwarder{
+		restConfig:   adminConfig,
+		StopChannel:  make(chan struct{}, 1),
+		ReadyChannel: make(chan struct{}, 1),
+	}
+}
+
+func (f *defaultPortForwarder) ForwardPortsAndExecute(pod *corev1.Pod, ports []string, toExecute func()) error {
+	if len(ports) < 1 {
+		return fmt.Errorf("at least 1 PORT is required for port-forward")
+	}
+
+	restClient, err := rest.RESTClientFor(setRESTConfigDefaults(*f.restConfig))
+	if err != nil {
+		return err
+	}
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("unable to forward port because pod is not running. Current status=%v", pod.Status.Phase)
+	}
+
+	stdout := bytes.NewBuffer(nil)
+	req := restClient.Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("portforward")
+
+	transport, upgrader, err := spdy.RoundTripperFor(f.restConfig)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+	fw, err := portforward.New(dialer, ports, f.StopChannel, f.ReadyChannel, stdout, ioutil.Discard)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		if f.StopChannel != nil {
+			defer close(f.StopChannel)
+		}
+
+		<-f.ReadyChannel
+		toExecute()
+	}()
+
+	return fw.ForwardPorts()
+}
+
+func setRESTConfigDefaults(config rest.Config) *rest.Config {
+	if config.GroupVersion == nil {
+		config.GroupVersion = &schema.GroupVersion{Group: "", Version: "v1"}
+	}
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs
+	}
+	if len(config.UserAgent) == 0 {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	config.APIPath = "/api"
+	return &config
+}
+
+func newInsecureRESTClientForHost(host string) (rest.Interface, error) {
+	insecure := true
+
+	configFlags := &genericclioptions.ConfigFlags{}
+	configFlags.Insecure = &insecure
+	configFlags.APIServer = &host
+
+	newConfig, err := configFlags.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return rest.RESTClientFor(setRESTConfigDefaults(*newConfig))
+}
+
+type RemoteContainerPort struct {
+	Port     int32
+	Protocol string
+}
+
+type PortForwardURLGetter struct {
+	Protocol  string
+	Host      string
+	LocalPort string
+}
+
+func (c *PortForwardURLGetter) Get(urlPath string, pod *corev1.Pod, config *rest.Config, containerPort *RemoteContainerPort) (string, error) {
+	var result string
+
+	return result, c.ForwardRequests(pod, config, containerPort, func(restClient rest.Interface) error {
+		ioCloser, err := restClient.Get().RequestURI(urlPath).Stream(context.TODO())
+		if err != nil {
+			return err
+		}
+		defer ioCloser.Close()
+
+		data := bytes.NewBuffer(nil)
+		if _, err := io.Copy(data, ioCloser); err != nil {
+			return err
+		}
+		result = data.String()
+		return nil
+	})
+}
+
+func (c *PortForwardURLGetter) ForwardRequests(pod *corev1.Pod, config *rest.Config, containerPort *RemoteContainerPort, fn func(rest.Interface) error) error {
+	var lastErr error
+	forwarder := NewDefaultPortForwarder(config)
+
+	if err := forwarder.ForwardPortsAndExecute(pod, []string{fmt.Sprintf("%v:%v", c.LocalPort, containerPort.Port)}, func() {
+		url := fmt.Sprintf("%s://%s:%s", containerPort.Protocol, c.Host, c.LocalPort)
+		restClient, err := newInsecureRESTClientForHost(url)
+		if err != nil {
+			lastErr = err
+			return
+		}
+
+		if err := fn(restClient); err != nil {
+			lastErr = err
+			return
+		}
+	}); err != nil {
+		return err
+	}
+	return lastErr
+}

--- a/pkg/inspect/resource.go
+++ b/pkg/inspect/resource.go
@@ -1,0 +1,186 @@
+package inspect
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	clusterScopedResourcesDirname = "cluster-scoped-resources"
+	namespaceResourcesDirname     = "namespaces"
+
+	configResourceDataKey   = "/cluster-scoped-resources/config.openshift.io"
+	operatorResourceDataKey = "/cluster-scoped-resources/operator.openshift.io"
+)
+
+// InspectResource receives an object to gather debugging data for, and a context to keep track of
+// already-seen objects when following related-object reference chains.
+func InspectResource(info *resource.Info, context *resourceContext, o *InspectOptions) error {
+	if context.visited.Has(infoToContextKey(info)) {
+		klog.V(1).Infof("Skipping previously-inspected resource: %q ...", infoToContextKey(info))
+		return nil
+	}
+	context.visited.Insert(infoToContextKey(info))
+
+	switch info.ResourceMapping().Resource.GroupResource() {
+	case configv1.GroupVersion.WithResource("clusteroperators").GroupResource():
+		unstr, ok := info.Object.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unexpected type. Expecting %q but got %T", "*unstructured.Unstructured", info.Object)
+		}
+
+		// first, gather config.openshift.io resource data
+		errs := []error{}
+		if err := o.gatherConfigResourceData(path.Join(o.destDir, "/cluster-scoped-resources/config.openshift.io"), context); err != nil {
+			errs = append(errs, err)
+		}
+
+		// then, gather operator.openshift.io resource data
+		if err := o.gatherOperatorResourceData(path.Join(o.destDir, "/cluster-scoped-resources/operator.openshift.io"), context); err != nil {
+			errs = append(errs, err)
+		}
+
+		// save clusteroperator resources to disk
+		if err := gatherClusterOperatorResource(o.destDir, unstr, o.fileWriter); err != nil {
+			errs = append(errs, err)
+		}
+
+		// obtain associated objects for the current resource
+		if err := gatherRelatedObjects(context, unstr, o); err != nil {
+			errs = append(errs, err)
+		}
+
+		return errors.NewAggregate(errs)
+
+	case corev1.SchemeGroupVersion.WithResource("namespaces").GroupResource():
+		errs := []error{}
+		if err := o.gatherNamespaceData(o.destDir, info.Name); err != nil {
+			errs = append(errs, err)
+		}
+		resourcesToCollect := namespaceResourcesToCollect()
+		for _, resource := range resourcesToCollect {
+			if context.visited.Has(resourceToContextKey(resource, info.Name)) {
+				continue
+			}
+			resourceInfos, err := groupResourceToInfos(o.configFlags, resource, info.Name)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			for _, resourceInfo := range resourceInfos {
+				if err := InspectResource(resourceInfo, context, o); err != nil {
+					errs = append(errs, err)
+					continue
+				}
+			}
+		}
+
+		return errors.NewAggregate(errs)
+
+	case corev1.SchemeGroupVersion.WithResource("secrets").GroupResource():
+		if err := inspectSecretInfo(info, o); err != nil {
+			return err
+		}
+		return nil
+
+	case schema.GroupResource{Group: "route.openshift.io", Resource: "routes"}:
+		if err := inspectRouteInfo(info, o); err != nil {
+			return err
+		}
+		return nil
+	default:
+		unstr, ok := info.Object.(*unstructured.Unstructured)
+		if ok {
+			// obtain associated objects for the current resource
+			if err := gatherRelatedObjects(context, unstr, o); err != nil {
+				return err
+			}
+		}
+
+		// save the current object to disk
+		dirPath := dirPathForInfo(o.destDir, info)
+		filename := filenameForInfo(info)
+		// ensure destination path exists
+		if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+			return err
+		}
+
+		return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), info.Object)
+	}
+}
+
+func gatherRelatedObjects(context *resourceContext, unstr *unstructured.Unstructured, o *InspectOptions) error {
+	relatedObjReferences, err := obtainRelatedObjects(unstr)
+	if err != nil {
+		return err
+	}
+
+	errs := []error{}
+	for _, relatedRef := range relatedObjReferences {
+		if context.visited.Has(objectRefToContextKey(relatedRef)) {
+			continue
+		}
+
+		relatedInfos, err := objectReferenceToResourceInfos(o.configFlags, relatedRef)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("skipping gathering %s due to error: %v", objectReferenceToString(relatedRef), err))
+			continue
+		}
+
+		for _, relatedInfo := range relatedInfos {
+			if err := InspectResource(relatedInfo, context, o); err != nil {
+				errs = append(errs, fmt.Errorf("skipping gathering %s due to error: %v", objectReferenceToString(relatedRef), err))
+				continue
+			}
+		}
+	}
+
+	return errors.NewAggregate(errs)
+}
+
+func gatherClusterOperatorResource(baseDir string, obj *unstructured.Unstructured, fileWriter *MultiSourceFileWriter) error {
+	klog.V(1).Infof("Gathering cluster operator resource data...\n")
+
+	// ensure destination path exists
+	destDir := path.Join(baseDir, "/"+clusterScopedResourcesDirname, "/"+obj.GroupVersionKind().Group, "/clusteroperators")
+	if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf("%s.yaml", obj.GetName())
+	return fileWriter.WriteFromResource(path.Join(destDir, "/"+filename), obj)
+}
+
+func obtainRelatedObjects(obj *unstructured.Unstructured) ([]*configv1.ObjectReference, error) {
+	// obtain related namespace info for the current resource
+	klog.V(1).Infof("Gathering related object reference information for %q...\n", unstructuredToString(obj))
+
+	val, found, err := unstructured.NestedSlice(obj.Object, "status", "relatedObjects")
+	if !found || err != nil {
+		klog.V(1).Infof("%q does not contain .status.relatedObjects", unstructuredToString(obj))
+		return nil, nil
+	}
+
+	relatedObjs := []*configv1.ObjectReference{}
+	for _, relatedObj := range val {
+		ref := &configv1.ObjectReference{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(relatedObj.(map[string]interface{}), ref); err != nil {
+			return nil, err
+		}
+		relatedObjs = append(relatedObjs, ref)
+		klog.V(1).Infof("    Found related object %q...\n", objectReferenceToString(ref))
+	}
+
+	return relatedObjs, nil
+}

--- a/pkg/inspect/route.go
+++ b/pkg/inspect/route.go
@@ -1,0 +1,70 @@
+package inspect
+
+import (
+	"os"
+	"path"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+func inspectRouteInfo(info *resource.Info, o *InspectOptions) error {
+	obj := info.Object
+
+	if unstructureObj, ok := obj.(*unstructured.Unstructured); ok {
+		structuredRoute := &routev1.Route{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructureObj.Object, structuredRoute)
+		if err != nil {
+			return err
+		}
+		obj = structuredRoute
+	}
+	if unstructureObjList, ok := obj.(*unstructured.UnstructuredList); ok {
+		structuredRouteList := &routev1.RouteList{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructureObjList.Object, structuredRouteList)
+		if err != nil {
+			return err
+		}
+		for _, unstructureObj := range unstructureObjList.Items {
+			structuredRoute := &routev1.Route{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructureObj.Object, structuredRoute)
+			if err != nil {
+				return err
+			}
+			structuredRouteList.Items = append(structuredRouteList.Items, *structuredRoute)
+		}
+
+		obj = structuredRouteList
+	}
+
+	switch castObj := obj.(type) {
+	case *routev1.Route:
+		elideRoute(castObj)
+
+	case *routev1.RouteList:
+		for i := range castObj.Items {
+			elideRoute(&castObj.Items[i])
+		}
+
+	case *unstructured.UnstructuredList:
+
+	}
+
+	// save the current object to disk
+	dirPath := dirPathForInfo(o.destDir, info)
+	filename := filenameForInfo(info)
+	// ensure destination path exists
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return err
+	}
+	return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), obj)
+}
+
+func elideRoute(route *routev1.Route) {
+	if route.Spec.TLS == nil {
+		return
+	}
+	route.Spec.TLS.Key = ""
+}

--- a/pkg/inspect/secret.go
+++ b/pkg/inspect/secret.go
@@ -1,0 +1,90 @@
+package inspect
+
+import (
+	"os"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+func inspectSecretInfo(info *resource.Info, o *InspectOptions) error {
+	obj := info.Object
+
+	if unstructureObj, ok := obj.(*unstructured.Unstructured); ok {
+		structuredSecret := &corev1.Secret{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructureObj.Object, structuredSecret)
+		if err != nil {
+			return err
+		}
+		obj = structuredSecret
+	}
+	if unstructureObjList, ok := obj.(*unstructured.UnstructuredList); ok {
+		structuredSecretList := &corev1.SecretList{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructureObjList.Object, structuredSecretList)
+		if err != nil {
+			return err
+		}
+		for _, unstructureObj := range unstructureObjList.Items {
+			structuredSecret := &corev1.Secret{}
+			err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructureObj.Object, structuredSecret)
+			if err != nil {
+				return err
+			}
+			structuredSecretList.Items = append(structuredSecretList.Items, *structuredSecret)
+		}
+
+		obj = structuredSecretList
+	}
+
+	switch castObj := obj.(type) {
+	case *corev1.Secret:
+		elideSecret(castObj)
+
+	case *corev1.SecretList:
+		for i := range castObj.Items {
+			elideSecret(&castObj.Items[i])
+		}
+
+	case *unstructured.UnstructuredList:
+
+	}
+
+	// save the current object to disk
+	dirPath := dirPathForInfo(o.destDir, info)
+	filename := filenameForInfo(info)
+	// ensure destination path exists
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return err
+	}
+	return o.fileWriter.WriteFromResource(path.Join(dirPath, filename), obj)
+}
+
+var publicSecretKeys = sets.NewString(
+	// we know that tls.crt contains certificate (public) data, not private data.  This allows inspection of signing names for signers.
+	"tls.crt",
+	// we know that ca.crt contains certificate (public) data, not private data.  This allows inspection of sa token ca.crt trust.
+	"ca.crt",
+	// we know that service-ca.crt contains certificate (public) data, not private data.  This allows inspection of sa token service-ca.crt trust.
+	"service-ca.crt",
+)
+
+func elideSecret(secret *corev1.Secret) {
+	for k := range secret.Data {
+		// some secrets keys are safe to include because know their content.
+		if publicSecretKeys.Has(k) {
+			continue
+		}
+		secret.Data[k] = []byte{}
+	}
+
+	if _, ok := secret.Annotations["openshift.io/token-secret.value"]; ok {
+		secret.Annotations["openshift.io/token-secret.value"] = ""
+	}
+	if _, ok := secret.Annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+		secret.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = ""
+	}
+}

--- a/pkg/inspect/util.go
+++ b/pkg/inspect/util.go
@@ -1,0 +1,280 @@
+package inspect
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+// resourceContext is used to keep track of previously seen objects
+type resourceContext struct {
+	visited sets.String
+}
+
+func NewResourceContext() *resourceContext {
+	return &resourceContext{
+		visited: sets.NewString(),
+	}
+}
+
+func objectReferenceToString(ref *configv1.ObjectReference) string {
+	resource := ref.Resource
+	group := ref.Group
+	name := ref.Name
+	if len(name) > 0 {
+		name = "/" + name
+	}
+	if len(group) > 0 {
+		group = "." + group
+	}
+	return resource + group + name
+}
+
+func unstructuredToString(obj *unstructured.Unstructured) string {
+	resource := obj.GetKind()
+	var group string
+	if gv, err := schema.ParseGroupVersion(obj.GetAPIVersion()); err != nil {
+		group = gv.Group
+	}
+	name := obj.GetName()
+	if len(name) > 0 {
+		name = "/" + name
+	}
+	if len(group) > 0 {
+		group = "." + group
+	}
+	return resource + group + name
+
+}
+
+func objectReferenceToResourceInfos(clientGetter genericclioptions.RESTClientGetter, ref *configv1.ObjectReference) ([]*resource.Info, error) {
+	b := resource.NewBuilder(clientGetter).
+		Unstructured().
+		ResourceTypeOrNameArgs(true, objectReferenceToString(ref)).
+		NamespaceParam(ref.Namespace).DefaultNamespace().AllNamespaces(len(ref.Namespace) == 0).
+		Flatten().
+		Latest()
+
+	infos, err := b.Do().Infos()
+	if err != nil {
+		return nil, err
+	}
+
+	return infos, nil
+}
+
+func groupResourceToInfos(clientGetter genericclioptions.RESTClientGetter, ref schema.GroupResource, namespace string) ([]*resource.Info, error) {
+	resourceString := ref.Resource
+	if len(ref.Group) > 0 {
+		resourceString = fmt.Sprintf("%s.%s", resourceString, ref.Group)
+	}
+	b := resource.NewBuilder(clientGetter).
+		Unstructured().
+		ResourceTypeOrNameArgs(false, resourceString).
+		SelectAllParam(true).
+		NamespaceParam(namespace).
+		Latest()
+
+	return b.Do().Infos()
+}
+
+// infoToContextKey receives a resource.Info and returns a unique string for use in keeping track of objects previously seen
+func infoToContextKey(info *resource.Info) string {
+	name := info.Name
+	if meta.IsListType(info.Object) {
+		name = "*"
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", info.Namespace, info.ResourceMapping().GroupVersionKind.Group, info.ResourceMapping().Resource.Resource, name)
+}
+
+// objectRefToContextKey is a variant of infoToContextKey that receives a configv1.ObjectReference and returns a unique string for use in keeping track of object references previously seen
+func objectRefToContextKey(objRef *configv1.ObjectReference) string {
+	return fmt.Sprintf("%s/%s/%s/%s", objRef.Namespace, objRef.Group, objRef.Resource, objRef.Name)
+}
+
+func resourceToContextKey(resource schema.GroupResource, namespace string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", namespace, resource.Group, resource.Resource, "*")
+}
+
+// dirPathForInfo receives a *resource.Info and returns a relative path
+// corresponding to the directory location of that object on disk
+func dirPathForInfo(baseDir string, info *resource.Info) string {
+	groupName := "core"
+	if len(info.Mapping.GroupVersionKind.Group) > 0 {
+		groupName = info.Mapping.GroupVersionKind.Group
+	}
+
+	groupPath := path.Join(baseDir, namespaceResourcesDirname, info.Namespace, groupName)
+	if len(info.Namespace) == 0 {
+		groupPath = path.Join(baseDir, clusterScopedResourcesDirname, "/"+groupName)
+	}
+	if meta.IsListType(info.Object) {
+		return groupPath
+	}
+
+	objPath := path.Join(groupPath, info.ResourceMapping().Resource.Resource)
+	if len(info.Namespace) == 0 {
+		objPath = path.Join(groupPath, info.ResourceMapping().Resource.Resource)
+	}
+	return objPath
+}
+
+// filenameForInfo receives a *resource.Info and returns the basename
+func filenameForInfo(info *resource.Info) string {
+	if meta.IsListType(info.Object) {
+		return info.ResourceMapping().Resource.Resource + ".yaml"
+	}
+
+	return info.Name + ".yaml"
+}
+
+// getAllEventsRecursive returns a union (not deconflicted) or all events under a directory
+func getAllEventsRecursive(rootDir string) (*corev1.EventList, error) {
+	// now gather all the events into a single file and produce a unified file
+	eventLists := &corev1.EventList{}
+	err := filepath.Walk(rootDir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.Name() != "events.yaml" {
+				return nil
+			}
+			eventBytes, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			events, err := readEvents(eventBytes)
+			if err != nil {
+				return err
+			}
+			eventLists.Items = append(eventLists.Items, events.Items...)
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return eventLists, nil
+}
+
+func createEventFilterPageFromFile(eventFile string, rootDir string) error {
+	var jsonStream io.Reader
+	var err error
+
+	if strings.HasPrefix(eventFile, "https://") || strings.HasPrefix(eventFile, "http://") {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: tr}
+		resp, err := client.Get(eventFile)
+		if err != nil {
+			return err
+		}
+		jsonStream = resp.Body
+		defer resp.Body.Close()
+	} else {
+		jsonStream, err = os.Open(eventFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	decoder := json.NewDecoder(jsonStream)
+	var events corev1.EventList
+	if err := decoder.Decode(&events); err != nil {
+		return err
+	}
+	return createEventFilterPage(&events, rootDir)
+}
+
+func createEventFilterPage(events *corev1.EventList, rootDir string) error {
+	sort.Slice(events.Items, func(i, j int) bool {
+		return events.Items[i].LastTimestamp.Time.Before(events.Items[j].LastTimestamp.Time)
+	})
+
+	t := template.Must(template.New("events").Funcs(template.FuncMap{
+		"formatTime": func(created, firstSeen, lastSeen metav1.Time, count int32) template.HTML {
+			countMsg := ""
+			if count > 1 {
+				countMsg = fmt.Sprintf(" <small>(x%d)</small>", count)
+			}
+			if lastSeen.IsZero() {
+				lastSeen = created
+			}
+			return template.HTML(fmt.Sprintf(`<time datetime="%s" title="First Seen: %s">%s</time>%s`, lastSeen.String(), firstSeen.Format("15:04:05"), lastSeen.Format("15:04:05"), countMsg))
+		},
+		"formatReason": func(r string) template.HTML {
+			switch {
+			case strings.Contains(strings.ToLower(r), "fail"),
+				strings.Contains(strings.ToLower(r), "error"),
+				strings.Contains(strings.ToLower(r), "kill"),
+				strings.Contains(strings.ToLower(r), "backoff"):
+				return template.HTML(`<p class="text-danger">` + r + `</p>`)
+			case strings.Contains(strings.ToLower(r), "notready"),
+				strings.Contains(strings.ToLower(r), "unhealthy"),
+				strings.Contains(strings.ToLower(r), "missing"):
+				return template.HTML(`<p class="text-warning">` + r + `</p>`)
+			}
+			return template.HTML(`<p class="text-muted">` + r + `</p>`)
+		},
+	}).Parse(eventHTMLPage))
+
+	out := bytes.NewBuffer([]byte{})
+	if err := t.Execute(out, events); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filepath.Join(rootDir, "event-filter.html"), out.Bytes(), 0644)
+}
+
+// CreateEventFilterPage reads all events in rootDir recursively, produces a single file, and produces a webpage
+// that can be viewed locally to filter the events.
+func CreateEventFilterPage(rootDir string) error {
+	events, err := getAllEventsRecursive(rootDir)
+	if err != nil {
+		return err
+	}
+	return createEventFilterPage(events, rootDir)
+}
+
+var (
+	coreScheme = runtime.NewScheme()
+	coreCodecs = serializer.NewCodecFactory(coreScheme)
+)
+
+func init() {
+	if err := corev1.AddToScheme(coreScheme); err != nil {
+		panic(err)
+	}
+}
+
+func readEvents(objBytes []byte) (*corev1.EventList, error) {
+	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(corev1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		return nil, err
+	}
+	return requiredObj.(*corev1.EventList), nil
+}

--- a/pkg/inspect/writer.go
+++ b/pkg/inspect/writer.go
@@ -1,0 +1,91 @@
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+type fileWriterSource interface {
+	Stream(context.Context) (io.ReadCloser, error)
+}
+
+type TextWriterSource struct {
+	Text string
+}
+
+func (t *TextWriterSource) Stream(ctx context.Context) (io.ReadCloser, error) {
+	return &resourceWriterReadCloser{buffer: bytes.NewBuffer([]byte(t.Text))}, nil
+}
+
+type resourceWriterSource struct {
+	obj     runtime.Object
+	printer printers.ResourcePrinter
+}
+
+func (r *resourceWriterSource) Stream(ctx context.Context) (io.ReadCloser, error) {
+	buf := bytes.NewBuffer(nil)
+	if err := r.printer.PrintObj(r.obj, buf); err != nil {
+		return nil, err
+	}
+
+	return &resourceWriterReadCloser{buffer: buf}, nil
+}
+
+type resourceWriterReadCloser struct {
+	buffer *bytes.Buffer
+}
+
+func (r *resourceWriterReadCloser) Read(p []byte) (n int, err error) {
+	return r.buffer.Read(p)
+}
+
+func (r *resourceWriterReadCloser) Close() error {
+	return nil
+}
+
+type simpleFileWriter struct{}
+
+func (f *simpleFileWriter) Write(filepath string, src fileWriterSource) error {
+	dest, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer dest.Close()
+
+	readCloser, err := src.Stream(context.TODO())
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	_, err = io.Copy(dest, readCloser)
+	return err
+}
+
+type MultiSourceFileWriter struct {
+	printer printers.ResourcePrinter
+}
+
+func (f *MultiSourceFileWriter) WriteFromSource(filepath string, source fileWriterSource) error {
+	writer := &simpleFileWriter{}
+	return writer.Write(filepath, source)
+}
+
+func (f *MultiSourceFileWriter) WriteFromResource(filepath string, obj runtime.Object) error {
+	source := &resourceWriterSource{
+		obj:     obj,
+		printer: f.printer,
+	}
+
+	writer := &simpleFileWriter{}
+	return writer.Write(filepath, source)
+}
+
+func NewMultiSourceWriter(printer printers.ResourcePrinter) *MultiSourceFileWriter {
+	return &MultiSourceFileWriter{printer: printer}
+}

--- a/vendor/k8s.io/client-go/tools/portforward/doc.go
+++ b/vendor/k8s.io/client-go/tools/portforward/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package portforward adds support for SSH-like port forwarding from the client's
+// local host to remote containers.
+package portforward // import "k8s.io/client-go/tools/portforward"

--- a/vendor/k8s.io/client-go/tools/portforward/portforward.go
+++ b/vendor/k8s.io/client-go/tools/portforward/portforward.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	netutils "k8s.io/utils/net"
+)
+
+// PortForwardProtocolV1Name is the subprotocol used for port forwarding.
+// TODO move to API machinery and re-unify with kubelet/server/portfoward
+const PortForwardProtocolV1Name = "portforward.k8s.io"
+
+// PortForwarder knows how to listen for local connections and forward them to
+// a remote pod via an upgraded HTTP request.
+type PortForwarder struct {
+	addresses []listenAddress
+	ports     []ForwardedPort
+	stopChan  <-chan struct{}
+
+	dialer        httpstream.Dialer
+	streamConn    httpstream.Connection
+	listeners     []io.Closer
+	Ready         chan struct{}
+	requestIDLock sync.Mutex
+	requestID     int
+	out           io.Writer
+	errOut        io.Writer
+}
+
+// ForwardedPort contains a Local:Remote port pairing.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+/*
+valid port specifications:
+
+5000
+- forwards from localhost:5000 to pod:5000
+
+8888:5000
+- forwards from localhost:8888 to pod:5000
+
+0:5000
+:5000
+  - selects a random available local port,
+    forwards from localhost:<random port> to pod:5000
+*/
+func parsePorts(ports []string) ([]ForwardedPort, error) {
+	var forwards []ForwardedPort
+	for _, portString := range ports {
+		parts := strings.Split(portString, ":")
+		var localString, remoteString string
+		if len(parts) == 1 {
+			localString = parts[0]
+			remoteString = parts[0]
+		} else if len(parts) == 2 {
+			localString = parts[0]
+			if localString == "" {
+				// support :5000
+				localString = "0"
+			}
+			remoteString = parts[1]
+		} else {
+			return nil, fmt.Errorf("invalid port format '%s'", portString)
+		}
+
+		localPort, err := strconv.ParseUint(localString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing local port '%s': %s", localString, err)
+		}
+
+		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing remote port '%s': %s", remoteString, err)
+		}
+		if remotePort == 0 {
+			return nil, fmt.Errorf("remote port must be > 0")
+		}
+
+		forwards = append(forwards, ForwardedPort{uint16(localPort), uint16(remotePort)})
+	}
+
+	return forwards, nil
+}
+
+type listenAddress struct {
+	address     string
+	protocol    string
+	failureMode string
+}
+
+func parseAddresses(addressesToParse []string) ([]listenAddress, error) {
+	var addresses []listenAddress
+	parsed := make(map[string]listenAddress)
+	for _, address := range addressesToParse {
+		if address == "localhost" {
+			if _, exists := parsed["127.0.0.1"]; !exists {
+				ip := listenAddress{address: "127.0.0.1", protocol: "tcp4", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+			if _, exists := parsed["::1"]; !exists {
+				ip := listenAddress{address: "::1", protocol: "tcp6", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+		} else if netutils.ParseIPSloppy(address).To4() != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp4", failureMode: "any"}
+		} else if netutils.ParseIPSloppy(address) != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp6", failureMode: "any"}
+		} else {
+			return nil, fmt.Errorf("%s is not a valid IP", address)
+		}
+	}
+	addresses = make([]listenAddress, len(parsed))
+	id := 0
+	for _, v := range parsed {
+		addresses[id] = v
+		id++
+	}
+	// Sort addresses before returning to get a stable order
+	sort.Slice(addresses, func(i, j int) bool { return addresses[i].address < addresses[j].address })
+
+	return addresses, nil
+}
+
+// New creates a new PortForwarder with localhost listen addresses.
+func New(dialer httpstream.Dialer, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	return NewOnAddresses(dialer, []string{"localhost"}, ports, stopChan, readyChan, out, errOut)
+}
+
+// NewOnAddresses creates a new PortForwarder with custom listen addresses.
+func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	if len(addresses) == 0 {
+		return nil, errors.New("you must specify at least 1 address")
+	}
+	parsedAddresses, err := parseAddresses(addresses)
+	if err != nil {
+		return nil, err
+	}
+	if len(ports) == 0 {
+		return nil, errors.New("you must specify at least 1 port")
+	}
+	parsedPorts, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+	return &PortForwarder{
+		dialer:    dialer,
+		addresses: parsedAddresses,
+		ports:     parsedPorts,
+		stopChan:  stopChan,
+		Ready:     readyChan,
+		out:       out,
+		errOut:    errOut,
+	}, nil
+}
+
+// ForwardPorts formats and executes a port forwarding request. The connection will remain
+// open until stopChan is closed.
+func (pf *PortForwarder) ForwardPorts() error {
+	defer pf.Close()
+
+	var err error
+	pf.streamConn, _, err = pf.dialer.Dial(PortForwardProtocolV1Name)
+	if err != nil {
+		return fmt.Errorf("error upgrading connection: %s", err)
+	}
+	defer pf.streamConn.Close()
+
+	return pf.forward()
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
+	var err error
+
+	listenSuccess := false
+	for i := range pf.ports {
+		port := &pf.ports[i]
+		err = pf.listenOnPort(port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			if pf.errOut != nil {
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+			}
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("unable to listen on any of the requested ports: %v", pf.ports)
+	}
+
+	if pf.Ready != nil {
+		close(pf.Ready)
+	}
+
+	// wait for interrupt or conn closure
+	select {
+	case <-pf.stopChan:
+	case <-pf.streamConn.CloseChan():
+		runtime.HandleError(errors.New("lost connection to pod"))
+	}
+
+	return nil
+}
+
+// listenOnPort delegates listener creation and waits for connections on requested bind addresses.
+// An error is raised based on address groups (default and localhost) and their failure modes
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	var errors []error
+	failCounters := make(map[string]int, 2)
+	successCounters := make(map[string]int, 2)
+	for _, addr := range pf.addresses {
+		err := pf.listenOnPortAndAddress(port, addr.protocol, addr.address)
+		if err != nil {
+			errors = append(errors, err)
+			failCounters[addr.failureMode]++
+		} else {
+			successCounters[addr.failureMode]++
+		}
+	}
+	if successCounters["all"] == 0 && failCounters["all"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	if failCounters["any"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		fmt.Fprintf(pf.out, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		return nil, fmt.Errorf("error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Forwarding from %s -> %d\n", net.JoinHostPort(hostname, strconv.Itoa(int(localPortUInt))), port.Remote)
+	}
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		select {
+		case <-pf.streamConn.CloseChan():
+			return
+		default:
+			conn, err := listener.Accept()
+			if err != nil {
+				// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+				if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+					runtime.HandleError(fmt.Errorf("error accepting connection on port %d: %v", port.Local, err))
+				}
+				return
+			}
+			go pf.handleConnection(conn, port)
+		}
+	}
+}
+
+func (pf *PortForwarder) nextRequestID() int {
+	pf.requestIDLock.Lock()
+	defer pf.requestIDLock.Unlock()
+	id := pf.requestID
+	pf.requestID++
+	return id
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
+	}
+
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+
+	localError := make(chan struct{})
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// inform server we're not sending any more data after copy unblocks
+		defer dataStream.Close()
+
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
+			// break out of the select below without waiting for the other copy to finish
+			close(localError)
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+	case <-localError:
+	}
+
+	// always expect something on errorChan (it may be nil)
+	err = <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+		pf.streamConn.Close()
+	}
+}
+
+// Close stops all listeners of PortForwarder.
+func (pf *PortForwarder) Close() {
+	// stop all listeners
+	for _, l := range pf.listeners {
+		if err := l.Close(); err != nil {
+			runtime.HandleError(fmt.Errorf("error closing listener: %v", err))
+		}
+	}
+}
+
+// GetPorts will return the ports that were forwarded; this can be used to
+// retrieve the locally-bound port in cases where the input was port 0. This
+// function will signal an error if the Ready channel is nil or if the
+// listeners are not ready yet; this function will succeed after the Ready
+// channel has been closed.
+func (pf *PortForwarder) GetPorts() ([]ForwardedPort, error) {
+	if pf.Ready == nil {
+		return nil, fmt.Errorf("no Ready channel provided")
+	}
+	select {
+	case <-pf.Ready:
+		return pf.ports, nil
+	default:
+		return nil, fmt.Errorf("listeners not ready")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2137,6 +2137,7 @@ k8s.io/client-go/tools/leaderelection
 k8s.io/client-go/tools/leaderelection/resourcelock
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/portforward
 k8s.io/client-go/tools/record
 k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference


### PR DESCRIPTION
This is a prototype of `microshift inspect` command which copies the `oc adm inspect` command inside microshift binary.
The first commit is just pure copy and wiring, the second commit allows to run `inspect` command without additional parameters with defaults set to microshift (admin kubeconfig, resources, etc).

The output of this command is a directory that matches the `oc must-gather` 1-1,  including events and directory structure. That allows for future analytic tools to be built and shared between microshift and OCP.

As for the next steps/GA, we need to figure out how to share the `oc adm inspect` between `oc` and `microshift`, and possibly extract that command into library-go or to shared space.
In addition, the inspect command need to collect microshift binary logs (!) and audit logs. This can be added as an optional step  into "inspect" command (a post-run-hook or something). 