### PR TITLE
OCPBUGS-11660: fix show-config not including changes to etcd config

### DIFF
--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -68,6 +68,9 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 				Debugging: config.Debugging{
 					LogLevel: logLevels[cfg.LogVLevel],
 				},
+				Etcd: config.Etcd{
+					MemoryLimitMB: cfg.Etcd.MemoryLimit,
+				},
 			}
 			marshalled, err := yaml.Marshal(userCfg)
 			cmdutil.CheckErr(err)


### PR DESCRIPTION
Changes to etcd's config were not being shown by the 'show-config' subcommand on microshift.