### PR TITLE
NO-ISSUE: add developer tool for getting CI pull secret

### DIFF
--- a/scripts/auto-rebase/get-ci-token.sh
+++ b/scripts/auto-rebase/get-ci-token.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Taken from utils.sh in openshift-metal3/dev-scripts
+
+CI_TOKEN=${CI_TOKEN:-$1}
+CI_SERVER=${CI_SERVER:-api.ci.l2s4.p1.openshiftapps.com}
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [[ ${#CI_TOKEN} = 0 ]]; then
+    cat - <<EOF
+
+Login to the console using SSO:
+
+  https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/
+
+Use the menu at the top right, where your name is, to access the "Copy
+login command" feature.
+
+Authenticate to the app a second time.
+
+Click "Display token".
+
+Copy the API token and pass it to this script as the first argument
+(you may need to put it in quotes).
+
+EOF
+    exit 1
+fi
+
+# Get a current pull secret for registry.ci.openshift.org using the token
+tmpkubeconfig="/tmp/registry-kubeconfig"
+oc login https://${CI_SERVER}:6443 --kubeconfig=$tmpkubeconfig --token=${CI_TOKEN}
+tmppullsecret="/tmp/registry-pull-secret"
+echo '{}' >$tmppullsecret
+oc registry login --kubeconfig=$tmpkubeconfig --to=$tmppullsecret
+
+echo "Add this to your ~/.pull_secret.json file:"
+echo
+cat $tmppullsecret
+echo


### PR DESCRIPTION
The script uses the token from the console web app to login and get
the pull secret value for the CI registry, then prints it to the
screen to be copied and pasted into ~/.pull_secret.json