### PR TITLE
USHIFT-1043: ignore case when looking at logging level

### DIFF
--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/debugging.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/debugging.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 type Debugging struct {
 	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
 	// Defaults to "Normal".
@@ -8,17 +10,14 @@ type Debugging struct {
 
 // GetVerbosity returns the numerical value for LogLevel which is an enum
 func (c *Config) GetVerbosity() int {
-	var verbosity int
-	switch c.Debugging.LogLevel {
-	case "Normal":
-		verbosity = 2
-	case "Debug":
-		verbosity = 4
-	case "Trace":
-		verbosity = 6
-	case "TraceAll":
-		verbosity = 8
-	default:
+	var levelNames = map[string]int{
+		"normal":   2,
+		"debug":    4,
+		"trace":    6,
+		"traceall": 8,
+	}
+	verbosity, ok := levelNames[strings.ToLower(c.Debugging.LogLevel)]
+	if !ok {
 		verbosity = 2
 	}
 	return verbosity

--- a/pkg/config/debugging.go
+++ b/pkg/config/debugging.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 type Debugging struct {
 	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
 	// Defaults to "Normal".
@@ -8,17 +10,14 @@ type Debugging struct {
 
 // GetVerbosity returns the numerical value for LogLevel which is an enum
 func (c *Config) GetVerbosity() int {
-	var verbosity int
-	switch c.Debugging.LogLevel {
-	case "Normal":
-		verbosity = 2
-	case "Debug":
-		verbosity = 4
-	case "Trace":
-		verbosity = 6
-	case "TraceAll":
-		verbosity = 8
-	default:
+	var levelNames = map[string]int{
+		"normal":   2,
+		"debug":    4,
+		"trace":    6,
+		"traceall": 8,
+	}
+	verbosity, ok := levelNames[strings.ToLower(c.Debugging.LogLevel)]
+	if !ok {
 		verbosity = 2
 	}
 	return verbosity

--- a/pkg/config/debugging_test.go
+++ b/pkg/config/debugging_test.go
@@ -16,7 +16,15 @@ func TestGetVerbosity(t *testing.T) {
 			level:   2,
 		},
 		{
+			setting: "normal",
+			level:   2,
+		},
+		{
 			setting: "Debug",
+			level:   4,
+		},
+		{
+			setting: "debug",
 			level:   4,
 		},
 		{
@@ -24,11 +32,23 @@ func TestGetVerbosity(t *testing.T) {
 			level:   6,
 		},
 		{
+			setting: "trace",
+			level:   6,
+		},
+		{
 			setting: "TraceAll",
 			level:   8,
 		},
 		{
+			setting: "traceall",
+			level:   8,
+		},
+		{
 			setting: "Unknown",
+			level:   2,
+		},
+		{
+			setting: "unknown",
 			level:   2,
 		},
 		{


### PR DESCRIPTION
Don't require the user to capitalize the log level name correctly.