### PR TITLE
OCPBUGS-2869: patch out unused components in openshift-kube-apiserver

### DIFF
--- a/scripts/auto-rebase/rebase_patches/0003-disable-clusterQuotaMapping-controller.patch
+++ b/scripts/auto-rebase/rebase_patches/0003-disable-clusterQuotaMapping-controller.patch
@@ -1,0 +1,108 @@
+diff --git a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+index d402786d..eb81d0bc 100644
+--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
++++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+@@ -6,25 +6,18 @@
+ 
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
+-	"github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
+ 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
+ 	configclient "github.com/openshift/client-go/config/clientset/versioned"
+ 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
+-	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
+-	quotainformer "github.com/openshift/client-go/quota/informers/externalversions"
+-	quotav1informer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
+ 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
+ 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+ 	userclient "github.com/openshift/client-go/user/clientset/versioned"
+ 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
+ 	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
+ 	"github.com/openshift/library-go/pkg/apiserver/apiserverconfig"
+-	"github.com/openshift/library-go/pkg/quota/clusterquotamapping"
+ 	"k8s.io/apiserver/pkg/admission"
+-	"k8s.io/apiserver/pkg/quota/v1/generic"
+ 	genericapiserver "k8s.io/apiserver/pkg/server"
+ 	clientgoinformers "k8s.io/client-go/informers"
+-	corev1informers "k8s.io/client-go/informers/core/v1"
+ 	"k8s.io/client-go/rest"
+ 	"k8s.io/client-go/tools/cache"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
+@@ -32,7 +25,6 @@
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
+-	"k8s.io/kubernetes/pkg/quota/v1/install"
+ 
+ 	// magnet to get authorizer package in hack/update-vendor.sh
+ 	_ "github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
+@@ -57,21 +49,11 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
+ 	genericConfig.LongRunningFunc = apiserverconfig.IsLongRunningRequest
+ 
+ 	// ADMISSION
+-	clusterQuotaMappingController := newClusterQuotaMappingController(kubeInformers.Core().V1().Namespaces(), openshiftInformers.OpenshiftQuotaInformers.Quota().V1().ClusterResourceQuotas())
+-	genericConfig.AddPostStartHookOrDie("quota.openshift.io-clusterquotamapping", func(context genericapiserver.PostStartHookContext) error {
+-		go clusterQuotaMappingController.Run(5, context.StopCh)
+-		return nil
+-	})
+ 
+ 	*pluginInitializers = append(*pluginInitializers,
+ 		imagepolicy.NewInitializer(imagereferencemutators.KubeImageMutators{}, enablement.OpenshiftConfig().ImagePolicyConfig.InternalRegistryHostname),
+ 		restrictusers.NewInitializer(openshiftInformers.getOpenshiftUserInformers()),
+ 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
+-		clusterresourcequota.NewInitializer(
+-			openshiftInformers.getOpenshiftQuotaInformers().Quota().V1().ClusterResourceQuotas(),
+-			clusterQuotaMappingController.GetClusterQuotaMapper(),
+-			generic.NewRegistry(install.NewQuotaConfigurationForAdmission().Evaluators()),
+-		),
+ 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
+ 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
+ 		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
+@@ -125,10 +107,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 	// ClusterResourceQuota is served using CRD resource any status update must use JSON
+ 	jsonLoopbackClientConfig := makeJSONRESTConfig(loopbackClientConfig)
+ 
+-	quotaClient, err := quotaclient.NewForConfig(jsonLoopbackClientConfig)
+-	if err != nil {
+-		return nil, err
+-	}
+ 	securityClient, err := securityv1client.NewForConfig(jsonLoopbackClientConfig)
+ 	if err != nil {
+ 		return nil, err
+@@ -147,7 +125,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 	const defaultInformerResyncPeriod = 10 * time.Minute
+ 
+ 	ret := &kubeAPIServerInformers{
+-		OpenshiftQuotaInformers:    quotainformer.NewSharedInformerFactory(quotaClient, defaultInformerResyncPeriod),
+ 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
+ 		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
+ 		OpenshiftConfigInformers:   configv1informer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
+@@ -162,15 +139,11 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ }
+ 
+ type kubeAPIServerInformers struct {
+-	OpenshiftQuotaInformers    quotainformer.SharedInformerFactory
+ 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
+ 	OpenshiftUserInformers     userinformer.SharedInformerFactory
+ 	OpenshiftConfigInformers   configv1informer.SharedInformerFactory
+ }
+ 
+-func (i *kubeAPIServerInformers) getOpenshiftQuotaInformers() quotainformer.SharedInformerFactory {
+-	return i.OpenshiftQuotaInformers
+-}
+ func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
+ 	return i.OpenshiftSecurityInformers
+ }
+@@ -182,12 +155,7 @@ func (i *kubeAPIServerInformers) getOpenshiftInfraInformers() configv1informer.S
+ }
+ 
+ func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
+-	i.OpenshiftQuotaInformers.Start(stopCh)
+ 	i.OpenshiftSecurityInformers.Start(stopCh)
+ 	i.OpenshiftUserInformers.Start(stopCh)
+ 	i.OpenshiftConfigInformers.Start(stopCh)
+ }
+-
+-func newClusterQuotaMappingController(nsInternalInformer corev1informers.NamespaceInformer, clusterQuotaInformer quotav1informer.ClusterResourceQuotaInformer) *clusterquotamapping.ClusterQuotaMappingController {
+-	return clusterquotamapping.NewClusterQuotaMappingController(nsInternalInformer, clusterQuotaInformer)
+-}

--- a/scripts/auto-rebase/rebase_patches/0004-remove-config-informer.patch
+++ b/scripts/auto-rebase/rebase_patches/0004-remove-config-informer.patch
@@ -1,0 +1,69 @@
+diff --git a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+index eb81d0bc..39b266a0 100644
+--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
++++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+@@ -7,8 +7,6 @@
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
+ 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
+ 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
+-	configclient "github.com/openshift/client-go/config/clientset/versioned"
+-	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
+ 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
+ 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+ 	userclient "github.com/openshift/client-go/user/clientset/versioned"
+@@ -22,7 +20,6 @@
+ 	"k8s.io/client-go/tools/cache"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache"
+-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
+ 
+@@ -56,7 +53,6 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
+ 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
+ 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
+ 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
+-		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
+ 	)
+ 
+ 	// This is needed in order to have the correct initializers for the SCC admission plugin which is used to mutate
+@@ -115,10 +111,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	configClient, err := configclient.NewForConfig(loopbackClientConfig)
+-	if err != nil {
+-		return nil, err
+-	}
+ 
+ 	// TODO find a single place to create and start informers.  During the 1.7 rebase this will come more naturally in a config object,
+ 	// before then we should try to eliminate our direct to storage access.  It's making us do weird things.
+@@ -127,7 +119,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 	ret := &kubeAPIServerInformers{
+ 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
+ 		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
+-		OpenshiftConfigInformers:   configv1informer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
+ 	}
+ 	if err := ret.OpenshiftUserInformers.User().V1().Groups().Informer().AddIndexers(cache.Indexers{
+ 		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
+@@ -141,7 +132,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ type kubeAPIServerInformers struct {
+ 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
+ 	OpenshiftUserInformers     userinformer.SharedInformerFactory
+-	OpenshiftConfigInformers   configv1informer.SharedInformerFactory
+ }
+ 
+ func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
+@@ -150,12 +140,8 @@ func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1infor
+ func (i *kubeAPIServerInformers) getOpenshiftUserInformers() userinformer.SharedInformerFactory {
+ 	return i.OpenshiftUserInformers
+ }
+-func (i *kubeAPIServerInformers) getOpenshiftInfraInformers() configv1informer.SharedInformerFactory {
+-	return i.OpenshiftConfigInformers
+-}
+ 
+ func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
+ 	i.OpenshiftSecurityInformers.Start(stopCh)
+ 	i.OpenshiftUserInformers.Start(stopCh)
+-	i.OpenshiftConfigInformers.Start(stopCh)
+ }

--- a/scripts/auto-rebase/rebase_patches/0005-remove-user-informer.patch
+++ b/scripts/auto-rebase/rebase_patches/0005-remove-user-informer.patch
@@ -1,0 +1,72 @@
+diff --git a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+index 39b266a0..676fe562 100644
+--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
++++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+@@ -9,17 +9,12 @@
+ 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
+ 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
+ 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+-	userclient "github.com/openshift/client-go/user/clientset/versioned"
+-	userinformer "github.com/openshift/client-go/user/informers/externalversions"
+ 	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
+ 	"github.com/openshift/library-go/pkg/apiserver/apiserverconfig"
+ 	"k8s.io/apiserver/pkg/admission"
+ 	genericapiserver "k8s.io/apiserver/pkg/server"
+ 	clientgoinformers "k8s.io/client-go/informers"
+ 	"k8s.io/client-go/rest"
+-	"k8s.io/client-go/tools/cache"
+-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
+-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
+ 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
+ 
+@@ -49,7 +44,6 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
+ 
+ 	*pluginInitializers = append(*pluginInitializers,
+ 		imagepolicy.NewInitializer(imagereferencemutators.KubeImageMutators{}, enablement.OpenshiftConfig().ImagePolicyConfig.InternalRegistryHostname),
+-		restrictusers.NewInitializer(openshiftInformers.getOpenshiftUserInformers()),
+ 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
+ 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
+ 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
+@@ -107,10 +101,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	userClient, err := userclient.NewForConfig(loopbackClientConfig)
+-	if err != nil {
+-		return nil, err
+-	}
+ 
+ 	// TODO find a single place to create and start informers.  During the 1.7 rebase this will come more naturally in a config object,
+ 	// before then we should try to eliminate our direct to storage access.  It's making us do weird things.
+@@ -118,12 +108,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 
+ 	ret := &kubeAPIServerInformers{
+ 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
+-		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
+-	}
+-	if err := ret.OpenshiftUserInformers.User().V1().Groups().Informer().AddIndexers(cache.Indexers{
+-		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
+-	}); err != nil {
+-		return nil, err
+ 	}
+ 
+ 	return ret, nil
+@@ -131,17 +115,12 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
+ 
+ type kubeAPIServerInformers struct {
+ 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
+-	OpenshiftUserInformers     userinformer.SharedInformerFactory
+ }
+ 
+ func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
+ 	return i.OpenshiftSecurityInformers
+ }
+-func (i *kubeAPIServerInformers) getOpenshiftUserInformers() userinformer.SharedInformerFactory {
+-	return i.OpenshiftUserInformers
+-}
+ 
+ func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
+ 	i.OpenshiftSecurityInformers.Start(stopCh)
+-	i.OpenshiftUserInformers.Start(stopCh)
+ }

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -9,17 +9,12 @@ import (
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
-	userclient "github.com/openshift/client-go/user/clientset/versioned"
-	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
 	"github.com/openshift/library-go/pkg/apiserver/apiserverconfig"
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	clientgoinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
 
@@ -49,7 +44,6 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 
 	*pluginInitializers = append(*pluginInitializers,
 		imagepolicy.NewInitializer(imagereferencemutators.KubeImageMutators{}, enablement.OpenshiftConfig().ImagePolicyConfig.InternalRegistryHostname),
-		restrictusers.NewInitializer(openshiftInformers.getOpenshiftUserInformers()),
 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
@@ -107,10 +101,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 	if err != nil {
 		return nil, err
 	}
-	userClient, err := userclient.NewForConfig(loopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
 
 	// TODO find a single place to create and start informers.  During the 1.7 rebase this will come more naturally in a config object,
 	// before then we should try to eliminate our direct to storage access.  It's making us do weird things.
@@ -118,12 +108,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 
 	ret := &kubeAPIServerInformers{
 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
-		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
-	}
-	if err := ret.OpenshiftUserInformers.User().V1().Groups().Informer().AddIndexers(cache.Indexers{
-		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
-	}); err != nil {
-		return nil, err
 	}
 
 	return ret, nil
@@ -131,17 +115,12 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 
 type kubeAPIServerInformers struct {
 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
-	OpenshiftUserInformers     userinformer.SharedInformerFactory
 }
 
 func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
 	return i.OpenshiftSecurityInformers
 }
-func (i *kubeAPIServerInformers) getOpenshiftUserInformers() userinformer.SharedInformerFactory {
-	return i.OpenshiftUserInformers
-}
 
 func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
 	i.OpenshiftSecurityInformers.Start(stopCh)
-	i.OpenshiftUserInformers.Start(stopCh)
 }

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -7,8 +7,6 @@ import (
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
 	userclient "github.com/openshift/client-go/user/clientset/versioned"
@@ -22,7 +20,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache"
-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
 
@@ -56,7 +53,6 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
-		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
 	)
 
 	// This is needed in order to have the correct initializers for the SCC admission plugin which is used to mutate
@@ -115,10 +111,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 	if err != nil {
 		return nil, err
 	}
-	configClient, err := configclient.NewForConfig(loopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
 
 	// TODO find a single place to create and start informers.  During the 1.7 rebase this will come more naturally in a config object,
 	// before then we should try to eliminate our direct to storage access.  It's making us do weird things.
@@ -127,7 +119,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 	ret := &kubeAPIServerInformers{
 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
 		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
-		OpenshiftConfigInformers:   configv1informer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
 	}
 	if err := ret.OpenshiftUserInformers.User().V1().Groups().Informer().AddIndexers(cache.Indexers{
 		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
@@ -141,7 +132,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 type kubeAPIServerInformers struct {
 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
 	OpenshiftUserInformers     userinformer.SharedInformerFactory
-	OpenshiftConfigInformers   configv1informer.SharedInformerFactory
 }
 
 func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
@@ -150,12 +140,8 @@ func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1infor
 func (i *kubeAPIServerInformers) getOpenshiftUserInformers() userinformer.SharedInformerFactory {
 	return i.OpenshiftUserInformers
 }
-func (i *kubeAPIServerInformers) getOpenshiftInfraInformers() configv1informer.SharedInformerFactory {
-	return i.OpenshiftConfigInformers
-}
 
 func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
 	i.OpenshiftSecurityInformers.Start(stopCh)
 	i.OpenshiftUserInformers.Start(stopCh)
-	i.OpenshiftConfigInformers.Start(stopCh)
 }

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -6,25 +6,18 @@ import (
 
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
 	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators"
-	"github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
 	"github.com/openshift/apiserver-library-go/pkg/securitycontextconstraints/sccadmission"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informer "github.com/openshift/client-go/config/informers/externalversions"
-	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
-	quotainformer "github.com/openshift/client-go/quota/informers/externalversions"
-	quotav1informer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
 	userclient "github.com/openshift/client-go/user/clientset/versioned"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
 	"github.com/openshift/library-go/pkg/apiserver/apiserverconfig"
-	"github.com/openshift/library-go/pkg/quota/clusterquotamapping"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/apiserver/pkg/quota/v1/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	clientgoinformers "k8s.io/client-go/informers"
-	corev1informers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers"
@@ -32,7 +25,6 @@ import (
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/autoscaling/managementcpusoverride"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/scheduler/nodeenv"
 	"k8s.io/kubernetes/openshift-kube-apiserver/enablement"
-	"k8s.io/kubernetes/pkg/quota/v1/install"
 
 	// magnet to get authorizer package in hack/update-vendor.sh
 	_ "github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer"
@@ -57,21 +49,11 @@ func OpenShiftKubeAPIServerConfigPatch(genericConfig *genericapiserver.Config, k
 	genericConfig.LongRunningFunc = apiserverconfig.IsLongRunningRequest
 
 	// ADMISSION
-	clusterQuotaMappingController := newClusterQuotaMappingController(kubeInformers.Core().V1().Namespaces(), openshiftInformers.OpenshiftQuotaInformers.Quota().V1().ClusterResourceQuotas())
-	genericConfig.AddPostStartHookOrDie("quota.openshift.io-clusterquotamapping", func(context genericapiserver.PostStartHookContext) error {
-		go clusterQuotaMappingController.Run(5, context.StopCh)
-		return nil
-	})
 
 	*pluginInitializers = append(*pluginInitializers,
 		imagepolicy.NewInitializer(imagereferencemutators.KubeImageMutators{}, enablement.OpenshiftConfig().ImagePolicyConfig.InternalRegistryHostname),
 		restrictusers.NewInitializer(openshiftInformers.getOpenshiftUserInformers()),
 		sccadmission.NewInitializer(openshiftInformers.getOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints()),
-		clusterresourcequota.NewInitializer(
-			openshiftInformers.getOpenshiftQuotaInformers().Quota().V1().ClusterResourceQuotas(),
-			clusterQuotaMappingController.GetClusterQuotaMapper(),
-			generic.NewRegistry(install.NewQuotaConfigurationForAdmission().Evaluators()),
-		),
 		nodeenv.NewInitializer(enablement.OpenshiftConfig().ProjectConfig.DefaultNodeSelector),
 		admissionrestconfig.NewInitializer(*rest.CopyConfig(genericConfig.LoopbackClientConfig)),
 		managementcpusoverride.NewInitializer(openshiftInformers.getOpenshiftInfraInformers().Config().V1().Infrastructures()),
@@ -125,10 +107,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 	// ClusterResourceQuota is served using CRD resource any status update must use JSON
 	jsonLoopbackClientConfig := makeJSONRESTConfig(loopbackClientConfig)
 
-	quotaClient, err := quotaclient.NewForConfig(jsonLoopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
 	securityClient, err := securityv1client.NewForConfig(jsonLoopbackClientConfig)
 	if err != nil {
 		return nil, err
@@ -147,7 +125,6 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 	const defaultInformerResyncPeriod = 10 * time.Minute
 
 	ret := &kubeAPIServerInformers{
-		OpenshiftQuotaInformers:    quotainformer.NewSharedInformerFactory(quotaClient, defaultInformerResyncPeriod),
 		OpenshiftSecurityInformers: securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
 		OpenshiftUserInformers:     userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
 		OpenshiftConfigInformers:   configv1informer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
@@ -162,15 +139,11 @@ func newInformers(loopbackClientConfig *rest.Config) (*kubeAPIServerInformers, e
 }
 
 type kubeAPIServerInformers struct {
-	OpenshiftQuotaInformers    quotainformer.SharedInformerFactory
 	OpenshiftSecurityInformers securityv1informer.SharedInformerFactory
 	OpenshiftUserInformers     userinformer.SharedInformerFactory
 	OpenshiftConfigInformers   configv1informer.SharedInformerFactory
 }
 
-func (i *kubeAPIServerInformers) getOpenshiftQuotaInformers() quotainformer.SharedInformerFactory {
-	return i.OpenshiftQuotaInformers
-}
 func (i *kubeAPIServerInformers) getOpenshiftSecurityInformers() securityv1informer.SharedInformerFactory {
 	return i.OpenshiftSecurityInformers
 }
@@ -182,12 +155,7 @@ func (i *kubeAPIServerInformers) getOpenshiftInfraInformers() configv1informer.S
 }
 
 func (i *kubeAPIServerInformers) Start(stopCh <-chan struct{}) {
-	i.OpenshiftQuotaInformers.Start(stopCh)
 	i.OpenshiftSecurityInformers.Start(stopCh)
 	i.OpenshiftUserInformers.Start(stopCh)
 	i.OpenshiftConfigInformers.Start(stopCh)
-}
-
-func newClusterQuotaMappingController(nsInternalInformer corev1informers.NamespaceInformer, clusterQuotaInformer quotav1informer.ClusterResourceQuotaInformer) *clusterquotamapping.ClusterQuotaMappingController {
-	return clusterquotamapping.NewClusterQuotaMappingController(nsInternalInformer, clusterQuotaInformer)
 }


### PR DESCRIPTION
Remove startup code that adds the resource quota controller and informers
for the Group and User APIs, because none of the relevant APIs are
present in MicroShift.

/hold