### PR TITLE
PERFSCALE-2108: Enable logging for Microshift built-in kubelet metrics

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -109,12 +109,11 @@ The MicroShift host name or IP address must be configured to match the current e
 > The following Ansible command line options can be used instead of editing the `inventory/inventory` file.
 > - `-e ansible_host_var=<hostname>`
 > - `-e ansible_user_var=<username>`
-> - `-e private_ip_var=<ipaddress>`
 
 **Sample Inventory File**
 ```
 [microshift]
-microshift-dev ansible_host=microshift-dev private_ip=
+microshift-dev ansible_host=microshift-dev
 
 [microshift:vars]
 ansible_user=microshift

--- a/ansible/inventory/inventory
+++ b/ansible/inventory/inventory
@@ -1,5 +1,5 @@
 [microshift]
-microshift-dev ansible_host="{{ ansible_host_var | default('microshift-dev') }}" private_ip="{{ private_ip_var | default('') }}"
+microshift-dev ansible_host="{{ ansible_host_var | default('microshift-dev') }}"
 
 [microshift:vars]
 ansible_user="{{ ansible_user_var | default('microshift') }}"

--- a/ansible/roles/add-kubelet-logging/defaults/main.yml
+++ b/ansible/roles/add-kubelet-logging/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# add-kubelet-logging default vars
+
+prometheus_dir: /etc/prometheus
+prometheus_config: "{{ prometheus_dir}}/prometheus.yml"
+kubelet_auth_token_file: "{{ prometheus_dir}}/token"

--- a/ansible/roles/add-kubelet-logging/files/metrics-sa.yaml
+++ b/ansible/roles/add-kubelet-logging/files/metrics-sa.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/ansible/roles/add-kubelet-logging/tasks/main.yml
+++ b/ansible/roles/add-kubelet-logging/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# add-kubelet-logging tasks
+
+- name: check to ensure promdir target exists
+  ansible.builtin.stat:
+    path: "{{ prometheus_dir }}"
+  register: promdir
+
+- name: load sa-token from localhost
+  ansible.builtin.slurp:
+    src: sa-token
+  register: bearer_token
+  delegate_to: localhost
+
+- name: copy metrics service account yaml
+  ansible.builtin.copy:
+    content: "{{ bearer_token.content | b64decode }}"
+    dest: "{{ kubelet_auth_token_file }}"
+  when: promdir.stat.exists
+
+- name: append kubelet scrape config target to prometheus config
+  ansible.builtin.blockinfile:
+    path: "{{ prometheus_config }}"
+    block: |
+      # kubelet targets
+        - job_name: kubelet
+          scheme: https
+          authorization:
+            credentials_file: "{{ kubelet_auth_token_file }}"
+          tls_config:
+            insecure_skip_verify: true
+          static_configs:
+            - targets:
+              - microshift-dev:10250
+
+        - job_name: kubelet cadvisor
+          scheme: https
+          authorization:
+            credentials_file: "{{ kubelet_auth_token_file }}"
+          tls_config:
+            insecure_skip_verify: true
+          metrics_path: /metrics/cadvisor
+          static_configs:
+            - targets:
+              - microshift-dev:10250
+
+- name: restart prometheus to pick up new target
+  ansible.builtin.systemd:
+    state: restarted
+    name: prometheus

--- a/ansible/roles/configure-firewall/defaults/main.yml
+++ b/ansible/roles/configure-firewall/defaults/main.yml
@@ -19,6 +19,7 @@ firewall_ports:
   - 9100/tcp
   - 9256/tcp
   - 9537/tcp
+  - 10250/tcp
   - 17001/tcp
   - 30000-32767/tcp
   - 30000-32767/udp

--- a/ansible/roles/create-service-account/defaults/main.yml
+++ b/ansible/roles/create-service-account/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# create-service-account default vars
+
+prometheus_dir: /etc/prometheus

--- a/ansible/roles/create-service-account/tasks/main.yml
+++ b/ansible/roles/create-service-account/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# create-service-account tasks
+
+- name: copy metrics service account yaml
+  ansible.builtin.copy:
+    src: metrics-sa.yaml
+    dest: metrics-sa.yaml
+
+- name: create service account for metrics gathering from kubelet
+  ansible.builtin.command: oc create -f metrics-sa.yaml
+
+- name: create token for service account
+  ansible.builtin.command: oc create token metrics-server -n kube-system
+  register: token
+
+- name: remove metrics service account yaml
+  ansible.builtin.file:
+    path: metrics-sa.yaml
+    state: absent
+
+- name: save token to disk
+  ansible.builtin.copy:
+    content: "{{ token.stdout }}"
+    dest: sa-token
+  delegate_to: localhost

--- a/ansible/roles/create-service-account/tasks/metrics-sa.yaml
+++ b/ansible/roles/create-service-account/tasks/metrics-sa.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/ansible/roles/install-logging-exporters/defaults/main.yml
+++ b/ansible/roles/install-logging-exporters/defaults/main.yml
@@ -1,9 +1,9 @@
+cadvisor_external: false
 cadvisor_url: https://github.com/google/cadvisor/releases/download/v0.39.2/cadvisor
 cadvisor_checksum: sha256:65109ea14132bce91bb2a92dc70248c705ba26fb2a7d55e295bf4192940a396c
 
 process_exporter_url: https://github.com/ncabatoff/process-exporter/releases/download/v0.7.10/process-exporter_0.7.10_linux_amd64.rpm
 
 prometheus_services:
-  - cadvisor
   - process-exporter
   - prometheus-node-exporter

--- a/ansible/roles/install-logging-exporters/tasks/main.yml
+++ b/ansible/roles/install-logging-exporters/tasks/main.yml
@@ -1,34 +1,42 @@
-- name: setup prometheus exporters
+- name: install node-exporter
+  ansible.builtin.dnf:
+    name:
+    - golang-github-prometheus-node-exporter
+    state: present
+
+- name: install process-exporter
+  ansible.builtin.dnf:
+    name: "{{ process_exporter_url }}"
+    disable_gpg_check: true
+    state: present
+
+- name: external cadvisor steps
   block:
-  - name: install node-exporter
-    ansible.builtin.dnf:
-      name:
-      - golang-github-prometheus-node-exporter
-      state: present
+    - name: download cadvisor
+      ansible.builtin.get_url:
+        url: "{{ cadvisor_url }}"
+        dest: /usr/bin/cadvisor
+        checksum: "{{ cadvisor_checksum }}"
+        mode: '0755'
 
-  - name: install process-exporter
-    ansible.builtin.dnf:
-      name: "{{ process_exporter_url }}"
-      disable_gpg_check: true
-      state: present
+    - name: install systemd unit for cadvisor
+      ansible.builtin.template:
+        src: cadvisor.service.j2
+        dest: /usr/lib/systemd/system/cadvisor.service
+        backup: true
 
-  - name: download cadvisor
-    ansible.builtin.get_url:
-      url: "{{ cadvisor_url }}"
-      dest: /usr/bin/cadvisor
-      checksum: "{{ cadvisor_checksum }}"
-      mode: '0755'
+    - name: start and enable cadvisor service
+      ansible.builtin.systemd:
+        name: cadvisor
+        daemon_reload: yes
+        state: started
+        enabled: yes
+  when: cadvisor_external | bool
 
-  - name: install systemd unit for cadvisor
-    ansible.builtin.template:
-      src: cadvisor.service.j2
-      dest: /usr/lib/systemd/system/cadvisor.service
-      backup: true
-
-  - name: start and enable prometheus services
-    ansible.builtin.systemd:
-      name: "{{ item }}"
-      daemon_reload: yes
-      state: started
-      enabled: yes
-    with_items: "{{ prometheus_services }}"
+- name: start and enable prometheus exporter services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    daemon_reload: yes
+    state: started
+    enabled: yes
+  with_items: "{{ prometheus_services }}"

--- a/ansible/roles/install-logging/templates/prometheus.yml.j2
+++ b/ansible/roles/install-logging/templates/prometheus.yml.j2
@@ -29,27 +29,27 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
-        - {{ hostvars[host].private_ip }}:9100
+        - {{ host }}:9100
 {% endfor %}
 
   - job_name: process
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
-        - {{ hostvars[host].private_ip }}:9256
+        - {{ host }}:9256
 {% endfor %}
 
   - job_name: cadvisor
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
-        - {{ hostvars[host].private_ip }}:8082
+        - {{ host }}:8082
 {% endfor %}
 
   - job_name: crio
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
-        - {{ hostvars[host].private_ip }}:9537
+        - {{ host }}:9537
 {% endfor %}
 

--- a/ansible/roles/microshift-start/tasks/main.yml
+++ b/ansible/roles/microshift-start/tasks/main.yml
@@ -128,6 +128,9 @@
   until: (pods.stdout | int ) >= 1
   retries: 10
 
+- name: create service account task(s)
+  include_tasks: roles/create-service-account/tasks/main.yml
+
 - name: wait for pods running
   ansible.builtin.shell: oc get pods -A -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}' | grep -c False
   retries: 120

--- a/ansible/setup-node.yml
+++ b/ansible/setup-node.yml
@@ -63,3 +63,12 @@
     - vars/all.yml
   roles:
     - role: microshift-start
+
+- name: add kubelet endpoint to prometheus
+  hosts: logging
+  become: yes
+  gather_facts: no
+  vars_files:
+    - vars/all.yml
+  roles:
+    - role: add-kubelet-logging


### PR DESCRIPTION
- Make external cadvisor process conditional
- Create role to create metrics service account
- Add firewall port for kubelet endpoint
- Create role to modify prometheus config
- Fix file location in microshift-start
- Append kubelet endpoint to prometheus config in playbook