### PR TITLE
Start using RHEL 9.2 in the devenv and edge

### DIFF
--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -4,7 +4,7 @@ It is recommended to review the current document and use the automation instruct
 
 ## Create Development Virtual Machine
 Start by downloading one of the supported boot images for the `x86_64` or `aarch64` architecture:
-* RHEL 9.1 from https://developers.redhat.com/products/rhel/download
+* RHEL 9.2 from https://developers.redhat.com/products/rhel/download
 * CentOS 9 Stream from https://www.centos.org/download
 
 ### Creating VM
@@ -66,19 +66,6 @@ sudo dnf clean all -y
 sudo dnf update -y
 sudo dnf install -y git cockpit make golang selinux-policy-devel rpm-build jq bash-completion
 sudo systemctl enable --now cockpit.socket
-
-# Install go1.19
-# This is installed into different location (/usr/local/bin/go) from dnf installed Go (/usr/bin/go) so it doesn't conflict
-# /usr/local/bin is before /usr/bin in $PATH so newer one is picked up
-GO_VER=1.19.4
-GO_ARCH=$([ "$(uname -i)" == "x86_64" ] && echo "amd64" || echo "arm64")
-curl -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.linux-${GO_ARCH}.tar.gz" &&
-    sudo rm -rf "/usr/local/go${GO_VER}" && \
-    sudo mkdir -p "/usr/local/go${GO_VER}" && \
-    sudo tar -C "/usr/local/go${GO_VER}" -xzf "go${GO_VER}.linux-${GO_ARCH}.tar.gz" --strip-components 1 && \
-    sudo rm -rfv /usr/local/bin/{go,gofmt} && \
-    sudo ln --symbolic /usr/local/go${GO_VER}/bin/{go,gofmt} /usr/local/bin/ && \
-    rm -rfv "go${GO_VER}.linux-${GO_ARCH}.tar.gz"
 ```
 You should now be able to access the VM Cockpit console using `https://<vm_ip>:9090` URL.
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -9,7 +9,7 @@
 }
 
 # golang specifics
-%global golang_version 1.18
+%global golang_version 1.19
 #debuginfo not supported with Go
 %global debug_package %{nil}
 # modifying the Go binaries breaks the DWARF debugging
@@ -296,6 +296,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Wed Mar 29 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.13.0
+- Upgrade golang build-time dependency to 1.19 version
+
 * Wed Mar 01 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.13.0
 - Add lvmd.yaml and ovn.yaml default configuration files
 

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -72,19 +72,6 @@ if $INSTALL_BUILD_DEPS || $BUILD_AND_RUN; then
     sudo dnf update -y
     sudo dnf install -y git cockpit make golang jq selinux-policy-devel rpm-build jq bash-completion
     sudo systemctl enable --now cockpit.socket
-
-    # Install go1.19
-    # This is installed into different location (/usr/local/bin/go) from dnf installed Go (/usr/bin/go) so it doesn't conflict
-    # /usr/local/bin is before /usr/bin in $PATH so newer one is picked up
-    GO_VER=1.19.4
-    GO_ARCH=$([ "$(uname -i)" == "x86_64" ] && echo "amd64" || echo "arm64")
-    curl -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.linux-${GO_ARCH}.tar.gz" &&
-        sudo rm -rf "/usr/local/go${GO_VER}" &&
-        sudo mkdir -p "/usr/local/go${GO_VER}" &&
-        sudo tar -C "/usr/local/go${GO_VER}" -xzf "go${GO_VER}.linux-${GO_ARCH}.tar.gz" --strip-components 1 &&
-        sudo rm -rfv /usr/local/bin/{go,gofmt} &&
-        sudo ln --symbolic /usr/local/go${GO_VER}/bin/{go,gofmt} /usr/local/bin/ &&
-        rm -rfv "go${GO_VER}.linux-${GO_ARCH}.tar.gz"
 fi
 
 if $BUILD_AND_RUN; then

--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -3,10 +3,59 @@ set -exo pipefail
 
 OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
 
+function osbuild_rhel9_beta() {
+    local json_file=$1
+    sudo mkdir -p $(dirname ${json_file})
+    sudo tee ${json_file} >/dev/null <<EOF
+{
+  "x86_64": [
+    {
+      "name": "baseos",
+      "baseurl": "https://cdn.redhat.com/content/beta/rhel9/9/x86_64/baseos/os",
+      "rhsm": true,
+      "check_gpg": false
+    },
+    {
+      "name": "appstream",
+      "baseurl": "https://cdn.redhat.com/content/beta/rhel9/9/x86_64/appstream/os",
+      "rhsm": true,
+      "check_gpg": false
+    }
+  ],
+  "aarch64": [
+    {
+      "name": "baseos",
+      "baseurl": "https://cdn.redhat.com/content/beta/rhel9/9/aarch64/baseos/os",
+      "rhsm": true,
+      "check_gpg": false
+    },
+    {
+      "name": "appstream",
+      "baseurl": "https://cdn.redhat.com/content/beta/rhel9/9/aarch64/appstream/os",
+      "rhsm": true,
+      "check_gpg": false
+    }
+  ]
+}
+EOF
+
+    sudo systemctl stop --now osbuild-composer.socket osbuild-composer.service osbuild-worker@1.service
+    sleep 5
+    sudo rm -rf /var/cache/osbuild-worker/* /var/lib/osbuild-composer/*
+}
+
 sudo dnf install -y git osbuild-composer composer-cli ostree rpm-ostree \
     cockpit-composer cockpit-machines bash-completion podman genisoimage \
     createrepo yum-utils selinux-policy-devel jq wget lorax rpm-build \
     containernetworking-plugins
+
+# Configure osbuild-composer to use RHEL 9.2 beta repositories
+# This is a workaround until RHEL 9.2 becomes GA
+if grep -q 'Red Hat Enterprise Linux release 9.2 Beta' /etc/redhat-release ; then
+    JSON_FILE=/etc/osbuild-composer/repositories/rhel-92.json
+    [ ! -e ${JSON_FILE} ] && osbuild_rhel9_beta ${JSON_FILE}
+fi
+
 sudo systemctl enable osbuild-composer.socket --now
 sudo systemctl enable cockpit.socket --now
 sudo firewall-cmd --add-service=cockpit --permanent


### PR DESCRIPTION
* Switch the development environment to use RHEL 9.2 beta
* Enable osbuild configuration to use RHEL 9.2 beta channels
* Use golang that comes with the OS
* Fix the golang dependency in the MicroShift RPM spec file

Closes:
* [USHIFT-1023](https://issues.redhat.com//browse/USHIFT-1023)
* [OCPBUGS-10472](https://issues.redhat.com//browse/OCPBUGS-10472)
