### PR TITLE
Make the kubeconfig file available to root

### DIFF
--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -60,4 +60,7 @@ chown -R redhat:redhat /home/redhat/
 firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16
 firewall-offline-cmd --zone=trusted --add-source=169.254.169.1
 
+# Make the KUBECONFIG from MicroShift directly available for the root user
+echo -e 'export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig' >> /root/.profile
+
 %end


### PR DESCRIPTION
This is a developer-friendliness change.

In this way we avoid the need to type the kubeconfig export
every time you switch to the root user.
