### PR TITLE
USHIFT-938: Ansible RHEL9 & 4.13 changes

### DIFF
--- a/ansible/roles/install-logging/defaults/main.yml
+++ b/ansible/roles/install-logging/defaults/main.yml
@@ -2,8 +2,8 @@
 # install-logging default vars
 
 logging_packages:
- - golang-github-prometheus
- - grafana
+  - golang-github-prometheus
+  - grafana
 
 logging_services:
   - prometheus

--- a/ansible/roles/install-logging/tasks/main.yml
+++ b/ansible/roles/install-logging/tasks/main.yml
@@ -23,7 +23,7 @@
   when: (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat") or (ansible_distribution == "Fedora")
 
 - name: copy prometheus config
-  template:
+  ansible.builtin.template:
     src: prometheus.yml.j2
     dest: /etc/prometheus/prometheus.yml
     backup: true
@@ -38,6 +38,10 @@
 - name: get content of microshift grafana dashboard
   ansible.builtin.set_fact:
     microshift_dashboard: "{{ lookup('ansible.builtin.file', 'microshift_perf.json') }}"
+
+# The following URI commands fail without accessing some external network
+- name: wake up network access
+  ansible.builtin.command: curl github.com
 
 - name: create prometheus datasource in grafana
   ansible.builtin.uri:

--- a/ansible/roles/manage-repos/defaults/main.yml
+++ b/ansible/roles/manage-repos/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 # manage-repos default vars
 
+ocp_repo_name: rhocp-4.13-for-rhel-{{ ansible_distribution_major_version }}-mirrorbeta-{{ ansible_architecture }}-rpms
+ocp_version: 4.12
 rhel_repos:
-  - rhel-8-for-x86_64-baseos-rpms
-  - rhel-8-for-x86_64-appstream-rpms
-  - codeready-builder-for-rhel-8-x86_64-rpms
-  - fast-datapath-for-rhel-8-x86_64-rpms
-  - rhocp-4.10-for-rhel-8-x86_64-rpms
+  - rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-baseos-rpms
+  - rhel-{{ ansible_distribution_major_version }}-for-{{ ansible_architecture }}-appstream-rpms
+  - codeready-builder-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms
+  #- fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms
+  #- rhocp-{{ ocp_version }}-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms

--- a/ansible/roles/manage-repos/tasks/main.yml
+++ b/ansible/roles/manage-repos/tasks/main.yml
@@ -41,6 +41,11 @@
       name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm'
       disable_gpg_check: true
       state: present
+
+  - name: install ocp beta repo
+    ansible.builtin.template:
+      src: ocpbeta.repo.j2
+      dest: /etc/yum.repos.d/{{ ocp_repo_name }}.repo
   when: ansible_distribution == "RedHat"
 
 - name: gather the package facts

--- a/ansible/roles/manage-repos/templates/ocpbeta.repo.j2
+++ b/ansible/roles/manage-repos/templates/ocpbeta.repo.j2
@@ -1,0 +1,6 @@
+[{{ ocp_repo_name }}]
+name=Beta rhocp-4.13 RPMs for RHEL {{ ansible_distribution_major_version }} 
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/dependencies/rpms/4.13-el{{ ansible_distribution_major_version }}-beta/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0

--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -1,11 +1,19 @@
 ---
 # setup-microshift-host default vars
 
+go_arch: arm64
+go_files:
+  - go
+  - gofmt
+go_version: 1.19.6
+go_install_dir: /usr/local/go{{ go_version }}
+
 install_packages:
   - bash-completion
   - firewalld
   - git
   - golang
+  - jq
   - lvm2
   - make
   - openshift-clients
@@ -13,6 +21,7 @@ install_packages:
   - perf
   - rpm-build
   - selinux-policy-devel 
+  - tar
   - vnstat
 
 vg_name: rhel

--- a/ansible/roles/setup-microshift-host/tasks/main.yml
+++ b/ansible/roles/setup-microshift-host/tasks/main.yml
@@ -7,6 +7,31 @@
     state: present
     update_cache: true
 
+- name: determine system architecture
+  ansible.builtin.set_fact:
+    go_arch: amd64
+  when: ansible_facts['architecture'] == "x86_64"
+
+- name: create target directory for go version
+  ansible.builtin.file:
+    path: "{{ go_install_dir }}"
+    state: directory
+
+- name: download & extract newer version of golang
+  ansible.builtin.unarchive:
+    src: https://go.dev/dl/go{{ go_version }}.linux-{{ go_arch }}.tar.gz
+    dest: "{{ go_install_dir }}"
+    remote_src: yes
+    extra_opts:
+      - "--strip-components=1"
+
+- name: create symbolic links
+  ansible.builtin.file:
+    src: "{{ go_install_dir }}/bin/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    state: link
+  with_items: "{{ go_files }}"
+
 - name: start and enable firewalld
   ansible.builtin.systemd:
     name: firewalld
@@ -28,6 +53,7 @@
   ansible.builtin.dnf:
     name: "*"
     state: latest
+    nobest: true
   notify: reboot machine
 
 - name: flush handlers


### PR DESCRIPTION
- Hack to fix URI module for grafana manipulation
- Add OCP beta mirror repo for 4.13
- Add go 1.19 to build for 4.13
- Small spacing changes
- Reorder package installation and add package for RHEL9 prereqs
