### PR TITLE
USHIFT-960: Replace RHEL 8 references by RHEL 9 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ scale testing, and provisioning of lightweight Kubernetes control planes.
 To run MicroShift, the minimum system requirements are:
 
 - x86_64 or aarch64 CPU architecture
-- Red Hat Enterprise Linux 8 with Extended Update Support (8.6 or later)
+- Red Hat Enterprise Linux 9 with Extended Update Support (9.2 or later)
 - 2 CPU cores
 - 2GB of RAM
 - 2GB of free system root storage for MicroShift and its container images
@@ -34,7 +34,7 @@ Depending on user workload requirements, it may be necessary to add more resourc
 performance, disk space in a root partition for container images, an LVM group for container storage, etc.
 
 ## Deploying MicroShift on Edge Devices
-For production deployments, MicroShift can be run on bare metal hardware or hypervisors supported and certified for the Red Hat Enterprise Linux 8 operating system.
+For production deployments, MicroShift can be run on bare metal hardware or hypervisors supported and certified for the Red Hat Enterprise Linux 9 operating system.
 
 - [Edge systems certified for Red Hat Enterprise Linux](https://catalog.redhat.com/hardware/search?c_catalog_channel=Edge%20System&p=1)
 - [Hypervisors certified for Red Hat Enterprise Linux](https://access.redhat.com/solutions/certified-hypervisors)
@@ -75,4 +75,4 @@ Community documentation sources are managed at <https://github.com/redhat-et/mic
 
 To get started with MicroShift, please refer to the [Getting Started](https://microshift.io/docs/getting-started/) section of the MicroShift [User Documentation](https://microshift.io/docs/user-documentation/).
 
-For information about getting in touch with the MicroShift community, check our [community page](https://microshift.io/docs/community/). 
+For information about getting in touch with the MicroShift community, check our [community page](https://microshift.io/docs/community/).

--- a/docs/devenv_cloud.md
+++ b/docs/devenv_cloud.md
@@ -49,8 +49,7 @@ Proceed by creating a virtual instance using the following parameters.
 * Use a descriptive name prefixed by your user name if the account is shared with others (i.e. `myuser-ushift-dev`)
 * Select the Red Hat Linux operating system family
 * Select the `64-bit (x86)` or `64 bit (Arm)` architecture
-* Select Red Hat Enterprise Linux 8 (HVM) operating system. 
-> Do not attempt to use RHEL 9 as it is not supported for the development environment. The operating system will be upgraded to the 8.7 version in the configuration stage.
+* Select Red Hat Enterprise Linux 9 (HVM) operating system.
 * Select the instance type depending on your architecture of choice:
     * e.g. `c5.metal` for `x86_64`
     * e.g. `c6g.metal` for `aarch64`
@@ -60,7 +59,7 @@ Proceed by creating a virtual instance using the following parameters.
     * 90 GiB root volume on `gp3` storage type
     * 10 GiB data volume on `gp3` storage type
 
-Review your selections and lauch the cloud instance. 
+Review your selections and lauch the cloud instance.
 > Unless noted otherwise, all further configuration should be performed on the cloud instance created in this section.
 
 ### Other Cloud Environments
@@ -84,7 +83,7 @@ sudo useradd -m -s /bin/bash -p "$(openssl passwd -1 ${PASSWORD})" microshift
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift
 
 sudo sed -i 's/PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
-sudo systemctl reload sshd.service 
+sudo systemctl reload sshd.service
 ```
 > Choose a strong password and make sure you configure the security group to limit inbound connections on the SSH port 22 **only** from your IP address.
 
@@ -132,7 +131,7 @@ Follow the instructions in the [Create Virtual Machine](./devenv_setup_auto.md#c
 ```bash
 ./scripts/devenv-builder/create-vm.sh microshift-bench \
     /var/lib/libvirt/images \
-    /var/lib/libvirt/images/rhel-8.7-$(uname -i)-dvd.iso \
+    /var/lib/libvirt/images/rhel-baseos-9.*-$(uname -i)-dvd.iso \
     2 2 10 0 1
 ```
 
@@ -140,7 +139,7 @@ Follow the instructions in the [Create Virtual Machine](./devenv_setup_auto.md#c
 
 ### Virtual Machine Management
 
-To manage a virtual machine remotely, it is possible to use `virsh` command line or `Cockpit` Web interface running on the MicroShift development host. 
+To manage a virtual machine remotely, it is possible to use `virsh` command line or `Cockpit` Web interface running on the MicroShift development host.
 
 However, it is recommended to use the Virtual Machine Manager application to connect to the host remotely via the `File > Add Connection` menu option.
 

--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -41,7 +41,7 @@ In the OS installation wizard, set the following options:
 - Select "Installation Destination"
     - Under "Storage Configuration" sub-section, select "Custom" radial button
     - Select "Done" to open a window for configuring partitions
-    - Under "New Red Hat Enterprise Linux 8.x Installation", click "Click here to create them automatically"
+    - Under "New Red Hat Enterprise Linux 9.x Installation", click "Click here to create them automatically"
     - Select the root partition (`/`)
         - On the right side of the menu, set "Desired Capacity" to `40 GiB`
         - On the right side of the menu, verify the volume group is `rhel`.
@@ -107,7 +107,7 @@ make srpm
 
 The artifacts of the build are located in the `_output/rpmbuild` directory.
 ```bash
-$ cd ~/microshift/_output/rpmbuild && find . -name \*.rpm 
+$ cd ~/microshift/_output/rpmbuild && find . -name \*.rpm
 ./RPMS/x86_64/microshift-4.13.0_0.nightly_2023_01_17_152326_20230124054037_b67f6bc3_dirty-1.el8.x86_64.rpm
 ./RPMS/x86_64/microshift-networking-4.13.0_0.nightly_2023_01_17_152326_20230124054037_b67f6bc3_dirty-1.el8.x86_64.rpm
 ./RPMS/noarch/microshift-release-info-4.13.0_0.nightly_2023_01_17_152326_20230124054037_b67f6bc3_dirty-1.el8.noarch.rpm
@@ -128,7 +128,7 @@ Enable the repositories required for installing MicroShift dependencies.
 
 <details><summary>RHEL</summary>
 
-When working with MicroShift based on a pre-release _minor_ version `Y` of OpenShift, the corresponding RPM repository `rhocp-4.$Y-for-rhel-8-$ARCH-rpms` may not be available yet. In that case, use the `Y-1` released version or a `Y-beta` version from the public `https://mirror.openshift.com/pub/openshift-v4/$ARCH/dependencies/rpms/` OpenShift mirror repository.
+When working with MicroShift based on a pre-release _minor_ version `Y` of OpenShift, the corresponding RPM repository `rhocp-4.$Y-for-rhel-9-$ARCH-rpms` may not be available yet. In that case, use the `Y-1` released version or a `Y-beta` version from the public `https://mirror.openshift.com/pub/openshift-v4/$ARCH/dependencies/rpms/` OpenShift mirror repository.
 
 ```bash
 OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
@@ -314,7 +314,7 @@ To view all the available profiles, run `oc get --raw /debug/pprof`.
 The following error message may be encountered when enabling the OpenShift RPM repositories.
 
 ```
-Error: 'fast-datapath-for-rhel-8-x86_64-rpms' does not match a valid repository ID.
+Error: 'fast-datapath-for-rhel-9-x86_64-rpms' does not match a valid repository ID.
 Use "subscription-manager repos --list" to see valid repositories.
 ```
 
@@ -325,18 +325,18 @@ $ sudo subscription-manager repos --list-enabled
 +----------------------------------------------------------+
     Available Repositories in /etc/yum.repos.d/redhat.repo
 +----------------------------------------------------------+
-Repo ID:   rhel-8-for-x86_64-appstream-rpms
-Repo Name: Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-Repo URL:  https://cdn.redhat.com/content/dist/rhel8/$releasever/x86_64/appstream/os
+Repo ID:   rhel-9-for-x86_64-baseos-rpms
+Repo Name: Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
+Repo URL:  https://cdn.redhat.com/content/dist/rhel9/$releasever/x86_64/baseos/os
 Enabled:   1
 
-Repo ID:   fast-datapath-for-rhel-8-x86_64-rpms
-Repo Name: Fast Datapath for RHEL 8 x86_64 (RPMs)
-Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os
+Repo ID:   fast-datapath-for-rhel-9-x86_64-rpms
+Repo Name: Fast Datapath for RHEL 9 x86_64 (RPMs)
+Repo URL:  https://cdn.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os
 Enabled:   1
 
-Repo ID:   rhel-8-for-x86_64-baseos-rpms
-Repo Name: Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
-Repo URL:  https://cdn.redhat.com/content/dist/rhel8/$releasever/x86_64/baseos/os
+Repo ID:   rhel-9-for-x86_64-appstream-rpms
+Repo Name: Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)
+Repo URL:  https://cdn.redhat.com/content/dist/rhel9/$releasever/x86_64/appstream/os
 Enabled:   1
 ```

--- a/docs/greenboot_dev.md
+++ b/docs/greenboot_dev.md
@@ -109,13 +109,13 @@ previous state. Use the `rpm-ostree` command to verify the current deployment.
 $ rpm-ostree status
 State: idle
 Deployments:
-  edge:rhel/8/x86_64/edge
-                  Version: 8.7 (2022-12-26T10:28:32Z)
+  edge:rhel/9/x86_64/edge
+                  Version: 9.1 (2022-12-26T10:28:32Z)
                      Diff: 1 removed
       RemovedBasePackages: hostname 3.20-6.el8
 
-* edge:rhel/8/x86_64/edge
-                  Version: 8.7 (2022-12-26T10:28:32Z)
+* edge:rhel/9/x86_64/edge
+                  Version: 9.1 (2022-12-26T10:28:32Z)
 ```
 
 Finish by checking that all MicroShift pods run normally and cleaning up
@@ -197,8 +197,8 @@ previous state. Use the `rpm-ostree` command to verify the current deployment.
 $ rpm-ostree status
 State: idle
 Deployments:
-* edge:rhel/8/x86_64/edge
-                  Version: 8.7 (2022-12-28T16:50:54Z)
+* edge:rhel/9/x86_64/edge
+                  Version: 9.1 (2022-12-28T16:50:54Z)
 
   edge:eae8486a204bd72eb56ac35ca9c911a46aff3c68e83855f377ae36a3ea4e87ef
                 Timestamp: 2022-12-29T14:44:48Z

--- a/docs/network/ovn_kubernetes_traffic_flows.md
+++ b/docs/network/ovn_kubernetes_traffic_flows.md
@@ -29,7 +29,7 @@ Below is the node/service/pod information used for the traffic flow examples in 
 ```text
 (host)$ oc get nodes -o wide
 NAME             STATUS   ROLES                         AGE    VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE
-microshift-dev   Ready    control-plane,master,worker   6d6h   v1.25.0   192.168.122.14   <none>        Red Hat Enterprise Linux 8.6 (Ootpa)
+microshift-dev   Ready    control-plane,master,worker   6d6h   v1.26.0   192.168.122.14   <none>        Red Hat Enterprise Linux 9.1 (Plow)
 
 (host)$ oc get pods -A -o wide
 NAMESPACE                  NAME                                  READY   STATUS       RESTARTS     AGE    IP               NODE


### PR DESCRIPTION
All except Getting Started document, which will be handled in a separate PR

Closes [USHIFT-960](https://issues.redhat.com//browse/USHIFT-960)
