### PR TITLE
OCPBUGS-11395: Remove stale kubeconfigs

### DIFF
--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/kubeconfig.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/kubeconfig.go
@@ -20,5 +20,9 @@ func (cfg *Config) KubeConfigPath(id KubeConfigID) string {
 }
 
 func (cfg *Config) KubeConfigAdminPath(id string) string {
-	return filepath.Join(DataDir, "resources", string(KubeAdmin), id, "kubeconfig")
+	return filepath.Join(cfg.KubeConfigRootAdminPath(), id, "kubeconfig")
+}
+
+func (cfg *Config) KubeConfigRootAdminPath() string {
+	return filepath.Join(DataDir, "resources", string(KubeAdmin))
 }

--- a/pkg/config/kubeconfig.go
+++ b/pkg/config/kubeconfig.go
@@ -20,5 +20,9 @@ func (cfg *Config) KubeConfigPath(id KubeConfigID) string {
 }
 
 func (cfg *Config) KubeConfigAdminPath(id string) string {
-	return filepath.Join(DataDir, "resources", string(KubeAdmin), id, "kubeconfig")
+	return filepath.Join(cfg.KubeConfigRootAdminPath(), id, "kubeconfig")
+}
+
+func (cfg *Config) KubeConfigRootAdminPath() string {
+	return filepath.Join(DataDir, "resources", string(KubeAdmin))
 }


### PR DESCRIPTION
Remove any kubeconfig that is not part of the hostname or SAN values in configuration.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
