### PR TITLE
USHIFT-1008: Justify why healthz endpoints are not TLS verified

### DIFF
--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -117,7 +117,8 @@ func (s *KubeControllerManager) Run(ctx context.Context, ready chan<- struct{}, 
 
 	// run readiness check
 	go func() {
-		healthcheckStatus := util.RetryInsecureHttpsGet("https://localhost:10257/healthz")
+		// This endpoint uses a self-signed certificate on purpose, we need to skip verification.
+		healthcheckStatus := util.RetryInsecureGet("https://localhost:10257/healthz")
 		if healthcheckStatus != 200 {
 			klog.Errorf("kube-controller-manager failed to start")
 			errorChannel <- errors.New("kube-controller-manager failed to start")

--- a/pkg/controllers/kube-scheduler.go
+++ b/pkg/controllers/kube-scheduler.go
@@ -80,7 +80,8 @@ func (s *KubeScheduler) Run(ctx context.Context, ready chan<- struct{}, stopped 
 
 	// run readiness check
 	go func() {
-		healthcheckStatus := util.RetryInsecureHttpsGet("https://localhost:10259/healthz")
+		// This endpoint uses a self-signed certificate on purpose, we need to skip verification.
+		healthcheckStatus := util.RetryInsecureGet("https://localhost:10259/healthz")
 		if healthcheckStatus != 200 {
 			klog.Errorf("%s healthcheck failed", s.Name(), fmt.Errorf("kube-scheduler failed to start"))
 			errorChannel <- errors.New("kube-scheduler healthcheck failed")

--- a/pkg/node/kubelet.go
+++ b/pkg/node/kubelet.go
@@ -146,7 +146,8 @@ func (s *KubeletServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 	defer close(stopped)
 	// run readiness check
 	go func() {
-		healthcheckStatus := util.RetryInsecureHttpsGet("http://localhost:10248/healthz")
+		// This endpoint does not use TLS, but reusing the same function without verification.
+		healthcheckStatus := util.RetryInsecureGet("http://localhost:10248/healthz")
 		if healthcheckStatus != 200 {
 			klog.Fatalf("", fmt.Errorf("%s failed to start", s.Name()))
 		}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -54,12 +54,17 @@ func GetHostIP() (string, error) {
 	return gatewayIP, nil
 }
 
-func RetryInsecureHttpsGet(url string) int {
-
+func RetryInsecureGet(url string) int {
 	status := 0
 	err := wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		resp, err := http.Get(url)
+		c := http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+		resp, err := c.Get(url)
 		if err == nil {
 			status = resp.StatusCode
 			return true, nil


### PR DESCRIPTION
Includes http client configuration instead of changing global http package variables.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
