### PR TITLE
USHIFT-896: Use UUID for enabling automatic network device connections in kickstart

### DIFF
--- a/scripts/devenv-builder/config/kickstart.ks.template
+++ b/scripts/devenv-builder/config/kickstart.ks.template
@@ -44,7 +44,7 @@ cdrom
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' > /etc/sudoers.d/microshift
 
 # Make sure all the Ethernet network interfaces are connected automatically
-for dev in $(nmcli -f name,type,autoconnect connection | awk '$2 == "ethernet" && $3 == "no" {print $1}') ; do
+for dev in $(nmcli -f uuid,type,autoconnect connection | awk '$2 == "ethernet" && $3 == "no" {print $1}') ; do
     nmcli connection modify ${dev} connection.autoconnect yes
 done
 

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -66,7 +66,7 @@ firewall-offline-cmd --zone=trusted --add-source=169.254.169.1
 echo -e 'export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig' >> /root/.profile
 
 # Make sure all the Ethernet network interfaces are connected automatically
-for dev in $(nmcli -f name,type,autoconnect connection | awk '$2 == "ethernet" && $3 == "no" {print $1}') ; do
+for dev in $(nmcli -f uuid,type,autoconnect connection | awk '$2 == "ethernet" && $3 == "no" {print $1}') ; do
     nmcli connection modify ${dev} connection.autoconnect yes
 done
 


### PR DESCRIPTION
Use UUID instead of names in the command to make it work for device names with spaces
Closes [USHIFT-896](https://issues.redhat.com//browse/USHIFT-896)
