### PR TITLE
USHIFT-816: rebase.py - personal tokens

### DIFF
--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -208,8 +208,11 @@ def create_pr(gh_repo, base_branch, branch_name, title, desc):
 
     pr = gh_repo.create_pull(title=title, body=desc, base=base_branch, head=branch_name, maintainer_can_modify=True)
     logging.info(f"Created pull request: {pr.html_url}")
-    pr.create_review_request(reviewers=REVIEWERS)
-    logging.info(f"Requested review from {REVIEWERS}")
+    try:
+        pr.create_review_request(reviewers=REVIEWERS)
+        logging.info(f"Requested review from {REVIEWERS}")
+    except GithubException as e:
+        logging.info(f"Failed to request review from {REVIEWERS} because: {e}")
     return pr
 
 

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -6,6 +6,7 @@ import json
 import logging
 import subprocess
 from collections import namedtuple
+from timeit import default_timer as timer
 
 from git import Repo, PushInfo  # GitPython
 from github import GithubIntegration, Github, GithubException  # pygithub
@@ -54,12 +55,14 @@ def run_rebase_sh(release_amd64, release_arm64):
     script_dir = os.path.abspath(os.path.dirname(__file__))
     args = [f"{script_dir}/rebase.sh", "to", release_amd64, release_arm64]
     logging.info(f"Running: '{' '.join(args)}'")
+    start = timer()
     result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
     logging.info(f"Return code: {result.returncode}. Output:\n" +
                  "==================================================\n" +
                  f"{result.stdout}" +
                  "==================================================\n")
-    logging.info(f"Script returned code: {result.returncode}")
+    end = timer() - start
+    logging.info(f"Script returned code: {result.returncode}. It ran for {end/60:.0f}m{end%60:.0f}s.")
     return RebaseScriptResult(success=result.returncode == 0, output=result.stdout)
 
 

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -295,7 +295,7 @@ def get_expected_branch_name(amd, arm):
 
 def cleanup_branches(gh_repo):
     logging.info("Cleaning up branches for closed PRs")
-    rebase_branches = [b for b in gh_repo.get_branches() if b.name.startswith("rebase-")]
+    rebase_branches = [b for b in gh_repo.get_branches() if b.name.startswith("rebase-4")]
     deleted_branches = []
     for branch in rebase_branches:
         prs = gh_repo.get_pulls(head=f"{gh_repo.owner.login}:{branch.name}", state="all")

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -316,7 +316,8 @@ def cleanup_branches(gh_repo):
                     logging.warning(f"Failed to delete '{ref.ref}' because: {e}")
                     _extra_msgs.append(f"Failed to delete '{ref.ref}' because: {e}")
 
-    _extra_msgs.append(f"Deleted following branches: " + ", ".join(deleted_branches))
+    if len(deleted_branches) != 0:
+        _extra_msgs.append(f"Deleted following branches: " + ", ".join(deleted_branches))
 
 
 def get_token(org, repo):

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -399,6 +399,7 @@ def main():
         cleanup_branches(gh_repo)
     post_comment(pr, comment)
 
+    git_remote.remove(git_repo, BOT_REMOTE_NAME)
     sys.exit(0 if rebase_result.success else 1)
 
 

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -233,8 +233,9 @@ def post_comment(pr, comment=""):
         comment += "Extra messages:\n - " + "\n - ".join(_extra_msgs)
 
     if comment.strip() != "":
+        logging.info(f"Comment to post: {comment}")
         if REMOTE_DRY_RUN:
-            logging.info(f"[DRY RUN] Post a comment on PR: {comment}")
+            logging.info(f"[DRY RUN] Posted a comment")
             return
         issue = pr.as_issue()
         issue.create_comment(comment)

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -22,6 +22,7 @@ ARM64_RELEASE_ENV = "ARM64_RELEASE"
 JOB_NAME_ENV = "JOB_NAME"
 BUILD_ID_ENV = "BUILD_ID"
 DRY_RUN_ENV = "DRY_RUN"
+BASE_BRANCH_ENV = "BASE_BRANCH"
 
 BOT_REMOTE_NAME = "bot-creds"
 REMOTE_ORIGIN = "origin"
@@ -335,6 +336,7 @@ def main():
     repo = try_get_env(REPO_ENV)
     release_amd = try_get_env(AMD64_RELEASE_ENV)
     release_arm = try_get_env(ARM64_RELEASE_ENV)
+    base_branch_override = try_get_env(BASE_BRANCH_ENV, die=False)
 
     global REMOTE_DRY_RUN
     REMOTE_DRY_RUN = False if try_get_env(DRY_RUN_ENV, die=False) == "" else True
@@ -344,7 +346,9 @@ def main():
     token = get_token(org, repo)
     gh_repo = Github(token).get_repo(f"{org}/{repo}")
     git_repo = Repo('.')
-    base_branch = git_repo.active_branch.name
+    base_branch = (git_repo.active_branch.name
+        if base_branch_override == ""
+        else base_branch_override)
 
     rebase_result = run_rebase_sh(release_amd, release_arm)
     if rebase_result.success:


### PR DESCRIPTION
- Allow for using Personal Access Token (PAT) to test against a developer's fork (`TOKEN` env var)
- Add information about `rebase.sh` execution time
- Allow to override `base_branch` so the PR can be created against `main` when script is executed from other branch, not yet existing on the remote (`BASE_BRANCH` env var)
- Don't crash on "review request" failures
- Use more precise prefix to pick branches for deletion (`rebase-4`)
- Delete temporary remote at the end of script, so next time it's executed on dev machine git doesn't have old remote refs.

Usage:
```
TOKEN=ghp_... \
BASE_BRANCH=main \
ORG=pmtk \
REPO=microshift \
AMD64_RELEASE="registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-01-24-061922" \
ARM64_RELEASE="registry.ci.openshift.org/ocp-arm64/release-arm64:4.13.0-0.nightly-arm64-2023-01-25-015243" \
./scripts/auto-rebase/rebase.py
```