### PR TITLE
USHIFT-1116: Use connect-to instead of resolve in router smoke test

### DIFF
--- a/e2e/tests/0030-router-smoke-test.sh
+++ b/e2e/tests/0030-router-smoke-test.sh
@@ -30,7 +30,7 @@ oc wait pods -l app=microshift-test --for condition=Ready --timeout=60s
 
 for _ in $(seq "${RETRIES}"); do
     set +e
-    response=$(curl -i http://microshift-test.cluster.local --resolve "microshift-test.cluster.local:80:${USHIFT_IP}" 2>&1)
+    response=$(curl -i http://microshift-test.cluster.local --connect-to "microshift-test.cluster.local:80:${USHIFT_IP}:80" 2>&1)
     result=$?
     set -e
 


### PR DESCRIPTION
Use --connect-to instead of --resolve option in curl to support both IPs and hostnames in the e2e tests.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
