### PR TITLE
Fix formatting after changing CI's image to go1.19

### DIFF
--- a/pkg/controllers/cluster-policy-controller.go
+++ b/pkg/controllers/cluster-policy-controller.go
@@ -3,7 +3,9 @@ Copyright © 2022 MicroShift Contributors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/controllers/openshift-crd-manager.go
+++ b/pkg/controllers/openshift-crd-manager.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/controllers/openshift-default-scc-manager.go
+++ b/pkg/controllers/openshift-default-scc-manager.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/mdns/routes.go
+++ b/pkg/mdns/routes.go
@@ -61,7 +61,7 @@ func (c *MicroShiftmDNSController) run(stopCh chan struct{}, dc dynamic.Interfac
 }
 
 // TODO: The need for this indicates that the openshift-default-scc-manager is declaring itself ready before
-//       it really is. If we don't wait for the route API the informer will start throwing ugly errors.
+// it really is. If we don't wait for the route API the informer will start throwing ugly errors.
 func (c *MicroShiftmDNSController) waitForRouterAPI(dc dynamic.Interface, routersGVR *schema.GroupVersionResource) {
 	backoff := wait.Backoff{
 		Cap:      3 * time.Minute,

--- a/pkg/mdns/server/resolver.go
+++ b/pkg/mdns/server/resolver.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/mdns/server/server.go
+++ b/pkg/mdns/server/server.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/util/sigchannel/sigchannel.go
+++ b/pkg/util/sigchannel/sigchannel.go
@@ -2,7 +2,7 @@ package sigchannel
 
 // IsClosed tests whether a signalling channel has been closed.
 // Note: Must only be used on broadcast signalling channels, i.e. channels
-//       that only ever get closed, not sent any values.
+// that only ever get closed, not sent any values.
 func IsClosed(channel <-chan struct{}) bool {
 	select {
 	case <-channel:
@@ -14,7 +14,7 @@ func IsClosed(channel <-chan struct{}) bool {
 
 // AllClosed tests whether all signalling channels have been closed.
 // Note: Must only be used on broadcast signalling channels, i.e. channels
-//       that only ever get closed, not sent any values.
+// that only ever get closed, not sent any values.
 func AllClosed(channels []<-chan struct{}) bool {
 	for _, channel := range channels {
 		if !IsClosed(channel) {
@@ -27,9 +27,9 @@ func AllClosed(channels []<-chan struct{}) bool {
 // And returns a signalling channel that will be closed when all operand
 // signalling channels have been closed.
 // Note: As both And() and close() are async, it is possible and normal
-//       for And() to return 'false' immediately after close() has been
-//       called on its operands. Therefore, always use as blocking or in
-//       a for-select-loop.
+// for And() to return 'false' immediately after close() has been
+// called on its operands. Therefore, always use as blocking or in
+// a for-select-loop.
 func And(channels []<-chan struct{}) <-chan struct{} {
 	andChannel := make(chan struct{})
 	go func() {


### PR DESCRIPTION
I'm suspecting that changing CI image from `rhel-8-release-golang-1.18-openshift-4.12` to `rhel-8-release-golang-1.19-openshift-4.13` (note the golang change) change gofmt's behavior 