### PR TITLE
USHIFT-896: Enable activations of all ethernet interfaces in kickstart

### DIFF
--- a/scripts/devenv-builder/config/kickstart.ks.template
+++ b/scripts/devenv-builder/config/kickstart.ks.template
@@ -43,4 +43,9 @@ cdrom
 # Allow the default user to run sudo commands without password
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' > /etc/sudoers.d/microshift
 
+# Make sure all the Ethernet network interfaces are connected automatically
+for dev in $(nmcli -f name,type,autoconnect connection | awk '$2 == "ethernet" && $3 == "no" {print $1}') ; do
+    nmcli connection modify ${dev} connection.autoconnect yes
+done
+
 %end

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -65,4 +65,9 @@ firewall-offline-cmd --zone=trusted --add-source=169.254.169.1
 # Make the KUBECONFIG from MicroShift directly available for the root user
 echo -e 'export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig' >> /root/.profile
 
+# Make sure all the Ethernet network interfaces are connected automatically
+for dev in $(nmcli -f name,type,autoconnect connection | awk '$2 == "ethernet" && $3 == "no" {print $1}') ; do
+    nmcli connection modify ${dev} connection.autoconnect yes
+done
+
 %end


### PR DESCRIPTION
Closes [USHIFT-896](https://issues.redhat.com//browse/USHIFT-896)
