### PR TITLE
USHIFT-60: Streamline R4E ISO creation on aarch64 platform for AWS environment

### DIFF
--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -173,7 +173,7 @@ cd /var/lib/libvirt/images/ && \
 virt-install \
     --name ${VMNAME} \
     --vcpus 2 \
-    --memory 3096 \
+    --memory 3072 \
     --disk path=./${VMNAME}.qcow2,size=20 \
     --network network=default,model=virtio \
     --os-type generic \

--- a/scripts/devenv-builder/create-vm.sh
+++ b/scripts/devenv-builder/create-vm.sh
@@ -52,7 +52,14 @@ if [ "${SWAPSIZE}" -eq 0 ] ; then
     sed -i "s;^part swap;#part swap;" ${KICKSTART_FILE}
 fi
 
-sudo dnf install -y libvirt virt-manager virt-viewer libvirt-client qemu-kvm qemu-img
+sudo dnf install -y libvirt virt-manager virt-install virt-viewer libvirt-client qemu-kvm qemu-img
+if [ $(systemctl is-active libvirtd.socket) != "active" ] ; then
+    echo "Restart your host to initialize the virtualization environment"
+    exit 1
+fi
+# Necessary to allow remote connections in the virt-viewer application
+sudo usermod -a -G libvirt $(whoami)
+
 sudo -b bash -c " \
 cd ${VMDISKDIR} && \
 virt-install \

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -196,8 +196,8 @@ done
 if [ -z "${OSTREE_SERVER_NAME}" ] || [ -z "${OCP_PULL_SECRET_FILE}" ] ; then
     usage
 fi
-if [ ! -e ${OCP_PULL_SECRET_FILE} ] ; then
-    echo "ERROR: pull_secret_file file does not exist: ${OCP_PULL_SECRET_FILE}"
+if [ ! -r ${OCP_PULL_SECRET_FILE} ] ; then
+    echo "ERROR: pull_secret_file file does not exist or not readable: ${OCP_PULL_SECRET_FILE}"
     exit 1
 fi
 if [ -n "${AUTHORIZED_KEYS_FILE}" ]; then
@@ -307,7 +307,7 @@ if ${EMBED_CONTAINERS} ; then
     # TODO: This should be removed when RHEL 8.x stream gets an up-to-date package
     # Include up-to-date ostree packages in the image builder to support whiteouts    
     repo_name=ostree-copr
-    cp -f ${SCRIPTDIR}/config/${repo_name}.toml .
+    cat ${SCRIPTDIR}/config/${repo_name}.toml | sed "s;REPLACE_ARCH_VALUE;${BUILD_ARCH};g" > ${repo_name}.toml
     sudo composer-cli sources delete ${repo_name} 2>/dev/null || true
     sudo composer-cli sources add ${BUILDDIR}/${repo_name}.toml
 

--- a/scripts/image-builder/config/ostree-copr.toml
+++ b/scripts/image-builder/config/ostree-copr.toml
@@ -1,7 +1,7 @@
 id = "ostree-copr"
 name = "Copr repo for ostreerhel8 owned by walters"
 type = "yum-baseurl"
-url = "https://download.copr.fedorainfracloud.org/results/walters/ostreerhel8/centos-stream-8-x86_64/"
+url = "https://download.copr.fedorainfracloud.org/results/walters/ostreerhel8/centos-stream-8-REPLACE_ARCH_VALUE/"
 check_gpg = false
 check_ssl = false
 system = false

--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -12,3 +12,18 @@ sudo firewall-cmd --add-service=cockpit --permanent
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 sudo dnf install -y mock 
 sudo usermod -a -G mock $(whoami)
+
+# Verify umask and home directory permissions
+TEST_FILE=/tmp/configure_perm_test.$$
+
+touch ${TEST_FILE}
+mkdir ${TEST_FILE}.dir
+HOME_PERM=$(stat -c 0%a ~)
+FILE_PERM=$(stat -c 0%a ${TEST_FILE})
+DIR_PERM=$(stat -c 0%a ${TEST_FILE}.dir)
+rm -rf ${TEST_FILE}*
+
+if [ ${HOME_PERM} -lt 0755 ] || [ ${FILE_PERM} -lt 0644 ] || [ ${DIR_PERM} -lt 0755 ] ; then
+    echo "Check home directory permissions and umask. The settings must allow read to group and others"
+    exit 1
+fi

--- a/scripts/image-builder/create-vm.sh
+++ b/scripts/image-builder/create-vm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+ROOTDIR=$(git rev-parse --show-toplevel)
+ISODIR=${ROOTDIR}/_output/image-builder
+
+if [ $# -ne 2 ] ; then
+    echo "Usage: $(basename $0) <vm_name> <network_name>"
+    exit 1
+fi
+
+VMNAME=$1
+NETNAME=$2
+CDROM=$(ls -1 $ISODIR/microshift-installer-*.$(uname -i).iso 2>/dev/null || true)
+
+if [ ! -e "${CDROM}" ] ; then
+    echo "The image ISO '${CDROM}' file does not exist. Run 'make iso' to create it"
+    exit 1
+fi
+
+sudo dnf install -y libvirt virt-manager virt-install virt-viewer libvirt-client qemu-kvm qemu-img
+if [ $(systemctl is-active libvirtd.socket) != "active" ] ; then
+    echo "Restart your host to initialize the virtualization environment"
+    exit 1
+fi
+# Necessary to allow remote connections in the virt-viewer application
+sudo usermod -a -G libvirt $(whoami)
+
+sudo -b bash -c " \
+virt-install \
+    --name ${VMNAME} \
+    --vcpus 2 \
+    --memory 3072 \
+    --disk path=/var/lib/libvirt/images/${VMNAME}.qcow2,size=20 \
+    --network network=${NETNAME},model=virtio \
+    --os-type generic \
+    --events on_reboot=restart \
+    --location ${CDROM} \
+    --noautoconsole \
+"


### PR DESCRIPTION
Minor fixes very necessary, mostly cosmetic:
- Fixed R4E memory allocation to be 3GB
- Make sure pull secret file is readable
- Verify user home directory permissions and umask for Image Builder to work
- Add scripts/image-builder/create-vm.sh script that streamlines R4E VM env setup and creation
- Make sure virt-install is installed

Closes [USHIFT-60](https://issues.redhat.com//browse/USHIFT-60)
