### PR TITLE
USHIFT-691: Configure RPM dependencies to use packages from OCP 4.13 beta mirror site

### DIFF
--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -131,11 +131,22 @@ When working with MicroShift based on a pre-release _minor_ version `Y` of OpenS
 
 ```bash
 OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
+OCP_REPO_NAME=rhocp-4.13-for-rhel-${OSVERSION}-mirrorbeta-$(uname -i)-rpms
+
+sudo tee /etc/yum.repos.d/${OCP_REPO_NAME}.repo >/dev/null <<EOF
+[${OCP_REPO_NAME}]
+name=Beta rhocp-4.13 RPMs for RHEL ${OSVERSION}
+baseurl=https://mirror.openshift.com/pub/openshift-v4/\$basearch/dependencies/rpms/4.13-el${OSVERSION}-beta/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0
+EOF
 
 sudo subscription-manager config --rhsm.manage_repos=1
-sudo subscription-manager repos \
-    --enable rhocp-4.12-for-rhel-${OSVERSION}-$(uname -i)-rpms \
-    --enable fast-datapath-for-rhel-${OSVERSION}-$(uname -i)-rpms
+# Uncomment this when OCP 4.13 is released
+# sudo subscription-manager repos \
+#     --enable rhocp-4.13-for-rhel-${OSVERSION}-$(uname -i)-rpms \
+#     --enable fast-datapath-for-rhel-${OSVERSION}-$(uname -i)-rpms
 ```
 </details>
 <details><summary>CentOS</summary>

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -87,11 +87,22 @@ fi
 # https://github.com/openshift/microshift/blob/main/docs/devenv_setup.md#runtime-prerequisites
 if [ $RHEL_SUBSCRIPTION = true ] ; then
     OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
+    OCP_REPO_NAME=rhocp-4.13-for-rhel-${OSVERSION}-mirrorbeta-$(uname -i)-rpms
+
+    sudo tee /etc/yum.repos.d/${OCP_REPO_NAME}.repo >/dev/null <<EOF
+[${OCP_REPO_NAME}]
+name=Beta rhocp-4.13 RPMs for RHEL ${OSVERSION}
+baseurl=https://mirror.openshift.com/pub/openshift-v4/\$basearch/dependencies/rpms/4.13-el${OSVERSION}-beta/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0
+EOF
 
     sudo subscription-manager config --rhsm.manage_repos=1
-    sudo subscription-manager repos \
-        --enable rhocp-4.12-for-rhel-${OSVERSION}-$(uname -i)-rpms \
-        --enable fast-datapath-for-rhel-${OSVERSION}-$(uname -i)-rpms
+    # Uncomment this when OCP 4.13 is released
+    # sudo subscription-manager repos \
+    #     --enable rhocp-4.13-for-rhel-${OSVERSION}-$(uname -i)-rpms \
+    #     --enable fast-datapath-for-rhel-${OSVERSION}-$(uname -i)-rpms
 else
     sudo dnf install -y centos-release-nfv-common
     sudo dnf copr enable -y @OKD/okd centos-stream-9-$(uname -i)

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -241,10 +241,10 @@ createrepo microshift-local >/dev/null
 
 # Download openshift local RPM packages (noarch for python and selinux packages)
 rm -rf openshift-local 2>/dev/null || true
-OCP_REPO_NAME=rhocp-4.12-for-rhel-${OSVERSION}-${BUILD_ARCH}-rpms
+OCP_REPO_NAME=rhocp-4.13-for-rhel-${OSVERSION}-mirrorbeta-${BUILD_ARCH}-rpms
 reposync -n -a ${BUILD_ARCH} -a noarch --download-path openshift-local \
-    --repo=${OCP_REPO_NAME} \
-    --repo=fast-datapath-for-rhel-${OSVERSION}-${BUILD_ARCH}-rpms >/dev/null
+    --repo=${OCP_REPO_NAME} >/dev/null
+#    --repo=fast-datapath-for-rhel-${OSVERSION}-${BUILD_ARCH}-rpms
 
 # Remove 'coreos' packages to avoid conflicts
 find openshift-local -name \*coreos\* -exec rm -f {} \;


### PR DESCRIPTION
Switch to using OCP mirror site for 4.13 RPM dependencies.

The following testing was performed:
- Reconfiguring and testing the current RHEL 8 x86 devenv
- Creating x86 RHEL 8/9 devenv machines from scratch and making sure the devenv procedures work
- Creating x86 RHEL 8/9 ISO images and making sure they install and run properly

Closes [USHIFT-691](https://issues.redhat.com//browse/USHIFT-691)
