### PR TITLE
USHIFT-662: remove user directory configuration file

### DIFF
--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -1,5 +1,5 @@
 # Configuration
-The MicroShift configuration file must be located at `~/.microshift/config.yaml` (user-specific) and `/etc/microshift/config.yaml` (system-wide), while the former takes precedence if it exists. A sample `/etc/microshift/config.yaml.default` configuration file is installed by the MicroShift RPM and it can be used as a template when customizing MicroShift.
+The MicroShift configuration file must be located at `/etc/microshift/config.yaml`. A sample `/etc/microshift/config.yaml.default` configuration file is installed by the MicroShift RPM and it can be used as a template when customizing MicroShift.
 
 The format of the `config.yaml` configuration file is as follows.
 

--- a/pkg/components/networking.go
+++ b/pkg/components/networking.go
@@ -40,7 +40,7 @@ func startCNIPlugin(cfg *config.Config, kubeconfigPath string) error {
 		}
 	)
 
-	ovnConfig, err := ovn.NewOVNKubernetesConfigFromFileOrDefault(filepath.Dir(config.DefaultGlobalConfigFile))
+	ovnConfig, err := ovn.NewOVNKubernetesConfigFromFileOrDefault(filepath.Dir(config.ConfigFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -17,7 +17,7 @@ import (
 // the lvmd config.  If not found, returns a default-value lvmd config.  If an unmarshalling errors, returns nil
 // and the error.
 func getCSIPluginConfig() (*lvmd.Lvmd, error) {
-	lvmdConfig := filepath.Join(filepath.Dir(config.DefaultGlobalConfigFile), lvmd.LvmdConfigFileName)
+	lvmdConfig := filepath.Join(filepath.Dir(config.ConfigFile), lvmd.LvmdConfigFileName)
 	if _, err := os.Stat(lvmdConfig); !errors.Is(err, os.ErrNotExist) {
 		return lvmd.NewLvmdConfigFromFile(lvmdConfig)
 	}


### PR DESCRIPTION
Simplify the configuration approach by removing the search in multiple
places for a configuration file. Use only the file in
/etc/microshift/config.yaml.