### PR TITLE
USHIFT-667: Avoid regenerating keypair for Service Account tokens

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -343,8 +343,11 @@ func certSetup(cfg *config.MicroshiftConfig) (*certchains.CertificateChains, err
 		return nil, err
 	}
 
-	if err := util.GenKeys(filepath.Join(microshiftDataDir, "/resources/kube-apiserver/secrets/service-account-key"),
-		"service-account.crt", "service-account.key"); err != nil {
+	saKeyDir := filepath.Join(microshiftDataDir, "/resources/kube-apiserver/secrets/service-account-key")
+	if err := util.EnsureKeyPair(
+		filepath.Join(saKeyDir, "service-account.pub"),
+		filepath.Join(saKeyDir, "service-account.key"),
+	); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -205,7 +205,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			},
 		},
 		ServiceAccountPublicKeyFiles: []string{
-			microshiftDataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.crt",
+			microshiftDataDir + "/resources/kube-apiserver/secrets/service-account-key/service-account.pub",
 		},
 		ServicesSubnet:        cfg.Cluster.ServiceCIDR,
 		ServicesNodePortRange: cfg.Cluster.ServiceNodePortRange,


### PR DESCRIPTION
Signed-off-by: Ricardo Noriega <rnoriega@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first contribution, read our Contributing guide https://github.com/openshift/microshift/CONTRIBUTING.md
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remote the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

The issue happens when MicroShift is restarted, and the keypair used to verify service account tokens is regenerated. At first boot, KAS and KCM will read the content of the initial file and keep that information internally.  After restart, the user agents calling the API server with the private key will be unauthorized because it has changed. 

This PR prevents the regeneration of the key pair.

Closes [USHIFT-667](https://issues.redhat.com//browse/USHIFT-667)
