### PR TITLE
USHIFT-974: make the kustomize paths configurable

### DIFF
--- a/cockpit-plugin/packaging/config-openapi-spec.json
+++ b/cockpit-plugin/packaging/config-openapi-spec.json
@@ -5,6 +5,7 @@
     "debugging",
     "dns",
     "etcd",
+    "manifests",
     "network",
     "node"
   ],
@@ -65,6 +66,25 @@
           "description": "Set a memory limit on the etcd process; etcd will begin paging memory when it gets to this value. 0 means no limit.",
           "type": "integer",
           "format": "int64"
+        }
+      }
+    },
+    "manifests": {
+      "type": "object",
+      "required": [
+        "kustomizePaths"
+      ],
+      "properties": {
+        "kustomizePaths": {
+          "description": "The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests.",
+          "type": "array",
+          "default": [
+            "/var/lib/microshift/manifests",
+            "/etc/microshift/manifests"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -17,6 +17,9 @@ dns:
     baseDomain: ""
 etcd:
     memoryLimitMB: 0
+manifests:
+    kustomizePaths:
+        - ""
 network:
     clusterNetwork:
         - cidr: ""
@@ -50,6 +53,10 @@ dns:
     baseDomain: example.com
 etcd:
     memoryLimitMB: 0
+manifests:
+    kustomizePaths:
+        - /var/lib/microshift/manifests
+        - /etc/microshift/manifests
 network:
     clusterNetwork:
         - cidr: 10.42.0.0/16
@@ -117,6 +124,23 @@ The reason for providing multiple directories is to allow a flexible method to m
 |-------------------------------|--------|
 | /etc/microshift/manifests     | Read-write location for configuration management systems or development
 | /usr/lib/microshift/manifests | Read-only location for embedding configuration manifests on ostree based systems
+
+To override the list of paths, set `manifests.kustomizePaths` in the configuration file.
+
+```yaml
+manifests:
+    kustomizePaths:
+        - "/opt/alternate/path"
+```
+
+To disable loading manifests, set the configuration option to an empty
+list.
+
+```yaml
+manifests:
+    kustomizePaths: []
+```
+
 
 ## Manifest Example
 

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	ApiServer ApiServer  `json:"apiServer"`
 	Etcd      EtcdConfig `json:"etcd"`
 	Debugging Debugging  `json:"debugging"`
+	Manifests Manifests  `json:"manifests"`
 
 	// Internal-only fields
 	Ingress      IngressConfig `json:"-"`
@@ -105,6 +106,9 @@ func (c *Config) fillDefaults() error {
 		MaxFragmentedPercentage: 45,
 		DefragCheckFreq:         5 * time.Minute,
 	}
+	c.Manifests = Manifests{
+		KustomizePaths: []string{defaultManifestDirLib, defaultManifestDirEtc},
+	}
 
 	return nil
 }
@@ -163,6 +167,13 @@ func (c *Config) incorporateUserSettings(u *Config) {
 
 	if u.Debugging.LogLevel != "" {
 		c.Debugging.LogLevel = u.Debugging.LogLevel
+	}
+
+	// Check for nil instead of an empty list because if a user
+	// provides a list but it is empty we want to treat that as
+	// disabling the manifest loader.
+	if u.Manifests.KustomizePaths != nil {
+		c.Manifests.KustomizePaths = u.Manifests.KustomizePaths
 	}
 }
 

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/files.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/files.go
@@ -10,25 +10,7 @@ import (
 const (
 	ConfigFile = "/etc/microshift/config.yaml"
 	DataDir    = "/var/lib/microshift"
-	// for files managed via management system in /etc, i.e. user applications
-	defaultManifestDirEtc = "/etc/microshift/manifests"
-	// for files embedded in ostree. i.e. cni/other component customizations
-	defaultManifestDirLib = "/usr/lib/microshift/manifests"
 )
-
-var (
-	manifestsDir = findManifestsDir()
-)
-
-func GetManifestsDir() []string {
-	return manifestsDir
-}
-
-// Returns the default manifests directories
-func findManifestsDir() []string {
-	var manifestsDir = []string{defaultManifestDirLib, defaultManifestDirEtc}
-	return manifestsDir
-}
 
 func parse(contents []byte) (*Config, error) {
 	c := &Config{}

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
@@ -1,0 +1,18 @@
+package config
+
+const (
+	// for files managed via management system in /etc, i.e. user applications
+	defaultManifestDirEtc = "/etc/microshift/manifests"
+	// for files embedded in ostree. i.e. cni/other component customizations
+	defaultManifestDirLib = "/usr/lib/microshift/manifests"
+)
+
+type Manifests struct {
+	// The locations on the filesystem to scan for kustomization.yaml
+	// files to use to load manifests. Set to a list of paths to scan
+	// only those paths. Set to an empty list to disable loading
+	// manifests.
+	//
+	// +kubebuilder:default={"/var/lib/microshift/manifests","/etc/microshift/manifests"}
+	KustomizePaths []string `json:"kustomizePaths"`
+}

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -17,6 +17,11 @@ dns:
 etcd:
     # Set a memory limit on the etcd process; etcd will begin paging memory when it gets to this value. 0 means no limit.
     memoryLimitMB: 0
+manifests:
+    # The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests.
+    kustomizePaths:
+        - /var/lib/microshift/manifests
+        - /etc/microshift/manifests
 network:
     # IP address pool to use for pod IPs. This field is immutable after installation.
     clusterNetwork:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	ApiServer ApiServer  `json:"apiServer"`
 	Etcd      EtcdConfig `json:"etcd"`
 	Debugging Debugging  `json:"debugging"`
+	Manifests Manifests  `json:"manifests"`
 
 	// Internal-only fields
 	Ingress      IngressConfig `json:"-"`
@@ -105,6 +106,9 @@ func (c *Config) fillDefaults() error {
 		MaxFragmentedPercentage: 45,
 		DefragCheckFreq:         5 * time.Minute,
 	}
+	c.Manifests = Manifests{
+		KustomizePaths: []string{defaultManifestDirLib, defaultManifestDirEtc},
+	}
 
 	return nil
 }
@@ -163,6 +167,13 @@ func (c *Config) incorporateUserSettings(u *Config) {
 
 	if u.Debugging.LogLevel != "" {
 		c.Debugging.LogLevel = u.Debugging.LogLevel
+	}
+
+	// Check for nil instead of an empty list because if a user
+	// provides a list but it is empty we want to treat that as
+	// disabling the manifest loader.
+	if u.Manifests.KustomizePaths != nil {
+		c.Manifests.KustomizePaths = u.Manifests.KustomizePaths
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -170,6 +170,69 @@ func TestGetActiveConfigFromYAML(t *testing.T) {
 				return c
 			}(),
 		},
+		{
+			name: "manifests-default",
+			config: dedent(`
+            `),
+			expected: func() *Config {
+				c := mkDefaultConfig()
+				assert.NoError(t, c.updateComputedValues())
+				return c
+			}(),
+		},
+		{
+			name: "manifests-default2",
+			config: dedent(`
+            # the manifests struct is present, but no paths are listed
+            manifests:
+            `),
+			expected: func() *Config {
+				c := mkDefaultConfig()
+				assert.NoError(t, c.updateComputedValues())
+				return c
+			}(),
+		},
+		{
+			name: "manifests-default3",
+			config: dedent(`
+            # the manifests struct and paths keys are present but the paths
+            # item is not a YAML list
+            manifests:
+              kustomizePaths:
+            `),
+			expected: func() *Config {
+				c := mkDefaultConfig()
+				assert.NoError(t, c.updateComputedValues())
+				return c
+			}(),
+		},
+		{
+			name: "manifests-empty-list",
+			config: dedent(`
+            manifests:
+              kustomizePaths: []
+            `),
+			expected: func() *Config {
+				c := mkDefaultConfig()
+				c.Manifests.KustomizePaths = []string{}
+				assert.NoError(t, c.updateComputedValues())
+				return c
+			}(),
+		},
+		{
+			name: "manifests-override",
+			config: dedent(`
+            manifests:
+              kustomizePaths:
+                - /tmp/some/other/directory
+            `),
+			expected: func() *Config {
+				c := mkDefaultConfig()
+				c.Manifests.KustomizePaths = []string{"/tmp/some/other/directory"}
+				assert.NoError(t, c.updateComputedValues())
+				return c
+			}(),
+		},
 	}
 
 	for _, tt := range ttests {

--- a/pkg/config/files.go
+++ b/pkg/config/files.go
@@ -10,25 +10,7 @@ import (
 const (
 	ConfigFile = "/etc/microshift/config.yaml"
 	DataDir    = "/var/lib/microshift"
-	// for files managed via management system in /etc, i.e. user applications
-	defaultManifestDirEtc = "/etc/microshift/manifests"
-	// for files embedded in ostree. i.e. cni/other component customizations
-	defaultManifestDirLib = "/usr/lib/microshift/manifests"
 )
-
-var (
-	manifestsDir = findManifestsDir()
-)
-
-func GetManifestsDir() []string {
-	return manifestsDir
-}
-
-// Returns the default manifests directories
-func findManifestsDir() []string {
-	var manifestsDir = []string{defaultManifestDirLib, defaultManifestDirEtc}
-	return manifestsDir
-}
 
 func parse(contents []byte) (*Config, error) {
 	c := &Config{}

--- a/pkg/config/manifests.go
+++ b/pkg/config/manifests.go
@@ -1,0 +1,18 @@
+package config
+
+const (
+	// for files managed via management system in /etc, i.e. user applications
+	defaultManifestDirEtc = "/etc/microshift/manifests"
+	// for files embedded in ostree. i.e. cni/other component customizations
+	defaultManifestDirLib = "/usr/lib/microshift/manifests"
+)
+
+type Manifests struct {
+	// The locations on the filesystem to scan for kustomization.yaml
+	// files to use to load manifests. Set to a list of paths to scan
+	// only those paths. Set to an empty list to disable loading
+	// manifests.
+	//
+	// +kubebuilder:default={"/var/lib/microshift/manifests","/etc/microshift/manifests"}
+	KustomizePaths []string `json:"kustomizePaths"`
+}

--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -23,8 +23,6 @@ const (
 	retryTimeout  = 1 * time.Minute
 )
 
-var microshiftManifestsDir = config.GetManifestsDir()
-
 type Kustomizer struct {
 	paths      []string
 	kubeconfig string
@@ -32,7 +30,7 @@ type Kustomizer struct {
 
 func NewKustomizer(cfg *config.Config) *Kustomizer {
 	return &Kustomizer{
-		paths:      microshiftManifestsDir,
+		paths:      cfg.Manifests.KustomizePaths,
 		kubeconfig: cfg.KubeConfigPath(config.KubeAdmin),
 	}
 }


### PR DESCRIPTION
Add a configuration option to control the directories scanned for
kustomization.yaml files.

/assign @eggfoobar