### PR TITLE
OCPBUGS-10766: Change apiserver preferred addresses

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -180,7 +180,7 @@ func certSetup(cfg *config.MicroshiftConfig) (*certchains.CertificateChains, err
 						Name:         "kubelet-server",
 						ValidityDays: cryptomaterial.ShortLivedCertificateValidityDays,
 					},
-					Hostnames: []string{cfg.NodeName},
+					Hostnames: []string{cfg.NodeName, cfg.NodeIP},
 				},
 			),
 		),

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -133,7 +133,7 @@ func (s *KubeAPIServer) configure(cfg *config.MicroshiftConfig) error {
 			"kubelet-certificate-authority":   {cryptomaterial.CABundlePath(kubeCSRSignerDir)},
 			"kubelet-client-certificate":      {cryptomaterial.ClientCertPath(kubeletClientDir)},
 			"kubelet-client-key":              {cryptomaterial.ClientKeyPath(kubeletClientDir)},
-			"kubelet-preferred-address-types": {"Hostname"},
+			"kubelet-preferred-address-types": {"InternalIP", "Hostname"},
 
 			"proxy-client-cert-file":           {cryptomaterial.ClientCertPath(aggregatorClientCertDir)},
 			"proxy-client-key-file":            {cryptomaterial.ClientKeyPath(aggregatorClientCertDir)},


### PR DESCRIPTION
In order to avoid DNS configuration unless there is no other way, try using external and internal IPs to reach kubelet from apiserver. This allows having whatever hostname+domain name combinations without trying to resolve the name externally.
To allow this we need to include the node IP in the kubelet certificate as this is what the apiserver will target.
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
