### PR TITLE
USHIFT-1011: Fix the usage of predictable file names in /tmp

### DIFF
--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -190,7 +190,7 @@ sudo dnf install -y openshift-clients
 
 ```bash
 OCC_REM=https://mirror.openshift.com/pub/openshift-v4/$(uname -i)/clients/ocp-dev-preview/latest-4.13/openshift-client-linux.tar.gz
-OCC_LOC=/tmp/openshift-client-linux.tar.gz
+OCC_LOC=$(mktemp /tmp/openshift-client-linux-XXXXX.tar.gz)
 
 curl -s ${OCC_REM} --output ${OCC_LOC}
 sudo tar zxf ${OCC_LOC} -C /usr/bin
@@ -226,9 +226,9 @@ It should now be possible to run a standalone MicroShift executable file as pres
 ### Running MicroShift
 Run the MicroShift executable file in the background using the following command.
 ```bash
-nohup sudo ~/microshift/_output/bin/microshift run >> /tmp/microshift.log &
+nohup sudo ~/microshift/_output/bin/microshift run >> ~/microshift.log &
 ```
-Examine the `/tmp/microshift.log` log file to ensure a successful startup.
+Examine the `~/microshift.log` log file to ensure a successful startup.
 
 > An alternative way of running MicroShift is to update `/usr/bin/microshift` file and restart the service. The logs would then be accessible by running the `journalctl -xu microshift` command.
 > ```bash
@@ -252,7 +252,7 @@ watch oc get pods -A
 Run the following command to stop the MicroShift process and make sure it is shut down by examining its log file.
 ```bash
 sudo kill microshift && sleep 3
-tail -3 /tmp/microshift.log
+tail -3 ~/microshift.log
 ```
 > If MicroShift is running as a service, it is necessary to execute the `sudo systemctl stop microshift` command to shut it down and review the output of the `journalctl -xu microshift` command to verify the service termination.
 

--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -196,7 +196,7 @@ It may sometimes be necessary to install a virtual machine that does not have ac
 
 Create a new isolated `libvirt` network configuration by running the following commands.
 ```bash
-NETCONFIG_FILE=/tmp/isolated-network.xml
+NETCONFIG_FILE=$(mktemp /tmp/isolated-network-XXXXX.xml)
 cat > $NETCONFIG_FILE <<EOF
 <network>
   <name>isolated</name>
@@ -215,6 +215,7 @@ EOF
 sudo virsh net-define    $NETCONFIG_FILE
 sudo virsh net-start     isolated
 sudo virsh net-autostart isolated
+rm -f $NETCONFIG_FILE
 ```
 
 Follow the instruction in the [Install MicroShift for Edge](#install-microshift-for-edge) section to install a new virtual machine using the `isolated` network configuration.

--- a/packaging/images/openshift-ci/Dockerfile.test-runtime
+++ b/packaging/images/openshift-ci/Dockerfile.test-runtime
@@ -14,9 +14,11 @@ RUN dnf update -y && \
     dnf clean all && rm -rf /var/cache/dnf/*
 RUN YQ_URL=https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64 ; \
     YQ_HASH=9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582 ; \
-    echo -n "${YQ_HASH} -" > /tmp/sum.txt ; \
-    if ! (curl -Ls "${YQ_URL}" | tee /tmp/yq | sha256sum -c /tmp/sum.txt &>/dev/null); then \
-      echo "ERROR: Expected file at ${YQ_URL} to have checksum ${YQ_HASH} but instead got $(sha256sum </tmp/yq | cut -d' ' -f1)" ; \
+    YQ_EXE=$(mktemp /tmp/yq-exe.XXXXX) ; \
+    YQ_SUM=$(mktemp /tmp/yq-sum.XXXXX) ; \
+    echo -n "${YQ_HASH} -" > ${YQ_SUM} ; \
+    if ! (curl -Ls "${YQ_URL}" | tee ${YQ_EXE} | sha256sum -c ${YQ_SUM} &>/dev/null); then \
+      echo "ERROR: Expected file at ${YQ_URL} to have checksum ${YQ_HASH} but instead got $(sha256sum <${YQ_EXE} | cut -d' ' -f1)" ; \
       exit 1 ; \
     fi ; \
-    chmod +x /tmp/yq && mv /tmp/yq /usr/bin/yq
+    chmod +x ${YQ_EXE} && mv ${YQ_EXE} /usr/bin/yq

--- a/scripts/auto-rebase/get-ci-token.sh
+++ b/scripts/auto-rebase/get-ci-token.sh
@@ -28,9 +28,9 @@ EOF
 fi
 
 # Get a current pull secret for registry.ci.openshift.org using the token
-tmpkubeconfig="/tmp/registry-kubeconfig"
+tmpkubeconfig=$(mktemp /tmp/registry-kubeconfig-XXXXX)
 oc login https://${CI_SERVER}:6443 --kubeconfig=$tmpkubeconfig --token=${CI_TOKEN}
-tmppullsecret="/tmp/registry-pull-secret"
+tmppullsecret=$(mktemp /tmp/registry-pull-secret-XXXXX)
 echo '{}' >$tmppullsecret
 oc registry login --kubeconfig=$tmpkubeconfig --to=$tmppullsecret
 
@@ -38,3 +38,4 @@ echo "Add this to your ~/.pull_secret.json file:"
 echo
 cat $tmppullsecret
 echo
+rm -f $tmpkubeconfig $tmppullsecret

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -48,17 +48,20 @@ check_preconditions() {
     if ! hash yq; then
         title "Installing yq"
 
-        YQ_VER=4.26.1
-        YQ_HASH_amd64=9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582
-        YQ_HASH_arm64=8966f9698a9bc321eae6745ffc5129b5e1b509017d3f710ee0eccec4f5568766
-        yq_hash="YQ_HASH_$(go env GOARCH)"
-        YQ_URL=https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_$(go env GOARCH)
-        echo -n "${!yq_hash} -" > /tmp/sum.txt
-        if ! (curl -Ls "${YQ_URL}" | tee /tmp/yq | sha256sum -c /tmp/sum.txt &>/dev/null); then
-            echo "ERROR: Expected file at ${YQ_URL} to have checksum ${!yq_hash} but instead got $(sha256sum </tmp/yq | cut -d' ' -f1)"
+        local YQ_VER=4.26.1
+        local YQ_HASH_amd64=9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582
+        local YQ_HASH_arm64=8966f9698a9bc321eae6745ffc5129b5e1b509017d3f710ee0eccec4f5568766
+        local YQ_HASH="YQ_HASH_$(go env GOARCH)"
+        local YQ_URL=https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_$(go env GOARCH)
+        local YQ_EXE=$(mktemp /tmp/yq-exe.XXXXX)
+        local YQ_SUM=$(mktemp /tmp/yq-sum.XXXXX)
+        echo -n "${!YQ_HASH} -" > ${YQ_SUM}
+        if ! (curl -Ls "${YQ_URL}" | tee ${YQ_EXE} | sha256sum -c ${YQ_SUM} &>/dev/null); then
+            echo "ERROR: Expected file at ${YQ_URL} to have checksum ${!YQ_HASH} but instead got $(sha256sum <${YQ_EXE} | cut -d' ' -f1)"
             exit 1
         fi
-        chmod +x /tmp/yq && sudo cp /tmp/yq /usr/bin/yq
+        chmod +x ${YQ_EXE} && sudo cp ${YQ_EXE} /usr/bin/yq
+        rm -f ${YQ_EXE} ${YQ_SUM}
     fi
 
     if ! hash python3; then

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -130,7 +130,7 @@ if [ $RHEL_SUBSCRIPTION = true ] ; then
     sudo dnf install -y openshift-clients
 else
     OCC_REM=https://mirror.openshift.com/pub/openshift-v4/$(uname -i)/clients/ocp-dev-preview/latest-4.13/openshift-client-linux.tar.gz
-    OCC_LOC=/tmp/openshift-client-linux.tar.gz
+    OCC_LOC=$(mktemp /tmp/openshift-client-linux-XXXXX.tar.gz)
 
     curl -s ${OCC_REM} --output ${OCC_LOC}
     sudo tar zxf ${OCC_LOC} -C /usr/bin

--- a/scripts/devenv-builder/create-vm.sh
+++ b/scripts/devenv-builder/create-vm.sh
@@ -42,7 +42,7 @@ SYSROOTSIZE=$(( ${SYSROOTSIZE} * 1024 ))
 # Swap size is expected in MB
 SWAPSIZE=$(( ${SWAPSIZE} * 1024 ))
 
-KICKSTART_FILE=/tmp/${VMNAME}-kickstart.ks
+KICKSTART_FILE=$(mktemp /tmp/kickstart-${VMNAME}-XXXXX.ks)
 cat ${ROOTDIR}/config/kickstart.ks.template | \
     sed "s;REPLACE_HOST_NAME;${VMNAME};" | \
     sed "s;REPLACE_SWAP_SIZE;${SWAPSIZE};" | \

--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -17,12 +17,12 @@ sudo dnf install -y mock
 sudo usermod -a -G mock $(whoami)
 
 # Verify umask and home directory permissions
-TEST_FILE=/tmp/configure_perm_test.$$
+TEST_FILE=$(mktemp /tmp/configure-perm-test.XXXXX)
 
-touch ${TEST_FILE}
+touch ${TEST_FILE}.file
 mkdir ${TEST_FILE}.dir
 HOME_PERM=$(stat -c 0%a ~)
-FILE_PERM=$(stat -c 0%a ${TEST_FILE})
+FILE_PERM=$(stat -c 0%a ${TEST_FILE}.file)
 DIR_PERM=$(stat -c 0%a ${TEST_FILE}.dir)
 rm -rf ${TEST_FILE}*
 


### PR DESCRIPTION
After this fix the following /tmp references remain:
```
$ grep -rn /tmp scripts/ hack/ docs/ packaging/ validate-microshift/ | grep -v mktemp
scripts/image-builder/cleanup.sh:60:    sudo rm -rf /tmp/containers/* 2>/dev/null || true
docs/debugging_tips.md:45:The report archives can be found in the `/var/tmp/sosreport-*` files.
docs/debugging_tips.md:48:$ sudo ls -tr /var/tmp/sosreport-* | tail -2
docs/debugging_tips.md:49:/var/tmp/sosreport-host0-2022-11-24-pvbcaji-obfuscated.tar.xz
docs/debugging_tips.md:50:/var/tmp/sosreport-host0-2022-11-24-pvbcaji-obfuscated.tar.xz.sha256
docs/debugging_tips.md:58:sudo rm -f /var/tmp/sosreport-*
docs/rhel4edge_iso.md:27:- The user `~/.cache` and `/tmp/containers` directory contents are deleted to clean various cache files
```

Closes [USHIFT-1011](https://issues.redhat.com//browse/USHIFT-1011)
