### PR TITLE
[Bug] Docs - add caveat to storage capacity tracking

### DIFF
--- a/docs/default_csi_plugin.md
+++ b/docs/default_csi_plugin.md
@@ -19,6 +19,13 @@ boots. [StorageCapacity tracking](https://kubernetes.io/docs/concepts/storage/st
 Pods with an LVMS PVC are not scheduled if the requested storage is greater than the volume group's remaining free
 storage.
 
+> **IMPORTANT!** StorageCapacity tracking poses a race condition in which the node's storage capacity is not up-to-date
+> before reconciling a PVC.  This can lead to a situtation where total provisioned LVs exceed the capacity of the node, 
+> calculated as VolumeGroupTotalCapacity - SpareGigabyte.  When this happens, the over-scheduled LVs will be reclaimed
+> and the scheduler will attempt to find another node _without updating the PV or PVCs._  It is important to ensure
+> workloads are right-sized to their target device.  See [Topolvm Limitations](https://github.com/topolvm/topolvm/blob/main/docs/limitations.md#capacity-aware-scheduling-may-go-wrong)
+> and [Kubernetes 1.24 documentation](https://kubernetes.io/blog/2022/05/06/storage-capacity-ga/) for more info.
+
 ### Configuring LVMS
 
 MicroShift supports pass-through of users' LVMS configuration and allows users to specify custom volume-groups, thin volume provisioning parameters, reserved unallocated volume-group space, among others.  This file can be specified anytime.  If MicroShift is already running, simply restart it to pick up the latest config.

--- a/docs/default_csi_plugin.md
+++ b/docs/default_csi_plugin.md
@@ -19,12 +19,13 @@ boots. [StorageCapacity tracking](https://kubernetes.io/docs/concepts/storage/st
 Pods with an LVMS PVC are not scheduled if the requested storage is greater than the volume group's remaining free
 storage.
 
-> **IMPORTANT!** StorageCapacity tracking poses a race condition in which the node's storage capacity is not up-to-date
-> before reconciling a PVC.  This can lead to a situtation where total provisioned LVs exceed the capacity of the node, 
-> calculated as VolumeGroupTotalCapacity - SpareGigabyte.  When this happens, the over-scheduled LVs will be reclaimed
-> and the scheduler will attempt to find another node _without updating the PV or PVCs._  It is important to ensure
-> workloads are right-sized to their target device.  See [Topolvm Limitations](https://github.com/topolvm/topolvm/blob/main/docs/limitations.md#capacity-aware-scheduling-may-go-wrong)
-> and [Kubernetes 1.24 documentation](https://kubernetes.io/blog/2022/05/06/storage-capacity-ga/) for more info.
+> **IMPORTANT!** Use of the LVMD field `spare-gb`is strongly discouraged. A race condition exists where the remaining
+> availabe storage of a node (Total Actual Capacity - SpareGb) will become stale after provisioning multiple PVCs in close
+> succession.  This occurs because the node's capacity is not updated synchronously after a PVC is provisoined, which leads 
+> to more availabe storage being reported than actually is.  The affect is that, when deploying more than 1 PVC at once, the SpareGb
+> value will be effectively lost. If it is still necessary to define SpareGB, ensure workloads are right-sized to their hardware.  
+> See [Topolvm Limitations](https://github.com/topolvm/topolvm/blob/main/docs/limitations.md#capacity-aware-scheduling-may-go-wrong) and 
+> [Kubernetes 1.24 documentation](https://kubernetes.io/blog/2022/05/06/storage-capacity-ga/) for more info.
 
 ### Configuring LVMS
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

- Add documentation on storage capacity tracking to warn users of the potential for over-provisioning LVs.

Relates to [USHIFT-507](https://issues.redhat.com//browse/USHIFT-507)
