### PR TITLE
OCPBUGS-7779: apply service ca-bundle directly to ingress configmap

### DIFF
--- a/assets/components/openshift-router/configmap.yaml
+++ b/assets/components/openshift-router/configmap.yaml
@@ -3,5 +3,3 @@ kind: ConfigMap
 metadata:
   namespace: openshift-ingress
   name: service-ca-bundle 
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -760,6 +760,8 @@ update_openshift_manifests() {
     sed -i '/#.*set at runtime/d' "${REPOROOT}"/assets/components/openshift-router/service-internal.yaml
 
     # MicroShift-specific changes
+    #-- ingress ----------------------------------------
+    yq -i 'del(.metadata.annotations)' "${REPOROOT}"/assets/components/openshift-router/configmap.yaml
     #    Set replica count to 1, as we're single-node.
     yq -i '.spec.replicas = 1' "${REPOROOT}"/assets/components/openshift-router/deployment.yaml
     #    Set deployment strategy type to Recreate.


### PR DESCRIPTION
The data of openshift-ingress service-ca-bundle configmap is erased everytime when microshift starts since the configmap is applied without data. This results in delay in starting router-default deployment pod after reboot as it has to wait for service-ca controller to inject the ca-bundle again. This commit applies service-ca-bundle configmap directly with data generated in service-ca dir.