### PR TITLE
OCPBUGS-11538: upgrade openvswitch package version for 4.14

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -89,7 +89,7 @@ The microshift-selinux package provides the SELinux policy modules required by M
 
 %package networking
 Summary: Networking components for MicroShift
-Requires: openvswitch2.17
+Requires: openvswitch3.1
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -296,6 +296,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Wed Apr 12 2023 Zenghui Shi <zshi@redhat.com> 4.14.0
+- Upgrade openvswitch package version to 3.1
+
 * Wed Mar 29 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.13.0
 - Upgrade golang build-time dependency to 1.19 version
 


### PR DESCRIPTION
Minimal openvswitch version required by ovn-kubernetes in rhel9.2(4.14) is openvswitch3.1.
