### PR TITLE
NP-646: Prefer OVN-K gateway IP as the nodeIP

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -38,17 +38,18 @@ const (
 )
 
 func GetHostIP() (string, error) {
+	// Prefer OVN-K gateway IP if it is the CNI
+	gatewayIP, err := getOVNGatewayIP()
+	if err != nil && !strings.Contains(err.Error(), "no such network interface") {
+		return "", err
+	}
+	klog.V(2).Infof("ovn gateway IP address: %s", gatewayIP)
+
 	ip, err := net.ChooseHostInterface()
 	if err == nil {
 		return ip.String(), nil
 	}
 	klog.V(2).Infof("failed to find default route IP address: %v", err)
-
-	gatewayIP, err := getOVNGatewayIP()
-	if err != nil {
-		return "", err
-	}
-	klog.V(2).Infof("ovn gateway IP address: %s", gatewayIP)
 
 	return gatewayIP, nil
 }


### PR DESCRIPTION
In OCP, we always use the same IP as OVN-K gateway and kubelet node IP. We shall do the same thing for microshift.