### PR TITLE
OCPBUGS-11374: RPM: Match build and install time min versions

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -81,7 +81,7 @@ BuildRequires: selinux-policy >= %{selinux_policyver}
 BuildRequires: selinux-policy-devel >= %{selinux_policyver}
 Requires: container-selinux >= %{container_policy_epoch}:%{container_policyver}
 BuildArch: noarch
-%{?selinux_requires}
+Requires: selinux-policy >= %{selinux_policyver}
 
 %description selinux
 The microshift-selinux package provides the SELinux policy modules required by MicroShift.


### PR DESCRIPTION
**Which issue(s) this PR addresses**:
Aligns the build and install time selinux minimum versions.

Closes #<Issue Number>
