### PR TITLE
USHIFT-1007: Fix image builder and getting started configurations to require passord for sudoers

### DIFF
--- a/docs/config/microshift-starter.ks
+++ b/docs/config/microshift-starter.ks
@@ -44,8 +44,8 @@ selinux-policy-devel
 # Post install configuration
 %post --log=/var/log/anaconda/post-install.log --erroronfail
 
-# Allow the default user to run sudo commands without password
-echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' > /etc/sudoers.d/redhat
+# Allow the default user to run sudo commands with password
+echo -e 'redhat\tALL=(ALL)\tPASSWD: ALL' > /etc/sudoers.d/microshift
 
 # Import Red Hat public keys to allow RPM GPG check (not necessary if a system is registered)
 if ! subscription-manager status >& /dev/null ; then
@@ -54,7 +54,7 @@ fi
 
 # Configure systemd journal service to persist logs between boots and limit their size to 1G
 sudo mkdir -p /etc/systemd/journald.conf.d
-cat <<EOF | sudo tee /etc/systemd/journald.conf.d/microshift.conf &>/dev/null
+cat > /etc/systemd/journald.conf.d/microshift.conf <<EOF
 [Journal]
 Storage=persistent
 SystemMaxUse=1G

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -39,18 +39,18 @@ echo -e 'url=http://REPLACE_OSTREE_SERVER_NAME/repo/' >> /etc/ostree/remotes.d/e
 
 # The pull secret is mandatory for MicroShift builds on top of OpenShift, but not OKD
 # The /etc/crio/crio.conf.d/microshift.conf references the /etc/crio/openshift-pull-secret file
-cat > /etc/crio/openshift-pull-secret << EOF
+cat > /etc/crio/openshift-pull-secret <<EOF
 REPLACE_OCP_PULL_SECRET_CONTENTS
 EOF
 chmod 600 /etc/crio/openshift-pull-secret
 
-# Create a default redhat user, allowing it to run sudo commands without password
-useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 -G wheel redhat
-echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+# Create a default redhat user, allowing it to run sudo commands with password
+useradd -m -d /home/redhat -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 redhat
+echo -e 'redhat\tALL=(ALL)\tPASSWD: ALL' > /etc/sudoers.d/microshift
 
 # Add authorized ssh keys
 mkdir -m 700 /home/redhat/.ssh
-cat > /home/redhat/.ssh/authorized_keys << EOF
+cat > /home/redhat/.ssh/authorized_keys <<EOF
 REPLACE_REDHAT_AUTHORIZED_KEYS_CONTENTS
 EOF
 chmod 600 /home/redhat/.ssh/authorized_keys
@@ -67,7 +67,7 @@ echo -e 'export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig' >
 
 # Configure systemd journal service to persist logs between boots and limit their size to 1G
 sudo mkdir -p /etc/systemd/journald.conf.d
-cat <<EOF | sudo tee /etc/systemd/journald.conf.d/microshift.conf &>/dev/null
+cat > /etc/systemd/journald.conf.d/microshift.conf <<EOF
 [Journal]
 Storage=persistent
 SystemMaxUse=1G


### PR DESCRIPTION
- Fix sudoers file creation uses `PASSWD` option for image builder and getting started 
- Configuration files creation is now consistent using `cat` command
- Removed unnecessary `wheel` group assignment for `redhat` user in the R4E ISO

Closes USHIFT-1007
