### PR TITLE
Remove pprof port reference in CNI doc

### DIFF
--- a/docs/default_cni_plugin.md
+++ b/docs/default_cni_plugin.md
@@ -130,7 +130,6 @@ Host network `sysctl net.ipv4.ip_forward` is automatically enabled by ovn-kubern
 #### Host Ports
 
 Ingress routes are exposed on host port `80` and `443` automatically by `route-default` deployment in `openshift-ingress` namespace.
-Data profiling with pprof is exposed on host port `29500` when starting MicroShift with `--debug.pprof`, disabled by default.
 
 ## Network Topology
 


### PR DESCRIPTION
pprof is exposed over kubelet unauthenticated healthz endpoint on
port :10248 to localhost only [1], removing MicroShift specific pprof
port document.

[1]: https://github.com/kubernetes/kubernetes/issues/81023
