### PR TITLE
USHIFT-660: yet another cluster debug info improvement

### DIFF
--- a/validate-microshift/cluster-debug-info.sh
+++ b/validate-microshift/cluster-debug-info.sh
@@ -1,28 +1,40 @@
 #!/usr/bin/env bash
 
-set -x
+declare -a commands_to_run=()
+function to_run() {
+    cmd="$@"
+    commands_to_run+=("${cmd}")
+}
 
-echo -e "\n=== DEBUG INFORMATION ===\n\n"
-
-# wrapped in echo so we get a newline
-echo "$(oc get cm -n kube-public microshift-version -o=jsonpath='{.data}')"
-microshift version 
-microshift version -o yaml 
+to_run oc get cm -n kube-public microshift-version -o=jsonpath='{.data}'
+to_run microshift version 
+to_run microshift version -o yaml 
 
 RESOURCES=(node pod configmap deployment daemonset statefulset svc route)
 for resource in ${RESOURCES[*]}; do
-    oc get "${resource}" -A
-    oc get "${resource}" -A -o yaml 
+    to_run oc get "${resource}" -A
+    to_run oc get "${resource}" -A -o yaml 
 done
 
-oc get events -A 
+to_run oc get events -A 
 
 for ns in $(kubectl get namespace -o jsonpath='{.items..metadata.name}'); do
     for pod in $(kubectl get pods -n $ns -o name); do
-            oc describe -n $ns $pod 
+            to_run oc describe -n $ns $pod 
             for container in $(kubectl get -n $ns $pod -o jsonpath='{.spec.containers[*].name}'); do
-                oc logs -n $ns $pod $container 
-                oc logs --previous=true -n $ns $pod $container 
+                to_run oc logs -n $ns $pod $container 
+                to_run oc logs --previous=true -n $ns $pod $container 
             done
     done
+done
+
+echo -e "\n=== DEBUG INFORMATION ===\n"
+echo "Following commands will be executed:"
+for cmd in "${commands_to_run[@]}"; do
+    echo "    - ${cmd}"
+done
+
+for cmd in "${commands_to_run[@]}"; do
+    echo -e "\n\n> ${cmd}"
+    ${cmd} 2>&1 || true
 done


### PR DESCRIPTION
changed execution flow to:
* first register commands to run
* print a "table of contents" so it's obvious what command will be executed and easily searched for
* print a command with `>` prefix and execute the command

By replacing `set -x` with printing the cmd it is now visually clearer and suitable for inclusion in bug tickets (`./validate-microshift/cluster-debug-info.sh > /tmp/cluster.log`)