### PR TITLE
USHIFT-292: Streamline the Ansible documentation for devenv and edge benchmark flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Vagrantfile
 _output/*
 _output
 sshfile
+ansible/*.txt

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,7 +1,7 @@
 # Ansible MicroShift
 
 The purpose of this Ansible automation is to help gain insight into the footprint and start times of MicroShift.
-At this stage, we are capturing the first start, the second start (with cached images), disk usage data from a
+At present, we are capturing the first start, the second start (with cached images), disk usage data from a
 number of points in time as well as performance data for each of the two starts.
 
 ## Prerequisites
@@ -17,9 +17,76 @@ Run the following command on the Ansible server to install the Ansible package.
 sudo dnf install -y ansible
 ```
 
-## Variables
+## Running
 
-There are a few variables that may need user configuration and they are found in `vars/all.yml`.
+Follow the instructions below depending on whether the MicroShift server is set up as a clean, development or RHEL for Edge host.
+
+### Clean Host
+
+If the user has a fresh RHEL host to be used for running MicroShift performance benchmarks, it is necessary to first follow the instructions in [Clean Host Example Variables](#clean-host-example-variables) for editing the `vars/all.yml` file.
+
+Run the playbook using the following commands, making sure that the values of the MicroShift server host and user variables are appropriate for your environment.
+```bash
+USHIFT_HOST=microshift-clean
+USHIFT_USER=microshift
+
+ssh-copy-id ${USHIFT_USER}@${USHIFT_HOST}
+time ansible-playbook -v \
+    -e ansible_host_var=${USHIFT_HOST} -e ansible_user_var=${USHIFT_USER} \
+    -i inventory/inventory run-perf.yml
+```
+
+### Development Host
+
+If the user has an existing host used as the MicroShift development environment, the default settings in the `vars/all.yml` file can be used.
+> Review the instructions in [Development Host Example Variables](#development-host-example-variables) for more information on the configuration settings.
+
+Run the playbook using the following commands, making sure that the values of the MicroShift server host and user variables are appropriate for your environment.
+```bash
+USHIFT_HOST=microshift-dev
+USHIFT_USER=microshift
+
+ssh-copy-id ${USHIFT_USER}@${USHIFT_HOST}
+time ansible-playbook -v \
+    -e ansible_host_var=${USHIFT_HOST} -e ansible_user_var=${USHIFT_USER} \
+    -e install_microshift_arg=true \
+    -i inventory/inventory run-perf.yml
+```
+
+### RHEL for Edge Host
+
+If the user has deployed a RHEL for Edge image built with MicroShift, the default settings in the `vars/all.yml` file can be used. The image must be build with `-prometheus` option to enable benchmark information collection as described in the [Building Installer](../docs/rhel4edge_iso.md#building-installer) section.
+> Review the instructions in [RHEL for Edge Host Example Variables](#rhel-for-edge-host-example-variables) for more information on the configuration settings.
+
+Run the playbook using the following commands, making sure that the values of the MicroShift server host and user variables are appropriate for your environment.
+```bash
+USHIFT_HOST=microshift-edge
+USHIFT_USER=redhat
+
+ssh-copy-id ${USHIFT_USER}@${USHIFT_HOST}
+time ansible-playbook -v \
+    -e ansible_host_var=${USHIFT_HOST} -e ansible_user_var=${USHIFT_USER} \
+    -e prometheus_logging_arg=false \
+    -i inventory/inventory run-perf.yml
+```
+
+## Output
+
+The following text files will be created on the Ansible server running the playbook:
+- The `boot.txt` will have the time that it took the microshift service to start and for all the pods to enter the `Running` state
+- The `disk0.txt, disk1.txt, disk2.txt` files will have a snapshot of the disk usage at different stages of installation and execution.
+
+If Prometheus was enabled, the performance metrics will be uploaded to the Ansible server, where users can view all the captured performance data using the `http://<ansible-server-ip>:9091` URL. These metrics can be conveniently visualized in the Grafana dashboards accessible at the `http://<ansible-server-ip>:3000` site.
+> Use `admin:admin` credentials to log into the Grafana server.
+
+## Configuration Overview
+
+There are a few configuration files that can be configured before execution of the playbook.
+>Certain Ansible playbook variables can be overriden using the `--extra-args` or `-e` command line argument.
+
+### Variables
+
+The following variables found in `vars/all.yml` may need user configuration.
 
 | Variable Name  | Description | Default |
 | -------------- | ----------- | ------- |
@@ -33,13 +100,16 @@ There are a few variables that may need user configuration and they are found in
 | `install_microshift` | Build and install MicroShift from git | `false` |
 | `build_etcd_binary` | Build and deploy a separate etcd process | `false` |
 
-## Running
-
-There are a few places to configure before execution.
-
-As with any Ansible playbook, the first file to configure is the inventory located at `inventory/inventory`.
-
 ### Inventory Configuration
+
+The inventory configuration file is located at `inventory/inventory`.
+
+The MicroShift host name or IP address must be configured to match the current environment. If the user account available on the MicroShift server is not `microshift`, it should be changed as well.
+
+> The following Ansible command line options can be used instead of editing the `inventory/inventory` file.
+> - `-e ansible_host_var=<hostname>`
+> - `-e ansible_user_var=<username>`
+> - `-e private_ip_var=<ipaddress>`
 
 **Sample Inventory File**
 ```
@@ -53,12 +123,12 @@ ansible_user=microshift
 localhost ansible_connection=local
 ```
 
-The user needs to configure the MicroShift host name or IP address to match their environment.
-> If the configured user on the node is not `microshift`, it should be changed as well.
-
 ### Global Variables Configuration
 
-The next location for configuration will be the global variables file located at `vars/all.yml`.
+The global variables file is located at `vars/all.yml`.
+> The following Ansible command line options can be used instead of editing the `vars/all.yml` file.
+> - `-e install_microshift_arg=<true | false>`
+> - `-e prometheus_logging_arg=<true | false>`
 
 #### Clean Host Example Variables
 
@@ -88,7 +158,7 @@ build_etcd_binary: false
 If the user has an existing host used as the MicroShift development environment, the scripts can be run without the initial configuration steps.
 > Such host can be created using the instructions from the [MicroShift Development Environment on RHEL 8](../docs/devenv_rhel8.md) document.
 
-The `manage_subscription` and `setup_microshift_host` variables have been set to `false`.
+The `manage_subscription`, `manage_repos` and `setup_microshift_host` variables have been set to `false`.
 
 **Sample vars/all.yml File**
 ```
@@ -96,7 +166,7 @@ manage_subscription: false
 rhel_username:
 rhel_password:
 rhel_pool_id:
-manage_repos: true
+manage_repos: false
 
 setup_microshift_host: false
 prometheus_logging: true
@@ -104,12 +174,12 @@ install_microshift: true
 build_etcd_binary: false
 ```
 
-#### RHEL4Edge Host Example Variables
+#### RHEL for Edge Host Example Variables
 
-If the user has deployed a RHEL4Edge image built with MicroShift, the scripts can be run with a few more variables disabled as the host is fully configured out of the box.
+If the user has deployed a RHEL for Edge image built with MicroShift, the scripts can be run with a few more variables disabled as the host is fully configured out of the box.
 > Such host can be created using the instructions from the [Install MicroShift on RHEL for Edge](../docs/rhel4edge_iso.md) document.
 
-The `manage_subscription`, `manage_repos`, `setup_microshift_host` and `install_microshift` variables have been set to `false`.
+The `manage_subscription`, `manage_repos`, `setup_microshift_host`, `prometheus_logging` and `install_microshift` variables have been set to `false`.
 
 **Sample vars/all.yml File**
 ```
@@ -117,25 +187,10 @@ manage_subscription: false
 rhel_username:
 rhel_password:
 rhel_pool_id:
-manage_repos: true
+manage_repos: false
 
 setup_microshift_host: false
-prometheus_logging: true
+prometheus_logging: false
 install_microshift: false
 build_etcd_binary: false
 ```
-
-### Run Playbook
-
-Once the `inventory` has been edited and the `vars/all.yml` have been configured, we can now run the playbook.
-```
-time ansible-playbook -v -i inventory/inventory run-perf.yml
-```
-
-### Output
-
-The following text files be created on the local system running the playbook:
-- The `boot.txt` will have the time that it took the microshift service to start and for all the pods to enter the `Running` state
-- The `disk0.txt, disk1.txt, disk2.txt` files will have a snapshot of the disk usage at different stages of installation and execution.
-
-If Prometheus was enabled, the performance metrics will be uploaded to the Ansible server, where the user can view all the captured performance data using the `http://<ansible-server-ip>:9091` URL.

--- a/ansible/inventory/inventory
+++ b/ansible/inventory/inventory
@@ -1,8 +1,8 @@
 [microshift]
-microshift-dev ansible_host=microshift-dev private_ip=
+microshift-dev ansible_host="{{ ansible_host_var | default('microshift-dev') }}" private_ip="{{ private_ip_var | default('') }}"
 
 [microshift:vars]
-ansible_user=microshift
+ansible_user="{{ ansible_user_var | default('microshift') }}"
 
 [logging]
 localhost ansible_connection=local

--- a/ansible/roles/microshift-start/tasks/main.yml
+++ b/ansible/roles/microshift-start/tasks/main.yml
@@ -178,9 +178,11 @@
 - name: get vnstat network usage
   command: vnstat
   register: vnstat
+  when: vnstat_check.rc == 0
 
 - name: record network usage to file
   local_action:
     module: copy
     content: "{{ vnstat.stdout }}"
     dest: network.txt
+  when: vnstat_check.rc == 0

--- a/ansible/vars/all.yml
+++ b/ansible/vars/all.yml
@@ -5,8 +5,8 @@ rhel_pool_id:
 manage_repos: false
 
 setup_microshift_host: false
-prometheus_logging: true
-install_microshift: false
+prometheus_logging: "{{ prometheus_logging_arg | default('true')  }}"
+install_microshift: "{{ install_microshift_arg | default('false') }}"
 build_etcd_binary: false
 
 install_pbench: false


### PR DESCRIPTION
The following enhancement were implemented as part of testing:
* Streamlined the documentation flow to let users get to running the benchmark with default params and command line arguments
* Flow tested on devenv and R4E hosts
* Fixed minor problems in the roles to work properly in the devenv / R4E cases
* Added variables for some configuration values to streamline benchmark invocation 

Closes [USHIFT-292](https://issues.redhat.com//browse/USHIFT-292)
