### PR TITLE
NO-ISSUE: fix rebase branch name for GH query

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -828,7 +828,7 @@ rebase_to() {
         arm64_date="$(cat ${STAGING_DIR}/release_arm64.json | jq -r .config.created | cut -f1 -dT)"
     fi
 
-    rebase_branch="rebase-${ver_stream}+amd64-${amd64_date}+arm64-${arm64_date}"
+    rebase_branch="rebase-${ver_stream}_amd64-${amd64_date}_arm64-${arm64_date}"
     git branch -D "${rebase_branch}" || true
     git checkout -b "${rebase_branch}"
 


### PR DESCRIPTION
'+' is used in GitHub as a character for joining filters in query and breaks prow.ci.openshift.org PR search