### PR TITLE
[release-4.13] OCPBUGS-10532: update ovn-kubernetes to rhel9 based image

### DIFF
--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
       # ovn-northd: convert network objects in nbdb to flows in sbdb
       - name: northd
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
         command:
         - /bin/bash
         - -c
@@ -97,7 +97,7 @@ spec:
 
       # nbdb: the northbound, or logical network object DB. In raft mode
       - name: nbdb
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
         command:
         - /bin/bash
         - -c
@@ -223,7 +223,7 @@ spec:
 
       # sbdb: The southbound, or flow DB. In raft mode
       - name: sbdb
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
         command:
         - /bin/bash
         - -c
@@ -315,7 +315,7 @@ spec:
 
       # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
         command:
         - /bin/bash
         - -c

--- a/assets/components/ovn/node/daemonset.yaml
+++ b/assets/components/ovn/node/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
         command:
         - /bin/bash
         - -c

--- a/assets/release/release-aarch64.json
+++ b/assets/release/release-aarch64.json
@@ -8,7 +8,7 @@
     "haproxy-router": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b7e855f833595e8871b140b2b02ec51bf553c2186615b095f2caf34bfec99fc6",
     "kube-rbac-proxy": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f67aabd2c69a990bcf8ff6565b615ef5c519bedd6ad3f74784bd2ce126cb0540",
     "openssl": "registry.access.redhat.com/ubi8/openssl@sha256:9e743d947be073808f7f1750a791a3dbd81e694e37161e8c6c6057c2c342d671",
-    "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca",
+    "ovn-kubernetes-microshift-rhel-9": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ce7b69828d3928ff464a8c0decfbf668d4ac3d6cc932ed67867c7b2c2d4c5b53",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8dd1449567b0a39e4dd99868caba37a61e212f1865df45538a2030001d9c3ac2",
     "topolvm_csi": "registry.redhat.io/lvms4/topolvm-rhel8@sha256:10bffded5317da9de6c45ba74f0bb10e0a08ddb2bfef23b11ac61287a37f10a1",

--- a/assets/release/release-x86_64.json
+++ b/assets/release/release-x86_64.json
@@ -8,7 +8,7 @@
     "haproxy-router": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ce5e10eef4461c3717d9e0283cb04d592dfa1dcff3f9c27ca71ac908b967a0ea",
     "kube-rbac-proxy": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:017a208e4b613bd3085a0504a8494eb60763af28ed9906a94affdb884b54a04e",
     "openssl": "registry.access.redhat.com/ubi8/openssl@sha256:9e743d947be073808f7f1750a791a3dbd81e694e37161e8c6c6057c2c342d671",
-    "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ab6561dbe5a00a9b96e1c29818d8376c8e871e6757875c9cf7f48e333425065",
+    "ovn-kubernetes-microshift-rhel-9": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ab6561dbe5a00a9b96e1c29818d8376c8e871e6757875c9cf7f48e333425065",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c204064227e6e8eb388e75d7e44c1e4a6d79895433c5962266d8a349ac7f081d",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c9ee67ac927595049bd3854b5c224269452873bb446115d0cf6fe382f54c94b0",
     "topolvm_csi": "registry.redhat.io/lvms4/topolvm-rhel8@sha256:10bffded5317da9de6c45ba74f0bb10e0a08ddb2bfef23b11ac61287a37f10a1",

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -646,13 +646,13 @@ update_images() {
             "${REPOROOT}/packaging/crio.conf.d/microshift_${goarch}.conf"
     done
 
-    # 2023-03-02: Freeze ovn-kubernetes-microshift to avoid using image "double metrics registration panic" issue
+    # 2023-03-02: Freeze ovn-kubernetes-microshift-rhel-9 to avoid using image "double metrics registration panic" issue
     # TODO: Remove when issue is fixed
-    jq -e '.images."ovn-kubernetes-microshift" = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ab6561dbe5a00a9b96e1c29818d8376c8e871e6757875c9cf7f48e333425065"' \
+    jq -e '.images."ovn-kubernetes-microshift-rhel-9" = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5ab6561dbe5a00a9b96e1c29818d8376c8e871e6757875c9cf7f48e333425065"' \
         "${REPOROOT}/assets/release/release-x86_64.json" > "${REPOROOT}/assets/release/release-x86_64.json.tmp"
     mv "${REPOROOT}/assets/release/release-x86_64.json.tmp" "${REPOROOT}/assets/release/release-x86_64.json"
 
-    jq -e '.images."ovn-kubernetes-microshift" = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca"' \
+    jq -e '.images."ovn-kubernetes-microshift-rhel-9" = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca"' \
         "${REPOROOT}/assets/release/release-aarch64.json" > "${REPOROOT}/assets/release/release-aarch64.json.tmp"
     mv "${REPOROOT}/assets/release/release-aarch64.json.tmp" "${REPOROOT}/assets/release/release-aarch64.json"
 


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>
(cherry picked from commit f0585c67818cfe9fe2b68bfe9cb4581f520bb0a8)