### PR TITLE
USHIFT-737: Fix user workload greenboot verification to check for 1 pod

### DIFF
--- a/docs/config/busybox_running_check.sh
+++ b/docs/config/busybox_running_check.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_NAME=$(basename $0)
 PODS_NS_LIST=(busybox)
-PODS_CT_LIST=(3      )
+PODS_CT_LIST=(1      )
 
 # Source the MicroShift health check functions library
 source /usr/share/microshift/functions/greenboot.sh

--- a/docs/greenboot_dev.md
+++ b/docs/greenboot_dev.md
@@ -53,7 +53,7 @@ definition of the user workload namespaces and the expected count of pods.
 
 ```bash
 PODS_NS_LIST=(busybox)
-PODS_CT_LIST=(3      )
+PODS_CT_LIST=(1      )
 ```
 
 The script starts by running sanity checks to verify that it is executed from


### PR DESCRIPTION
Closes [USHIFT-737](https://issues.redhat.com//browse/USHIFT-737)
