### PR TITLE
Fix LVM-not-detected log rendering

### DIFF
--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -72,7 +72,7 @@ func startCSIPlugin(cfg *config.MicroshiftConfig, kubeconfigPath string) error {
 	)
 
 	if err := lvmd.LvmSupported(); err != nil {
-		klog.Warning("skipping CSI deployment: %v", err)
+		klog.Warningf("skipping CSI deployment: %w", err)
 		return nil
 	}
 


### PR DESCRIPTION
Oneliner to make the warning log line render the error message.