### PR TITLE
OCPBUGS-6785: Use systemd-resolved in CoreDNS configmap

### DIFF
--- a/assets/components/openshift-dns/dns/configmap.yaml
+++ b/assets/components/openshift-dns/dns/configmap.yaml
@@ -16,7 +16,7 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         prometheus 127.0.0.1:9153
-        forward . /etc/resolv.conf {
+        forward . {{if eq .UpstreamResolver ""}}/etc/resolv.conf{{else}}{{.UpstreamResolver}}{{end}} {
             policy sequential
         }
         cache 900 {

--- a/assets/components/openshift-dns/dns/configmap.yaml
+++ b/assets/components/openshift-dns/dns/configmap.yaml
@@ -16,7 +16,7 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         prometheus 127.0.0.1:9153
-        forward . {{if eq .UpstreamResolver ""}}/etc/resolv.conf{{else}}{{.UpstreamResolver}}{{end}} {
+        forward . {{with .UpstreamResolver}}{{.}}{{else}}/etc/resolv.conf{{end}} {
             policy sequential
         }
         cache 900 {

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -199,6 +199,7 @@ func startDNSController(cfg *config.MicroshiftConfig, kubeconfigPath string) err
 		klog.Warningf("Failed to apply", "namespace", ns, "err", err)
 		return err
 	}
+
 	extraParams := assets.RenderParams{
 		"ClusterIP": cfg.Cluster.DNS,
 	}
@@ -219,7 +220,14 @@ func startDNSController(cfg *config.MicroshiftConfig, kubeconfigPath string) err
 		klog.Warningf("Failed to apply serviceAccount %v %v", sa, err)
 		return err
 	}
-	if err := assets.ApplyConfigMaps(cm, nil, nil, kubeconfigPath); err != nil {
+	// set DNS forward to systemd-resolved resolver if exists
+	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
+	if _, err := os.Stat(config.DefaultSystemdResolvedFile); err == nil {
+		extraParams["UpstreamResolver"] = config.DefaultSystemdResolvedFile
+	} else {
+		extraParams["UpstreamResolver"] = ""
+	}
+	if err := assets.ApplyConfigMaps(cm, renderTemplate, renderParamsFromConfig(cfg, extraParams), kubeconfigPath); err != nil {
 		klog.Warningf("Failed to apply configMap %v %v", cm, err)
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,8 @@ const (
 	defaultManifestDirEtc = "/etc/microshift/manifests"
 	// for files embedded in ostree. i.e. cni/other component customizations
 	defaultManifestDirLib = "/usr/lib/microshift/manifests"
+	// default DNS resolve file when systemd-resolved is used
+	DefaultSystemdResolvedFile = "/run/systemd/resolve/resolv.conf"
 )
 
 var (

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -18,7 +18,6 @@ package node
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -132,8 +131,8 @@ serverTLSBootstrap: false #TODO`)
 
 	// Load real resolv.conf in case systemd-resolved is used
 	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
-	if _, err := os.Stat("/run/systemd/resolve/resolv.conf"); !errors.Is(err, os.ErrNotExist) {
-		data = append(data, "\nresolvConf: /run/systemd/resolve/resolv.conf"...)
+	if _, err := os.Stat(config.DefaultSystemdResolvedFile); err == nil {
+		data = append(data, fmt.Sprintf("\nresolvConf: %s\n", config.DefaultSystemdResolvedFile)...)
 	}
 
 	path := filepath.Join(microshiftDataDir, "resources", "kubelet", "config", "config.yaml")

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -601,7 +601,6 @@ update_manifests() {
     sed -i 's|REPLACE_COREDNS_IMAGE|{{ .ReleaseImage.coredns }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_RBAC_PROXY_IMAGE|{{ .ReleaseImage.kube_rbac_proxy }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_CLUSTER_IP|{{.ClusterIP}}|' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
-    sed -i 's|forward.*|{{with .UpstreamResolver}}{{.}}{{else}}/etc/resolv.conf{{end}} {|' "${REPOROOT}"/assets/components/openshift-dns/dns/configmap.yaml
 
 
     #-- openshift-router ----------------------------------

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -601,7 +601,7 @@ update_manifests() {
     sed -i 's|REPLACE_COREDNS_IMAGE|{{ .ReleaseImage.coredns }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_RBAC_PROXY_IMAGE|{{ .ReleaseImage.kube_rbac_proxy }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_CLUSTER_IP|{{.ClusterIP}}|' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
-    sed -i 's|forward.*|forward . {{if eq .UpstreamResolver ""}}/etc/resolv.conf{{else}}{{.UpstreamResolver}}{{end}} {|' "${REPOROOT}"/assets/components/openshift-dns/dns/configmap.yaml
+    sed -i 's|forward.*|{{with .UpstreamResolver}}{{.}}{{else}}/etc/resolv.conf{{end}} {|' "${REPOROOT}"/assets/components/openshift-dns/dns/configmap.yaml
 
 
     #-- openshift-router ----------------------------------

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -601,6 +601,7 @@ update_manifests() {
     sed -i 's|REPLACE_COREDNS_IMAGE|{{ .ReleaseImage.coredns }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_RBAC_PROXY_IMAGE|{{ .ReleaseImage.kube_rbac_proxy }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i 's|REPLACE_CLUSTER_IP|{{.ClusterIP}}|' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
+    sed -i 's|forward.*|forward . {{if eq .UpstreamResolver ""}}/etc/resolv.conf{{else}}{{.UpstreamResolver}}{{end}} {|' "${REPOROOT}"/assets/components/openshift-dns/dns/configmap.yaml
 
 
     #-- openshift-router ----------------------------------


### PR DESCRIPTION
systemd-resolved conf is used by kubelet as alternative dns resolver when exists. This commit aligns the DNS Corefile conf with kubelet resolvConf when default systemd-resolved config is detected.

Co-authored-by: Miciah Dashiel Butler Masters <mmasters@redhat.com>
(cherry picked from commit 24ae57ee616e7ccdb4298c6f159ae5442bc87abc)