### PR TITLE
Fix greenboot script errors when variables are specified in /etc/greenboot/greenboot.conf file

### DIFF
--- a/packaging/greenboot/microshift-pre-rollback.sh
+++ b/packaging/greenboot/microshift-pre-rollback.sh
@@ -3,6 +3,9 @@ set -e -o pipefail
 
 SCRIPT_NAME=$(basename $0)
 
+# Source the MicroShift health check functions library
+source /usr/share/microshift/functions/greenboot.sh
+
 # Set the exit handler to log the exit status
 trap 'script_exit' EXIT
 
@@ -28,13 +31,8 @@ fi
 
 echo "STARTED"
 
-# Dump GRUB boot variables and ostree status affecting the script behavior.
-# This information is important for troubleshooting cleanup issues.
-grub_vars=$(grub2-editenv - list | grep ^boot_ || true)
-[ -z "${grub_vars}" ] && grub_vars=None
-
-echo -e "GRUB boot variables:\n${grub_vars}"
-echo -e "The ostree status:\n$(ostree admin status || true)"
+# Print the boot variable status
+print_boot_status
 
 # Exit normally if the boot counter is not set to zero
 if ! grub2-editenv - list | grep -q ^boot_counter=0 ; then

--- a/packaging/greenboot/microshift-running-check.sh
+++ b/packaging/greenboot/microshift-running-check.sh
@@ -77,17 +77,8 @@ fi
 
 echo "STARTED"
 
-# Dump GRUB boot, Greenboot variables and ostree status affecting the script behavior.
-# This information is important for troubleshooting rollback issues.
-grub_vars=$(grub2-editenv - list | grep ^boot_ || true)
-boot_vars=$(set | egrep '^GREENBOOT_|^MICROSHIFT_' || true)
-
-[ -z "${grub_vars}" ] && grub_vars=None
-[ -z "${boot_vars}" ] && boot_vars=None
-
-echo -e "GRUB boot variables:\n${grub_vars}"
-echo -e "Greenboot variables:\n${boot_vars}"
-echo -e "The ostree status:\n$(ostree admin status || true)"
+# Print the boot variable status
+print_boot_status
 
 # Exit if the MicroShift service is not enabled
 if [ $(systemctl is-enabled microshift.service 2>/dev/null) != "enabled" ] ; then


### PR DESCRIPTION
* Introduce print_boot_status function to properly print variables from all the scripts
* Fix error redirection in the get_wait_timeout function

Closes:
[USHIFT-985](https://issues.redhat.com//browse/USHIFT-985)
[USHIFT-990](https://issues.redhat.com//browse/USHIFT-990)

