### PR TITLE
USHIFT-910: Remove redundant coreos package deletion from build.sh

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -246,8 +246,6 @@ reposync -n -a ${BUILD_ARCH} -a noarch --download-path openshift-local \
     --repo=${OCP_REPO_NAME} \
     --repo=fast-datapath-for-rhel-${OSVERSION}-${BUILD_ARCH}-rpms >/dev/null
 
-# Remove 'coreos' packages to avoid conflicts
-find openshift-local -name \*coreos\* -exec rm -f {} \;
 # Remove 'microshift' packages to avoid overrides from the remote repository
 find openshift-local -name \*microshift\* -exec rm -f {} \;
 # Exit if no RPM packages were found


### PR DESCRIPTION
Tested ISO image creation and boot using build.sh script on RHEL 8 x86.
Closes [USHIFT-910](https://issues.redhat.com//browse/USHIFT-910)
