### PR TITLE
USHIFT-949: cache getAllHostnames

### DIFF
--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
@@ -58,7 +59,7 @@ type IngressConfig struct {
 	ServingKey         []byte
 }
 
-type EtcdConfig struct {
+type InternalEtcdConfig struct {
 	// The limit on the size of the etcd database; etcd will start failing writes if its size on disk reaches this value
 	QuotaBackendBytes int64
 	// If the backend is fragmented more than `maxFragmentedPercentage`
@@ -67,6 +68,19 @@ type EtcdConfig struct {
 	MaxFragmentedPercentage float64
 	// How often to check the conditions for defragging (0 means no defrags, except for a single on startup if `doStartupDefrag` is set).
 	DefragCheckFreq time.Duration
+	// Whether or not to do a defrag when the server finishes starting
+	DoStartupDefrag bool
+}
+
+type EtcdConfig struct {
+	// The limit on the size of the etcd database; etcd will start failing writes if its size on disk reaches this value
+	QuotaBackendSize string
+	// If the backend is fragmented more than `maxFragmentedPercentage`
+	//		and the database size is greater than `minDefragSize`, do a defrag.
+	MinDefragSize           string
+	MaxFragmentedPercentage float64
+	// How often to check the conditions for defragging (0 means no defrags, except for a single on startup if `doStartupDefrag` is set).
+	DefragCheckFreq string
 	// Whether or not to do a defrag when the server finishes starting
 	DoStartupDefrag bool
 }
@@ -89,17 +103,18 @@ type MicroshiftConfig struct {
 	BaseDomain       string        `json:"baseDomain"`
 	Cluster          ClusterConfig `json:"cluster"`
 
-	Ingress IngressConfig `json:"-"`
-	Etcd    EtcdConfig    `json:"etcd"`
+	Ingress IngressConfig      `json:"-"`
+	Etcd    InternalEtcdConfig `json:"etcd"`
 }
 
 // Top level config file
 type Config struct {
-	DNS       DNS       `json:"dns"`
-	Network   Network   `json:"network"`
-	Node      Node      `json:"node"`
-	ApiServer ApiServer `json:"apiServer"`
-	Debugging Debugging `json:"debugging"`
+	DNS       DNS        `json:"dns"`
+	Network   Network    `json:"network"`
+	Node      Node       `json:"node"`
+	ApiServer ApiServer  `json:"apiServer"`
+	Debugging Debugging  `json:"debugging"`
+	Etcd      EtcdConfig `json:"etcd"`
 }
 
 type Network struct {
@@ -196,7 +211,12 @@ func (cfg *MicroshiftConfig) KubeConfigAdminPath(id string) string {
 	return filepath.Join(dataDir, "resources", string(KubeAdmin), id, "kubeconfig")
 }
 
+var allHostnames []string
+
 func getAllHostnames() ([]string, error) {
+	if len(allHostnames) != 0 {
+		return allHostnames, nil
+	}
 	cmd := exec.Command("/bin/hostname", "-A")
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -209,7 +229,8 @@ func getAllHostnames() ([]string, error) {
 	// Remove duplicates to avoid having them in the certificates.
 	names := strings.Split(outString, " ")
 	set := sets.NewString(names...)
-	return set.List(), nil
+	allHostnames = set.List()
+	return allHostnames, nil
 }
 
 func NewMicroshiftConfig() *MicroshiftConfig {
@@ -229,7 +250,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 	return &MicroshiftConfig{
 		LogVLevel:       2,
 		SubjectAltNames: subjectAltNames,
-		NodeName:        nodeName,
+		NodeName:        strings.ToLower(nodeName),
 		NodeIP:          nodeIP,
 		BaseDomain:      "example.com",
 		Cluster: ClusterConfig{
@@ -238,7 +259,7 @@ func NewMicroshiftConfig() *MicroshiftConfig {
 			ServiceCIDR:          "10.43.0.0/16",
 			ServiceNodePortRange: "30000-32767",
 		},
-		Etcd: EtcdConfig{
+		Etcd: InternalEtcdConfig{
 			MinDefragBytes:          100 * 1024 * 1024, // 100MB
 			MaxFragmentedPercentage: 45,                // percent
 			DefragCheckFreq:         5 * time.Minute,
@@ -254,7 +275,7 @@ func (c *MicroshiftConfig) isDefaultNodeName() bool {
 	if err != nil {
 		klog.Fatalf("Failed to get hostname %v", err)
 	}
-	return c.NodeName == hostname
+	return c.NodeName == strings.ToLower(hostname)
 }
 
 // Read or set the NodeName that will be used for this MicroShift instance
@@ -378,7 +399,7 @@ func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	// Wire new Config type to existing MicroshiftConfig
 	c.LogVLevel = config.GetVerbosity()
 	if config.Node.HostnameOverride != "" {
-		c.NodeName = config.Node.HostnameOverride
+		c.NodeName = strings.ToLower(config.Node.HostnameOverride)
 	}
 	if config.Node.NodeIP != "" {
 		c.NodeIP = config.Node.NodeIP
@@ -401,6 +422,36 @@ func (c *MicroshiftConfig) ReadFromConfigFile(configFile string) error {
 	if len(config.ApiServer.AdvertiseAddress) > 0 {
 		c.KASAdvertiseAddress = config.ApiServer.AdvertiseAddress
 	}
+
+	if config.Etcd.DefragCheckFreq != "" {
+		d, err := time.ParseDuration(config.Etcd.DefragCheckFreq)
+		if err != nil {
+			return fmt.Errorf("failed to parse etcd defragCheckFreq: %v", err)
+		}
+		c.Etcd.DefragCheckFreq = d
+	}
+	if config.Etcd.MinDefragSize != "" {
+		q, err := resource.ParseQuantity(config.Etcd.MinDefragSize)
+		if err != nil {
+			return fmt.Errorf("failed to parse etcd minDefragSize: %v", err)
+		}
+		if !q.IsZero() {
+			c.Etcd.MinDefragBytes = q.Value()
+		}
+	}
+	if config.Etcd.MaxFragmentedPercentage > 0 {
+		c.Etcd.MaxFragmentedPercentage = config.Etcd.MaxFragmentedPercentage
+	}
+	if config.Etcd.QuotaBackendSize != "" {
+		q, err := resource.ParseQuantity(config.Etcd.QuotaBackendSize)
+		if err != nil {
+			return fmt.Errorf("failed to parse etcd quotaBackendSize: %v", err)
+		}
+		if !q.IsZero() {
+			c.Etcd.QuotaBackendBytes = q.Value()
+		}
+	}
+	c.Etcd.DoStartupDefrag = config.Etcd.DoStartupDefrag
 
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -211,7 +211,12 @@ func (cfg *MicroshiftConfig) KubeConfigAdminPath(id string) string {
 	return filepath.Join(dataDir, "resources", string(KubeAdmin), id, "kubeconfig")
 }
 
+var allHostnames []string
+
 func getAllHostnames() ([]string, error) {
+	if len(allHostnames) != 0 {
+		return allHostnames, nil
+	}
 	cmd := exec.Command("/bin/hostname", "-A")
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -224,7 +229,8 @@ func getAllHostnames() ([]string, error) {
 	// Remove duplicates to avoid having them in the certificates.
 	names := strings.Split(outString, " ")
 	set := sets.NewString(names...)
-	return set.List(), nil
+	allHostnames = set.List()
+	return allHostnames, nil
 }
 
 func NewMicroshiftConfig() *MicroshiftConfig {


### PR DESCRIPTION
getAllHostnames is meant to run once on startup to help populate
configuration. In the test suite it may run many times, and it
occasionally blocks looking up the FQDN for hosts. This change caches
the first set of results to avoid blocking on future calls and to make
the tests run more quickly. This change is safe because MicroShift
should be restarted (automatically or by the user) if the network
settings of the host change in a significant way.