### PR TITLE
USHIFT-956: optimize rpm build time

### DIFF
--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -57,7 +57,12 @@ EOF
   cat "${SCRIPT_DIR}/microshift.spec" >> "${RPMBUILD_DIR}SPECS/microshift.spec"
 
   title "Building RPM packages"
-  rpmbuild --quiet ${RPMBUILD_OPT} --define "_topdir ${RPMBUILD_DIR}" "${RPMBUILD_DIR}"SPECS/microshift.spec
+  # _binary_payload refers to the compression algorithm to be used in the final RPM.
+  # To see the defaults run `rpmbuild --showrc | grep binary_payload`. In this case
+  # it yields w19.zstdio, which means compression level 19 using zstd algorithm. To
+  # speed this up it runs w19T8.zstdio, which is the 8 thread version of the same
+  # algorithm.
+  rpmbuild --quiet ${RPMBUILD_OPT} --define "_topdir ${RPMBUILD_DIR}" --define "_binary_payload w19T8.zstdio" "${RPMBUILD_DIR}"SPECS/microshift.spec
 }
 
 usage() {


### PR DESCRIPTION
Use 8 threads parallelization with the same compression algorithm.
Results in a dev machine with 3 cores:
Before optimization
$ time make rpm
real	1m57.313s
user	2m0.536s
sys	0m5.801s

After optimization
$ time make rpm
real	0m25.741s
user	0m30.174s
sys	0m5.869s

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
