### PR TITLE
USHIFT-605: Change MicroShift embedded & RPM version scheme

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -6,7 +6,7 @@
 
 
 # golang specifics
-%global golang_version 1.17
+%global golang_version 1.18
 #debuginfo not supported with Go
 %global debug_package %{nil}
 # modifying the Go binaries breaks the DWARF debugging


### PR DESCRIPTION
```
$ microshift version
MicroShift Version: 4.12.0-20221128123124-8fb675d4
Base OCP Version: 4.12.0-0.nightly-2022-11-22-215931

$ microshift version
MicroShift Version: 4.12.0-20221128123124-8fb675d4-dirty
Base OCP Version: 4.12.0-0.nightly-2022-11-22-215931
```

```
microshift-4.12.0_20221128123124_8fb675d4-1.el8.x86_64.rpm
microshift-networking-4.12.0_20221128123124_8fb675d4-1.el8.x86_64.rpm

microshift-4.12.0_20221128123124_8fb675d4_dirty-1.el8.x86_64.rpm
microshift-networking-4.12.0_20221128123124_8fb675d4_dirty-1.el8.x86_64.rpm
```