### PR TITLE
OCPBUGS-7139: Add minimum CRIO version as rpm requirement for MicroShift 4.12

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -50,8 +50,8 @@ BuildRequires: make
 BuildRequires: policycoreutils
 BuildRequires: systemd
 
-Requires: cri-o
-Requires: cri-tools
+Requires: cri-o >= 1.25
+Requires: cri-tools >= 1.25
 Requires: iptables
 Requires: microshift-selinux
 Requires: microshift-networking
@@ -257,6 +257,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Mon Feb 06 2023 Ricardo Noriega de Soto <rnoriega@redhat.com> 4.12.2
+- Require minimum CRIO version
+
 * Wed Dec 14 2022 Frank A. Zdarsky <fzdarsky@redhat.com> 4.12.0
 - Add microshift-release-info subpackage
 


### PR DESCRIPTION
Signed-off-by: Ricardo Noriega [rnoriega@redhat.com](mailto:rnoriega@redhat.com)

Which issue(s) this PR addresses:
Closes #[OCPBUGS-7139](https://issues.redhat.com/browse/OCPBUGS-7139)

We are using a minimum requirement for CRIO, assuming the release team will only provide the CRIO version according to the OCP requirements of that release.