### PR TITLE
rebase.sh: remove previous last_rebase.sh

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -149,7 +149,7 @@ update_last_rebase() {
 
     local last_rebase_script="${REPOROOT}/scripts/auto-rebase/last_rebase.sh"
 
-    rm -rf "${last_rebase_script}"
+    rm -f "${last_rebase_script}"
     cat - >"${last_rebase_script}" <<EOF
 #!/bin/bash -x
 ./scripts/auto-rebase/rebase.sh to "${release_image_amd64}" "${release_image_arm64}"

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -149,6 +149,7 @@ update_last_rebase() {
 
     local last_rebase_script="${REPOROOT}/scripts/auto-rebase/last_rebase.sh"
 
+    rm -rf "${last_rebase_script}"
     cat - >"${last_rebase_script}" <<EOF
 #!/bin/bash -x
 ./scripts/auto-rebase/rebase.sh to "${release_image_amd64}" "${release_image_arm64}"


### PR DESCRIPTION
CI jobs script run as nonroot, but repo is cloned as root.
Job can change files' contents freely or even delete files, but it's unable to change permissions of files it doesn't own:
```
chmod: changing permissions of '(...)/last_rebase.sh': Operation not permitted
```