### PR TITLE
ETCD-403: Revert user configuration for etcd and change default max quota

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -21,11 +21,7 @@ apiServer:
 debugging:
   logLevel: ""
 etcd:
-  quotaBackendSize: ""
-  defragCheckFreq: ""
-  doStartupDefrag: false
-  minDefragSize: ""
-  maxFragmentedPercentage: 0
+  memoryLimitMB: 0
 ```
 
 ## Default Settings
@@ -49,11 +45,7 @@ apiServer:
 debugging:
   logLevel: "Normal"
 etcd:
-  quotaBackendSize: "2Gi"
-  defragCheckFreq: "5m"
-  doStartupDefrag: true
-  minDefragSize: "100Mi"
-  maxFragmentedPercentage: 45
+  memoryLimitMB: 0
 ```
 
 ## Service NodePort range
@@ -89,6 +81,14 @@ List of ports that you must avoid:
 | 10248/tcp     | kubelet healthz port
 | 10259/tcp     | kube scheduler
 |---------------|-----------------------------------------------------------------|
+
+## Etcd Memory Limit
+
+By default, etcd will be allowed to use as much memory as it needs to handle the load on the system; however, in memory constrained systems, it may be preferred or necessary to limit the amount of memory etcd is allowed to use at a given time.
+
+Setting the `memoryLimitMB` to a value greater than 0 will result in a soft memory limit being applied to etcd; etcd will be allowed to go over this value during operation, but memory will be more aggresively reclaimed from it if it does. A value of `128` megabytes is the recommended starting place for this limit; however, the configuration floor is `50` megabytes - attempting to set the limit below 50 megabytes will result in the configuration being 50 megabytes.
+
+Please note that values between 50 and 128 megabytes will heavily trade off memory footprint for etcd performance: the lower the memory limit, the more time etcd will spend on paging memory to disk and will take longer to respond to queries or even timing requests out if the limit is low and the etcd usage is high.
 
 # Auto-applying Manifests
 

--- a/etcd/cmd/microshift-etcd/run.go
+++ b/etcd/cmd/microshift-etcd/run.go
@@ -186,6 +186,9 @@ func setURL(hostnames []string, port string) []url.URL {
 	return urls
 }
 
+// The following 'fragemented' logic is copied from the Openshift Cluster Etcd Operator.
+//
+//	https://github.com/openshift/cluster-etcd-operator/blob/0584b0d1c8868535baf889d8c199f605aef4a3ae/pkg/operator/defragcontroller/defragcontroller.go#L282
 func isBackendFragmented(b backend.Backend, maxFragmentedPercentage float64, minDefragBytes int64) bool {
 	fragmentedPercentage := checkFragmentationPercentage(b.Size(), b.SizeInUse())
 	if fragmentedPercentage > 0.00 {

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -31,18 +31,5 @@ debugging:
   #logLevel: 'Normal'
 
 etcd:
-  # The limit on the size of the etcd database; the etcd server will start failing writes if its size on disk reaches this value. (Default: 2GB)
-  #quotaBackendSize: '2Gi'
-
-  # How often to check the conditions for defragmenting the etcd database (0 means no defrags, except for a single on startup if `doStartupDefrag` is set). (Default: 5 minutes)
-  #defragCheckFreq: '5m'
-
-  # Whether or not to defragment the etcd database when the etcd server finishes starting. (Default: true)
-  #doStartupDefrag: true
-
-  # Defragment conditions: if both of the following are true when the condition check (controlled by the DefragCheckFreq) runs, defragment the etcd database.
-  # The minimum size of the etcd database, if the database is smaller than this value, defragmenting will not occur. (Default: 100MB)
-  #minDefragSize: '100Mi'
-
-  # The maximum allowed fragmented percentage, if the database is fragmented less than this value, defragmenting will not occur. (Default: 45)
-  #maxFragmentedPercentage: 45
+  # Memory limit for etcd, in Megabytes: 0 is no limit.
+  #memoryLimitMB: 0

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -57,13 +57,6 @@ func TestConfigFile(t *testing.T) {
 				Debugging: Debugging{
 					LogLevel: "Debug",
 				},
-				Etcd: EtcdConfig{
-					QuotaBackendSize:        "2Gi",
-					MinDefragSize:           "100Mi",
-					MaxFragmentedPercentage: 45,
-					DefragCheckFreq:         "5m",
-					DoStartupDefrag:         true,
-				},
 			},
 			expected: MicroshiftConfig{
 				LogVLevel:           4,
@@ -78,8 +71,9 @@ func TestConfigFile(t *testing.T) {
 					ServiceCIDR:          "40.30.20.10/16",
 					ServiceNodePortRange: "1024-32767",
 				},
-				Etcd: InternalEtcdConfig{
-					QuotaBackendBytes:       2 * 1024 * 1024 * 1024,
+				Etcd: EtcdConfig{
+					MemoryLimit:             0,
+					QuotaBackendBytes:       8 * 1024 * 1024 * 1024,
 					MinDefragBytes:          100 * 1024 * 1024,
 					MaxFragmentedPercentage: 45,
 					DefragCheckFreq:         5 * time.Minute,
@@ -157,13 +151,6 @@ func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 				Debugging: Debugging{
 					LogLevel: "Debug",
 				},
-				Etcd: EtcdConfig{
-					QuotaBackendSize:        "2Gi",
-					MinDefragSize:           "100Mi",
-					MaxFragmentedPercentage: 45,
-					DefragCheckFreq:         "5m",
-					DoStartupDefrag:         true,
-				},
 			},
 			expected: MicroshiftConfig{
 				LogVLevel:           4,
@@ -180,8 +167,9 @@ func TestMicroshiftConfigReadAndValidate(t *testing.T) {
 					ServiceNodePortRange: "1024-32767",
 					DNS:                  "40.30.0.10",
 				},
-				Etcd: InternalEtcdConfig{
-					QuotaBackendBytes:       2 * 1024 * 1024 * 1024,
+				Etcd: EtcdConfig{
+					MemoryLimit:             0,
+					QuotaBackendBytes:       8 * 1024 * 1024 * 1024,
 					MinDefragBytes:          100 * 1024 * 1024,
 					MaxFragmentedPercentage: 45,
 					DefragCheckFreq:         5 * time.Minute,


### PR DESCRIPTION
To simplify the configuration, this PR reverts the changes made by #1435. Also, this sets the maximum on-disk quota for etcd to be the maximum allowed (and aligned with Openshift) as the default to reduce the likelihood that a customer will hit the quota during runtime.
