### PR TITLE
NP-603: default to system mtu in ovnk

### DIFF
--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -364,6 +364,7 @@ spec:
             --sb-address "" \
             --enable-multicast \
             --disable-snat-multiple-gws \
+            --single-node \
             --acl-logging-rate-limit "20"
         lifecycle:
           preStop:

--- a/docs/network/default_cni_plugin.md
+++ b/docs/network/default_cni_plugin.md
@@ -63,14 +63,16 @@ MicroShift will assume default ovn-kubernetes config values if ovn-kubernetes co
 
 The following configs are supported in ovn-kubernetes config file:
 
-|Field                            |Required |Type    |Default |Description                                                       |Example|
-|:--------------------------------|:--------|:-------|:-------|:-----------------------------------------------------------------|:------|
-|ovsInit.disableOVSInit           |N        |bool    |false   |Skip configuring OVS bridge "br-ex" in microshift-ovs-init.service|true   |
-|ovsInit.gatewayInterface         |N        |string  |""      |Interface to be added in OVS gateway bridge "br-ex"               |eth0   |
-|ovsInit.externalGatewayInterface |N        |string  |""      |Interface to be added in external OVS gateway bridge "br-ex1"     |eth1   |
-|mtu                              |N        |uint32  |1400    |MTU value to be used for the Pods                                 |1300   |
+|Field                            |Required |Type    |Default |Description                                                                  |Example|
+|:--------------------------------|:--------|:-------|:-------|:----------------------------------------------------------------------------|:------|
+|ovsInit.disableOVSInit           |N        |bool    |false   |Skip configuring OVS bridge "br-ex" in microshift-ovs-init.service           |true   |
+|ovsInit.gatewayInterface         |N        |string  |""      |Interface to be added in OVS gateway bridge "br-ex"                          |eth0   |
+|ovsInit.externalGatewayInterface |N        |string  |""      |Interface to be added in external OVS gateway bridge "br-ex1"                |eth1   |
+|mtu                              |N        |int     |*auto*  |MTU value to be used for the Pods, must be less than or equal to the MTU of default route interface|1500|
 
 > When `disableOVSInit` is true, OVS bridge "br-ex" needs to be configured manually. This OVS bridge is required by ovn-kubernetes CNI. See section [OVS bridge](#ovs-bridge) for guidance on configuring the OVS gateway bridge manually.
+> When `gatewayInterface` is not provided, it defaults to the default route interface.
+> When `mtu` is not provided, it defaults to the MTU of `gatewayInterface` interface. In the case that `gatewayInterface` is not specified, it is set to the default route MTU.
 
 Below is an example of `ovn.yaml`:
 
@@ -79,7 +81,7 @@ ovsInit:
   disableOVSInit: true
   gatewayInterface: eth0
   externalGatewayInterface: eth1
-mtu: 1300
+mtu: 1500
 ```
 **NOTE:* The change of `mtu` configuration in `ovn.yaml` requires node reboot to take effect. <br>
 

--- a/docs/network/host_networking.md
+++ b/docs/network/host_networking.md
@@ -108,10 +108,10 @@ Special routes are associated to `br-ex` interface to facilitate traffic destina
 
 ```text
 (host)$ ip route show 10.43.0.0/16
-10.43.0.0/16 via 169.254.169.4 dev br-ex mtu 1400
+10.43.0.0/16 via 169.254.169.4 dev br-ex mtu 1500
 
 (host)$ ip route show 169.254.169.1
-169.254.169.1 dev br-ex src 192.168.122.14 mtu 1400
+169.254.169.1 dev br-ex src 192.168.122.14 mtu 1500
 
 (host)$ ip route show 169.254.169.3
 169.254.169.3 via 10.42.0.1 dev ovn-k8s-mp0

--- a/docs/network/ovn_kubernetes_traffic_flows.md
+++ b/docs/network/ovn_kubernetes_traffic_flows.md
@@ -69,7 +69,7 @@ Step 1, IP and route inside `pod-1`:
 (host)$ oc -n default exec -it pod-1 -- bash
 
 (pod-1)$ ifconfig eth0
-eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1400
+eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         inet 10.42.0.12  netmask 255.255.255.0  broadcast 10.42.0.255
         inet6 fe80::858:aff:fe2a:c  prefixlen 64  scopeid 0x20<link>
         ether 0a:58:0a:2a:00:0c  txqueuelen 0  (Ethernet)
@@ -124,7 +124,7 @@ Step 3, ovn management port ovn-k8s-mp0 on the host:
 
 ```text
 (host)$ ifconfig ovn-k8s-mp0
-ovn-k8s-mp0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1400
+ovn-k8s-mp0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         inet 10.42.0.2  netmask 255.255.255.0  broadcast 10.42.0.255
         inet6 fe80::743a:81ff:fe5a:5d7  prefixlen 64  scopeid 0x20<link>
         ether 76:3a:81:5a:05:d7  txqueuelen 1000  (Ethernet)
@@ -493,7 +493,7 @@ Step 2, route in host network:
 
 ```text
 (host)$ ip route
-10.43.0.0/16 via 169.254.169.4 dev br-ex mtu 1400
+10.43.0.0/16 via 169.254.169.4 dev br-ex mtu 1500
 ```
 
 **NOTE:** The rest traffic flow for external to nodePortService is the same as [Host to ClusterServer](#host-to-clusterservice) or [Host to HostService](#host-to-hostservice)


### PR DESCRIPTION
OVNKubernetes builds overlay networking implementation based on geneve
tunnel which adds extra header for packets coming from overlay (Pod) to
underlay network. However, the geneve tunnel is only useful for
cross-nodes communication and not required for microshift single node
deployment. This PR leverages the single-node change[1] in OVNKubernetes
and updates the default overlay MTU to the same size as default uplink
MTU (1500).

[1]: https://github.com/ovn-org/ovn-kubernetes/pull/3290