### PR TITLE
OCPBUGS-11635: rename ovn-kubernetes-microshift image

### DIFF
--- a/assets/components/ovn/master/daemonset.yaml
+++ b/assets/components/ovn/master/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
       # ovn-northd: convert network objects in nbdb to flows in sbdb
       - name: northd
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -97,7 +97,7 @@ spec:
 
       # nbdb: the northbound, or logical network object DB. In raft mode
       - name: nbdb
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -223,7 +223,7 @@ spec:
 
       # sbdb: The southbound, or flow DB. In raft mode
       - name: sbdb
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c
@@ -315,7 +315,7 @@ spec:
 
       # ovnkube master: convert kubernetes objects in to nbdb logical network components
       - name: ovnkube-master
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c

--- a/assets/components/ovn/node/daemonset.yaml
+++ b/assets/components/ovn/node/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       # ovn-controller: programs the vswitch with flows from the sbdb
       - name: ovn-controller
-        image: {{ .ReleaseImage.ovn_kubernetes_microshift_rhel_9 }}
+        image: {{ .ReleaseImage.ovn_kubernetes_microshift }}
         command:
         - /bin/bash
         - -c

--- a/assets/release/release-aarch64.json
+++ b/assets/release/release-aarch64.json
@@ -8,7 +8,7 @@
     "haproxy-router": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0fcaff5e758f3217b54c4d220692f7428babfaa766153549e9be687f347ebde2",
     "kube-rbac-proxy": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:955c6a5087d6c845c224af527fa04e26da6ad9f98f0ac84027251ab9642dfdbc",
     "openssl": "registry.access.redhat.com/ubi8/openssl@sha256:9e743d947be073808f7f1750a791a3dbd81e694e37161e8c6c6057c2c342d671",
-    "ovn-kubernetes-microshift-rhel-9": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca",
+    "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ad6a1b1a01f928dad3ed9b1d1288c4d5e665868c1713ca54c64ff21ebe4fb8ca",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:db77498f062c865577bf2debf0b062255275af6cbf07708f28d2361d6ab05a42",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8c53d3cf91fda236d104a6ba39559f4494a68866e08300722fa0099c9607fdfa",
     "topolvm_csi": "registry.redhat.io/lvms4/topolvm-rhel8@sha256:10bffded5317da9de6c45ba74f0bb10e0a08ddb2bfef23b11ac61287a37f10a1",

--- a/assets/release/release-x86_64.json
+++ b/assets/release/release-x86_64.json
@@ -8,7 +8,7 @@
     "haproxy-router": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fb034e05ff9e2feec9fc7ad21cbc307b1e55dccc60cca159df2cc6c23bf6dd82",
     "kube-rbac-proxy": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:998d9728e65b492ad5ff213ef055c5d091da5c0b8c84f8f654c17123694ec8b9",
     "openssl": "registry.access.redhat.com/ubi8/openssl@sha256:9e743d947be073808f7f1750a791a3dbd81e694e37161e8c6c6057c2c342d671",
-    "ovn-kubernetes-microshift-rhel-9": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d9c895661c6a7cdb603b51f6b47f607c81666ff3497bb1e0942e9898567fe70f",
+    "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d9c895661c6a7cdb603b51f6b47f607c81666ff3497bb1e0942e9898567fe70f",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:322e2796976ee9d134e8fa28206755d70eaf794a4bed6e63b0f75c91273fb1bc",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:39be614c87a58f6dfcbdc9b74588fdc8667221aa2e9c30611344db765c150d79",
     "topolvm_csi": "registry.redhat.io/lvms4/topolvm-rhel8@sha256:10bffded5317da9de6c45ba74f0bb10e0a08ddb2bfef23b11ac61287a37f10a1",


### PR DESCRIPTION
ovn-kubernetes-microshift-rhel-9 has been renamed to ovn-kubernetes-microshift in 4.14 release payload via https://github.com/openshift/release/pull/37816