### PR TITLE
USHIFT-626: Install sos utility with MicroShift and document its usage

### DIFF
--- a/docs/debugging_tips.md
+++ b/docs/debugging_tips.md
@@ -27,3 +27,33 @@ metadata:
   name: microshift-version
   namespace: kube-public
 ```
+
+## Generating an SOS Report
+
+The MicroShift RPMs have an explicit dependency on the `sos` utility allowing to collect
+configuration, diagnostic, and troubleshooting data to be provided to Red Hat Technical Support.
+
+> See [Generating sos reports for technical support](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/generating_sos_reports_for_technical_support/index) for more information on the `sos` utility usage.
+
+Log into the host running MicroShift and execute the following command to generate an obfuscated
+report that should not contain sensitive information.
+
+```bash
+sudo sos report --batch --clean
+```
+
+The report archives can be found in the `/var/tmp/sosreport-*` files.
+
+```bash
+$ sudo ls -tr /var/tmp/sosreport-* | tail -2
+/var/tmp/sosreport-host0-2022-11-24-pvbcaji-obfuscated.tar.xz
+/var/tmp/sosreport-host0-2022-11-24-pvbcaji-obfuscated.tar.xz.sha256
+```
+
+Upload the archives to Red Hat Technical Support as described in [this section](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/generating_sos_reports_for_technical_support/index#methods-for-providing-an-sos-report-to-red-hat-technical-support_generating-an-sosreport-for-technical-support)
+
+The `sos` archives may consume significant disk space. Make sure to delete the report files after uploading them.
+
+```bash
+sudo rm -f /var/tmp/sosreport-*
+```

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -62,6 +62,7 @@ Requires: iptables
 Requires: microshift-selinux
 Requires: microshift-networking
 Requires: conntrack-tools
+Requires: sos
 
 %{?systemd_requires}
 
@@ -268,6 +269,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" microshift.spec
 %changelog
+* Fri Nov 25 2022 Gregory Giguashvili <ggiguash@redhat.com> 4.12.0
+- Install sos utility with MicroShift and document its usage
+
 * Mon Oct 24 2022 Zenghui Shi <zshi@redhat.com> 4.12.0
 - Add arch specific crio conf
 


### PR DESCRIPTION
Ensure the `sos` presence on MicroShift hosts.

Also created [USHIFT-628](https://issues.redhat.com//browse/USHIFT-628) task to follow-up on embedding MicroShift-specific information in the reports generated by the `sos` utility.

Closes [USHIFT-626](https://issues.redhat.com//browse/USHIFT-626)
