### PR TITLE
USHIFT-645: Pass version from spec to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export TIMESTAMP ?=$(shell echo $(BIN_TIMESTAMP) | tr -d ':' | tr 'T' '-' | tr -
 SOURCE_GIT_COMMIT_TIMESTAMP ?= $(shell TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
 
 OCP_VERSION := $(shell awk -F'["-]' '/var Base/ {print $$2}'  ${PROJECT_DIR}/pkg/release/release.go)
-MICROSHIFT_VERSION := $(subst -clean,,$(shell echo '${OCP_VERSION}-${SOURCE_GIT_COMMIT_TIMESTAMP}-${SOURCE_GIT_COMMIT}-${SOURCE_GIT_TREE_STATE}'))
+MICROSHIFT_VERSION ?= $(subst -clean,,$(shell echo '${OCP_VERSION}-${SOURCE_GIT_COMMIT_TIMESTAMP}-${SOURCE_GIT_COMMIT}-${SOURCE_GIT_TREE_STATE}'))
 
 # Overload SOURCE_GIT_TAG value set in vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
 # because since it doesn't work with our version scheme.

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -134,9 +134,9 @@ GOARCH=amd64
 
 # if we have git commit/tag/state to be embedded in the binary pass it down to the makefile
 %if 0%{?embedded_git_commit:1}
-make _build_local GOOS=${GOOS} GOARCH=${GOARCH} EMBEDDED_GIT_COMMIT=%{embedded_git_commit} EMBEDDED_GIT_TAG=%{embedded_git_tag} EMBEDDED_GIT_TREE_STATE=%{embedded_git_tree_state}
+make _build_local GOOS=${GOOS} GOARCH=${GOARCH} EMBEDDED_GIT_COMMIT=%{embedded_git_commit} EMBEDDED_GIT_TAG=%{embedded_git_tag} EMBEDDED_GIT_TREE_STATE=%{embedded_git_tree_state} MICROSHIFT_VERSION=%{version}
 %else
-make _build_local GOOS=${GOOS} GOARCH=${GOARCH}
+make _build_local GOOS=${GOOS} GOARCH=${GOARCH} MICROSHIFT_VERSION=%{version}
 %endif
 
 cp ./_output/bin/${GOOS}_${GOARCH}/microshift ./_output/microshift


### PR DESCRIPTION
As a result, `%{version}` given to .spec will be printed out when running `microshift version` command and will match version part of RPM filename.