### PR TITLE
Add mdns service in firewalld

### DIFF
--- a/docs/howto_firewall.md
+++ b/docs/howto_firewall.md
@@ -32,6 +32,7 @@ sudo systemctl enable firewalld --now
 # Mandatory settings
 sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16 
 sudo firewall-cmd --permanent --zone=trusted --add-source=169.254.169.1
+sudo firewall-cmd --permanent --add-service=mdns
 sudo firewall-cmd --reload
 # Optional settings
 sudo firewall-cmd --permanent --zone=public --add-port=80/tcp

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -131,6 +131,7 @@ if [ $BUILD_AND_INSTALL = true ] ; then
     sudo systemctl enable firewalld --now
     sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
     sudo firewall-cmd --permanent --zone=trusted --add-source=169.254.169.1
+    sudo firewall-cmd --permanent --add-service=mdns
     sudo firewall-cmd --reload
 
     # Run MicroShift Executable > Configuring MicroShift


### PR DESCRIPTION
multicast dns query will be rejected by firewalld if not enabled

Related-Issue: https://issues.redhat.com/browse/OCPBUGS-6862

Signed-off-by: Zenghui Shi <zshi@redhat.com>