### PR TITLE
USHIFT-583: add script for generating API docs

### DIFF
--- a/docs/howto_gen_api_guide.md
+++ b/docs/howto_gen_api_guide.md
@@ -1,0 +1,37 @@
+# Generating the REST API Guide
+
+The MicroShift REST API supports a subset of the OCP APIs and some
+additional APIs not present in OCP by default. We therefore generate
+the files for the API guide from a MicroShift deployment, instead of
+manually curating the set of API definitions from the OCP
+documentation.
+
+1. Set up a host with MicroShift following any of the sets of
+   instructions for creating a development environment.
+
+2. Ensure `podman` is installed.
+
+   $ sudo dnf -y install podman
+
+3. Ensure the `microshift` user has a valid `~/.kube/config` file for
+   the local deployment.
+
+   $ mkdir -p ~/.kube
+   $ sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig > .kube/config
+
+4. From the root of the local `microshift` git repository, run the
+   script to generate the asciidoc files.
+
+   $ ./hack/gen-api-docs.sh
+
+The asciidoc files are written to
+`./_output/openshift-apidocs-gen/microshift_rest_api`. Copy that
+directory and its contents to replace the same directory in the
+`openshift-docs` git repository.
+
+The topic map content is written to
+`./_output/openshift-apidocs-gen/_topic_map_segment.yml`. Update the
+"API Reference" section of the file `_topic_maps/_topic_map_ms.yml` in
+the `openshift-docs` repository using the contents of the newly
+generated file. Make sure to retain the comments before and after the
+"API Reference" section.

--- a/hack/Dockerfile.apidocs
+++ b/hack/Dockerfile.apidocs
@@ -1,0 +1,13 @@
+# Build a container including openshift-apidocs-gen
+# https://github.com/jboxman-rh/openshift-apidocs-gen
+FROM fedora
+
+RUN dnf -y module enable nodejs:14 && dnf -y install nodejs
+RUN dnf -y install git
+# The package name referenced in the readme is wrong, see
+# https://github.com/jboxman/openshift-apidocs-gen/issues/44
+#RUN npm install -g openshift-apidocs-gen
+# Install from source to get the latest version of the code.
+RUN npm install -g https://github.com/jboxman-rh/openshift-apidocs-gen
+
+WORKDIR /workdir

--- a/hack/cleanup_openapi.py
+++ b/hack/cleanup_openapi.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import sys
+
+
+url_pat = re.compile('#\S+"$')
+
+def fix_values(data, location=''):
+    if isinstance(data, str):
+        # Remove trailing quotes from strings like
+        #
+        #   Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        #
+        # so the conversion from asciidoc to DocBook does not result
+        # in invalid XML.
+        if url_pat.search(data):
+            print(f'fixing {location}')
+            data = data.rstrip('"')
+        return data
+
+    if not isinstance(data, dict):
+        return data
+
+    for key, value in list(data.items()):
+        data[key] = fix_values(value, location + '.' + key)
+
+    return data
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit('script requires 2 arguments, input_file and output_file')
+    input_filename = sys.argv[1]
+    output_filename = sys.argv[2]
+
+    with open(input_filename, 'r') as inf:
+        data = json.load(inf)
+
+    data = fix_values(data)
+
+    with open(output_filename, 'w') as outf:
+        json.dump(data, outf)
+
+
+if __name__ == '__main__':
+    main()

--- a/hack/gen-api-docs.sh
+++ b/hack/gen-api-docs.sh
@@ -1,0 +1,123 @@
+#!/bin/bash -x
+
+set -e
+set -o pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPOROOT=$(git rev-parse --show-toplevel)
+OUTDIR="$REPOROOT/_output/openshift-apidocs-gen"
+
+##
+## Build the image we need to run openshift-api-docs
+##
+
+podman build -f "$SCRIPTDIR/Dockerfile.apidocs" -t openshift-apidocs-gen
+
+mkdir -p "$OUTDIR"
+cd "$OUTDIR"
+
+# Get the APIs present in the local microshift instance and clean up
+# the JSON data produced.
+oc get --raw /openapi/v2 | jq . > openapi-raw.json
+python3 $SCRIPTDIR/cleanup_openapi.py openapi-raw.json openapi-clean.json
+cat openapi-clean.json | jq . > openapi.json
+
+cp "$SCRIPTDIR/openshift-apidocs-gen-config.yaml" api-config.yaml
+
+# We do not want selinux relabeling done if we're on a Mac.
+# https://github.com/containers/podman/issues/13631
+systype=$(uname)
+if [ "$systype" = "Darwin" ]; then
+    selinux_suffix=""
+else
+    selinux_suffix=":Z"
+fi
+
+function run {
+    podman run \
+           --tty \
+           --rm=true \
+           --workdir /workdir \
+           --env LC_ALL=C.UTF-8 \
+           -v $(pwd):/workdir${selinux_suffix} \
+           openshift-apidocs-gen \
+           $@
+}
+
+##
+## Produce the asciidoc files for the API docs
+##
+
+# This step to create the config file doesn't seem to work, so we
+# created the config file by copying the one from openshift-docs and
+# modifying it.
+#
+# run openshift-apidocs-gen create-resources openapi.json >> config.yaml
+
+run openshift-apidocs-gen build openapi.json
+
+##
+## Generate the snippet of the topic map file based on the generated
+## content.
+##
+
+function get_name {
+    typeset f="$1"
+    grep '^= ' $f | cut -c3- | sed -e "s|^|'|" -e "s|\$|'|"
+}
+
+function gen_topic_map {
+    oc get configmap -n kube-public microshift-version -o yaml > $OUTDIR/version.yaml
+    version=$(cat $OUTDIR/version.yaml | yq .data.version)
+
+    # The first few entries are always the same and are manually ordered.
+    cat - <<EOF
+# Last updated for $version
+# $(date)
+Name: API reference
+Dir: microshift_rest_api
+Distros: microshift
+Topics:
+- Name: Understanding API tiers
+  File: understanding-api-support-tiers
+- Name: API compatibility guidelines
+  File: understanding-compatibility-guidelines
+- Name: API list
+  File: index
+- Name: Common object reference
+  Dir: objects
+  Topics:
+  - Name: Index
+    File: index
+EOF
+
+    # The entries for each API are ordered alphabetically.
+
+    cd "$OUTDIR/microshift_rest_api"
+    for d in $(ls -d *_apis); do
+        pushd $d >/dev/null
+        indexfile=$(ls *index.adoc)
+        if [ -z "$indexfile" ]; then
+            echo "No index file in $d" 1>&2
+            return 1
+        fi
+        name=$(grep '^= ' $indexfile | cut -c3-)
+        cat -<<EOF
+- Name: $(get_name $indexfile)
+  Dir: $d
+  Topics:
+EOF
+        for f in $(ls *.adoc); do
+            if [ "$f" = "$indexfile" ]; then
+                continue
+            fi
+            cat - <<EOF
+  - Name: $(get_name $f)
+    File: $(basename $f .adoc)
+EOF
+        done
+        popd >/dev/null
+    done
+}
+
+gen_topic_map > $OUTDIR/_topic_map_segment.yml

--- a/hack/openshift-apidocs-gen-config.yaml
+++ b/hack/openshift-apidocs-gen-config.yaml
@@ -1,0 +1,184 @@
+# TODO - Add APIResource && APIGroup to Metadata APIs
+version: 2
+outputDir: microshift_rest_api
+apiMap:
+- name: Autoscale APIs
+  resources:
+  - kind: HorizontalPodAutoscaler
+    group: autoscaling
+    version: v2
+  - kind: Scale
+    group: autoscaling
+    version: v1
+- name: Extension APIs
+  resources:
+  - kind: APIService
+    group: apiregistration.k8s.io
+    version: v1
+  - kind: CustomResourceDefinition
+    group: apiextensions.k8s.io
+    version: v1
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    version: v1
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    version: v1
+- name: Metadata APIs
+  resources:
+  - kind: Binding
+    version: v1
+  - kind: ComponentStatus
+    version: v1
+  - kind: ConfigMap
+    version: v1
+  - kind: ControllerRevision
+    group: apps
+    version: v1
+  - kind: Event
+    group: events.k8s.io
+    version: v1
+  - kind: Event
+    version: v1
+  - kind: Lease
+    group: coordination.k8s.io
+    version: v1
+  - kind: Namespace
+    version: v1
+- name: Network APIs
+  resources:
+  - kind: Endpoints
+    version: v1
+  - kind: EndpointSlice
+    group: discovery.k8s.io
+    version: v1
+  - kind: Ingress
+    group: networking.k8s.io
+    version: v1
+  - kind: IngressClass
+    group: networking.k8s.io
+    version: v1
+  - kind: NetworkPolicy
+    group: networking.k8s.io
+    version: v1
+  - kind: Route
+    group: route.openshift.io
+    version: v1
+  - kind: Service
+    version: v1
+- name: Node APIs
+  resources:
+  - kind: Node
+    version: v1
+  - kind: RuntimeClass
+    group: node.k8s.io
+    version: v1
+- name: Policy APIs
+  resources:
+  - kind: Eviction
+    group: policy
+    version: v1
+  - kind: PodDisruptionBudget
+    group: policy
+    version: v1
+- name: RBAC APIs
+  resources:
+  - kind: ClusterRoleBinding
+    group: rbac.authorization.k8s.io
+    version: v1
+  - kind: ClusterRole
+    group: rbac.authorization.k8s.io
+    version: v1
+  - kind: RoleBinding
+    group: rbac.authorization.k8s.io
+    version: v1
+  - kind: Role
+    group: rbac.authorization.k8s.io
+    version: v1
+- name: Schedule and quota APIs
+  resources:
+  - kind: FlowSchema
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta1
+  - kind: LimitRange
+    version: v1
+  - kind: PriorityClass
+    group: scheduling.k8s.io
+    version: v1
+  - kind: PriorityLevelConfiguration
+    group: flowcontrol.apiserver.k8s.io
+    version: v1beta1
+  - kind: ResourceQuota
+    version: v1
+- name: Security APIs
+  resources:
+  - kind: CertificateSigningRequest
+    group: certificates.k8s.io
+    version: v1
+  - kind: Secret
+    version: v1
+  - kind: SecurityContextConstraints
+    group: security.openshift.io
+    version: v1
+  - kind: ServiceAccount
+    version: v1
+- name: Storage APIs
+  resources:
+  - kind: CSIDriver
+    group: storage.k8s.io
+    version: v1
+  - kind: CSINode
+    group: storage.k8s.io
+    version: v1
+  - kind: CSIStorageCapacity
+    group: storage.k8s.io
+    version: v1
+  - kind: PersistentVolumeClaim
+    version: v1
+  - kind: StorageClass
+    group: storage.k8s.io
+    version: v1
+  - kind: VolumeAttachment
+    group: storage.k8s.io
+    version: v1
+  - kind: LogicalVolume
+    group: topolvm.io
+    version: v1
+- name: Template APIs
+  resources:
+  - kind: PodTemplate
+    version: v1
+- name: Workloads APIs
+  resources:
+  - kind: CronJob
+    group: batch
+    version: v1
+  - kind: DaemonSet
+    group: apps
+    version: v1
+  - kind: Deployment
+    group: apps
+    version: v1
+  - kind: Job
+    group: batch
+    version: v1
+  - kind: Pod
+    version: v1
+  - kind: ReplicationController
+    version: v1
+  - kind: PersistentVolume
+    version: v1
+  - kind: ReplicaSet
+    group: apps
+    version: v1
+  - kind: StatefulSet
+    group: apps
+    version: v1
+
+# TBD
+#  - kind: NodeMetrics
+#    group: metrics.k8s.io
+#    version: v1beta1
+#  - kind: PodMetrics
+#    group: metrics.k8s.io
+#    version: v1beta1


### PR DESCRIPTION
Set up a docker container to run the openshift-apdocs-gen tool and a
script to wrap it to use the container to generate documentation for
MicroShift.

See https://github.com/openshift/openshift-docs/pull/55564 for an example of the output.