### PR TITLE
Switch MicroShift devenv to RHEL 8.7 OS and rhocp-4.12 BETA channel

### DIFF
--- a/ansible/roles/setup-microshift-host/tasks/main.yml
+++ b/ansible/roles/setup-microshift-host/tasks/main.yml
@@ -7,21 +7,6 @@
     state: present
     update_cache: true
 
-# Install go1.18
-# This is installed into different location (/usr/local/bin/go) from dnf installed Go (/usr/bin/go) so it doesn't conflict
-# /usr/local/bin is before /usr/bin in $PATH so newer one is picked up
-# To be removed when go1.18 is available in repositories
-- name: install golang
-  ansible.builtin.shell: |
-    export GO_VER=1.18.7
-    curl -L -o go${GO_VER}.linux-amd64.tar.gz https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz &&
-        sudo rm -rf /usr/local/go${GO_VER} && \
-        sudo mkdir -p /usr/local/go${GO_VER} && \
-        sudo tar -C /usr/local/go${GO_VER} -xzf go${GO_VER}.linux-amd64.tar.gz --strip-components 1 && \
-        sudo rm -rfv /usr/local/bin/{go,gofmt}
-        sudo ln --symbolic /usr/local/go1.18.7/bin/go /usr/local/go1.18.7/bin/gofmt /usr/local/bin/ && \
-        rm -rfv go${GO_VER}.linux-amd64.tar.gz
-
 - name: start and enable firewalld
   ansible.builtin.systemd:
     name: firewalld

--- a/docs/devenv_rhel8_auto.md
+++ b/docs/devenv_rhel8_auto.md
@@ -24,7 +24,7 @@ As an example, run the following command to create a virtual machine named `micr
 > See the [Recommended system swap size](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/getting-started-with-swap_managing-storage-devices#recommended-system-swap-space_getting-started-with-swap) document for more information.
 
 ```bash
-./scripts/devenv-builder/create-vm.sh microshift-dev /var/lib/libvirt/images /var/lib/libvirt/images/rhel-8.6-x86_64-dvd.iso 4 6 50 6 2
+./scripts/devenv-builder/create-vm.sh microshift-dev /var/lib/libvirt/images /var/lib/libvirt/images/rhel-8.7-x86_64-dvd.iso 4 6 50 6 2
 ```
 
 or
@@ -32,7 +32,7 @@ or
 ```bash
 export VMNAME=microshift-dev
 export VMDISKDIR=/var/lib/libvirt/images
-export RHELISO=/var/lib/libvirt/images/rhel-8.6-x86_64-dvd.iso
+export RHELISO=/var/lib/libvirt/images/rhel-8.7-x86_64-dvd.iso
 export NCPUS=4
 export RAMSIZE=6
 export DISKSIZE=50

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@
 > This page describes an opinionated setup to facilitate a quick bootstrap of MicroShift in a virtual environment for **experimentation-only** purpose.
 > See [Install MicroShift on RHEL for Edge](./rhel4edge_iso.md) for more information on setting up a production-grade system with MicroShift.
 
-The remainder of this document describes how to install a virtual machine running RHEL 8.6 operating system and an **experimental version** of MicroShift from the [@redhat-et/microshift-testing](https://copr.fedorainfracloud.org/coprs/g/redhat-et/microshift-testing) `copr` repository.
+The remainder of this document describes how to install a virtual machine running RHEL 8.7 operating system and an **experimental version** of MicroShift from the [@redhat-et/microshift-testing](https://copr.fedorainfracloud.org/coprs/g/redhat-et/microshift-testing) `copr` repository.
 
 ## Prerequisites
 
@@ -18,8 +18,8 @@ Run the following command to install the necessary components for the [libvirt](
 sudo dnf install -y libvirt virt-manager virt-viewer libvirt-client qemu-kvm qemu-img
 ```
 
-Download the [Red Hat Enterprise Linux 8.6 DVD ISO](https://developers.redhat.com/content-gateway/file/rhel-8.6-x86_64-dvd.iso) image for the x86_64 architecture from [Red Hat Developer](https://developers.redhat.com/products/rhel/download) site and copy the file to the `/var/lib/libvirt/images` directory.
-> Other architectures, versions or flavors of operating systems are not supported. For this setup, only use the RHEL 8.6 DVD image for x86_64 architecture.
+Download the Red Hat Enterprise Linux 8.7 DVD ISO image for the x86_64 architecture from [Red Hat Developer](https://developers.redhat.com/products/rhel/download) site and copy the file to the `/var/lib/libvirt/images` directory.
+> Other architectures, versions or flavors of operating systems are not supported. For this setup, only use the RHEL 8.7 DVD image for x86_64 architecture.
 
 Download the OpenShift pull secret from the https://console.redhat.com/openshift/downloads#tool-pull-secret page and save it into the `~/.pull-secret.json` file.
 
@@ -29,7 +29,7 @@ Run the following commands to initiate the creation process of the `microshift-s
 
 ```bash
 VMNAME=microshift-starter
-DVDISO=/var/lib/libvirt/images/rhel-8.6-x86_64-dvd.iso
+DVDISO=/var/lib/libvirt/images/rhel-8.7-x86_64-dvd.iso
 KICKSTART=https://raw.githubusercontent.com/openshift/microshift/main/docs/config/microshift-starter.ks
 
 sudo -b bash -c " \

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -242,14 +242,15 @@ createrepo microshift-local >/dev/null
 # Download openshift local RPM packages (noarch for python and selinux packages)
 rm -rf openshift-local 2>/dev/null || true
 reposync -n -a ${BUILD_ARCH} -a noarch --download-path openshift-local \
-            --repo=rhocp-4.11-for-rhel-8-${BUILD_ARCH}-rpms \
-            --repo=fast-datapath-for-rhel-8-${BUILD_ARCH}-rpms >/dev/null
+    --repo=rhocp-4.12-el8-beta-${BUILD_ARCH}-rpms \
+    --repo=fast-datapath-for-rhel-8-${BUILD_ARCH}-rpms >/dev/null
+#   --repo=rhocp-4.12-for-rhel-8-${BUILD_ARCH}-rpms \
 
 # Remove coreos packages to avoid conflicts
 find openshift-local -name \*coreos\* -exec rm -f {} \;
 # Exit if no RPM packages were found
 if [ $(find openshift-local -name '*.rpm' | wc -l) -eq 0 ] ; then
-    echo "No RPM packages were found at the 'rhocp-4.11-for-rhel-8-${BUILD_ARCH}-rpms' repository. Exiting..."
+    echo "No RPM packages were found at the 'rhocp-4.12-for-rhel-8-${BUILD_ARCH}-rpms' repository. Exiting..."
     exit 1
 fi
 createrepo openshift-local >/dev/null


### PR DESCRIPTION
- Start using beta rhocp-4.12 channel available at OCP mirror site.
- Remove Golang 1.18 workaround as the new version is now available via the RHEL 8.7 channels
- Upgrade documentation references to use RHEL 8.7
- Update puddle repo references to use 4.13 channel

Closes: [USHIFT-495](https://issues.redhat.com//browse/USHIFT-495) and [USHIFT-578](https://issues.redhat.com//browse/USHIFT-578)