### PR TITLE
USHIFT-574: Add node IP to the KAS external serving cert

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -204,7 +204,7 @@ func initCerts(cfg *config.MicroshiftConfig) (*cryptomaterial.CertificateChains,
 					ValidityDays: cryptomaterial.KubeAPIServerServingCertValidityDays,
 				},
 				Hostnames: []string{
-					cfg.NodeName,
+					cfg.NodeName, cfg.NodeIP,
 				},
 			},
 		),


### PR DESCRIPTION
The IP is not set in the OCP use-case but seems to make sense for Microshift.

cc @mangelajo 
