### PR TITLE
[WIP] Consolidate NodeIP and URL usage

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -17,7 +17,6 @@ cluster:
   dns: ""
   domain: ""
   url: ""
-nodeIP: ""
 nodeName: ""
 logVLevel: ""
 ```
@@ -32,7 +31,6 @@ The configuration settings alongside with the supported command line arguments a
 | dns                 | --cluster-dns             | MICROSHIFT_CLUSTER_DNS                  | The Kubernetes service IP address where pods query for name resolution
 | domain              | --cluster-domain          | MICROSHIFT_CLUSTER_DOMAIN               | Base DNS domain used to construct fully qualified pod and service domain names
 | url                 | --url                     | MICROSHIFT_CLUSTER_URL                  | URL of the API server for the cluster.
-| nodeIP              | --node-ip                 | MICROSHIFT_NODEIP                       | The IP address of the node, defaults to IP of the default route
 | nodeName            | --node-name               | MICROSHIFT_NODENAME                     | The name of the node, defaults to hostname
 | logVLevel           | --v                       | MICROSHIFT_LOGVLEVEL                    | Log verbosity (0-5)
 
@@ -48,7 +46,6 @@ cluster:
   dns: 10.43.0.10
   domain: cluster.local
   url: https://127.0.0.1:6443
-nodeIP: ""
 nodeName: ""
 logVLevel: 0
 ```

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -22,8 +22,5 @@ cluster:
 # Log verbosity (0-5)
 #logVLevel: 0
 
-# The IP of the node (defaults to IP of default route)
-#nodeIP: ""
-
 # The name of the node (defaults to hostname)
 #nodeName: ""

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -30,7 +30,6 @@ func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	flags := cmd.Flags()
 	// All other flags will be read after reading both config file and env vars.
 	flags.String("node-name", cfg.NodeName, "The hostname of the node.")
-	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
 	flags.String("url", cfg.Cluster.URL, "The URL of the API server.")
 	flags.String("cluster-cidr", cfg.Cluster.ClusterCIDR, "The IP range in CIDR notation for pods in the cluster.")
 	flags.String("service-cidr", cfg.Cluster.ServiceCIDR, "The IP range in CIDR notation for services in the cluster.")
@@ -64,6 +63,12 @@ func RunMicroshift(cfg *config.MicroshiftConfig, flags *pflag.FlagSet) error {
 	if os.Geteuid() > 0 {
 		klog.Fatalf("MicroShift must be run privileged")
 	}
+
+	nodeIP, err := cfg.Cluster.ApiServerHostName()
+	if err != nil {
+		klog.Fatalf("failed to get node IP: %v", err)
+	}
+	cfg.NodeIP = nodeIP
 
 	// TO-DO: When multi-node is ready, we need to add the controller host-name/mDNS hostname
 	//        or VIP to this list on start

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -30,7 +30,6 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 
 			switch opts.Mode {
 			case "default":
-				cfg.NodeIP = ""
 				cfg.NodeName = ""
 			case "effective":
 				// Load the current configuration

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,7 +43,6 @@ func TestCommandLineConfig(t *testing.T) {
 			config: &MicroshiftConfig{
 				LogVLevel: 4,
 				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://1.2.3.4:6443",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -64,7 +63,6 @@ func TestCommandLineConfig(t *testing.T) {
 		// all other flags unbound (looked up by name) and defaulted
 		flags.Int("v", config.LogVLevel, "")
 		flags.String("node-name", config.NodeName, "")
-		flags.String("node-ip", config.NodeIP, "")
 		flags.String("url", config.Cluster.URL, "")
 		flags.String("cluster-cidr", config.Cluster.ClusterCIDR, "")
 		flags.String("service-cidr", config.Cluster.ServiceCIDR, "")
@@ -77,7 +75,6 @@ func TestCommandLineConfig(t *testing.T) {
 		err = flags.Parse([]string{
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
 			"--node-name=" + tt.config.NodeName,
-			"--node-ip=" + tt.config.NodeIP,
 			"--url=" + tt.config.Cluster.URL,
 			"--cluster-cidr=" + tt.config.Cluster.ClusterCIDR,
 			"--service-cidr=" + tt.config.Cluster.ServiceCIDR,
@@ -115,7 +112,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			desiredMicroShiftConfig: &MicroshiftConfig{
 				LogVLevel: 23,
 				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://cluster.com:4343/endpoint",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -132,7 +128,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			}{
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_NODENAME", "node1"},
-				{"MICROSHIFT_NODEIP", "1.2.3.4"},
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
 				{"MICROSHIFT_CLUSTER_CLUSTERCIDR", "10.20.30.40/16"},
 				{"MICROSHIFT_CLUSTER_SERVICECIDR", "40.30.20.10/16"},
@@ -145,7 +140,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			desiredMicroShiftConfig: &MicroshiftConfig{
 				LogVLevel: 23,
 				NodeName:  "node1",
-				NodeIP:    "1.2.3.4",
 				Cluster: ClusterConfig{
 					URL:                  "https://cluster.com:4343/endpoint",
 					ClusterCIDR:          "10.20.30.40/16",
@@ -162,7 +156,6 @@ func TestEnvironmentVariableConfig(t *testing.T) {
 			}{
 				{"MICROSHIFT_LOGVLEVEL", "23"},
 				{"MICROSHIFT_NODENAME", "node1"},
-				{"MICROSHIFT_NODEIP", "1.2.3.4"},
 				{"MICROSHIFT_CLUSTER_URL", "https://cluster.com:4343/endpoint"},
 				{"MICROSHIFT_CLUSTER_CLUSTERCIDR", "10.20.30.40/16"},
 				{"MICROSHIFT_CLUSTER_SERVICECIDR", "40.30.20.10/16"},

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -109,7 +109,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 		return err
 	}
 
-	s.masterURL = cfg.Cluster.URL
+	s.masterURL = fmt.Sprintf("https://localhost:%d", apiServerPort)
 	s.servingCAPath = cryptomaterial.ServiceAccountTokenCABundlePath(certsDir)
 
 	overrides := &kubecontrolplanev1.KubeAPIServerConfig{

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,7 +1,6 @@
 ---
 logVLevel: 4
 nodeName: node1
-nodeIP: '1.2.3.4'
 cluster:
   url: https://1.2.3.4:6443
   clusterCIDR: '10.20.30.40/16'


### PR DESCRIPTION
The current host name portion of URL field is unused and they can be used
to configure node IP information which should be used to set `advertise-address`,
`etcd` config, `kubelet` config and others which should use the same IP.

For the default setting value, this host name will be localhost IP. User can
configure the hostname which will serve as node IP using config file, env var and cli.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
