### PR TITLE
Override osbuild-composer to use rhel-92 nightly repositories.

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -47,6 +47,20 @@ if [ $RHEL_SUBSCRIPTION = true ] ; then
     fi
 fi
 
+# Temporarily use RHEL 9.2 nightly repositories
+sudo tee /etc/yum.repos.d/rhel-92.repo >/dev/null <<EOF
+[rhel-9-for-x86_64-appstream-nightly-rpms]
+name = Red Hat Enterprise Linux 9 for x86_64 - AppStream Nightly (RPMs)
+baseurl = http://download.eng.tlv.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os/
+enabled = 1
+gpgcheck = 0
+
+[rhel-9-for-x86_64-baseos-nightly-rpms]
+name = Red Hat Enterprise Linux 9 for x86_64 - BaseOS nightly (RPMs)
+baseurl = http://download.eng.tlv.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os/
+enabled = 1
+gpgcheck = 0
+EOF
 # Create Development Virtual Machine > Configuring VM
 # https://github.com/openshift/microshift/blob/main/docs/devenv_setup.md#configuring-vm
 echo -e 'microshift\tALL=(ALL)\tNOPASSWD: ALL' | sudo tee /etc/sudoers.d/microshift

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -318,6 +318,29 @@ ports = ["9256:tcp"]
 EOF
 fi
 
+# Temporarily override osbuild-conposer to use RHEL 9.2 nightly repositories
+sudo mkdir -p /etc/osbuild-composer/repositories/
+sudo tee /etc/osbuild-composer/repositories/rhel-92.json >/dev/null <<EOF
+{
+  "x86_64": [
+    {
+      "name": "baseos",
+      "baseurl": "http://download.eng.tlv.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os/",
+      "rhsm": false,
+      "check_gpg": false
+    },
+    {
+      "name": "appstream",
+      "baseurl": "http://download.eng.tlv.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os/",
+      "rhsm": false,
+      "check_gpg": false
+    }
+  ]
+}
+EOF
+sudo rm -rf /var/cache/osbuild-composer/*
+sudo systemctl restart osbuild-composer
+
 build_image blueprint_v0.0.1.toml "${IMGNAME}-container" 0.0.1 edge-container
 build_image installer.toml        "${IMGNAME}-installer" 0.0.0 edge-installer "${IMGNAME}-container" 0.0.1
 


### PR DESCRIPTION
Provides [rhel-92](https://issues.redhat.com//browse/rhel-92) rpm repo overrides for the composer image build and dev env VM.
**Which issue(s) this PR addresses**:[USHIFT-980](https://issues.redhat.com/browse/USHIFT-980
