### PR TITLE
USHIFT-1044: fix image verification test

### DIFF
--- a/scripts/verify_images.sh
+++ b/scripts/verify_images.sh
@@ -36,6 +36,8 @@ while read source_file image; do
             debug "$image OK";;
         registry.redhat.io/odf4/*)
             debug "$image OK";;
+        registry.redhat.io/lvms4/*)
+            debug "$image OK";;
         *)
             echo "$image used in $source_file is not from an approved location" 1>&2
             approved=false;;

--- a/scripts/verify_images.sh
+++ b/scripts/verify_images.sh
@@ -14,8 +14,17 @@ function debug() {
 
 ROOTDIR=$(git rev-parse --show-toplevel)
 
+RC=0
 approved=true
-jq -r '.images | .[] | (input_filename) + " " + (.)' assets/release/release-*.json | while read source_file image; do
+image_list=$(mktemp)
+
+function cleanup() {
+    rm -f $image_list
+}
+trap cleanup EXIT
+jq -r '.images | .[] | (input_filename) + " " + (.)' assets/release/release-*.json > $image_list
+
+while read source_file image; do
     case $image in
         quay.io/microshift/*)
             debug "$image OK";;
@@ -31,9 +40,10 @@ jq -r '.images | .[] | (input_filename) + " " + (.)' assets/release/release-*.js
             echo "$image used in $source_file is not from an approved location" 1>&2
             approved=false;;
     esac
-done
+done < $image_list
 
 if ! $approved; then
     echo "Invalid image reference found" 1>&2
     exit 1
 fi
+exit 0


### PR DESCRIPTION
* add registry.redhat.io/lvms4/ to allowed image locations

  The LVMS images are published 'lvms4' instead of 'odf4' now that the
  project has been renamed.

* exit with error if an image does not match accepted pattern

  Restructure the script so the while loop does not end up in a sub-shell, so
  the `approve` variable value is remembered after the loop. This allows the
  script to exit with an error when an image is found from an unaccepted
  source.

/assign @eggfoobar