### PR TITLE
OCPBUGS-11564: Explicitly install runc before building ISO images

### DIFF
--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -45,7 +45,7 @@ EOF
 }
 
 sudo dnf install -y git osbuild-composer composer-cli ostree rpm-ostree \
-    cockpit-composer cockpit-machines bash-completion podman genisoimage \
+    cockpit-composer cockpit-machines bash-completion podman runc genisoimage \
     createrepo yum-utils selinux-policy-devel jq wget lorax rpm-build \
     containernetworking-plugins
 


### PR DESCRIPTION
Closes OCPBUGS-11564
