### PR TITLE
Add arch info for assets/release/release-x86_64.json base section

### DIFF
--- a/assets/release/release-x86_64.json
+++ b/assets/release/release-x86_64.json
@@ -1,6 +1,6 @@
 {
   "release": {
-    "base": "4.12.0-0.nightly-2023-01-03-161331"
+    "base": "4.12.0-0.nightly-amd64-2023-01-03-161331"
   },
   "images": {
     "cli": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9945c3f5475a37e145160d2fe6bb21948f1024a856827bc9e7d5bc882f44a750",


### PR DESCRIPTION
As of now assets/release/release-aarch64.json file have arch info as part of base section `"base": "4.12.0-0.nightly-arm64-2023-01-03-161334"` but it is not present for assets/release/release-x86_64.json. This PR puts the arch info in base same as aarch64 asset file.
