### PR TITLE
USHIFT-577: Change prometheus port to fix cadvisor conflict

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -138,4 +138,4 @@ The following text files be created on the local system running the playbook:
 - The `boot.txt` will have the time that it took the microshift service to start and for all the pods to enter the `Running` state
 - The `disk0.txt, disk1.txt, disk2.txt` files will have a snapshot of the disk usage at different stages of installation and execution.
 
-If Prometheus was enabled, the performance metrics will be uploaded to the Ansible server, where the user can view all the captured performance data using the `http://<ansible-server-ip>:9090` URL.
+If Prometheus was enabled, the performance metrics will be uploaded to the Ansible server, where the user can view all the captured performance data using the `http://<ansible-server-ip>:9091` URL.

--- a/ansible/roles/configure-firewall/defaults/main.yml
+++ b/ansible/roles/configure-firewall/defaults/main.yml
@@ -10,10 +10,12 @@ firewall_ports:
   - 80/tcp
   - 443/tcp
   - 2379/tcp
+  - 3000/tcp
   - 5353/udp
   - 6443/tcp
   - 8080/tcp
   - 8082/tcp
+  - 9091/tcp
   - 9100/tcp
   - 9256/tcp
   - 9537/tcp

--- a/ansible/roles/install-logging/defaults/main.yml
+++ b/ansible/roles/install-logging/defaults/main.yml
@@ -1,14 +1,17 @@
 ---
 # install-logging default vars
 
-grafana_username: admin
-grafana_password: admin
-grafana_port: 3000
-
 logging_packages:
  - golang-github-prometheus
  - grafana
 
 logging_services:
   - prometheus
-  - grafana
+  - grafana-server
+
+grafana_username: admin
+grafana_password: admin
+grafana_port: 3000
+
+prometheus_port: 9091
+prometheus_vars_file: /etc/default/prometheus

--- a/ansible/roles/install-logging/tasks/main.yml
+++ b/ansible/roles/install-logging/tasks/main.yml
@@ -8,6 +8,18 @@
         name: "{{ logging_packages }}"
         state: present
         update_cache: true
+
+    - name: check that the prometheus cli vars file exists
+      ansible.builtin.stat:
+        path: "{{ prometheus_vars_file }}"
+      register: prometheus_vars
+    
+    - name: set prometheus args to change listen port
+      ansible.builtin.replace:
+        path: "{{ prometheus_vars_file }}"
+        regexp: "ARGS=''"
+        replace: "ARGS='--web.listen-address=0.0.0.0:{{ prometheus_port }}'"
+      when: prometheus_vars.stat.exists
   when: (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat") or (ansible_distribution == "Fedora")
 
 - name: copy prometheus config
@@ -39,7 +51,7 @@
     headers:
       Accept: application/json
       Content-Type: application/json
-    body: "{{ lookup('ansible.builtin.file', 'prometheus_datasource.json') }}"
+    body: "{{ lookup('ansible.builtin.template', 'prometheus_datasource.json.j2') }}"
 
 - name: create microshift perf dashboard in grafana
   ansible.builtin.uri:

--- a/ansible/roles/install-logging/templates/prometheus.yml.j2
+++ b/ansible/roles/install-logging/templates/prometheus.yml.j2
@@ -23,7 +23,7 @@ scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost:{{ prometheus_port }}']
 
   - job_name: node
     static_configs:

--- a/ansible/roles/install-logging/templates/prometheus_datasource.json.j2
+++ b/ansible/roles/install-logging/templates/prometheus_datasource.json.j2
@@ -2,7 +2,7 @@
   "name": "Prometheus",
   "type": "prometheus",
   "access": "proxy",
-  "url": "http://localhost:9090",
+  "url": "http://localhost:{{ prometheus_port }}",
   "basicAuth": false,
   "withCredentials": false,
   "isDefault": true,


### PR DESCRIPTION
Cadvisor also uses port 9090, made a var to set the Prometheus port.
New default Prometheus port updated across configs (including grafana), and set to `9091` which seems to be unused.