### PR TITLE
OCPBUGS-7056: fix ovn config file path

### DIFF
--- a/pkg/components/networking.go
+++ b/pkg/components/networking.go
@@ -39,7 +39,7 @@ func startCNIPlugin(cfg *config.MicroshiftConfig, kubeconfigPath string) error {
 		}
 	)
 
-	ovnConfig, err := ovn.NewOVNKubernetesConfigFromFileOrDefault(filepath.Join(filepath.Dir(config.GetConfigFile()), ovn.ConfigFileName))
+	ovnConfig, err := ovn.NewOVNKubernetesConfigFromFileOrDefault(filepath.Join(filepath.Dir(config.DefaultGlobalConfigFile), ovn.ConfigFileName))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
GetConfigFile() may return empty path or user defined path, but ovn config file is only supported under /etc/microshift

Signed-off-by: Zenghui Shi <zshi@redhat.com>