### PR TITLE
rebase.sh: don't fail if last_rebase.sh didn't change

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -145,7 +145,7 @@ update_last_rebase() {
     local release_image_amd64=$1
     local release_image_arm64=$2
 
-    title "## updating last_rebase.sh"
+    title "## Updating last_rebase.sh"
 
     local last_rebase_script="${REPOROOT}/scripts/auto-rebase/last_rebase.sh"
 
@@ -156,8 +156,10 @@ EOF
     chmod +x "${last_rebase_script}"
 
     (cd "${REPOROOT}" && \
+         test -n "$(git status -s scripts/auto-rebase/last_rebase.sh)" && \
+         title "## Committing changes to last_rebase.sh" && \
          git add scripts/auto-rebase/last_rebase.sh && \
-         git commit -m "update last_rebase.sh")
+         git commit -m "update last_rebase.sh" || true)
 }
 
 # Updates the ReplaceDirective for an old ${modulepath} with the new modulepath


### PR DESCRIPTION
Addresses scenario when last_rebase.sh and git commit exits with 1 because there were no files to commit

```
Switched to a new branch 'rebase-4.12.0-0.nightly-2022-12-23-190941'
## updating last_rebase.sh
On branch rebase-4.12.0-0.nightly-2022-12-23-190941
nothing to commit, working tree clean
Script exited with error.
Script exited with error.
```