### PR TITLE
[release-4.13] OCPBUGS-11512 build without jq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export BIN_TIMESTAMP ?=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 export TIMESTAMP ?=$(shell echo $(BIN_TIMESTAMP) | tr -d ':' | tr 'T' '-' | tr -d 'Z')
 SOURCE_GIT_COMMIT_TIMESTAMP ?= $(shell TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
 
-OCP_VERSION := $(shell jq -r '.release.base' ${PROJECT_DIR}/assets/release/release-$(shell uname -i).json)
+include Makefile.version.$(shell uname -i).var
 MICROSHIFT_VERSION ?= $(subst -clean,,$(shell echo '${OCP_VERSION}-${SOURCE_GIT_COMMIT_TIMESTAMP}-${SOURCE_GIT_COMMIT}-${SOURCE_GIT_TREE_STATE}'))
 
 # Overload SOURCE_GIT_TAG value set in vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -774,6 +774,24 @@ update_openshift_manifests() {
     popd >/dev/null
 }
 
+update_version_makefile() {
+    local arch="$1"
+    local uname_i="$2"
+
+    local release_file
+    case "$arch" in
+        amd64|x86_64)   release_file="${REPOROOT}/assets/release/release-x86_64.json"   ;;
+        arm64|aarch64)  release_file="${REPOROOT}/assets/release/release-aarch64.json"  ;;
+    esac
+
+    local -r version_makefile="${REPOROOT}/Makefile.version.${uname_i}.var"
+    local -r ocp_version=$(jq -r '.release.base' "$release_file")
+
+    cat <<EOF > "$version_makefile"
+OCP_VERSION := ${ocp_version}
+EOF
+}
+
 # Updates buildfiles like the Makefile
 update_buildfiles() {
     KUBE_ROOT="${STAGING_DIR}/kubernetes"
@@ -796,6 +814,9 @@ KUBE_GIT_TREE_STATE=${KUBE_GIT_TREE_STATE-}
 EOF
 
     popd >/dev/null
+
+    update_version_makefile amd64 x86_64
+    update_version_makefile arm64 aarch64
 }
 
 

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -180,26 +180,6 @@ update_lvms_manifests() {
     done
 }
 
-update_release_go() {
-    local src=$1
-    local arch=$2
-
-    case "$arch" in
-        amd64|x86_64)   release_file="${REPOROOT}/pkg/assets/release-x86_64.json"   ;;
-        arm64|aarch64)  release_file="${REPOROOT}/pkg/assets/release-aarch64.json"  ;;
-    esac
-
-    local staged_release
-    staged_release="$(mktemp -d)/$(basename "$release_file")"
-    cp "$release_file" "${staged_release}" || return 1
-    # shellcheck disable=SC2155
-    local images
-    images="$(parse_images "$src")" || return 1
-    while IFS=' ' read -r line; do
-        yq '.images['""']'
-    done <"$images"
-    cp -f "$staged_release" "$release_file" || return 1
-}
 # Clone a repo at a commit
 clone_repo() {
     local repo="$1"


### PR DESCRIPTION
This is a manual backport of #1631 because that PR includes 4.14 version numbers that we do not want in the 4.13 branch.