### PR TITLE
USHIFT-289: Revert "change names of rebase image configmaps"

### DIFF
--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -17,11 +17,11 @@ cp /secrets/ci-pull-secret/.dockercfg "$HOME/.pull-secret.json" || {
     echo "WARN: Could not copy registry secret file"
 }
 
-release_amd64="$(oc get configmap/release-release-images-nightly-amd64 -o yaml \
-    | yq '.data."release-images-nightly-amd64.yaml"' \
+release_amd64="$(oc get configmap/release-release-images-latest -o yaml \
+    | yq '.data."release-images-latest.yaml"' \
     | jq -r '.metadata.name')"
-release_arm64="$(oc get configmap/release-release-images-nightly-arm64 -o yaml \
-    | yq '.data."release-images-nightly-arm64.yaml"' \
+release_arm64="$(oc get configmap/release-release-images-arm64-latest -o yaml \
+    | yq '.data."release-images-arm64-latest.yaml"' \
     | jq -r '.metadata.name')"
 # LVMS is not tracked in the OCP release image.  Instead, rely on the latest X.Y stream as the release image.
 #  LVMS also does not cut nightly releases where ocp-release does.  This means that latest ocp-releases' y-stream


### PR DESCRIPTION
This reverts commit 3570ead6e36cfc5def9d6b01bdc6908ea69c6e29.

/assign @pmtk