### PR TITLE
USHIFT-912: Fix 4.13 devenv installation instructions to only use RHEL / CentOS 9.x

### DIFF
--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -4,7 +4,7 @@ It is recommended to review the current document and use the automation instruct
 
 ## Create Development Virtual Machine
 Start by downloading one of the supported boot images for the `x86_64` or `aarch64` architecture:
-* RHEL 8.7 or RHEL 9.1 from https://developers.redhat.com/products/rhel/download
+* RHEL 9.1 from https://developers.redhat.com/products/rhel/download
 * CentOS 9 Stream from https://www.centos.org/download
 
 ### Creating VM
@@ -19,7 +19,7 @@ sudo dnf install -y libvirt virt-manager virt-install virt-viewer libvirt-client
 Move the ISO image to `/var/lib/libvirt/images` directory and run the following commands to create a virtual machine.
 ```bash
 VMNAME="microshift-dev"
-ISONAME=rhel-8.7-$(uname -i)-boot.iso
+ISONAME=rhel-baseos-9.1-$(uname -i)-boot.iso
 
 sudo -b bash -c " \
 cd /var/lib/libvirt/images/ && \
@@ -63,7 +63,7 @@ Run the following commands to configure SUDO, upgrade the system, install basic 
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift
 sudo dnf clean all -y
 sudo dnf update -y
-sudo dnf install -y git cockpit make golang selinux-policy-devel rpm-build bash-completion
+sudo dnf install -y git cockpit make golang selinux-policy-devel rpm-build jq bash-completion
 sudo systemctl enable --now cockpit.socket
 
 # Install go1.19

--- a/docs/devenv_setup_auto.md
+++ b/docs/devenv_setup_auto.md
@@ -27,7 +27,7 @@ As an example, run the following command to create a virtual machine named `micr
 > See the [Recommended system swap size](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/getting-started-with-swap_managing-storage-devices#recommended-system-swap-space_getting-started-with-swap) document for more information.
 
 ```bash
-ISONAME=rhel-8.7-$(uname -i)-dvd.iso
+ISONAME=rhel-baseos-9.1-$(uname -i)-dvd.iso
 
 ./scripts/devenv-builder/create-vm.sh microshift-dev \
     /var/lib/libvirt/images \
@@ -38,7 +38,7 @@ ISONAME=rhel-8.7-$(uname -i)-dvd.iso
 or
 
 ```bash
-ISONAME=rhel-8.7-$(uname -i)-dvd.iso
+ISONAME=rhel-baseos-9.1-$(uname -i)-dvd.iso
 
 export VMNAME=microshift-dev
 export VMDISKDIR=/var/lib/libvirt/images
@@ -57,18 +57,24 @@ Watch the output in the `virt-viewer` popup, waiting for a successful completion
 Log into the hypervisor host and run the following command to get the IP address of the development virtual machine and use it to remotely connect to the system.
 ```bash
 sudo virsh domifaddr microshift-dev
+...
+...
+VMIPADDR=192.168.122.29
+```
+
+Configure SSH not to require a password when logging into the system.
+```bash
+ssh-copy-id -f microshift@${VMIPADDR}
 ```
 
 Copy the configuration script and your OpenShift pull secret file to the virtual machine using `microshift:microshift` credentials.
 ```bash
-VMIPADDR=192.168.122.29
 scp scripts/devenv-builder/configure-vm.sh microshift@${VMIPADDR}:
 scp ~/.pull-secret.json microshift@${VMIPADDR}:
 ```
 
 Log into the development virtual machine using `microshift:microshift` credentials and run the following command to configure MicroShift.
 ```bash
-chmod a+x ~/configure-vm.sh
 ~/configure-vm.sh ~/.pull-secret.json
 ```
 

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -52,7 +52,7 @@ fi
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift
 sudo dnf clean all -y
 sudo dnf update -y
-sudo dnf install -y git cockpit make golang jq selinux-policy-devel rpm-build bash-completion
+sudo dnf install -y git cockpit make golang jq selinux-policy-devel rpm-build jq bash-completion
 sudo systemctl enable --now cockpit.socket
 
 # Install go1.19


### PR DESCRIPTION
Closes [USHIFT-912](https://issues.redhat.com//browse/USHIFT-912)
