### PR TITLE
USHIFT-950: add verification step to ensure etcd/vendor is kept up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,3 +287,15 @@ vendor:
 		git mailinfo /dev/null /dev/stderr 2<&1- < $$p | git apply --reject || exit 1; \
 	done
 .PHONY: vendor
+
+# Update the etcd dependencies, including especially MicroShift itself.
+vendor-etcd:
+	$(MAKE) -C etcd vendor
+.PHONY: vendor-etcd
+
+# There should be no modified files in the etcd/vendor directory after
+# running `make vendor-etcd`.
+.PHONY: verify-vendor-etcd
+verify: verify-vendor-etcd
+verify-vendor-etcd: vendor-etcd
+	./hack/verify-vendor-etcd.sh

--- a/etcd/vendor/github.com/openshift/microshift/pkg/util/cert.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/util/cert.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -69,7 +69,7 @@ func GenKeys(pubPath, keyPath string) error {
 		return fmt.Errorf("failed to write the private key to %s: %v", keyPath, err)
 	}
 
-	ioutil.WriteFile(pubPath, pubPEM, 0644)
+	os.WriteFile(pubPath, pubPEM, 0400)
 
 	return nil
 }

--- a/hack/verify-vendor-etcd.sh
+++ b/hack/verify-vendor-etcd.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# First stage any files under etcd/vendor in case there are new ones.
+git add etcd/vendor
+
+# Now get the list of files that would be committed.
+changed=$(git diff --cached --name-only etcd/vendor)
+
+if [ -n "$changed" ]; then
+    cat - <<EOF
+ERROR:
+
+You need to run 'make vendor-etcd' and commit the results to include
+these files in the PR:
+
+EOF
+    git diff --cached --name-only etcd/vendor
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
As we make changes to code in microshift that is vendored into etcd, we
need to ensure that we also update the vendored copy at the same time.

This change adds a Makefile target `vendor-etcd` that updates the
`etcd/vendor` directory and another target `verify-vendor-etcd` that fails
if there are any files added or modified after running `make vendor-etcd`.