### PR TITLE
USHIFT-568: Apply fixes to code and docs to run on aarch64 platform

### DIFF
--- a/docs/devenv_rhel8.md
+++ b/docs/devenv_rhel8.md
@@ -3,17 +3,20 @@ The development environment bootstrap and configuration procedures are automated
 It is recommended to review the current document and use the automation instructions to create and configure the environment.
 
 ## Create Development Virtual Machine
-Start by downloading the RHEL 8.7 or above ISO image from the https://developers.redhat.com/products/rhel/download location.
+Start by downloading the RHEL 8.7 ISO boot image for `x86_64` or `aarch64` architecture from the https://developers.redhat.com/products/rhel/download location.
 > RHEL 9.x operating system is not currently supported.
 
 ### Creating VM
-Create a RHEL 8 virtual machine with 2 cores, 4096MB of RAM and 50GB of storage. 
+Create a RHEL virtual machine with 2 cores, 4096MB of RAM and 50GB of storage. 
 > Visual Studio Code may consume around 2GB of RAM. For running the IDE on the development virtual machine, it is recommended to allocate at least 6144MB of RAM in total.
+
+Install the `libvirt` packages and reboot your system to start the virtualization environment.
+```
+sudo dnf install -y libvirt virt-manager virt-install virt-viewer libvirt-client qemu-kvm qemu-img
+```
 
 Move the ISO image to `/var/lib/libvirt/images` directory and run the following command to create a virtual machine.
 ```bash
-sudo dnf install -y libvirt virt-manager virt-viewer libvirt-client qemu-kvm qemu-img
-
 VMNAME="microshift-dev"
 sudo -b bash -c " \
 cd /var/lib/libvirt/images/ && \
@@ -111,6 +114,7 @@ gpgcheck=0
 skip_if_unavailable=1
 EOF
 
+sudo subscription-manager config --rhsm.manage_repos=1
 sudo subscription-manager repos \
     --enable fast-datapath-for-rhel-8-$(uname -i)-rpms
 #    --enable rhocp-4.12-for-rhel-8-$(uname -i)-rpms \

--- a/docs/devenv_rhel8_auto.md
+++ b/docs/devenv_rhel8_auto.md
@@ -24,7 +24,7 @@ As an example, run the following command to create a virtual machine named `micr
 > See the [Recommended system swap size](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/getting-started-with-swap_managing-storage-devices#recommended-system-swap-space_getting-started-with-swap) document for more information.
 
 ```bash
-./scripts/devenv-builder/create-vm.sh microshift-dev /var/lib/libvirt/images /var/lib/libvirt/images/rhel-8.7-x86_64-dvd.iso 4 6 50 6 2
+./scripts/devenv-builder/create-vm.sh microshift-dev /var/lib/libvirt/images /var/lib/libvirt/images/rhel-8.7-$(uname -i)-dvd.iso 4 6 50 6 2
 ```
 
 or
@@ -32,7 +32,7 @@ or
 ```bash
 export VMNAME=microshift-dev
 export VMDISKDIR=/var/lib/libvirt/images
-export RHELISO=/var/lib/libvirt/images/rhel-8.7-x86_64-dvd.iso
+export RHELISO=/var/lib/libvirt/images/rhel-8.7-$(uname -i)-dvd.iso
 export NCPUS=4
 export RAMSIZE=6
 export DISKSIZE=50

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -24,7 +24,7 @@ On the machine used for the rebase,
 * add a pull secret into `~/.pull-secret.json`, and
 * git clone your personal fork of microshift and `cd` into it.
 
-### Fully automatic rebaseing
+### Fully automatic rebasing
 
 The following command attempts a fully automatic rebase to a given target upstream release. It is what is run nighly from CI and should work for most cases within a z-stream. It creates a new branch namded after the target release, then runs the indidivual steps described in the following sections, including creating the respective commmits.
 

--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -109,15 +109,15 @@ $ lsblk /dev/sda
 NAME          MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
 sda             8:0    0   20G  0 disk
 ├─sda1          8:1    0  200M  0 part /boot/efi
-├─sda2          8:2    0    1G  0 part /boot
-└─sda3          8:3    0 18.8G  0 part
+├─sda2          8:2    0  800M  0 part /boot
+└─sda3          8:3    0   19G  0 part
   └─rhel-root 253:0    0    8G  0 lvm  /sysroot
 
 $ sudo vgdisplay -s
-  "rhel" <18.80 GiB [8.00 GiB  used / <10.80 GiB free]
+  "rhel" <18.80 GiB [8.00 GiB  used / <11 GiB free]
 ```
 
-> Unallocated disk space of 10.80GB size remains in the `rhel` volume group to be used by the CSI driver.
+> Unallocated disk space of 11GB size remains in the `rhel` volume group to be used by the CSI driver.
 
 ### Offline Containers
 The `scripts/image-builder/build.sh` script supports a special mode for including the MicroShift container image dependencies into the generated ISO. When the container images required by MicroShift are preinstalled, `CRI-O` does not attempt to pull them when MicroShift service is first started, saving network bandwidth and avoiding external network connections.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -185,11 +185,11 @@ func StringInList(s string, list []string) bool {
 func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	contents, err := os.ReadFile(configFile)
 	if err != nil {
-		return fmt.Errorf("reading config file %s: %v", configFile, err)
+		return fmt.Errorf("reading config file %q: %v", configFile, err)
 	}
 
 	if err := yaml.Unmarshal(contents, c); err != nil {
-		return fmt.Errorf("decoding config file %s: %v", configFile, err)
+		return fmt.Errorf("decoding config file %q: %v", configFile, err)
 	}
 
 	return nil

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -155,10 +155,10 @@ func (s *KubeletServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 
 	kubeletDeps, err := kubelet.UnsecuredDependencies(kubeletServer, utilfeature.DefaultFeatureGate)
 	if err != nil {
-		klog.Fatalf("Error in fetching depenedencies", err)
+		klog.Fatalf("Error in fetching depenedencies: %v", err)
 	}
 	if err := kubelet.Run(ctx, kubeletServer, kubeletDeps, utilfeature.DefaultFeatureGate); err != nil {
-		klog.Fatalf("Kubelet failed to start", err)
+		klog.Fatalf("Kubelet failed to start: %v", err)
 	}
 	return ctx.Err()
 }

--- a/pkg/release/release_arm64.go
+++ b/pkg/release/release_arm64.go
@@ -25,9 +25,14 @@ func init() {
 		"coredns":                   "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1b7be165834025aed05f874e83f7393a434f1e4e52ae7814941a67818d6a529f",
 		"haproxy_router":            "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f6b48c5a830c2f1d1c2f391daccae18cc3320a1fb6eba56a4b6c5a1c491c4c60",
 		"kube_rbac_proxy":           "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f4d4b35f8e4a9bf073ea40e71bb53c063e29cc9ab30fcbcb54e03a29781a6cd6",
-		"openssl":                   "registry.access.redhat.com/ubi8/openssl@sha256:3f781a07e59d164eba065dba7d8e7661ab2494b21199c379b65b0ff514a1b8d0",
-		"ovn_kubernetes_microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2be6ee34f6c4b3050476f5adf093f0b229f1b06b16ca1097b4f1bd3a71a90fb6",
-		"pod":                       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:093dc83ceb627acf673d04a9423ff5ca91a4763c4cb5508ebf298c9457e69c4d",
+		"odf_topolvm":               "registry.redhat.io/odf4/odf-topolvm-rhel8@sha256:362c41177d086fc7c8d4fa4ac3bbedb18b1902e950feead9219ea59d1ad0e7ad",
+		"openssl":                   "registry.access.redhat.com/ubi8/openssl@sha256:8b41865d30b7947de68a9c1747616bce4efab4f60f68f8b7016cd84d7708af6b",
+		"ose_csi_ext_provisioner":   "registry.redhat.io/openshift4/ose-csi-external-provisioner@sha256:4b7d8035055a867b14265495bd2787db608b9ff39ed4e6f65ff24488a2e488d2",
+		"ose_csi_ext_resizer":       "registry.redhat.io/openshift4/ose-csi-external-resizer@sha256:ca34c46c4a4c1a4462b8aa89d1dbb5427114da098517954895ff797146392898",
+		"ose_csi_node_registrar":    "registry.redhat.io/openshift4/ose-csi-node-driver-registrar@sha256:3babcf219371017d92f8bc3301de6c63681fcfaa8c344ec7891c8e84f31420eb",
+		"ose_csi_livenessprobe":     "registry.redhat.io/openshift4/ose-csi-livenessprobe@sha256:e4b0f6c89a12d26babdc2feae7d13d3f281ac4d38c24614c13c230b4a29ec56e",
+		"ovn_kubernetes_microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2fdcafe1efb12e28b2ea30823633c097d8990840ad66f2c6025969281ea80316",
+		"pod":                       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9b351c22effb786e01464e27283e3c8e151d2ceac00e7d59782df56c3d7e8a89",
 		"service_ca_operator":       "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:35cca3568753a576a93197d58fba68e5ab9a2c864fb330153b734d41733cffa6",
 	}
 }

--- a/scripts/devenv-builder/config/kickstart.ks.template
+++ b/scripts/devenv-builder/config/kickstart.ks.template
@@ -14,13 +14,15 @@ network --bootproto=dhcp --device=link --activate --onboot=on --hostname=REPLACE
 #
 # NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
 # sda             8:0    0  50G  0 disk 
-# ├─sda1          8:1    0   1G  0 part /boot
+# ├─sda1          8:1    0 200M  0 part /boot/efi
+# ├─sda2          8:1    0 800M  0 part /boot
 # └─sda2          8:2    0  49G  0 part 
 #  └─rhel-root  253:0    0  45G  0 lvm  /sysroot
 #
 zerombr
 clearpart --all --initlabel
-part /boot --fstype=xfs --asprimary --size=1024
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --asprimary --size=800
 part swap --fstype=swap --size=REPLACE_SWAP_SIZE
 part pv.01 --grow
 volgroup rhel pv.01

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -59,6 +59,7 @@ gpgcheck=0
 skip_if_unavailable=1
 EOF
 
+sudo subscription-manager config --rhsm.manage_repos=1
 sudo subscription-manager repos \
     --enable fast-datapath-for-rhel-8-$(uname -i)-rpms
 #    --enable rhocp-4.12-for-rhel-8-$(uname -i)-rpms \

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -14,14 +14,15 @@ network --bootproto=dhcp --device=link --activate --onboot=on
 #
 # NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
 # sda             8:0    0  20G  0 disk 
-# ├─sda1          8:1    0   1G  0 part /boot
+# ├─sda1          8:1    0 200M  0 part /boot/efi
+# ├─sda1          8:1    0 800M  0 part /boot
 # └─sda2          8:2    0  19G  0 part 
 #  └─rhel-root  253:0    0   8G  0 lvm  /sysroot
 #
 zerombr
 clearpart --all --initlabel
-part /boot/efi --fstype=efi --grow --maxsize=200 --size=20
-part /boot --fstype=xfs --asprimary --size=1024
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --asprimary --size=800
 # Uncomment this line to add a SWAP partition of the recommended size
 #part swap --fstype=swap --recommended
 part pv.01 --grow


### PR DESCRIPTION
- Fix docs to remove hard-coded x86_64 mentions and add aarch64 support on RHEL 8.7 OS
- Minor code fixes to error message formatting
- Add aarch64 container image references (all except TopoLVM should work)
- Fix partitioning to split /boot into 200/800MB for efi

Closes [USHIFT-568](https://issues.redhat.com//browse/USHIFT-568)
