### PR TITLE
USHIFT-712: Use crun as cri-o default runtime in MicroShift

### DIFF
--- a/packaging/crio.conf.d/microshift_amd64.conf
+++ b/packaging/crio.conf.d/microshift_amd64.conf
@@ -3,6 +3,7 @@ selinux = true
 conmon = ""
 conmon_cgroup = "pod"
 cgroup_manager = "systemd"
+default_runtime = "crun"
 
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here

--- a/packaging/crio.conf.d/microshift_arm64.conf
+++ b/packaging/crio.conf.d/microshift_arm64.conf
@@ -3,6 +3,7 @@ selinux = true
 conmon = ""
 conmon_cgroup = "pod"
 cgroup_manager = "systemd"
+default_runtime = "crun"
 
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -56,6 +56,7 @@ Requires: microshift-selinux
 Requires: microshift-networking
 Requires: conntrack-tools
 Requires: sos
+Requires: crun
 
 %{?systemd_requires}
 


### PR DESCRIPTION
Closes USHIFT-7121
