### PR TITLE
OCPBUGS-6080: Use rhocp-4.12 release channel for OCP dependencies

### DIFF
--- a/docs/devenv_rhel8.md
+++ b/docs/devenv_rhel8.md
@@ -107,20 +107,10 @@ When working with MicroShift based on a pre-release _minor_ version `Y` of OpenS
 Enable the needed repositories and install the MicroShift RPM packages. This procedure pulls in the required package dependencies, also installing the necessary configuration files and `systemd` units.
 
 ```bash
-# Temporary workaround until the rhocp-4.12-for-rhel-8-$(uname -i)-rpms repo can be used
-sudo tee /etc/yum.repos.d/rhocp-4.12-el8-beta-$(uname -i)-rpms.repo >/dev/null <<EOF
-[rhocp-4.12-el8-beta-$(uname -i)-rpms]
-name=Beta rhocp-4.12 RPMs for RHEL8
-baseurl=https://mirror.openshift.com/pub/openshift-v4/\$basearch/dependencies/rpms/4.12-el8-beta/
-enabled=1
-gpgcheck=1
-skip_if_unavailable=0
-EOF
-
 sudo subscription-manager config --rhsm.manage_repos=1
 sudo subscription-manager repos \
+    --enable rhocp-4.12-for-rhel-8-$(uname -i)-rpms \
     --enable fast-datapath-for-rhel-8-$(uname -i)-rpms
-#    --enable rhocp-4.12-for-rhel-8-$(uname -i)-rpms \
 sudo dnf localinstall -y ~/microshift/_output/rpmbuild/RPMS/*/*.rpm
 ```
 

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -75,19 +75,10 @@ fi
 
 # Run MicroShift Executable > Runtime Prerequisites
 # https://github.com/openshift/microshift/blob/main/docs/devenv_rhel8.md#runtime-prerequisites
-sudo tee /etc/yum.repos.d/rhocp-4.12-el8-beta-$(uname -i)-rpms.repo >/dev/null <<EOF
-[rhocp-4.12-el8-beta-$(uname -i)-rpms]
-name=Beta rhocp-4.12 RPMs for RHEL8
-baseurl=https://mirror.openshift.com/pub/openshift-v4/\$basearch/dependencies/rpms/4.12-el8-beta/
-enabled=1
-gpgcheck=1
-skip_if_unavailable=0
-EOF
-
 sudo subscription-manager config --rhsm.manage_repos=1
 sudo subscription-manager repos \
+    --enable rhocp-4.12-for-rhel-8-$(uname -i)-rpms \
     --enable fast-datapath-for-rhel-8-$(uname -i)-rpms
-#    --enable rhocp-4.12-for-rhel-8-$(uname -i)-rpms \
 if $BUILD_AND_INSTALL ; then
     sudo dnf localinstall -y ~/microshift/_output/rpmbuild/RPMS/*/*.rpm
 

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -240,16 +240,16 @@ createrepo microshift-local >/dev/null
 
 # Download openshift local RPM packages (noarch for python and selinux packages)
 rm -rf openshift-local 2>/dev/null || true
+OCP_REPO_NAME=rhocp-4.12-for-rhel-8-${BUILD_ARCH}-rpms
 reposync -n -a ${BUILD_ARCH} -a noarch --download-path openshift-local \
-    --repo=rhocp-4.12-el8-beta-${BUILD_ARCH}-rpms \
+    --repo=${OCP_REPO_NAME} \
     --repo=fast-datapath-for-rhel-8-${BUILD_ARCH}-rpms >/dev/null
-#   --repo=rhocp-4.12-for-rhel-8-${BUILD_ARCH}-rpms \
 
 # Remove coreos packages to avoid conflicts
 find openshift-local -name \*coreos\* -exec rm -f {} \;
 # Exit if no RPM packages were found
 if [ $(find openshift-local -name '*.rpm' | wc -l) -eq 0 ] ; then
-    echo "No RPM packages were found at the 'rhocp-4.12-for-rhel-8-${BUILD_ARCH}-rpms' repository. Exiting..."
+    echo "No RPM packages were found at the '${OCP_REPO_NAME}' repository. Exiting..."
     exit 1
 fi
 createrepo openshift-local >/dev/null


### PR DESCRIPTION
The 4.13 channels are not yet available, while rhocp-4.12-beta channels no longer work.

Closes OCPBUGS-6080
