### PR TITLE
OCPBUGS-10766: Stop using .local domain suffix in the MicroShift VMs

### DIFF
--- a/docs/config/microshift-starter.ks
+++ b/docs/config/microshift-starter.ks
@@ -5,7 +5,7 @@ text
 reboot
 
 # Configure network to use DHCP and activate on boot
-network --bootproto=dhcp --device=link --activate --onboot=on --hostname=microshift-starter.local --noipv6
+network --bootproto=dhcp --device=link --activate --onboot=on --hostname=microshift-starter --noipv6
 
 # Partition disk with a 1GB boot XFS partition and a 10GB LVM volume containing system root
 # The remainder of the volume will be used by the CSI driver for storing data

--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -50,7 +50,7 @@ In the OS installation wizard, set the following options:
     - Click "Done" button.
     - At the "Summary of Changes" window, select "Accept Changes"
 
-- Connect network card and set the hostname (i.e. `microshift-dev.localdomain`)
+- Connect network card and set the hostname (i.e. `microshift-dev`)
 - Register the system with Red Hat using your credentials (toggle off Red Hat Insights connection)
 - In the Software Selection, select Minimal Install base environment and toggle on Headless Management to enable Cockpit
 

--- a/scripts/devenv-builder/config/kickstart.ks.template
+++ b/scripts/devenv-builder/config/kickstart.ks.template
@@ -5,7 +5,7 @@ text
 reboot
 
 # Configure network to use DHCP and activate on boot
-network --bootproto=dhcp --device=link --activate --onboot=on --hostname=REPLACE_HOST_NAME.local --noipv6
+network --bootproto=dhcp --device=link --activate --onboot=on --hostname=REPLACE_HOST_NAME --noipv6
 
 # Partition disk with a 1GB boot XFS partition and an LVM volume containing system root
 # The remainder of the volume will be used by the CSI driver for storing data


### PR DESCRIPTION
Works around OCPBUGS-10766 by not appending .local domain suffix when creating MicroShift VMs. 
Users can explicitly specify an FQDN, which has to be resolved properly.
