### PR TITLE
USHIFT-23 fix cluster domain configuration in coredns

### DIFF
--- a/assets/components/openshift-dns/dns/configmap.yaml
+++ b/assets/components/openshift-dns/dns/configmap.yaml
@@ -11,7 +11,7 @@ data:
             lameduck 20s
         }
         ready
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
+        kubernetes {{ .ClusterDomain }} in-addr.arpa ip6.arpa {
             pods insecure
             fallthrough in-addr.arpa ip6.arpa
         }

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -219,7 +219,7 @@ func startDNSController(cfg *config.MicroshiftConfig, kubeconfigPath string) err
 		klog.Warningf("Failed to apply serviceAccount %v %v", sa, err)
 		return err
 	}
-	if err := assets.ApplyConfigMaps(cm, nil, nil, kubeconfigPath); err != nil {
+	if err := assets.ApplyConfigMaps(cm, renderTemplate, renderParamsFromConfig(cfg, nil), kubeconfigPath); err != nil {
 		klog.Warningf("Failed to apply configMap %v %v", cm, err)
 		return err
 	}


### PR DESCRIPTION
This replicates the behavior seen in [1]

[1] https://github.com/openshift/cluster-dns-operator/blob/1c136fe38b8cd5c0de99577d23157f884728d20b/pkg/operator/controller/controller_dns_configmap.go#L80

Closes: https://issues.redhat.com/browse/USHIFT-23
