### PR TITLE
USHIFT-791: Rebase: don't change Corefile in DNS's ConfigMap

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -604,7 +604,6 @@ update_manifests() {
     sed -i 's|REPLACE_COREDNS_IMAGE|{{ .ReleaseImage.coredns }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_RBAC_PROXY_IMAGE|{{ .ReleaseImage.kube_rbac_proxy }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_CLUSTER_IP|{{.ClusterIP}}|' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
-    sed -i 's|forward.*|{{with .UpstreamResolver}}{{.}}{{else}}/etc/resolv.conf{{end}} {|' "${REPOROOT}"/assets/components/openshift-dns/dns/configmap.yaml
 
 
     #-- openshift-router ----------------------------------


### PR DESCRIPTION
DNS's configmap.yaml is owned by MicroShift (it's a file that would be generated by the operator)