### PR TITLE
 reduce timeout between pod mount retries

### DIFF
--- a/scripts/auto-rebase/rebase_patches/0040-kubelet-podAttachAndMountTimeout.patch
+++ b/scripts/auto-rebase/rebase_patches/0040-kubelet-podAttachAndMountTimeout.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go b/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go
+index ee58b2fc..8c9c535a 100644
+--- a/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go
++++ b/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go
+@@ -76,7 +76,7 @@ const (
+ 	// request to the pod).
+ 	// Value is slightly offset from 2 minutes to make timeouts due to this
+ 	// constant recognizable.
+-	podAttachAndMountTimeout = 2*time.Minute + 3*time.Second
++	podAttachAndMountTimeout = 13 * time.Second
+ 
+ 	// podAttachAndMountRetryInterval is the amount of time the GetVolumesForPod
+ 	// call waits before retrying

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go
@@ -76,7 +76,7 @@ const (
 	// request to the pod).
 	// Value is slightly offset from 2 minutes to make timeouts due to this
 	// constant recognizable.
-	podAttachAndMountTimeout = 2*time.Minute + 3*time.Second
+	podAttachAndMountTimeout = 13 * time.Second
 
 	// podAttachAndMountRetryInterval is the amount of time the GetVolumesForPod
 	// call waits before retrying


### PR DESCRIPTION
podAttachAndMountTimeout indirectly controls how often VolumeManager processes a Pod by blocking goroutine for the value but marking Pod for processing happens just before that blocking

by reducing the timeout, it's marked for processing more frequently reducing overall time needed by Pod (w/ PVC) to start after system reboot (happens when kubelet wants to create the Pod before topolvm-node is running)