### PR TITLE
[BUG] USHIFT-657 MicroShift does not find lvmd config if no microshift config file exists.

### DIFF
--- a/pkg/components/render_test.go
+++ b/pkg/components/render_test.go
@@ -66,7 +66,7 @@ func Test_renderLvmdParams(t *testing.T) {
 
 func Test_renderLvmdConfig(t *testing.T) {
 
-	defL, _ := lvmd.NewLvmdConfigFromFileOrDefault("")
+	defL := (&lvmd.Lvmd{}).WithDefaults()
 
 	cmWrap := func(d []byte) []byte {
 		base :=

--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -13,19 +13,13 @@ import (
 	"github.com/openshift/microshift/pkg/config/lvmd"
 )
 
-// getCSIPluginConfig searches for a user-defined lvmd configuration file in predefined locations are returns the first
-// found, else a default-value lvmd config. Returns an error if the file exists and cannot be read, or exists and cannot
-// be deserialized (indicating a malformed config).  User's home directory is checked first.  If not found, global
-// MicroShift config directory is checked.
+// getCSIPluginConfig searches for a user-defined lvmd configuration file in /etc/microshift.  If found, returns
+// the lvmd config.  If not found, returns a default-value lvmd config.  If an unmarshalling errors, returns nil
+// and the error.
 func getCSIPluginConfig() (*lvmd.Lvmd, error) {
-	userCfg := filepath.Dir(config.DefaultUserConfigFile)
-	globalCfg := filepath.Dir(config.DefaultGlobalConfigFile)
-
-	if _, err := os.Stat(userCfg); errors.Is(err, os.ErrNotExist) {
-		return lvmd.NewLvmdConfigFromFile(filepath.Join(lvmd.LvmdConfigFileName))
-	}
-	if _, err := os.Stat(globalCfg); errors.Is(err, os.ErrNotExist) {
-		return lvmd.NewLvmdConfigFromFile(filepath.Join(globalCfg, lvmd.LvmdConfigFileName))
+	lvmdConfig := filepath.Join(filepath.Dir(config.DefaultGlobalConfigFile), lvmd.LvmdConfigFileName)
+	if _, err := os.Stat(lvmdConfig); errors.Is(err, os.ErrNotExist) {
+		return lvmd.NewLvmdConfigFromFile(filepath.Join(lvmdConfig, lvmd.LvmdConfigFileName))
 	}
 	return (&lvmd.Lvmd{}).WithDefaults(), nil
 }

--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -18,8 +18,8 @@ import (
 // and the error.
 func getCSIPluginConfig() (*lvmd.Lvmd, error) {
 	lvmdConfig := filepath.Join(filepath.Dir(config.DefaultGlobalConfigFile), lvmd.LvmdConfigFileName)
-	if _, err := os.Stat(lvmdConfig); errors.Is(err, os.ErrNotExist) {
-		return lvmd.NewLvmdConfigFromFile(filepath.Join(lvmdConfig, lvmd.LvmdConfigFileName))
+	if _, err := os.Stat(lvmdConfig); !errors.Is(err, os.ErrNotExist) {
+		return lvmd.NewLvmdConfigFromFile(lvmdConfig)
 	}
 	return (&lvmd.Lvmd{}).WithDefaults(), nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	defaultUserConfigFile   = "~/.microshift/config.yaml"
+	DefaultUserConfigFile   = "~/.microshift/config.yaml"
 	defaultUserDataDir      = "~/.microshift/data"
-	defaultGlobalConfigFile = "/etc/microshift/config.yaml"
+	DefaultGlobalConfigFile = "/etc/microshift/config.yaml"
 	defaultGlobalDataDir    = "/var/lib/microshift"
 	// for files managed via management system in /etc, i.e. user applications
 	defaultManifestDirEtc = "/etc/microshift/manifests"
@@ -219,12 +219,12 @@ func (c *ClusterConfig) ApiServerPort() (int, error) {
 // Returns the default user config file if that exists, else the default global
 // config file, else the empty string.
 func findConfigFile() string {
-	userConfigFile, _ := homedir.Expand(defaultUserConfigFile)
+	userConfigFile, _ := homedir.Expand(DefaultUserConfigFile)
 	if _, err := os.Stat(userConfigFile); errors.Is(err, os.ErrNotExist) {
-		if _, err := os.Stat(defaultGlobalConfigFile); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(DefaultGlobalConfigFile); errors.Is(err, os.ErrNotExist) {
 			return ""
 		} else {
-			return defaultGlobalConfigFile
+			return DefaultGlobalConfigFile
 		}
 	} else {
 		return userConfigFile

--- a/pkg/config/lvmd/lvmd_test.go
+++ b/pkg/config/lvmd/lvmd_test.go
@@ -57,15 +57,15 @@ func Test_newLvmdConfigFromFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newLvmdConfigFromFile(tt.args.p)
+			got, err := NewLvmdConfigFromFile(tt.args.p)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("newLvmdConfigFromFile() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NewLvmdConfigFromFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != nil && !reflect.DeepEqual(*got, *tt.want) {
 				g, _ := json.Marshal(got)
 				w, _ := json.Marshal(tt.want)
-				t.Errorf("newLvmdConfigFromFile() = %s, want %s", string(g), string(w))
+				t.Errorf("NewLvmdConfigFromFile() = %s, want %s", string(g), string(w))
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes # [USHIFT-657](https://issues.redhat.com//browse/USHIFT-657)


This PR removes the assumption that the microshift config and the lvmd config are always co-located.  This created a situation where, if a user does not create a microshift config, the search for the lvmd config would short circuit.  This isn't a safe assumption because the microshift default values, used when a user hasn't created a config file, are generally safe for common use cases.  The lvmd config however must usually be defined to describe the host's storage environment, which is probably less uniform with arbitrary volume group names.

This became and issue when the name of the microshift default/example config was changed in the RPM spec, which provided an anchor for the lvmd config logic to rely on when no user config was specified. 