### PR TITLE
USHIFT-335: fix mDNS server tests

### DIFF
--- a/pkg/mdns/server/server_test.go
+++ b/pkg/mdns/server/server_test.go
@@ -4,46 +4,62 @@ import (
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFunctionalServer(t *testing.T) {
-	// var stopCh = make(chan struct{})
-	// defer close(stopCh)
-	// r := NewResolver()
-	// populateResolverForTests(r)
+	var stopCh = make(chan struct{})
+	defer close(stopCh)
+	resolver := NewResolver()
+	populateResolverForTests(resolver)
 
-	// loopbackInterface, _ := net.InterfaceByName("lo")
-	// _, err := New(loopbackInterface, r, stopCh)
-	// if err != nil {
-	// 	t.Errorf("Error starting mDNS server on loopback: %q", err)
-	// 	return
-	// }
+	loopbackInterface, _ := net.InterfaceByName("lo")
+	_, err := New(loopbackInterface, resolver, stopCh)
+	if err != nil {
+		t.Errorf("Error starting mDNS server on loopback: %q", err)
+		return
+	}
 
-	// for fullHost, ips := range r.domain {
-	// 	host := strings.TrimRight(fullHost, ".")
-	// 	addrs, err := net.LookupHost(host)
-	// 	if err != nil {
-	// 		t.Errorf("Error resolving mDNS host: %q, %s", host, err)
-	// 	}
+	for fullHost, ips := range resolver.domain {
+		t.Run(fullHost, func(t *testing.T) {
 
-	// 	if countIPMatches(ips, addrs) != len(ips) {
-	// 		t.Errorf("Not all ips %+v for %q found in resolution: %+v", ips, fullHost, addrs)
-	// 	}
-	// }
+			host := strings.TrimRight(fullHost, ".")
+			addrs, err := net.LookupHost(host)
+			if err != nil {
+				t.Errorf("Error resolving mDNS host: %q, %s", host, err)
+			}
+			for _, ip := range ips {
+
+				// Avahi is configured to only return IPv4 addresses by
+				// default. Enabling IPv6 may introduce significant delays when
+				// looking for a name that does not exist. Therefore this test
+				// only checks IPv4 addresses, to keep the test fast and to ensure
+				// that the developer host configuration does not need to be set
+				// in a degraded state by default.
+				// https://unix.stackexchange.com/questions/586334/how-to-enable-mdns-for-ipv6-on-ubuntu-and-debian
+				// https://bugzilla.redhat.com/show_bug.cgi?id=821127
+				// https://fedoraproject.org/wiki/Tools/Avahi
+				if len(ip) == net.IPv6len {
+					continue
+				}
+
+				t.Run(ip.String(), func(t *testing.T) {
+					assert.True(t, ipInList(ip, addrs), "did not find %s in %v", ip, addrs)
+				})
+			}
+		})
+	}
 }
 
-func countIPMatches(ips []net.IP, addrs []string) int {
-	found := 0
-	for _, ip := range ips {
-		for _, addr := range addrs {
-			// resolved IPv6 come in the IP%interface format, like 2001:db8::dead:beef%lo
-			addrParts := strings.Split(addr, "%")
-			ip2 := net.ParseIP(addrParts[0])
-			if ip.Equal(ip2) {
-				found += 1
-				break
-			}
+func ipInList(ip net.IP, addrs []string) bool {
+	for _, addr := range addrs {
+		// resolved IPv6 come in the IP%interface format, like 2001:db8::dead:beef%lo
+		addrParts := strings.Split(addr, "%")
+		ip2 := net.ParseIP(addrParts[0])
+		if ip.Equal(ip2) {
+			return true
 		}
 	}
-	return found
+	return false
 }

--- a/pkg/mdns/server/server_test.go
+++ b/pkg/mdns/server/server_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestFunctionalServer(t *testing.T) {
+	// var stopCh = make(chan struct{})
+	// defer close(stopCh)
+	// r := NewResolver()
+	// populateResolverForTests(r)
+
+	// loopbackInterface, _ := net.InterfaceByName("lo")
+	// _, err := New(loopbackInterface, r, stopCh)
+	// if err != nil {
+	// 	t.Errorf("Error starting mDNS server on loopback: %q", err)
+	// 	return
+	// }
+
+	// for fullHost, ips := range r.domain {
+	// 	host := strings.TrimRight(fullHost, ".")
+	// 	addrs, err := net.LookupHost(host)
+	// 	if err != nil {
+	// 		t.Errorf("Error resolving mDNS host: %q, %s", host, err)
+	// 	}
+
+	// 	if countIPMatches(ips, addrs) != len(ips) {
+	// 		t.Errorf("Not all ips %+v for %q found in resolution: %+v", ips, fullHost, addrs)
+	// 	}
+	// }
+}
+
+func countIPMatches(ips []net.IP, addrs []string) int {
+	found := 0
+	for _, ip := range ips {
+		for _, addr := range addrs {
+			// resolved IPv6 come in the IP%interface format, like 2001:db8::dead:beef%lo
+			addrParts := strings.Split(addr, "%")
+			ip2 := net.ParseIP(addrParts[0])
+			if ip.Equal(ip2) {
+				found += 1
+				break
+			}
+		}
+	}
+	return found
+}

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -52,8 +52,9 @@ fi
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift
 sudo dnf clean all -y
 sudo dnf update -y
-sudo dnf install -y git cockpit make golang jq selinux-policy-devel rpm-build jq bash-completion
+sudo dnf install -y git cockpit make golang jq selinux-policy-devel rpm-build jq bash-completion nss-mdns
 sudo systemctl enable --now cockpit.socket
+sudo systemctl enable --now avahi-daemon.service
 
 # Install go1.19
 # This is installed into different location (/usr/local/bin/go) from dnf installed Go (/usr/bin/go) so it doesn't conflict


### PR DESCRIPTION
Limit the tests to IPv4 lookups only. Restructure the code so each address
lookup is its own subtest. Simplify the actual test using the assert
package to verify that the expected address appears in the list of
responses.