### PR TITLE
OCPBUGS-4577: Fix default router domain in GenericAPIServerConfig

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -165,7 +165,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 									APIVersion: "route.openshift.io/v1",
 									Kind:       "HostAssignmentAdmissionConfig",
 								},
-								Domain: config.DefaultClusterName + "." + cfg.BaseDomain,
+								Domain: "apps." + config.DefaultClusterName + "." + cfg.BaseDomain,
 							},
 						},
 					},


### PR DESCRIPTION
Default router domain is used to generate router hostname
when neither of host or subdomain is provided. This change
updates the default router domain to be consistent with
the env var ROUTER_DOMAIN in router-default deployment.

