### PR TITLE
[release-4.12] OCPBUGS-8411: Use lower case node names only 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -215,7 +215,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	return &MicroshiftConfig{
 		LogVLevel:       2,
 		SubjectAltNames: subjectAltNames,
-		NodeName:        nodeName,
+		NodeName:        strings.ToLower(nodeName),
 		NodeIP:          nodeIP,
 		BaseDomain:      "example.com",
 		Cluster: ClusterConfig{
@@ -233,7 +233,7 @@ func (c *MicroshiftConfig) isDefaultNodeName() bool {
 	if err != nil {
 		klog.Fatalf("Failed to get hostname %v", err)
 	}
-	return c.NodeName == hostname
+	return c.NodeName == strings.ToLower(hostname)
 }
 
 // Read or set the NodeName that will be used for this MicroShift instance
@@ -357,7 +357,7 @@ func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	// Wire new Config type to existing MicroshiftConfig
 	c.LogVLevel = config.GetVerbosity()
 	if config.Node.HostnameOverride != "" {
-		c.NodeName = config.Node.HostnameOverride
+		c.NodeName = strings.ToLower(config.Node.HostnameOverride)
 	}
 	if config.Node.NodeIP != "" {
 		c.NodeIP = config.Node.NodeIP


### PR DESCRIPTION
cherry-pick