### PR TITLE
OCPBUGS-8411: Use lower case node names only

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,7 +244,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	return &MicroshiftConfig{
 		LogVLevel:       2,
 		SubjectAltNames: subjectAltNames,
-		NodeName:        nodeName,
+		NodeName:        strings.ToLower(nodeName),
 		NodeIP:          nodeIP,
 		BaseDomain:      "example.com",
 		Cluster: ClusterConfig{
@@ -269,7 +269,7 @@ func (c *MicroshiftConfig) isDefaultNodeName() bool {
 	if err != nil {
 		klog.Fatalf("Failed to get hostname %v", err)
 	}
-	return c.NodeName == hostname
+	return c.NodeName == strings.ToLower(hostname)
 }
 
 // Read or set the NodeName that will be used for this MicroShift instance
@@ -393,7 +393,7 @@ func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	// Wire new Config type to existing MicroshiftConfig
 	c.LogVLevel = config.GetVerbosity()
 	if config.Node.HostnameOverride != "" {
-		c.NodeName = config.Node.HostnameOverride
+		c.NodeName = strings.ToLower(config.Node.HostnameOverride)
 	}
 	if config.Node.NodeIP != "" {
 		c.NodeIP = config.Node.NodeIP


### PR DESCRIPTION
While hostnames may have whatever case is desired by the user, resources in kubernetes must be lower case. Node name was directly copied from the hostname, resulting in upper case characters, if any. This prevents creation of the node and many other interactions between kubelet and apiserver.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
