### PR TITLE
Better cleanup of MicroShift resources for developers

### DIFF
--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -14,6 +14,7 @@ sudo bash -c "
     echo Stopping MicroShift
     set +e
     systemctl stop --now microshift 2>/dev/null
+    systemctl stop --now kubepods.slice 2>/dev/null
     systemctl disable microshift 2>/dev/null
     pkill -9 microshift
 


### PR DESCRIPTION
Without this, sometimes part of the container executables
stay running on the system under the kubepods.slice systemd
slice.
