### PR TITLE
USHIFT-517: LVMS bundle source depending on microshift branch

### DIFF
--- a/assets/release/release-aarch64.json
+++ b/assets/release/release-aarch64.json
@@ -11,10 +11,10 @@
     "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3ba74464c44486dc96ee871504b0c087ca724da0d589322a70904cfca16d9df6",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4eab31185869ef3affc8dcc9015a12b600789e09356a7bd4a6301742266cf444",
-    "topolvm_csi": "registry.redhat.io/lvms4/topolvm-rhel8@sha256:10bffded5317da9de6c45ba74f0bb10e0a08ddb2bfef23b11ac61287a37f10a1",
-    "topolvm_csi_registrar": "registry.redhat.io/openshift4/ose-csi-node-driver-registrar@sha256:a4319ff7c736ca9fe20500dc3e5862d6bb446f2428ea2eadfb5f042195f4f860",
-    "topolvm_csi_livenessprobe": "registry.redhat.io/openshift4/ose-csi-livenessprobe@sha256:9df24be671271f5ea9414bfd08e58bc2fa3dc4bc68075002f3db0fd020b58be0",
-    "topolvm_csi_resizer": "registry.redhat.io/openshift4/ose-csi-external-resizer@sha256:9d486daffd348664c00d8b80bd0da973b902f3650acdef37e1b813278ed6c107",
-    "topolvm_csi_provisioner": "registry.redhat.io/openshift4/ose-csi-external-provisioner@sha256:199eac2ba4c8390daa511b040315e415cfbcfa80aa7af978a33624445b96c17c"
+    "topolvm_csi": "quay.io/rhceph-dev/lvms4-topolvm-rhel8@sha256:8b83680c069677f5e541482e63087232a29f61f631f4f1fc3d7ecafa81dd9bb3",
+    "topolvm_csi_registrar": "quay.io/rhceph-dev/openshift-ose-csi-node-driver-registrar@sha256:df29101fc9f8e47ee64d641a25dd527aa700240f6d97fdd79c4544ae0aa84553",
+    "topolvm_csi_livenessprobe": "quay.io/rhceph-dev/openshift-ose-csi-livenessprobe@sha256:7417e06cbe4eb12e6c81eac5a2f6a5462e1ce775d4e9e46f04ebc4ea62fd4fb8",
+    "topolvm_csi_resizer": "quay.io/rhceph-dev/openshift-ose-csi-external-resizer@sha256:66bd5d06f5b452cccbf2fa18fd92aa90c5050d0bc2531cb1a7a66ec5ae6d7b28",
+    "topolvm_csi_provisioner": "quay.io/rhceph-dev/openshift-ose-csi-external-provisioner@sha256:2b373ee7206b65636332e8c747847a9abed6a5d042b65a0febc52b6c167673c2"
   }
 }

--- a/assets/release/release-x86_64.json
+++ b/assets/release/release-x86_64.json
@@ -11,10 +11,10 @@
     "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ab6561dbe5a00a9b96e1c29818d8376c8e871e6757875c9cf7f48e333425065",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6b9d0e907a9d523423fbaee40c302df90e9e1b89ce3a5ae621821845e2b4188d",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:91e31c0e8171d92d991322419c860cde1d4126fa927be2c453fbe14aa22743f7",
-    "topolvm_csi": "registry.redhat.io/lvms4/topolvm-rhel8@sha256:10bffded5317da9de6c45ba74f0bb10e0a08ddb2bfef23b11ac61287a37f10a1",
-    "topolvm_csi_registrar": "registry.redhat.io/openshift4/ose-csi-node-driver-registrar@sha256:a4319ff7c736ca9fe20500dc3e5862d6bb446f2428ea2eadfb5f042195f4f860",
-    "topolvm_csi_livenessprobe": "registry.redhat.io/openshift4/ose-csi-livenessprobe@sha256:9df24be671271f5ea9414bfd08e58bc2fa3dc4bc68075002f3db0fd020b58be0",
-    "topolvm_csi_resizer": "registry.redhat.io/openshift4/ose-csi-external-resizer@sha256:9d486daffd348664c00d8b80bd0da973b902f3650acdef37e1b813278ed6c107",
-    "topolvm_csi_provisioner": "registry.redhat.io/openshift4/ose-csi-external-provisioner@sha256:199eac2ba4c8390daa511b040315e415cfbcfa80aa7af978a33624445b96c17c"
+    "topolvm_csi": "quay.io/rhceph-dev/lvms4-topolvm-rhel8@sha256:8b83680c069677f5e541482e63087232a29f61f631f4f1fc3d7ecafa81dd9bb3",
+    "topolvm_csi_registrar": "quay.io/rhceph-dev/openshift-ose-csi-node-driver-registrar@sha256:df29101fc9f8e47ee64d641a25dd527aa700240f6d97fdd79c4544ae0aa84553",
+    "topolvm_csi_livenessprobe": "quay.io/rhceph-dev/openshift-ose-csi-livenessprobe@sha256:7417e06cbe4eb12e6c81eac5a2f6a5462e1ce775d4e9e46f04ebc4ea62fd4fb8",
+    "topolvm_csi_resizer": "quay.io/rhceph-dev/openshift-ose-csi-external-resizer@sha256:66bd5d06f5b452cccbf2fa18fd92aa90c5050d0bc2531cb1a7a66ec5ae6d7b28",
+    "topolvm_csi_provisioner": "quay.io/rhceph-dev/openshift-ose-csi-external-provisioner@sha256:2b373ee7206b65636332e8c747847a9abed6a5d042b65a0febc52b6c167673c2"
   }
 }

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -41,11 +41,13 @@ Finally. git clone your personal fork of microshift and `cd` into it.
 
 ### A Note on Rebasing MicroShift's CSI Plugin
 
-The Logical Volume Manager Service is not integrated with the ocp release image and must be passed explicitly to the rebase script as its 4th argument (including the sub-command). Images can be found at [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/lvms4/lvms-operator-bundle/63972de4d8764b33ec4dbf79?tag=v4.12.0-4&architecture=amd64&push_date=1673885582000&container-tabs=gti).
+The Logical Volume Manager Service is not integrated with the ocp release image and must be passed explicitly to the rebase script as its 4th argument (including the sub-command).
+Officially released images can be found at [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/lvms4/lvms-operator-bundle/63972de4d8764b33ec4dbf79?tag=v4.12.0-4&architecture=amd64&push_date=1673885582000&container-tabs=gti).
+Engineering Candidates built each sprint can be found on [Quay.io](https://quay.io/repository/rh-storage-partners/lvms4-lvms-operator-bundle?tab=tags&tag=latest).
 
 ### Fully automatic rebasing
 
-The following command attempts a fully automatic rebase to a given target upstream release. It is what is run nighly from CI and should work for most cases within a z-stream. It creates a new branch named after the target release, then runs the individual steps described in the following sections, including creating the respective commits.
+The following command attempts a fully automatic rebase to a given target upstream release. It is what is run nightly from CI and should work for most cases within a z-stream. It creates a new branch named after the target release, then runs the individual steps described in the following sections, including creating the respective commits.
 
 ```shell
 ./scripts/auto-rebase/rebase.sh to quay.io/openshift-release-dev/ocp-release:4.10.25-x86_64 quay.io/openshift-release-dev/ocp-release:4.10.25-aarch64 registry.redhat.io/lvms4/lvms-operator-bundle:[TAG || DIGEST]
@@ -257,12 +259,26 @@ To reduce a need of Pull Request synchronization between repositories, keep logi
 
 Rebase procedure expects references to AMD64 and ARM64 OpenShift release images, and LVM Storage (LVMS) Operator bundle image.
 OpenShift release images can be obtained from Release Status pages: [AMD64](https://amd64.ocp.releases.ci.openshift.org/) and [ARM64](https://arm64.ocp.releases.ci.openshift.org/) - navigate to section with nightly image builds for version that is currently worked on and pick latest approved for both architectures.
-LVMS Operator bundle image can be obtained from [Red Hat's catalog](https://catalog.redhat.com/software/containers/lvms4/lvms-operator-bundle/63972de4d8764b33ec4dbf79) - tag can be just appended to following URI: `registry.access.redhat.com/lvms4/lvms-operator-bundle:`.
+
+LVMS Operator bundle image can be obtained from either:
+- Official Release: [Red Hat's catalog](https://catalog.redhat.com/software/containers/lvms4/lvms-operator-bundle/63972de4d8764b33ec4dbf79) - tag can be just appended to following URI: `registry.access.redhat.com/lvms4/lvms-operator-bundle:`, or
+- Engineering Candidates (sprint builds): [Quay.io](https://quay.io/repository/rh-storage-partners/lvms4-lvms-operator-bundle?tab=tags&tag=latest) - pick latest image either manually or by running following command:
+  ```bash
+  echo "quay.io/rh-storage-partners/lvms4-lvms-operator-bundle@$(curl https://quay.io/api/v1/repository/rh-storage-partners/lvms4-lvms-operator-bundle/tag/ | jq -r '.tags | sort_by(.start_ts) | reverse | .[0].manifest_digest')"
+  ```
+
 These references are passed to `rebase.py` using `AMD64_RELEASE`, `ARM64_RELEASE`, and `LVMS_RELEASE` environment variables, for example:
 ```
 AMD64_RELEASE=registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-01-27-165107 \
 ARM64_RELEASE=registry.ci.openshift.org/ocp-arm64/release-arm64:4.13.0-0.nightly-arm64-2023-01-30-010253 \
 LVMS_RELEASE=registry.access.redhat.com/lvms4/lvms-operator-bundle:v4.12 \
+./scripts/auto-rebase/rebase.py
+
+# or use Quay refs for LVMS:
+
+AMD64_RELEASE=registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-01-27-165107 \
+ARM64_RELEASE=registry.ci.openshift.org/ocp-arm64/release-arm64:4.13.0-0.nightly-arm64-2023-01-30-010253 \
+LVMS_RELEASE=quay.io/rh-storage-partners/lvms4-lvms-operator-bundle@sha256:affe57ef424b866314e049e9a0605b8825ad6984cd30e5aee94df1788138351c \
 ./scripts/auto-rebase/rebase.py
 ```
 

--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -23,17 +23,18 @@ release_amd64="$(oc get configmap/release-release-images-latest -o yaml \
 release_arm64="$(oc get configmap/release-release-images-arm64-latest -o yaml \
     | yq '.data."release-images-arm64-latest.yaml"' \
     | jq -r '.metadata.name')"
-# LVMS is not tracked in the OCP release image.  Instead, rely on the latest X.Y stream as the release image.
-#  LVMS also does not cut nightly releases where ocp-release does.  This means that latest ocp-releases' y-stream
-#  can increment independently from LVMS, and will usually be 1 y-stream ahead of LVMS in-between OCP releases.
-#  For example, ocp-release at 4.13 will more often than not correspond to 4.12 LVMS, until the official 4.13 release when
-#  both components will be 4.13.
-release_lvms="v4.12"
 
 pullspec_release_amd64="registry.ci.openshift.org/ocp/release:${release_amd64}"
 pullspec_release_arm64="registry.ci.openshift.org/ocp-arm64/release-arm64:${release_arm64}"
-# Since LVMS is not part of the release payload, it is not kept in CI. Use the latest z-stream that coincides with the release payload's X.Y version
-pullspec_release_lvms="registry.access.redhat.com/lvms4/lvms-operator-bundle:${release_lvms}"
+
+branch_name="$(git branch --show-current)"
+if [[ "${branch_name}" == release-4* ]]; then
+    pullspec_release_lvms="registry.access.redhat.com/lvms4/lvms-operator-bundle:v${branch_name#*-}"
+else
+    quay_tags=$(curl https://quay.io/api/v1/repository/rhceph-dev/lvms4-lvms-operator-bundle/tag/)
+    latest_digest=$(echo "${quay_tags}" | jq -r '.tags | sort_by(.start_ts) | reverse | .[0].manifest_digest')
+    pullspec_release_lvms="quay.io/rhceph-dev/lvms4-lvms-operator-bundle@${latest_digest}"
+fi
 
 APP_ID=$(cat /secrets/pr-creds/app_id) \
 KEY=/secrets/pr-creds/key.pem \


### PR DESCRIPTION
Introduces logic that based on `microshift` currently active branch picks a registry to get LVMS Operator Bundle from:
- `release-4*` -> Red Hat Catalog with matching tag (e.g. `release-4.13` -> `v4.13`)
- otherwise (incl. `main`) -> LVMS Engineering Candidate (sprint build) from Quay.io 

Rebase script was executed and changes to image references in `assets/release/release-*.json` only include `registry/org/image` part - SHA digests are the same.