### PR TITLE
OCPBUGS-7874: set the pause exec path for openshift pod image

### DIFF
--- a/packaging/crio.conf.d/microshift_amd64.conf
+++ b/packaging/crio.conf.d/microshift_amd64.conf
@@ -17,3 +17,5 @@ plugin_dirs = [
 [crio.image]
 global_auth_file="/etc/crio/openshift-pull-secret"
 pause_image = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6b9d0e907a9d523423fbaee40c302df90e9e1b89ce3a5ae621821845e2b4188d"
+pause_image_auth_file = "/etc/crio/openshift-pull-secret"
+pause_command = "/usr/bin/pod"

--- a/packaging/crio.conf.d/microshift_amd64.conf
+++ b/packaging/crio.conf.d/microshift_amd64.conf
@@ -2,8 +2,17 @@
 selinux = true
 conmon = ""
 conmon_cgroup = "pod"
+default_env = [
+    "NSS_SDB_USE_CACHE=no",
+]
 cgroup_manager = "systemd"
 default_runtime = "crun"
+default_sysctls = [
+    "net.ipv4.ping_group_range=0 2147483647",
+]
+absent_mount_sources_to_reject = [
+    "/etc/hostname",
+]
 
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here

--- a/packaging/crio.conf.d/microshift_arm64.conf
+++ b/packaging/crio.conf.d/microshift_arm64.conf
@@ -17,3 +17,5 @@ plugin_dirs = [
 [crio.image]
 global_auth_file="/etc/crio/openshift-pull-secret"
 pause_image = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3ba74464c44486dc96ee871504b0c087ca724da0d589322a70904cfca16d9df6"
+pause_image_auth_file = "/etc/crio/openshift-pull-secret"
+pause_command = "/usr/bin/pod"

--- a/packaging/crio.conf.d/microshift_arm64.conf
+++ b/packaging/crio.conf.d/microshift_arm64.conf
@@ -2,8 +2,17 @@
 selinux = true
 conmon = ""
 conmon_cgroup = "pod"
+default_env = [
+    "NSS_SDB_USE_CACHE=no",
+]
 cgroup_manager = "systemd"
 default_runtime = "crun"
+default_sysctls = [
+    "net.ipv4.ping_group_range=0 2147483647",
+]
+absent_mount_sources_to_reject = [
+    "/etc/hostname",
+]
 
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here


### PR DESCRIPTION
openshift pod image places pause exec under /usr/bin/pod while the default path for pause exec is set to "/pause".
