### PR TITLE
USHIFT-673: Clean up config file format

### DIFF
--- a/assets/components/openshift-router/deployment.yaml
+++ b/assets/components/openshift-router/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: ROUTER_ALLOW_WILDCARD_ROUTES
               value: "false"
             - name: ROUTER_CANONICAL_HOSTNAME
-              value: router-default.apps.{{ .ClusterName }}.{{ .BaseDomain }}
+              value: router-default.apps.{{ .BaseDomain }}
             - name: ROUTER_CIPHERS
               value: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
             - name: ROUTER_CIPHERSUITES
@@ -62,7 +62,7 @@ spec:
             - name: GRACEFUL_SHUTDOWN_DELAY
               value: 1s
             - name: ROUTER_DOMAIN
-              value: apps.{{ .ClusterName }}.{{ .BaseDomain }}
+              value: apps.{{ .BaseDomain }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -10,19 +10,20 @@ The MicroShift configuration file must be located at `~/.microshift/config.yaml`
 The format of the `config.yaml` configuration file is as follows.
 
 ```yaml
-subjectAltNames:
-  - ""
-nodeName: ""
-nodeIP: ""
-url: ""
+dns:
+  baseDomain: ""
 network:
   clusterNetwork:
     - cidr: ""
   serviceNetwork:
     - ""
   serviceNodePortRange: ""
-dns:
-  baseDomain: ""
+node:
+  hostnameOverride: ""
+  nodeIP: ""
+apiServer:
+  subjectAltNames:
+    - ""
 debugging:
   logLevel: ""
 ```
@@ -34,10 +35,9 @@ The configuration settings alongside with the supported command line arguments a
 | cidr (clusterNetwork) | --cluster-cidr            | MICROSHIFT_CLUSTER_CLUSTERCIDR          | A block of IP addresses from which Pod IP addresses are allocated
 | serviceNetwork        | --service-cidr            | MICROSHIFT_CLUSTER_SERVICECIDR          | A block of virtual IP addresses for Kubernetes services
 | serviceNodePortRange  | --service-node-port-range | MICROSHIFT_CLUSTER_SERVICENODEPORTRANGE | The port range allowed for Kubernetes services of type NodePort
-| baseDomain            | --base-domain             | MICROSHIFT_BASEDOMAIN                   | Base DNS domain used to construct fully qualified router and API domain names.
-| url                   | --url                     | MICROSHIFT_CLUSTER_URL                  | URL of the API server for the cluster.
+| baseDomain            | --base-domain             | MICROSHIFT_BASEDOMAIN                   | Base domain of the cluster. All managed DNS records will be sub-domains of this base.
 | nodeIP                | --node-ip                 | MICROSHIFT_NODEIP                       | The IP address of the node, defaults to IP of the default route
-| nodeName              | --node-name               | MICROSHIFT_NODENAME                     | The name of the node, defaults to hostname
+| hostnameOverride      | --hostname-override       | MICROSHIFT_HOSTNAMEOVERRIDE             | The name of the node, defaults to hostname
 | logLevel              | --v                       | MICROSHIFT_LOGVLEVEL                    | Log verbosity (Normal, Debug, Trace, TraceAll)
 | subjectAltNames     | --subject-alt-names       | MICROSHIFT_SUBJECTALTNAMES              | Subject Alternative Names for apiserver certificates
 
@@ -46,17 +46,19 @@ The configuration settings alongside with the supported command line arguments a
 In case `config.yaml` is not provided, the following default settings will be used.
 
 ```yaml
-nodeName: ""
-nodeIP: ""
-url: https://127.0.0.1:6443
+dns:
+  baseDomain: microshift.example.com
 network:
   clusterNetwork:
     - cidr: 10.42.0.0/16
   serviceNetwork:
     - 10.43.0.0/16
   serviceNodePortRange: 30000-32767
-dns:
-  baseDomain: example.com
+node:
+  hostnameOverride: ""
+  nodeIP: ''
+apiServer:
+  subjectAltNames: []
 debugging:
   logLevel: "Normal"
 ```

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -1,30 +1,31 @@
-# Cluster settings
-cluster:
+dns:
+  # Base domain of the cluster. All managed DNS records will be sub-domains of this base.
+  #baseDomain: microshift.example.com
 
+network:
+  clusterNetwork:
   # IP range for use by the cluster
-  #clusterCIDR: 10.42.0.0/16
+  #- cidr: 10.42.0.0/16
 
-  # Base DNS domain used to construct fully qualified pod and service domain names
-  #domain: cluster.local
-
+  serviceNetwork:
   # IP range for services in the cluster
-  #serviceCIDR: 10.43.0.0/16
+  #- 10.43.0.0/16
 
   # Node ports allowed for services
   #serviceNodePortRange: 30000-32767
 
-  # URL of the API server for the cluster
-  #url: https://127.0.0.1:6443
+node:
+  # If non-empty, use this string to identify the node instead of the hostname
+  #hostnameOverride: ''
 
-# Log verbosity (0-5)
-#logVLevel: 0
+  # IP address of the node, passed to the kubelet.
+  # If not specified, kubelet will use the node's default IP address.
+  #nodeIP: ''
 
-# The IP of the node (defaults to IP of default route)
-#nodeIP: ""
+apiServer:
+  # The Subject Alternative Names for the external certificates in API server (defaults to hostname -A)
+  #subjectAltNames: []
 
-# The name of the node (defaults to hostname)
-#nodeName: ""
-
-# The Subject Alternative Names for the external certificates in API server (defaults to hostname -A)
-#subjectAltNames: ""
-
+debugging:
+  # Log verbosity ('Normal', 'Debug', 'Trace', 'TraceAll'):
+  #logLevel: 'Normal'

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -214,7 +214,7 @@ func certSetup(cfg *config.MicroshiftConfig) (*certchains.CertificateChains, err
 					ValidityDays: cryptomaterial.ShortLivedCertificateValidityDays,
 				},
 				Hostnames: []string{
-					"*.apps.microshift." + cfg.BaseDomain, // wildcard for any additional auto-generated domains
+					"*.apps." + cfg.BaseDomain, // wildcard for any additional auto-generated domains
 				},
 			},
 		),
@@ -234,10 +234,7 @@ func certSetup(cfg *config.MicroshiftConfig) (*certchains.CertificateChains, err
 				Hostnames: append(
 					cfg.SubjectAltNames,
 					cfg.NodeName,
-					"api."+config.DefaultClusterName+"."+cfg.BaseDomain,
-					// TODO: OpenShift actually uses  api.$ClusterName.$BaseDomain
-					// but we don't have a ClusterName parameter yet, using microshift
-					// for now
+					"api."+cfg.BaseDomain,
 				),
 			},
 		),
@@ -278,8 +275,8 @@ func certSetup(cfg *config.MicroshiftConfig) (*certchains.CertificateChains, err
 					"openshift.default",
 					"openshift.default.svc",
 					"openshift.default.svc.cluster.local",
-					"api." + config.DefaultClusterName + "." + cfg.BaseDomain,     // TODO: OpenShift actually uses  api.$ClusterName.$BaseDomain
-					"api-int." + config.DefaultClusterName + "." + cfg.BaseDomain, // TODO: OpenShift actually uses  api.$ClusterName.$BaseDomain
+					"api." + cfg.BaseDomain,
+					"api-int." + cfg.BaseDomain,
 					apiServerServiceIP.String(),
 				},
 			},

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -30,13 +30,13 @@ const (
 func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	flags := cmd.Flags()
 	// All other flags will be read after reading both config file and env vars.
-	flags.String("node-name", cfg.NodeName, "The hostname of the node.")
+	flags.String("hostname-override", cfg.NodeName, "The name to use to identify this node instead of the hostname.")
 	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
 	flags.String("url", cfg.Cluster.URL, "The URL of the API server.")
 	flags.String("cluster-cidr", cfg.Cluster.ClusterCIDR, "The IP range in CIDR notation for pods in the cluster.")
 	flags.String("service-cidr", cfg.Cluster.ServiceCIDR, "The IP range in CIDR notation for services in the cluster.")
 	flags.String("service-node-port-range", cfg.Cluster.ServiceNodePortRange, "The port range to reserve for services with NodePort visibility. This must not overlap with the ephemeral port range on nodes.")
-	flags.String("base-domain", cfg.BaseDomain, "Base domain for this cluster.")
+	flags.String("base-domain", cfg.BaseDomain, "The base domain for this cluster.")
 }
 
 func NewRunMicroshiftCommand() *cobra.Command {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -32,7 +32,6 @@ func addRunFlags(cmd *cobra.Command, cfg *config.MicroshiftConfig) {
 	// All other flags will be read after reading both config file and env vars.
 	flags.String("hostname-override", cfg.NodeName, "The name to use to identify this node instead of the hostname.")
 	flags.String("node-ip", cfg.NodeIP, "The IP address of the node.")
-	flags.String("url", cfg.Cluster.URL, "The URL of the API server.")
 	flags.String("cluster-cidr", cfg.Cluster.ClusterCIDR, "The IP range in CIDR notation for pods in the cluster.")
 	flags.String("service-cidr", cfg.Cluster.ServiceCIDR, "The IP range in CIDR notation for services in the cluster.")
 	flags.String("service-node-port-range", cfg.Cluster.ServiceNodePortRange, "The port range to reserve for services with NodePort visibility. This must not overlap with the ephemeral port range on nodes.")

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -48,9 +48,7 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 				klog.Fatal("logVLevel out of range [0..%d] %d", len(logLevels)-1, cfg.LogVLevel)
 			}
 			userCfg := config.Config{
-				NodeName: cfg.NodeName,
-				NodeIP:   cfg.NodeIP,
-				URL:      cfg.Cluster.URL,
+				URL: cfg.Cluster.URL,
 				Network: config.Network{
 					ClusterNetwork: []config.ClusterNetworkEntry{
 						{CIDR: cfg.Cluster.ClusterCIDR},
@@ -61,10 +59,16 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 				DNS: config.DNS{
 					BaseDomain: cfg.BaseDomain,
 				},
+				Node: config.Node{
+					HostnameOverride: cfg.NodeName,
+					NodeIP:           cfg.NodeIP,
+				},
+				ApiServer: config.ApiServer{
+					SubjectAltNames: cfg.SubjectAltNames,
+				},
 				Debugging: config.Debugging{
 					LogLevel: logLevels[cfg.LogVLevel],
 				},
-				SubjectAltNames: cfg.SubjectAltNames,
 			}
 			marshalled, err := yaml.Marshal(userCfg)
 			cmdutil.CheckErr(err)

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -48,7 +48,6 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 				klog.Fatal("logVLevel out of range [0..%d] %d", len(logLevels)-1, cfg.LogVLevel)
 			}
 			userCfg := config.Config{
-				URL: cfg.Cluster.URL,
 				Network: config.Network{
 					ClusterNetwork: []config.ClusterNetworkEntry{
 						{CIDR: cfg.Cluster.ClusterCIDR},

--- a/pkg/components/render.go
+++ b/pkg/components/render.go
@@ -29,7 +29,6 @@ func renderParamsFromConfig(cfg *config.MicroshiftConfig, extra assets.RenderPar
 		"ServiceCIDR":  cfg.Cluster.ServiceCIDR,
 		"ClusterDNS":   cfg.Cluster.DNS,
 		"BaseDomain":   cfg.BaseDomain,
-		"ClusterName":  config.DefaultClusterName,
 	}
 	for k, v := range extra {
 		params[k] = v

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,6 @@ const (
 	defaultManifestDirEtc = "/etc/microshift/manifests"
 	// for files embedded in ostree. i.e. cni/other component customizations
 	defaultManifestDirLib = "/usr/lib/microshift/manifests"
-	DefaultClusterName    = "microshift"
 )
 
 var (
@@ -108,9 +107,9 @@ type DNS struct {
 	// be sub-domains of this base.
 	//
 	// For example, given the base domain `example.com`, router exposed
-	// domains will be formed as `*.apps.microshift.example.com` by default,
-	// and API service will have a DNS entry for `api.microshift.example.com`,
-	// as well as "api-int.microshift.example.com" for internal k8s API access.
+	// domains will be formed as `*.apps.example.com` by default,
+	// and API service will have a DNS entry for `api.example.com`,
+	// as well as "api-int.example.com" for internal k8s API access.
 	//
 	// Once set, this field cannot be changed.
 	BaseDomain string `json:"baseDomain"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,7 @@ var (
 )
 
 type ClusterConfig struct {
-	URL                  string `json:"url"`
+	URL                  string `json:"-"`
 	ClusterCIDR          string `json:"clusterCIDR"`
 	ServiceCIDR          string `json:"serviceCIDR"`
 	ServiceNodePortRange string `json:"serviceNodePortRange"`
@@ -71,7 +71,6 @@ type MicroshiftConfig struct {
 
 // Top level config file
 type Config struct {
-	URL       string    `json:"url"`
 	DNS       DNS       `json:"dns"`
 	Network   Network   `json:"network"`
 	Node      Node      `json:"node"`
@@ -346,9 +345,6 @@ func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	if config.Node.NodeIP != "" {
 		c.NodeIP = config.Node.NodeIP
 	}
-	if config.URL != "" {
-		c.Cluster.URL = config.URL
-	}
 	if len(config.Network.ClusterNetwork) != 0 {
 		c.Cluster.ClusterCIDR = config.Network.ClusterNetwork[0].CIDR
 	}
@@ -387,9 +383,6 @@ func (c *MicroshiftConfig) ReadFromCmdLine(flags *pflag.FlagSet) error {
 	}
 	if s, err := flags.GetString("node-ip"); err == nil && flags.Changed("node-ip") {
 		c.NodeIP = s
-	}
-	if s, err := flags.GetString("url"); err == nil && flags.Changed("url") {
-		c.Cluster.URL = s
 	}
 	if s, err := flags.GetString("cluster-cidr"); err == nil && flags.Changed("cluster-cidr") {
 		c.Cluster.ClusterCIDR = s

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -81,7 +81,7 @@ func TestCommandLineConfig(t *testing.T) {
 		// all other flags unbound (looked up by name) and defaulted
 		flags.Int("v", config.LogVLevel, "")
 		flags.StringSlice("subject-alt-names", config.SubjectAltNames, "")
-		flags.String("node-name", config.NodeName, "")
+		flags.String("hostname-override", config.NodeName, "")
 		flags.String("node-ip", config.NodeIP, "")
 		flags.String("url", config.Cluster.URL, "")
 		flags.String("cluster-cidr", config.Cluster.ClusterCIDR, "")
@@ -94,7 +94,7 @@ func TestCommandLineConfig(t *testing.T) {
 		err = flags.Parse([]string{
 			"--v=" + strconv.Itoa(tt.config.LogVLevel),
 			"--subject-alt-names=" + strings.Join(tt.config.SubjectAltNames, ","),
-			"--node-name=" + tt.config.NodeName,
+			"--hostname-override=" + tt.config.NodeName,
 			"--node-ip=" + tt.config.NodeIP,
 			"--url=" + tt.config.Cluster.URL,
 			"--cluster-cidr=" + tt.config.Cluster.ClusterCIDR,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,7 +64,7 @@ func TestCommandLineConfig(t *testing.T) {
 				NodeIP:          "1.2.3.4",
 				BaseDomain:      "example.com",
 				Cluster: ClusterConfig{
-					URL:                  "https://1.2.3.4:6443",
+					URL:                  "https://127.0.0.1:6443",
 					ClusterCIDR:          "10.20.30.40/16",
 					ServiceCIDR:          "40.30.20.10/16",
 					ServiceNodePortRange: "1024-32767",
@@ -83,7 +83,6 @@ func TestCommandLineConfig(t *testing.T) {
 		flags.StringSlice("subject-alt-names", config.SubjectAltNames, "")
 		flags.String("hostname-override", config.NodeName, "")
 		flags.String("node-ip", config.NodeIP, "")
-		flags.String("url", config.Cluster.URL, "")
 		flags.String("cluster-cidr", config.Cluster.ClusterCIDR, "")
 		flags.String("service-cidr", config.Cluster.ServiceCIDR, "")
 		flags.String("service-node-port-range", config.Cluster.ServiceNodePortRange, "")
@@ -96,7 +95,6 @@ func TestCommandLineConfig(t *testing.T) {
 			"--subject-alt-names=" + strings.Join(tt.config.SubjectAltNames, ","),
 			"--hostname-override=" + tt.config.NodeName,
 			"--node-ip=" + tt.config.NodeIP,
-			"--url=" + tt.config.Cluster.URL,
 			"--cluster-cidr=" + tt.config.Cluster.ClusterCIDR,
 			"--service-cidr=" + tt.config.Cluster.ServiceCIDR,
 			"--service-node-port-range=" + tt.config.Cluster.ServiceNodePortRange,

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -165,7 +165,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 									APIVersion: "route.openshift.io/v1",
 									Kind:       "HostAssignmentAdmissionConfig",
 								},
-								Domain: "apps." + config.DefaultClusterName + "." + cfg.BaseDomain,
+								Domain: "apps." + cfg.BaseDomain,
 							},
 						},
 					},

--- a/pkg/controllers/kube-controller-manager_test.go
+++ b/pkg/controllers/kube-controller-manager_test.go
@@ -67,7 +67,7 @@ func TestConfigure(t *testing.T) {
 		"--secure-port=10257",
 		fmt.Sprintf("--service-account-private-key-file=%s", kcmServiceAccountPrivateKeyFile()),
 		"--use-service-account-credentials=true",
-		"-v=0",
+		"-v=2",
 	}
 
 	argsGot := kcm.args

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -571,7 +571,7 @@ update_manifests() {
     yq -i '.spec.template.spec.containers[0].env += {"name": "GRACEFUL_SHUTDOWN_DELAY", "value": "1s"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DOMAIN", "value": "apps.REPLACE_CLUSTER_DOMAIN"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
-    sed -i 's|REPLACE_CLUSTER_DOMAIN|{{ .ClusterName }}.{{ .BaseDomain }}|g' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    sed -i 's|REPLACE_CLUSTER_DOMAIN|{{ .BaseDomain }}|g' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     sed -i 's|REPLACE_ROUTER_IMAGE|{{ .ReleaseImage.haproxy_router }}|' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
 
 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,5 +1,4 @@
 ---
-url: https://127.0.0.1:6443
 network:
   clusterNetwork:
     - cidr: '10.20.30.40/16'

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,8 +1,4 @@
 ---
-subjectAltNames:
-  - '1.2.3.40'
-nodeName: node1
-nodeIP: '1.2.3.4'
 url: https://127.0.0.1:6443
 network:
   clusterNetwork:
@@ -11,6 +7,12 @@ network:
     - '40.30.20.10/16'
   serviceNodePortRange: 30000-32767
 dns:
-  baseDomain: 'example.com'
+  baseDomain: 'microshift.example.com'
+node:
+  hostnameOverride: node1
+  nodeIP: '1.2.3.4'
+apiServer:
+  subjectAltNames:
+    - '1.2.3.40'
 debugging:
   logLevel: 'Debug'

--- a/test/config_bad_subjectaltnames.yaml
+++ b/test/config_bad_subjectaltnames.yaml
@@ -1,14 +1,20 @@
 ---
-logVLevel: 4
-subjectAltNames:
-  - localhost
-  - '10.43.0.1'
-  - '1.2.3.4'
-nodeName: node1
-nodeIP: '1.2.3.4'
-cluster:
-  url: https://1.2.3.4:6443
-  clusterCIDR: '10.20.30.40/16'
-  serviceCIDR: '40.30.20.10/16'
-  domain: cluster.local
+url: https://127.0.0.1:6443
+network:
+  clusterNetwork:
+    - cidr: '10.20.30.40/16'
+  serviceNetwork:
+    - '40.30.20.10/16'
   serviceNodePortRange: 30000-32767
+dns:
+  baseDomain: 'microshift.example.com'
+node:
+  hostnameOverride: node1
+  nodeIP: '1.2.3.4'
+apiServer:
+  subjectAltNames:
+    - localhost
+    - '10.43.0.1'
+    - '1.2.3.4'
+debugging:
+  logLevel: 'Debug'

--- a/test/config_bad_subjectaltnames.yaml
+++ b/test/config_bad_subjectaltnames.yaml
@@ -1,5 +1,4 @@
 ---
-url: https://127.0.0.1:6443
 network:
   clusterNetwork:
     - cidr: '10.20.30.40/16'


### PR DESCRIPTION
- Groups cluster-, node-, and apiserver-related params.
- Wires-through the cluster-name parameter.
- Updates /etc/microshift/config.yaml.default to reflect the format correctly.
- Removes 'url' field from being user-configurable.
- Fixes a couple of parameter descriptions.

Closes [USHIFT-673](https://issues.redhat.com//browse/USHIFT-673)
