### PR TITLE
OCPBUGS-8425: Fix the kustomization procedure not to exit with fatal error

### DIFF
--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -56,7 +56,7 @@ func (s *Kustomizer) ApplyKustomizationPath(path string) {
 	if _, err := os.Stat(kustomization); !errors.Is(err, os.ErrNotExist) {
 		klog.Infof("Applying kustomization at %v ", kustomization)
 		if err := ApplyKustomizationWithRetries(path, s.kubeconfig); err != nil {
-			klog.Fatalf("Applying kustomization at %v failed: %s. Giving up.", kustomization, err)
+			klog.Errorf("Applying kustomization at %v failed: %s. Giving up.", kustomization, err)
 		} else {
 			klog.Infof("Kustomization at %v applied successfully.", kustomization)
 		}
@@ -66,7 +66,7 @@ func (s *Kustomizer) ApplyKustomizationPath(path string) {
 }
 
 func ApplyKustomizationWithRetries(kustomization string, kubeconfig string) error {
-	return wait.Poll(retryInterval, retryTimeout, func() (bool, error) {
+	return wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
 		if err := ApplyKustomization(kustomization, kubeconfig); err != nil {
 			klog.Infof("Applying kustomization failed: %s. Retrying in %s.", err, retryInterval)
 			return false, nil


### PR DESCRIPTION
Closes OCPBUGS-8425

Example of a failed run, which backs off after 1m of retries, logs an error and proceeds.
```
kustomizer I0312 18:30:20.289488  180399 manager.go:114] Starting kustomizer
kustomizer I0312 18:30:20.289524  180399 apply.go:64] No kustomization found at /usr/lib/microshift/manifests/kustomization.yaml
kustomizer I0312 18:30:20.289532  180399 apply.go:57] Applying kustomization at /etc/microshift/manifests/kustomization.yaml 
kustomizer I0312 18:30:20.738705  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:30:30.790331  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:30:40.806277  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:30:50.811309  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:31:00.794630  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:31:10.800532  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:31:20.785916  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer I0312 18:31:20.857375  180399 apply.go:71] Applying kustomization failed: accumulating resources: accumulating resources from 'busybox.yaml': MalformedYAMLError: yaml: line 20: could not find expected ':' in File: busybox.yaml. Retrying in 10s.
kustomizer E0312 18:31:20.857418  180399 apply.go:59] Applying kustomization at /etc/microshift/manifests/kustomization.yaml failed: timed out waiting for the condition. Giving up.
kustomizer I0312 18:31:20.857431  180399 manager.go:119] kustomizer completed
```
