### PR TITLE
USHIFT-852: assets.yaml declaring manifests to copy from releases

### DIFF
--- a/assets/components/lvms/topolvm-controller_deployment.yaml
+++ b/assets/components/lvms/topolvm-controller_deployment.yaml
@@ -26,7 +26,7 @@ spec:
       - command:
         - /topolvm-controller
         - --cert-dir=/certs
-        image: {{ .ReleaseImage.topolvm_csi }}
+        image: '{{ .ReleaseImage.topolvm_csi }}'
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -69,7 +69,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: {{ .ReleaseImage.topolvm_csi_provisioner }}
+        image: '{{ .ReleaseImage.topolvm_csi_provisioner }}'
         name: csi-provisioner
         resources:
           requests:
@@ -80,7 +80,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/run/topolvm/csi-topolvm.sock
-        image: {{ .ReleaseImage.topolvm_csi_resizer }}
+        image: '{{ .ReleaseImage.topolvm_csi_resizer }}'
         name: csi-resizer
         resources:
           requests:
@@ -91,7 +91,7 @@ spec:
           name: socket-dir
       - args:
         - --csi-address=/run/topolvm/csi-topolvm.sock
-        image: {{ .ReleaseImage.topolvm_csi_livenessprobe }}
+        image: '{{ .ReleaseImage.topolvm_csi_livenessprobe }}'
         name: liveness-probe
         resources:
           requests:
@@ -106,7 +106,7 @@ spec:
         - -c
         - openssl req -nodes -x509 -newkey rsa:4096 -subj '/DC=self_signed_certificate'
           -keyout /certs/tls.key -out /certs/tls.crt -days 3650
-        image: {{ .ReleaseImage.openssl }}
+        image: '{{ .ReleaseImage.openssl }}'
         name: self-signed-cert-generator
         resources: {}
         volumeMounts:

--- a/assets/components/lvms/topolvm-controller_rbac.authorization.k8s.io_v1_role.yaml
+++ b/assets/components/lvms/topolvm-controller_rbac.authorization.k8s.io_v1_role.yaml
@@ -4,14 +4,14 @@ metadata:
   name: topolvm-controller
   namespace: openshift-storage
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - watch
-      - list
-      - delete
-      - update
-      - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/assets/components/lvms/topolvm-controller_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/assets/components/lvms/topolvm-controller_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -8,6 +8,6 @@ roleRef:
   kind: Role
   name: topolvm-controller
 subjects:
-  - kind: ServiceAccount
-    name: topolvm-controller
-    namespace: openshift-storage
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/assets/components/lvms/topolvm-lvmd-config_configmap_v1.yaml
+++ b/assets/components/lvms/topolvm-lvmd-config_configmap_v1.yaml
@@ -1,8 +1,7 @@
-# Source: topolvm/templates/lvmd/configmap.yaml
 apiVersion: v1
+data:
+  lvmd.yaml: ""
 kind: ConfigMap
 metadata:
   name: lvmd
   namespace: openshift-storage
-data:
-  lvmd.yaml: {{ .lvmd }}

--- a/assets/components/lvms/topolvm-node-securitycontextconstraint.yaml
+++ b/assets/components/lvms/topolvm-node-securitycontextconstraint.yaml
@@ -5,16 +5,16 @@ allowHostPID: true
 allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
-allowedCapabilities:
+allowedCapabilities: []
 apiVersion: security.openshift.io/v1
-defaultAddCapabilities:
+defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny
 groups: []
 kind: SecurityContextConstraints
 metadata:
   name: topolvm-node
-priority:
+priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []
 runAsUser:

--- a/assets/components/lvms/topolvm-node_daemonset.yaml
+++ b/assets/components/lvms/topolvm-node_daemonset.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        lvms.microshift.io/lvmd_config_sha256sum: "{{ Sha256sum .lvmd }}"
+        lvms.microshift.io/lvmd_config_sha256sum: '{{ Sha256sum .lvmd }}'
       labels:
         app.kubernetes.io/component: topolvm-node
         app.kubernetes.io/managed-by: lvms-operator
@@ -30,16 +30,16 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-                - key: "kubernetes.io/os"
-                  operator: In
-                  values:
-                    - "linux"
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - command:
         - /lvmd
         - --config=/etc/topolvm/lvmd.yaml
         - --container=true
-        image: {{ .ReleaseImage.topolvm_csi }}
+        image: '{{ .ReleaseImage.topolvm_csi }}'
         name: lvmd
         resources:
           requests:
@@ -49,7 +49,7 @@ spec:
           privileged: true
           runAsUser: 0
         volumeMounts:
-        - mountPath: {{ Dir .SocketName  }}
+        - mountPath: '{{ Dir .SocketName  }}'
           name: lvmd-socket-dir
         - mountPath: /etc/topolvm
           name: lvmd-config-dir
@@ -61,7 +61,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: {{ .ReleaseImage.topolvm_csi }}
+        image: '{{ .ReleaseImage.topolvm_csi }}'
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -85,7 +85,7 @@ spec:
         volumeMounts:
         - mountPath: /run/topolvm
           name: node-plugin-dir
-        - mountPath: {{ Dir .SocketName  }}
+        - mountPath: '{{ Dir .SocketName  }}'
           name: lvmd-socket-dir
         - mountPath: /var/lib/kubelet/pods
           mountPropagation: Bidirectional
@@ -96,7 +96,7 @@ spec:
       - args:
         - --csi-address=/run/topolvm/csi-topolvm.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/topolvm.io/node/csi-topolvm.sock
-        image: {{ .ReleaseImage.topolvm_csi_registrar }}
+        image: '{{ .ReleaseImage.topolvm_csi_registrar }}'
         lifecycle:
           preStop:
             exec:
@@ -116,7 +116,7 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/run/topolvm/csi-topolvm.sock
-        image: {{ .ReleaseImage.topolvm_csi_livenessprobe }}
+        image: '{{ .ReleaseImage.topolvm_csi_livenessprobe }}'
         name: liveness-probe
         resources:
           requests:
@@ -132,7 +132,7 @@ spec:
         - -c
         - until [ -f /etc/topolvm/lvmd.yaml ]; do echo waiting for lvmd config file;
           sleep 5; done
-        image: {{ .ReleaseImage.openssl }}
+        image: '{{ .ReleaseImage.openssl }}'
         name: file-checker
         resources: {}
         volumeMounts:
@@ -156,12 +156,12 @@ spec:
           path: /var/lib/kubelet/pods/
           type: DirectoryOrCreate
         name: pod-volumes-dir
-      - name: lvmd-config-dir
-        configMap:
-          name: lvmd
+      - configMap:
           items:
-            - key: lvmd.yaml
-              path: lvmd.yaml
+          - key: lvmd.yaml
+            path: lvmd.yaml
+          name: lvmd
+        name: lvmd-config-dir
       - emptyDir:
           medium: Memory
         name: lvmd-socket-dir

--- a/assets/components/lvms/topolvm-openshift-storage_namespace.yaml
+++ b/assets/components/lvms/topolvm-openshift-storage_namespace.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-storage
   annotations:
     openshift.io/node-selector: ""
-    workload.openshift.io/allowed: "management"
+    workload.openshift.io/allowed: management
   labels:
     openshift.io/run-level: "0"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
+  name: openshift-storage

--- a/assets/components/openshift-dns/dns/daemonset.yaml
+++ b/assets/components/openshift-dns/dns/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
             requests:
               cpu: 50m
               memory: 70Mi
-          image: {{ .ReleaseImage.coredns }}
+          image: '{{ .ReleaseImage.coredns }}'
         - name: kube-rbac-proxy
           args:
             - --logtostderr
@@ -70,7 +70,7 @@ spec:
             - mountPath: /etc/tls/private
               name: metrics-tls
               readOnly: true
-          image: {{ .ReleaseImage.kube_rbac_proxy }}
+          image: '{{ .ReleaseImage.kube_rbac_proxy }}'
           imagePullPolicy: IfNotPresent
       dnsPolicy: Default
       volumes:

--- a/assets/components/openshift-dns/dns/service.yaml
+++ b/assets/components/openshift-dns/dns/service.yaml
@@ -14,7 +14,7 @@ spec:
       port: 9154
       targetPort: metrics
       protocol: TCP
-  clusterIP: {{.ClusterIP}}
+  clusterIP: '{{.ClusterIP}}'
   selector:
     dns.operator.openshift.io/daemonset-dns: default
 metadata:

--- a/assets/components/openshift-router/deployment.yaml
+++ b/assets/components/openshift-router/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             - mountPath: /var/run/configmaps/service-ca
               name: service-ca-bundle
               readOnly: true
-          image: {{ .ReleaseImage.haproxy_router }}
+          image: '{{ .ReleaseImage.haproxy_router }}'
           ports:
             - name: http
               containerPort: 80

--- a/assets/components/service-ca/deployment.yaml
+++ b/assets/components/service-ca/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: service-ca
       containers:
         - name: service-ca-controller
-          image: {{ .ReleaseImage.service_ca_operator }}
+          image: '{{ .ReleaseImage.service_ca_operator }}'
           imagePullPolicy: IfNotPresent
           command: ["service-ca-operator", "controller"]
           ports:
@@ -46,10 +46,10 @@ spec:
       volumes:
         - name: signing-key
           secret:
-            secretName: {{.TLSSecret}}
+            secretName: '{{.TLSSecret}}'
         - name: signing-cabundle
           configMap:
-            name: {{.CAConfigMap}}
+            name: '{{.CAConfigMap}}'
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"

--- a/pkg/components/render.go
+++ b/pkg/components/render.go
@@ -54,7 +54,7 @@ func renderLvmdParams(l *lvmd.Lvmd) (assets.RenderParams, error) {
 	if err != nil {
 		return nil, err
 	}
-	r["lvmd"] = fmt.Sprintf(`%q`, b)
+	r["lvmd"] = string(b)
 	r["SocketName"] = l.SocketName
 	return r, nil
 }

--- a/pkg/components/render_test.go
+++ b/pkg/components/render_test.go
@@ -46,7 +46,7 @@ func Test_renderLvmdParams(t *testing.T) {
 			wantErr: false,
 			want: assets.RenderParams{
 				"SocketName": "/run/lvmd/lvmd.socket",
-				"lvmd":       `"device-classes:\n- default: true\n  lvcreate-options: null\n  name: test\n  spare-gb: 5\n  stripe: null\n  stripe-size: \"\"\n  thin-pool: null\n  type: \"\"\n  volume-group: vg\nsocket-name: /run/lvmd/lvmd.socket\n"`,
+				"lvmd":       "device-classes:\n- default: true\n  lvcreate-options: null\n  name: test\n  spare-gb: 5\n  stripe: null\n  stripe-size: \"\"\n  thin-pool: null\n  type: \"\"\n  volume-group: vg\nsocket-name: /run/lvmd/lvmd.socket\n",
 			},
 		},
 	}
@@ -59,57 +59,6 @@ func Test_renderLvmdParams(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("renderLvmdParams() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_renderLvmdConfig(t *testing.T) {
-
-	defL := (&lvmd.Lvmd{}).WithDefaults()
-
-	cmWrap := func(d []byte) []byte {
-		base :=
-			`# Source: topolvm/templates/lvmd/configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: lvmd
-  namespace: openshift-storage
-data:
-  lvmd.yaml:`
-		return []byte(fmt.Sprintf("%s %q\n", base, d))
-	}
-
-	type args struct {
-		tb   []byte
-		data assets.RenderParams
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{
-			name: "should render topolvm configMap",
-			args: args{
-				tb:   embedded.MustAsset("components/lvms/topolvm-lvmd-config_configmap_v1.yaml"),
-				data: func() assets.RenderParams { p, _ := renderLvmdParams(defL); return p }(),
-			},
-			want:    cmWrap([]byte("device-classes:\n- default: true\n  lvcreate-options: null\n  name: default\n  spare-gb: 0\n  stripe: null\n  stripe-size: \"\"\n  thin-pool: null\n  type: \"\"\n  volume-group: rhel\nsocket-name: /run/lvmd/lvmd.socket\n")),
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := renderTemplate(tt.args.tb, tt.args.data)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("renderTemplate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("renderTemplate() got = %s, want %s", string(got), string(tt.want))
 			}
 		})
 	}

--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -60,9 +60,7 @@ func startCSIPlugin(cfg *config.MicroshiftConfig, kubeconfigPath string) error {
 		cd = []string{
 			"components/lvms/csi-driver.yaml",
 		}
-		cm = []string{
-			"components/lvms/topolvm-lvmd-config_configmap_v1.yaml",
-		}
+		cm = "components/lvms/topolvm-lvmd-config_configmap_v1.yaml"
 		ds = []string{
 			"components/lvms/topolvm-node_daemonset.yaml",
 		}
@@ -120,7 +118,7 @@ func startCSIPlugin(cfg *config.MicroshiftConfig, kubeconfigPath string) error {
 		klog.Warningf("Failed to apply clusterrolebinding %v: %v", crb, err)
 		return err
 	}
-	if err := assets.ApplyConfigMaps(cm, renderTemplate, lvmdRenderParams, kubeconfigPath); err != nil {
+	if err := assets.ApplyConfigMapWithData(cm, map[string]string{"lvmd.yaml": lvmdRenderParams["lvmd"].(string)}, kubeconfigPath); err != nil {
 		klog.Warningf("Failed to apply configMap %v: %v", crb, err)
 		return err
 	}

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -1,0 +1,223 @@
+assets:
+  - dir: components/openshift-dns/dns/
+    src: cluster-dns-operator/assets/dns/
+    files:
+      - file: cluster-role-binding.yaml
+      - file: cluster-role.yaml
+      - file: configmap.yaml
+        git_restore: True
+      - file: daemonset.yaml
+      - file: namespace.yaml
+      - file: service-account.yaml
+      - file: service.yaml
+
+  - dir: components/openshift-dns/node-resolver
+    src: cluster-dns-operator/assets/node-resolver/
+    files:
+      - file: daemonset.yaml
+        ignore: "it's created by processing daemonset.yaml.tmpl"
+      - file: daemonset.yaml.tmpl
+        git_restore: True
+      - file: service-account.yaml
+      - file: update-node-resolver.sh
+
+  - dir: components/openshift-router/
+    src: cluster-ingress-operator/assets/router/
+    files:
+      - file: cluster-role-binding.yaml
+      - file: cluster-role.yaml
+      - file: configmap.yaml
+        git_restore: True
+      - file: deployment.yaml
+      - file: namespace.yaml
+      - file: service-account.yaml
+      - file: service-internal.yaml
+      - file: serving-certificate.yaml
+        git_restore: True
+
+  - dir: components/lvms/
+    src: lvms/amd64/
+    no_clean: True
+    files:
+      - file: topolvm-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml
+      - file: topolvm-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+      - file: topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml
+      - file: topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+      - file: topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_role.yaml
+      - file: topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_rolebinding.yaml
+      - file: topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml
+      - file: topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+      - file: topolvm-csi-resizer_rbac.authorization.k8s.io_v1_role.yaml
+      - file: topolvm-csi-resizer_rbac.authorization.k8s.io_v1_rolebinding.yaml
+      - file: topolvm-metrics_rbac.authorization.k8s.io_v1_role.yaml
+      - file: topolvm-metrics_rbac.authorization.k8s.io_v1_rolebinding.yaml
+      - file: topolvm-node_rbac.authorization.k8s.io_v1_clusterrole.yaml
+      - file: topolvm-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+      - file: topolvm-node_v1_serviceaccount.yaml
+      - file: topolvm.io_logicalvolumes.yaml
+
+      - file: csi-driver.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-controller_deployment.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-controller_rbac.authorization.k8s.io_v1_role.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-controller_rbac.authorization.k8s.io_v1_rolebinding.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-controller_v1_serviceaccount.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrole.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-leader-election_rbac.authorization.k8s.io_v1_role.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-leader-election_rbac.authorization.k8s.io_v1_rolebinding.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-lvmd-config_configmap_v1.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-node-metrics_v1_service.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-node-scc_rbac.authorization.k8s.io_v1_clusterrole.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-node-scc_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-node-securitycontextconstraint.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-node_daemonset.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm-openshift-storage_namespace.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+      - file: topolvm_default-storage-class.yaml
+        ignore: "it's not yet available in LVMS Operator Bundle"
+
+
+
+  - dir: components/ovn/
+    ignore: "it's not covered by rebase script yet"
+    files:
+      - file: clusterrole.yaml
+      - file: clusterrolebinding.yaml
+      - file: configmap.yaml
+      - file: namespace.yaml
+      - file: role.yaml
+      - file: rolebinding.yaml
+    dirs:
+      - dir: master/
+        files:
+          - file: daemonset.yaml
+          - file: serviceaccount.yaml
+
+  - dir: components/service-ca/
+    src: service-ca-operator/bindata/v4.0.0/controller/
+    files:
+      - file: clusterrole.yaml
+      - file: clusterrolebinding.yaml
+      - file: deployment.yaml
+      - file: ns.yaml
+      - file: role.yaml
+      - file: rolebinding.yaml
+      - file: sa.yaml
+      - file: signing-cabundle.yaml
+      - file: signing-secret.yaml
+
+  - dir: controllers/cluster-policy-controller/
+    src: cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/
+    files:
+      - file: namespace-security-allocation-controller-clusterrole.yaml
+      - file: namespace-security-allocation-controller-clusterrolebinding.yaml
+      - file: podsecurity-admission-label-syncer-controller-clusterrole.yaml
+      - file: podsecurity-admission-label-syncer-controller-clusterrolebinding.yaml
+
+  - dir: controllers/kube-apiserver/
+    src: cluster-kube-apiserver-operator/bindata/assets/config/
+    files:
+      - file: config-overrides.yaml
+      - file: defaultconfig.yaml
+
+  - dir: controllers/kube-controller-manager/
+    src: cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/
+    files:
+      - file: defaultconfig.yaml
+        src: ../config/
+      - file: csr_approver_clusterrole.yaml
+      - file: csr_approver_clusterrolebinding.yaml
+      - file: namespace-openshift-kube-controller-manager.yaml
+        src: ns.yaml
+
+  - dir: controllers/openshift-default-scc-manager/
+    src: release-manifests/
+    files:
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-anyuid.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-hostaccess.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-hostmount-anyuid.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-hostnetwork-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-hostnetwork.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-nonroot-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-nonroot.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-privileged.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-restricted-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_cr-scc-restricted.yaml
+      - file: 0000_20_kube-apiserver-operator_00_crb-systemauthenticated-scc-restricted-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-anyuid.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-hostaccess.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-hostmount-anyuid.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-hostnetwork-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-hostnetwork.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-nonroot-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-nonroot.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-privileged.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-restricted-v2.yaml
+      - file: 0000_20_kube-apiserver-operator_00_scc-restricted.yaml
+
+  - dir: controllers/route-controller-manager/
+    src: cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/
+    files:
+      - file: 0000_50_cluster-openshift-route-controller-manager_00_namespace.yaml
+        src: route-controller-ns.yaml
+      - file: ingress-to-route-controller-clusterrole.yaml
+      - file: ingress-to-route-controller-clusterrolebinding.yaml
+      - file: route-controller-informer-clusterrole.yaml
+      - file: route-controller-informer-clusterrolebinding.yaml
+      - file: route-controller-leader-role.yaml
+      - file: route-controller-leader-rolebinding.yaml
+      - file: route-controller-sa.yaml
+      - file: route-controller-separate-sa-role.yaml
+      - file: route-controller-separate-sa-rolebinding.yaml
+      - file: route-controller-tokenreview-clusterrole.yaml
+      - file: route-controller-tokenreview-clusterrolebinding.yaml
+
+  - dir: core/
+    no_clean: True
+    files:
+      - file: 0000_50_cluster-openshift-controller-manager_00_namespace.yaml
+        src: /cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ns.yaml
+      - file: namespace-openshift-infra.yaml
+        src: /cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/
+      - file: priority-class-openshift-user-critical.yaml
+        ignore: "it's a priority class needed for oc debug node command - not available in any repo that rebase is using"
+      - file: securityv1-local-apiservice.yaml
+        ignore: "it's a local API service for security API group, needed if OpenShift API server is not present"
+
+  - dir: crd/
+    src: release-manifests/
+    files:
+      - file: 0000_03_security-openshift_01_scc.crd.yaml
+      - file: 0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
+      - file: route.crd.yaml
+        src:  /kubernetes/vendor/github.com/openshift/api/route/v1/
+
+  - dir: release/
+    ignore: "it contains files generated during rebase procedure"
+    files:
+      - release-aarch64.json
+      - release-x86_64.json
+
+  - dir: version/
+    no_clean: True
+    files:
+      - file: microshift-version.yaml
+        ignore: "it's a template for ConfigMap processed during runtime"
+
+  - file: embed.go
+    ignore: "it's a MicroShift specific Go file that embeds into a binary"

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -107,6 +107,10 @@ assets:
         files:
           - file: daemonset.yaml
           - file: serviceaccount.yaml
+      - dir: node/
+        files:
+          - file: daemonset.yaml
+          - file: serviceaccount.yaml
 
   - dir: components/service-ca/
     src: service-ca-operator/bindata/v4.0.0/controller/
@@ -210,8 +214,8 @@ assets:
   - dir: release/
     ignore: "it contains files generated during rebase procedure"
     files:
-      - release-aarch64.json
-      - release-x86_64.json
+      - file: release-aarch64.json
+      - file: release-x86_64.json
 
   - dir: version/
     no_clean: True

--- a/scripts/auto-rebase/handle-assets.py
+++ b/scripts/auto-rebase/handle-assets.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import yaml
+import shutil
+import logging
+import subprocess
+
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)-27s %(levelname)-10s %(message)s')
+
+ASSETS_DIR = "assets/"
+STAGING_DIR = "_output/staging/"
+
+
+def merge_paths(pathl, pathr):
+    if pathr.startswith("/"):
+        return pathr[1:]
+    return os.path.join(pathl, pathr)
+
+
+def run_command(args=[]):
+    if not args:
+        logging.error("run_command() received empty args")
+        sys.exit(1)
+
+    logging.debug(f"Executing '{' '.join(args)}'")
+    result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+
+    if result.returncode != 0:
+        logging.error(f"Command '{' '.join(args)}' returned {result.returncode}. Output: {result.stdout}")
+        sys.exit(1)
+
+    return result.returncode == 0
+
+
+def git_restore(path):
+    path = os.path.join(ASSETS_DIR, path)
+    logging.info(f"Restoring {path}")
+    return run_command(["git", "restore", path])
+
+
+def copy(src, dst):
+    src = os.path.join(STAGING_DIR, src)
+    dst = os.path.join(ASSETS_DIR, dst)
+    logging.debug(f"Copying {dst} <- {src}")
+    shutil.copyfile(src, dst)
+
+
+def clear_dir(path):
+    path = os.path.join(ASSETS_DIR, path)
+    logging.info(f"Clearing directory {path}")
+    shutil.rmtree(path)
+    os.makedirs(path)
+
+
+def should_be_ignored(asset, dst):
+    if 'ignore' in asset:
+        reason = asset['ignore']
+        if not reason:
+            logging.error(f"{dst} is missing a reason why it's ignored")
+            sys.exit(1)
+        logging.warning(f"Ignoring {dst} because {reason}")
+        return True
+    return False
+
+
+def handle_file(file, dst_dir="", src_prefix=""):
+    name = file['file']
+    dst = merge_paths(dst_dir, name)
+
+    if should_be_ignored(file, dst):
+        return
+
+    if 'git_restore' in file:
+        git_restore(dst)
+        return
+
+    src = src_prefix
+    if 'src' in file:
+        src = merge_paths(src, file['src'])
+    if os.path.extsep not in os.path.basename(src):
+        src = merge_paths(src, name)
+    copy(src, dst)
+
+
+def handle_dir(dir, dst_dir="", src_prefix=""):
+    dst = merge_paths(dst_dir, dir['dir'])
+    new_src_prefix = merge_paths(src_prefix, dir['src'] if "src" in dir else "")
+
+    if should_be_ignored(dir, dst):
+        return
+
+    if dir.get('no_clean', False):
+        logging.info(f"Not clearing dir {dst}")
+    else:
+        clear_dir(dst)
+
+    for f in dir.get('files', []):
+        handle_file(f, dst, new_src_prefix)
+
+    for d in dir.get('dirs', []):
+        handle_dir(d, dst, new_src_prefix)
+
+
+def main():
+    if not os.path.isdir(ASSETS_DIR):
+        logging.error(f"Expected to run in root directory of microshift repository but was in {os.getcwd()}")
+        sys.exit(1)
+
+    if not os.path.isdir(STAGING_DIR):
+        logging.error(f"{STAGING_DIR} does not exist")
+        sys.exit(1)
+
+    recipe_filepath = "./scripts/auto-rebase/assets.yaml"
+    recipe = yaml.load(open(recipe_filepath).read(), Loader=Loader)
+    for asset in recipe['assets']:
+        if "dir" in asset:
+            handle_dir(asset)
+
+        if 'file' in asset:
+            handle_file(asset)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -133,19 +133,9 @@ update_lvms_images(){
 }
 
 update_lvms_manifests() {
-    local src="${STAGING_DIR}/lvms/amd64"
+    title "Modifying LVMS manifests"
+
     local dest="${REPOROOT}/assets/components/lvms"
-    local cluster_scoped_manifests=(
-          "topolvm-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml"
-          "topolvm-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml"
-          "topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml"
-          "topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml"
-          "topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml"
-          "topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml"
-          "topolvm-node_rbac.authorization.k8s.io_v1_clusterrole.yaml"
-          "topolvm-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml"
-          "topolvm.io_logicalvolumes.yaml"
-    )
     local namespace_scoped_manifests=(
           "topolvm-controller_v1_serviceaccount.yaml"
           "topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_role.yaml"
@@ -157,11 +147,7 @@ update_lvms_manifests() {
           "topolvm-node-metrics_v1_service.yaml"
           "topolvm-node_v1_serviceaccount.yaml"
     )
-    for m in "${cluster_scoped_manifests[@]}"; do
-        cp "${src}/${m}" "${dest}/" || return 1
-    done
     for m in "${namespace_scoped_manifests[@]}"; do
-        cp "${src}/${m}" "${dest}/" || return 1
         yq -i '.metadata.namespace = "openshift-storage"' "${dest}/${m}" || return 1
     done
 }
@@ -638,142 +624,77 @@ update_images() {
 }
 
 
-# Updates embedded component manifests by gathering these from various places
-# in the staged repos and copying them into the asset directory.
-update_manifests() {
+copy_manifests() {
     if [ ! -f "${STAGING_DIR}/release_amd64.json" ]; then
         >&2 echo "No release found in ${STAGING_DIR}, you need to download one first."
         exit 1
     fi
+    title "Copying manifests"
+    "$REPOROOT/scripts/auto-rebase/handle-assets.py"
+}
+
+
+# Updates embedded component manifests by gathering these from various places
+# in the staged repos and copying them into the asset directory.
+update_openshift_manifests() {
     pushd "${STAGING_DIR}" >/dev/null
 
-    title "Rebasing manifests"
+    title "Modifying OpenShift manifests"
 
     #-- OpenShift control plane ---------------------------
-    # 1) Adopt resource manifests
-    #    Selectively copy in only those core manifests that MicroShift is already using
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ns.yaml" "${REPOROOT}"/assets/core/0000_50_cluster-openshift-controller-manager_00_namespace.yaml
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-ns.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/0000_50_cluster-openshift-route-controller-manager_00_namespace.yaml
-
-    # Copy embedded RBAC manifests that belong to the Route Controller Manager
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrole.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrolebinding.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-informer-clusterrole.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-informer-clusterrolebinding.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-leader-role.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-leader-rolebinding.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-sa.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-separate-sa-role.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-separate-sa-rolebinding.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-tokenreview-clusterrole.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-    cp "${STAGING_DIR}/cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/route-controller-tokenreview-clusterrolebinding.yaml" "${REPOROOT}"/assets/controllers/route-controller-manager/
-
-    # Copy various manifests needed by core components
-    cp "${STAGING_DIR}/cluster-kube-apiserver-operator/bindata/assets/config/config-overrides.yaml" "${REPOROOT}"/assets/controllers/kube-apiserver
-    cp "${STAGING_DIR}/cluster-kube-apiserver-operator/bindata/assets/config/defaultconfig.yaml" "${REPOROOT}"/assets/controllers/kube-apiserver
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/config/defaultconfig.yaml" "${REPOROOT}"/assets/controllers/kube-controller-manager
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/csr_approver_clusterrole.yaml" "${REPOROOT}"/assets/controllers/kube-controller-manager
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/csr_approver_clusterrolebinding.yaml" "${REPOROOT}"/assets/controllers/kube-controller-manager
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-openshift-infra.yaml" "${REPOROOT}"/assets/core
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/ns.yaml" "${REPOROOT}"/assets/controllers/kube-controller-manager/namespace-openshift-kube-controller-manager.yaml
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-security-allocation-controller-clusterrole.yaml" "${REPOROOT}"/assets/controllers/cluster-policy-controller
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/namespace-security-allocation-controller-clusterrolebinding.yaml" "${REPOROOT}"/assets/controllers/cluster-policy-controller
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrole.yaml" "${REPOROOT}"/assets/controllers/cluster-policy-controller
-    cp "${STAGING_DIR}/cluster-kube-controller-manager-operator/bindata/assets/kube-controller-manager/podsecurity-admission-label-syncer-controller-clusterrolebinding.yaml" "${REPOROOT}"/assets/controllers/cluster-policy-controller
-    #    Selectively copy in only those CRD manifests that MicroShift is already using
-    cp "${REPOROOT}"/vendor/github.com/openshift/api/route/v1/route.crd.yaml "${REPOROOT}"/assets/crd
-    cp "${STAGING_DIR}/release-manifests/0000_03_security-openshift_01_scc.crd.yaml" "${REPOROOT}"/assets/crd
-    cp "${STAGING_DIR}/release-manifests/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml" "${REPOROOT}"/assets/crd
-    # The following manifests are just MicroShift specific and are not present in any other OpenShift repo.
-    # - assets/core/securityv1-local-apiservice.yaml (local API service for security API group, needed if OpenShift API server is not present)
-
     yq -i 'with(.admission.pluginConfig.PodSecurity.configuration.defaults;
         .enforce = "restricted" | .audit = "restricted" | .warn = "restricted" |
         .enforce-version = "latest" | .audit-version = "latest" | .warn-version = "latest")' "${REPOROOT}"/assets/controllers/kube-apiserver/defaultconfig.yaml
     yq -i 'del(.extendedArguments.pv-recycler-pod-template-filepath-hostpath)' "${REPOROOT}"/assets/controllers/kube-controller-manager/defaultconfig.yaml
     yq -i 'del(.extendedArguments.pv-recycler-pod-template-filepath-nfs)' "${REPOROOT}"/assets/controllers/kube-controller-manager/defaultconfig.yaml
     yq -i 'del(.extendedArguments.flex-volume-plugin-dir)' "${REPOROOT}"/assets/controllers/kube-controller-manager/defaultconfig.yaml
-
-    #    Replace all SCC manifests and their CRs/CRBs
-    rm -f "${REPOROOT}"/assets/controllers/openshift-default-scc-manager/*.yaml
-    cp "${STAGING_DIR}"/release-manifests/0000_20_kube-apiserver-operator_00_cr-*.yaml "${REPOROOT}"/assets/controllers/openshift-default-scc-manager || true
-    cp "${STAGING_DIR}"/release-manifests/0000_20_kube-apiserver-operator_00_crb-*.yaml "${REPOROOT}"/assets/controllers/openshift-default-scc-manager || true
-    cp "${STAGING_DIR}"/release-manifests/0000_20_kube-apiserver-operator_00_scc-*.yaml "${REPOROOT}"/assets/controllers/openshift-default-scc-manager || true
-    # 2) Render operand manifest templates like the operator would
-    #    n/a
-    # 3) Make MicroShift-specific changes
-    #    Add the missing scc shortName
     yq -i '.spec.names.shortNames = ["scc"]' "${REPOROOT}"/assets/crd/0000_03_security-openshift_01_scc.crd.yaml
-    # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
-    #    n/a
 
     #-- openshift-dns -------------------------------------
-    # 1) Adopt resource manifests
-    #    Replace all openshift-dns operand manifests
-    rm -f "${REPOROOT}"/assets/components/openshift-dns/dns/*
-    cp "${STAGING_DIR}"/cluster-dns-operator/assets/dns/* "${REPOROOT}"/assets/components/openshift-dns/dns || true
-    rm -f "${REPOROOT}"/assets/components/openshift-dns/node-resolver/*
-    cp "${STAGING_DIR}/"cluster-dns-operator/assets/node-resolver/* "${REPOROOT}"/assets/components/openshift-dns/node-resolver || true
-    #    Restore the openshift-dns ConfigMap. It's content is the Corefile that the operator generates
-    #    in https://github.com/openshift/cluster-dns-operator/blob/master/pkg/operator/controller/controller_dns_configmap.go
-    git restore "${REPOROOT}"/assets/components/openshift-dns/dns/configmap.yaml
-    #    Restore the template for the node-resolver DaemonSet. It matches what's programmatically created by the operator
-    #    in https://github.com/openshift/cluster-dns-operator/blob/master/pkg/operator/controller/controller_dns_node_resolver_daemonset.go
-    git restore "${REPOROOT}"/assets/components/openshift-dns/node-resolver/daemonset.yaml.tmpl
-    # 2) Render operand manifest templates like the operator would
+    # Render operand manifest templates like the operator would
     #    Render the DNS DaemonSet
     yq -i '.metadata += {"name": "dns-default", "namespace": "openshift-dns"}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.metadata += {"labels": {"dns.operator.openshift.io/owning-dns": "default"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.selector = {"matchLabels": {"dns.operator.openshift.io/daemonset-dns": "default"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.metadata += {"labels": {"dns.operator.openshift.io/daemonset-dns": "default"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
-    yq -i '.spec.template.spec.containers[0].image = "REPLACE_COREDNS_IMAGE"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
-    yq -i '.spec.template.spec.containers[1].image = "REPLACE_RBAC_PROXY_IMAGE"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
+    yq -i '.spec.template.spec.containers[0].image = "{{ .ReleaseImage.coredns }}"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
+    yq -i '.spec.template.spec.containers[1].image = "{{ .ReleaseImage.kube_rbac_proxy }}"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.nodeSelector = {"kubernetes.io/os": "linux"}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.volumes[0].configMap.name = "dns-default"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.volumes[1] += {"secret": {"defaultMode": 420, "secretName": "dns-default-metrics-tls"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     yq -i '.spec.template.spec.tolerations = [{"key": "node-role.kubernetes.io/master", "operator": "Exists"}]' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
+
     #    Render the node-resolver script into the DaemonSet template
     export NODE_RESOLVER_SCRIPT="$(sed 's|^.|          &|' "${REPOROOT}"/assets/components/openshift-dns/node-resolver/update-node-resolver.sh)"
     envsubst < "${REPOROOT}"/assets/components/openshift-dns/node-resolver/daemonset.yaml.tmpl > "${REPOROOT}"/assets/components/openshift-dns/node-resolver/daemonset.yaml
+
     #    Render the DNS service
     yq -i '.metadata += {"annotations": {"service.beta.openshift.io/serving-cert-secret-name": "dns-default-metrics-tls"}}' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
     yq -i '.metadata += {"name": "dns-default", "namespace": "openshift-dns"}' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
-    yq -i '.spec.clusterIP = "REPLACE_CLUSTER_IP"' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
+    yq -i '.spec.clusterIP = "{{.ClusterIP}}"' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
     yq -i '.spec.selector = {"dns.operator.openshift.io/daemonset-dns": "default"}' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
     sed -i '/#.*automatically managed/d' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
-    # 3) Make MicroShift-specific changes
-    #    Fix missing imagePullPolicy
+
+    # Fix missing imagePullPolicy
     yq -i '.spec.template.spec.containers[1].imagePullPolicy = "IfNotPresent"' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
-    #    Temporary workaround for MicroShift's missing config parameter when rendering this DaemonSet
+    # Temporary workaround for MicroShift's missing config parameter when rendering this DaemonSet
     sed -i 's|OPENSHIFT_MARKER=|NAMESERVER=${DNS_DEFAULT_SERVICE_HOST}\n          OPENSHIFT_MARKER=|' "${REPOROOT}"/assets/components/openshift-dns/node-resolver/daemonset.yaml
-    # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
-    sed -i 's|REPLACE_COREDNS_IMAGE|{{ .ReleaseImage.coredns }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
-    sed -i 's|REPLACE_RBAC_PROXY_IMAGE|{{ .ReleaseImage.kube_rbac_proxy }}|' "${REPOROOT}"/assets/components/openshift-dns/dns/daemonset.yaml
-    sed -i 's|REPLACE_CLUSTER_IP|{{.ClusterIP}}|' "${REPOROOT}"/assets/components/openshift-dns/dns/service.yaml
 
 
     #-- openshift-router ----------------------------------
-    # 1) Adopt resource manifests
-    #    Replace all openshift-router operand manifests
-    rm -f "${REPOROOT}"/assets/components/openshift-router/*
-    git restore "${REPOROOT}"/assets/components/openshift-router/serving-certificate.yaml
-    cp "${STAGING_DIR}"/cluster-ingress-operator/assets/router/* "${REPOROOT}"/assets/components/openshift-router 2>/dev/null || true
-    #    Restore the openshift-router's service-ca ConfigMap
-    git restore "${REPOROOT}"/assets/components/openshift-router/configmap.yaml
-    rm -r "${REPOROOT}"/assets/components/openshift-router/service-cloud.yaml
-    # 2) Render operand manifest templates like the operator would
+    # Render operand manifest templates like the operator would
     yq -i '.metadata += {"name": "router-default", "namespace": "openshift-ingress"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.metadata += {"labels": {"ingresscontroller.operator.openshift.io/owning-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.minReadySeconds = 30' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.selector = {"matchLabels": {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.metadata += {"labels": {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.containers[0].image = "REPLACE_ROUTER_IMAGE"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].image = "{{ .ReleaseImage.haproxy_router }}"' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "STATS_PORT", "value": "1936"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "RELOAD_INTERVAL", "value": "5s"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_ALLOW_WILDCARD_ROUTES", "value": "false"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CANONICAL_HOSTNAME", "value": "router-default.apps.REPLACE_CLUSTER_DOMAIN"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CANONICAL_HOSTNAME", "value": "router-default.apps.{{ .BaseDomain }}"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CIPHERS", "value": "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_CIPHERSUITES", "value": "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DISABLE_HTTP2", "value": "true"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
@@ -809,7 +730,8 @@ update_manifests() {
     yq -i '.metadata += {"name": "router-internal-default", "namespace": "openshift-ingress"}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
     yq -i '.spec.selector = {"ingresscontroller.operator.openshift.io/deployment-ingresscontroller": "default"}' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
-    # 3) Make MicroShift-specific changes
+
+    # MicroShift-specific changes
     #    Set replica count to 1, as we're single-node.
     yq -i '.spec.replicas = 1' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     #    Set deployment strategy type to Recreate.
@@ -820,40 +742,24 @@ update_manifests() {
     #    Not use proxy protocol due to lack of load balancer support
     yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_USE_PROXY_PROTOCOL", "value": "false"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     yq -i '.spec.template.spec.containers[0].env += {"name": "GRACEFUL_SHUTDOWN_DELAY", "value": "1s"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DOMAIN", "value": "apps.REPLACE_CLUSTER_DOMAIN"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
-    sed -i 's|REPLACE_CLUSTER_DOMAIN|{{ .BaseDomain }}|g' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-    sed -i 's|REPLACE_ROUTER_IMAGE|{{ .ReleaseImage.haproxy_router }}|' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
-
+    yq -i '.spec.template.spec.containers[0].env += {"name": "ROUTER_DOMAIN", "value": "apps.{{ .BaseDomain }}"}' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
 
     #-- service-ca ----------------------------------------
-    # 1) Adopt resource manifests
-    #    Replace all service-ca operand manifests
-    rm -f "${REPOROOT}"/assets/components/service-ca/*
-    cp "${STAGING_DIR}"/service-ca-operator/bindata/v4.0.0/controller/* "${REPOROOT}"/assets/components/service-ca || true
-    # 2) Render operand manifest templates like the operator would
-    # TODO: Remov the following annotations once CPC correctly creates them automatically
+    # Render operand manifest templates like the operator would
+    # TODO: Remove the following annotations once CPC correctly creates them automatically
     yq -i '.spec.template.spec.containers[0].args = ["-v=2"]' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
-    yq -i '.spec.template.spec.volumes[0].secret.secretName = "REPLACE_TLS_SECRET"' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
-    yq -i '.spec.template.spec.volumes[1].configMap.name = "REPLACE_CA_CONFIG_MAP"' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
+    yq -i '.spec.template.spec.volumes[0].secret.secretName = "{{.TLSSecret}}"' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
+    yq -i '.spec.template.spec.volumes[1].configMap.name = "{{.CAConfigMap}}"' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
+    yq -i '.spec.template.spec.containers[0].image = "{{ .ReleaseImage.service_ca_operator }}"' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
     yq -i 'del(.metadata.labels)' "${REPOROOT}"/assets/components/service-ca/ns.yaml
-    # 3) Make MicroShift-specific changes
-    #    Set replica count to 1, as we're single-node.
+
+    # Make MicroShift-specific changes
     yq -i '.spec.replicas = 1' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
-    # 4) Replace MicroShift templating vars (do this last, as yq trips over Go templates)
-    sed -i 's|\${IMAGE}|{{ .ReleaseImage.service_ca_operator }}|' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
-    sed -i 's|REPLACE_TLS_SECRET|{{.TLSSecret}}|' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
-    sed -i 's|REPLACE_CA_CONFIG_MAP|{{.CAConfigMap}}|' "${REPOROOT}"/assets/components/service-ca/deployment.yaml
 
     #-- ovn-kubernetes -----------------------------------
-    # 1) Adopt resource manifests
-    #    Replace all ovn-kubernetes manifests
-    #
     # NOTE: As long as MicroShift is still based on OpenShift releases that do not yet contain the MicroShift-specific
     #       manifests we're manually updating them as needed for now.
-    # TODO: Remove this comments and uncomment the lines below once we've rebased to 4.12.
-    #rm -rf "${REPOROOT}"/assets/components/ovn/*
-    #cp -r "${STAGING_DIR}"/cluster-network-operator/bindata/network/ovn-kubernetes/microshift/* "${REPOROOT}"/assets/components/ovn || true
+    # TODO: Enable in assets.yaml and handle modifications
 
     popd >/dev/null
 }
@@ -1006,7 +912,8 @@ rebase_to() {
         echo "No changes in component images."
     fi
 
-    update_manifests
+    copy_manifests
+    update_openshift_manifests
     update_lvms_manifests
     if [[ -n "$(git status -s assets)" ]]; then
         title "## Committing changes to assets and pkg/assets"
@@ -1062,7 +969,8 @@ case "$command" in
         update_lvms_images
         ;;
     manifests)
-        update_manifests
+        copy_manifests
+        update_openshift_manifests
         update_lvms_manifests
         ;;
     *) usage;;

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -44,6 +44,34 @@ title() {
     echo -e "\E[34m$1\E[00m";
 }
 
+check_preconditions() {
+    if ! hash yq; then
+        title "Installing yq"
+
+        YQ_VER=4.26.1
+        YQ_HASH_amd64=9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582
+        YQ_HASH_arm64=8966f9698a9bc321eae6745ffc5129b5e1b509017d3f710ee0eccec4f5568766
+        yq_hash="YQ_HASH_$(go env GOARCH)"
+        YQ_URL=https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_$(go env GOARCH)
+        echo -n "${!yq_hash} -" > /tmp/sum.txt
+        if ! (curl -Ls "${YQ_URL}" | tee /tmp/yq | sha256sum -c /tmp/sum.txt &>/dev/null); then
+            echo "ERROR: Expected file at ${YQ_URL} to have checksum ${!yq_hash} but instead got $(sha256sum </tmp/yq | cut -d' ' -f1)"
+            exit 1
+        fi
+        chmod +x /tmp/yq && sudo cp /tmp/yq /usr/bin/yq
+    fi
+
+    if ! hash python3; then
+        echo "ERROR: python3 is not present on the system - please install"
+        exit 1
+    fi
+
+    if ! python3 -c "import yaml"; then
+        echo "ERROR: missing python's yaml library - please install"
+        exit 1
+    fi
+}
+
 # LVMS is not integrated into the ocp release image, so the work flow does not fit with core component rebase.  LVMS'
 # operator bundle is the authoritative source for manifest and image digests.
 download_lvms_operator_bundle_manifest(){
@@ -948,6 +976,8 @@ usage() {
     echo "$(basename "$0") manifests                                                               Rebases the component manifests to the downloaded release"
     exit 1
 }
+
+check_preconditions
 
 command=${1:-help}
 case "$command" in

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -68,17 +68,6 @@ curl -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.
     sudo ln --symbolic /usr/local/go${GO_VER}/bin/{go,gofmt} /usr/local/bin/ && \
     rm -rfv "go${GO_VER}.linux-${GO_ARCH}.tar.gz"
 
-YQ_URL=https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_$(go env GOARCH)
-YQ_HASH_amd64=9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582
-YQ_HASH_arm64=8966f9698a9bc321eae6745ffc5129b5e1b509017d3f710ee0eccec4f5568766
-yq_hash="YQ_HASH_$(go env GOARCH)"
-echo -n "${!yq_hash} -" > /tmp/sum.txt
-if ! (curl -Ls "${YQ_URL}" | tee /tmp/yq | sha256sum -c /tmp/sum.txt &>/dev/null); then
-    echo "ERROR: Expected file at ${YQ_URL} to have checksum ${!yq_hash} but instead got $(sha256sum </tmp/yq | cut -d' ' -f1)"
-    exit 1
-fi
-chmod +x /tmp/yq && sudo cp /tmp/yq /usr/bin/yq
-
 if [ $BUILD_AND_INSTALL = true ] ; then
     # Build MicroShift
     # https://github.com/openshift/microshift/blob/main/docs/devenv_setup.md#build-microshift


### PR DESCRIPTION
Adds asset.yaml that lists all the files in `assets/`. Focused only on sourcing the assets (either copying from `STAGING_DIR` or using `git restore`). It does not include any modifications (like yq) to the manifests (yet).
Its purpose is to have common place for both rebase procedure and rebase presubmit.
 
Introduces new way of copying manifests from staging dir based on contents of assets.yaml file.
Commands such as `cp`, `git restore`, `rm -rf` are removed from `rebase.sh`'s functions dealing with manifests (`assets/`).
 
Other changes include:
- wrapping `{{ .template  }}` inside quotes to get correct yaml file, so many `sed` commands are removed
- formatting lvms/topolvm manifests with `oc create --dry-run=client` (includes sorting) (a consequence of using `oc create --dry-run` on all lvms/topolvm manifests, not just the copied ones)
- changing method of creating "lvmd" ConfigMap from templating to overriding ConfigMap's data (because templating `"{{ .lvmd }}"` would keep the `"` resulting in incorrect data)
- removed `Test_renderLvmdConfig` because it was testing approach based on renderTemplate() which is no longer used



