### PR TITLE
USHIFT-539: fix(config): remove user ability to configure ingress config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,7 @@ type MicroshiftConfig struct {
 
 	Cluster ClusterConfig `json:"cluster"`
 
-	Ingress IngressConfig `json:"ingress"`
+	Ingress IngressConfig `json:"-"`
 }
 
 func GetConfigFile() string {


### PR DESCRIPTION
The ingress config doesn't need to be user-configurable. The ingress config will be generated by default.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
