### PR TITLE
Change %{X} to 'X macro' in spec changelog

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -259,7 +259,7 @@ systemctl enable --now --quiet openvswitch || true
 - Add commit macro and embed it into binary
 
 * Wed Nov 30 2022 Patryk Matuszak <pmatusza@redhat.com> 4.12.0
-- Pass %{version} to Makefile
+- Pass version macro to Makefile
 
 * Wed Nov 30 2022 Gregory Giguashvili <ggiguash@redhat.com> 4.12.0
 - Change the config.yaml file name to allow its overwrite by users

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -256,7 +256,7 @@ systemctl enable --now --quiet openvswitch || true
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" microshift.spec
 %changelog
 * Tue Dec 06 2022 Patryk Matuszak <pmatusza@redhat.com> 4.12.0
-- Add %{commit} and embed it into binary
+- Add commit macro and embed it into binary
 
 * Wed Nov 30 2022 Patryk Matuszak <pmatusza@redhat.com> 4.12.0
 - Pass %{version} to Makefile


### PR DESCRIPTION
`%{commit}` would get substituted for actual commit SHA in ART pipeline 