### PR TITLE
NO-ISSUE: Modify OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,30 +1,26 @@
 approvers:
-- benluddy
 - copejon
 - dhellmann
-- fzdarsky
 - ggiguash
-- mangelajo
-- oglok
-- sallyom
 - zshi-redhat
 - pmtk
 - pacevedom
-- stlaz
+- pliurh
+- eggfoobar
+- chiragkyal
 reviewers:
-- benluddy
 - copejon
 - dhellmann
-- fzdarsky
 - ggiguash
-- mangelajo
-- oglok
-- sallyom
-- zshi-redhat
 - pmtk
 - pacevedom
-- stlaz
 emeritus_approvers:
 - cooktheryan
 - husky-parul
 - rootfs
+- stlaz
+- benluddy
+- sallyom
+- mangelajo
+- oglok
+- fzdarsky


### PR DESCRIPTION
Since we are now running the team with core members, OCTO disengaged and there are only a few collaborations with other teams, we reduce the scope of the reviewers to the core members while keeping them in emeritus approvers for a second informed opinion if there is a need This way we avoid spamming folks who have no time to devote to MicroShift and we also dont slow down PR merge flow.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
