### PR TITLE
USHIFT-528: Mop up removal of manifests, configFile, and dataDir config fields.

### DIFF
--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -22,16 +22,8 @@ cluster:
   # MTU for CNI
   #mtu: "1400"
 
-# Location for data created by MicroShift
-#dataDir: /var/lib/microshift
-
 # Log verbosity (0-5)
 #logVLevel: 0
-
-# Locations to scan for manifests to load on startup
-#manifests:
-#- /usr/lib/microshift/manifests
-#- /etc/microshift/manifests
 
 # The IP of the node (defaults to IP of default route)
 #nodeIP: ""

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -57,8 +57,8 @@ func NewRunMicroshiftCommand() *cobra.Command {
 }
 
 func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
-	if err := cfg.ReadAndValidate("", flags); err != nil {
-		klog.Fatalf("Error in reading and validating flags", err)
+	if err := cfg.ReadAndValidate(config.GetConfigFile(), flags); err != nil {
+		klog.Fatalf("Error in reading and validating flags: %v", err)
 	}
 
 	// fail early if we don't have enough privileges

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -34,7 +34,7 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 				cfg.NodeName = ""
 			case "effective":
 				// Load the current configuration
-				if err := cfg.ReadAndValidate("", cmd.Flags()); err != nil {
+				if err := cfg.ReadAndValidate(config.GetConfigFile(), cmd.Flags()); err != nil {
 					cmdutil.CheckErr(err)
 				}
 			default:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -183,8 +183,6 @@ func StringInList(s string, list []string) bool {
 	return false
 }
 
-// Note: add a configFile parameter here because of unit test requiring custom
-// local directory
 func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	contents, err := os.ReadFile(configFile)
 	if err != nil {
@@ -243,11 +241,10 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 // Note: add a configFile parameter here because of unit test requiring custom
 // local directory
 func (c *MicroshiftConfig) ReadAndValidate(configFile string, flags *pflag.FlagSet) error {
-	if configFile == "" {
-		configFile = findConfigFile()
-	}
-	if err := c.ReadFromConfigFile(configFile); err != nil {
-		return err
+	if configFile != "" {
+		if err := c.ReadFromConfigFile(configFile); err != nil {
+			return err
+		}
 	}
 	if err := c.ReadFromEnv(); err != nil {
 		return err


### PR DESCRIPTION
- Removes references from sample config file.
- Remove defaulting behavior from ReadAndValidate.
- Don't try to load from file if no config file path is available.
