### PR TITLE
USHIFT-781: add 'get' command line client

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -38,5 +38,6 @@ func newCommand() *cobra.Command {
 	cmd.AddCommand(cmds.NewRunMicroshiftCommand())
 	cmd.AddCommand(cmds.NewVersionCommand(ioStreams))
 	cmd.AddCommand(cmds.NewShowConfigCommand(ioStreams))
+	cmd.AddCommand(cmds.NewGetCommand(ioStreams))
 	return cmd
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"os/user"
+
+	"github.com/openshift/microshift/pkg/config"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/cmd/get"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+func NewGetCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
+
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+
+	// Initialize the kubeconfig default path to the location we
+	// expect the server to have generated the file, but only if the
+	// user is root. That leaves the default lookup logic from kubectl
+	// in place for other users.
+	userInfo, err := user.Current()
+	if err != nil {
+		klog.Fatalf("Failed to detect the current user %v", err)
+	}
+	if userInfo.Uid == "0" {
+		cfg := config.NewMicroshiftConfig()
+		kubeconfig := cfg.KubeConfigPath(config.KubeAdmin)
+		kubeConfigFlags.KubeConfig = &kubeconfig
+	}
+
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
+
+	cmd := get.NewCmdGet("kubectl", f, ioStreams)
+	persistFlags := cmd.PersistentFlags()
+	persistFlags.SetNormalizeFunc(cliflag.WarnWordSepNormalizeFunc)
+	persistFlags.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+	kubeConfigFlags.AddFlags(persistFlags)
+
+	return cmd
+}


### PR DESCRIPTION
Expose the embedded 'kubectl get' command for use in greenboot and
sos.