### PR TITLE
USHIFT-1123: add manifests.d support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,14 @@ build: export CGO_ENABLED=0
 
 microshift: build
 
+# A target for local developer workflows. This assumes configure-vm.sh
+# was already run to build and install the RPM.
+.PHONY: install
+install: build
+	sudo systemctl stop microshift
+	sudo cp $(OUTPUT_DIR)/bin/microshift* /usr/bin/
+	sudo systemctl start microshift
+
 .PHONY: etcd
 export GO_BUILD_FLAGS
 etcd:

--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -76,7 +76,7 @@
       ],
       "properties": {
         "kustomizePaths": {
-          "description": "The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests.",
+          "description": "The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.",
           "type": "array",
           "default": [
             "/usr/lib/microshift/manifests",

--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -80,7 +80,9 @@
           "type": "array",
           "default": [
             "/usr/lib/microshift/manifests",
-            "/etc/microshift/manifests"
+            "/usr/lib/microshift/manifests.d/*",
+            "/etc/microshift/manifests",
+            "/etc/microshift/manifests.d/*"
           ],
           "items": {
             "type": "string"

--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -133,6 +133,14 @@ manifests:
         - "/opt/alternate/path"
 ```
 
+The values of `kustomizePaths` may be glob patterns.
+
+```yaml
+manifests:
+    kustomizePaths:
+        - "/opt/alternative/path.d/*"
+```
+
 To disable loading manifests, set the configuration option to an empty
 list.
 

--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -56,7 +56,9 @@ etcd:
 manifests:
     kustomizePaths:
         - /usr/lib/microshift/manifests
+        - /usr/lib/microshift/manifests.d/*
         - /etc/microshift/manifests
+        - /etc/microshift/manifests.d/*
 network:
     clusterNetwork:
         - 10.42.0.0/16
@@ -116,14 +118,16 @@ Please note that values close to the floor may be more likely to impact etcd per
 
 # Auto-applying Manifests
 
-MicroShift leverages `kustomize` for Kubernetes-native templating and declarative management of resource objects. Upon start-up, it searches `/etc/microshift/manifests` and `/usr/lib/microshift/manifests` directories for a `kustomization.yaml` file. If it finds one, it automatically runs `kubectl apply -k` command to apply that manifest.
+MicroShift leverages `kustomize` for Kubernetes-native templating and declarative management of resource objects. Upon start-up, it searches `/etc/microshift/manifests`, `/etc/microshift/manifests.d/*`, `/usr/lib/microshift/manifests`, and `/usr/lib/microshift/manifests.d/*` directories for a `kustomization.yaml` file. If it finds one, it automatically runs `kubectl apply -k` command to apply that manifest.
 
 The reason for providing multiple directories is to allow a flexible method to manage MicroShift workloads.
 
-| Location                      | Intent |
-|-------------------------------|--------|
-| /etc/microshift/manifests     | Read-write location for configuration management systems or development
-| /usr/lib/microshift/manifests | Read-only location for embedding configuration manifests on ostree based systems
+| Location                          | Intent |
+|-----------------------------------|--------|
+| /etc/microshift/manifests         | Read-write location for configuration management systems or development
+| /etc/microshift/manifests.d/*     | Read-write location for configuration management systems or development
+| /usr/lib/microshift/manifests     | Read-only location for embedding configuration manifests on ostree based systems
+| /usr/lib/microshift/manifestsd./* | Read-only location for embedding configuration manifests on ostree based systems
 
 To override the list of paths, set `manifests.kustomizePaths` in the configuration file.
 

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
@@ -107,7 +107,12 @@ func (c *Config) fillDefaults() error {
 		DefragCheckFreq:         5 * time.Minute,
 	}
 	c.Manifests = Manifests{
-		KustomizePaths: []string{defaultManifestDirLib, defaultManifestDirEtc},
+		KustomizePaths: []string{
+			defaultManifestDirLib,
+			defaultManifestDirLibGlob,
+			defaultManifestDirEtc,
+			defaultManifestDirEtcGlob,
+		},
 	}
 
 	c.MultiNode.Enabled = false

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
@@ -1,5 +1,13 @@
 package config
 
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"k8s.io/klog/v2"
+)
+
 const (
 	// for files managed via management system in /etc, i.e. user applications
 	defaultManifestDirEtc = "/etc/microshift/manifests"
@@ -11,8 +19,37 @@ type Manifests struct {
 	// The locations on the filesystem to scan for kustomization.yaml
 	// files to use to load manifests. Set to a list of paths to scan
 	// only those paths. Set to an empty list to disable loading
-	// manifests.
+	// manifests. The entries in the list can be glob patterns to
+	// match multiple subdirectories.
 	//
 	// +kubebuilder:default={"/usr/lib/microshift/manifests","/etc/microshift/manifests"}
 	KustomizePaths []string `json:"kustomizePaths"`
+}
+
+func (m *Manifests) GetKustomizationPaths() ([]string, error) {
+	results := []string{}
+	for _, path := range m.KustomizePaths {
+		pattern := filepath.Join(path, "kustomization.yaml")
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("Could not understand kustomizePath value %v: %w", path, err)
+		}
+		if len(matches) == 0 {
+			klog.Infof("No kustomize path matches %v", pattern)
+			continue
+		}
+		// We add kustomization.yaml to the pattern so we only return
+		// directories where there is something to apply, but the
+		// results we need are the directory names, so convert the
+		// full match string back to a directory.
+		//
+		// Glob() does not explicitly say it sorts its return value,
+		// so we do it to ensure deterministic behavior.
+		sort.Strings(matches)
+		for _, match := range matches {
+			klog.Infof("Adding kustomize path %v", filepath.Dir(match))
+			results = append(results, filepath.Dir(match))
+		}
+	}
+	return results, nil
 }

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
@@ -10,9 +10,11 @@ import (
 
 const (
 	// for files managed via management system in /etc, i.e. user applications
-	defaultManifestDirEtc = "/etc/microshift/manifests"
+	defaultManifestDirEtc     = "/etc/microshift/manifests"
+	defaultManifestDirEtcGlob = "/etc/microshift/manifests.d/*"
 	// for files embedded in ostree. i.e. cni/other component customizations
-	defaultManifestDirLib = "/usr/lib/microshift/manifests"
+	defaultManifestDirLib     = "/usr/lib/microshift/manifests"
+	defaultManifestDirLibGlob = "/usr/lib/microshift/manifests.d/*"
 )
 
 type Manifests struct {
@@ -22,7 +24,7 @@ type Manifests struct {
 	// manifests. The entries in the list can be glob patterns to
 	// match multiple subdirectories.
 	//
-	// +kubebuilder:default={"/usr/lib/microshift/manifests","/etc/microshift/manifests"}
+	// +kubebuilder:default={"/usr/lib/microshift/manifests","/usr/lib/microshift/manifests.d/*","/etc/microshift/manifests","/etc/microshift/manifests.d/*"}
 	KustomizePaths []string `json:"kustomizePaths"`
 }
 

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -21,7 +21,9 @@ manifests:
     # The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
     kustomizePaths:
         - /usr/lib/microshift/manifests
+        - /usr/lib/microshift/manifests.d/*
         - /etc/microshift/manifests
+        - /etc/microshift/manifests.d/*
 network:
     # IP address pool to use for pod IPs. This field is immutable after installation.
     clusterNetwork:

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -18,7 +18,7 @@ etcd:
     # Set a memory limit on the etcd process; etcd will begin paging memory when it gets to this value. 0 means no limit.
     memoryLimitMB: 0
 manifests:
-    # The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests.
+    # The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
     kustomizePaths:
         - /usr/lib/microshift/manifests
         - /etc/microshift/manifests

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -171,9 +171,15 @@ install -p -m644 packaging/systemd/microshift.service %{buildroot}%{_unitdir}/mi
 
 install -d -m755 %{buildroot}/%{_sysconfdir}/microshift
 install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/manifests
+install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/manifests.d
 install -p -m644 packaging/microshift/config.yaml %{buildroot}%{_sysconfdir}/microshift/config.yaml.default
 install -p -m644 packaging/microshift/lvmd.yaml %{buildroot}%{_sysconfdir}/microshift/lvmd.yaml.default
 install -p -m644 packaging/microshift/ovn.yaml %{buildroot}%{_sysconfdir}/microshift/ovn.yaml.default
+
+# /usr/lib/microshift manifest directories for other packages to add to
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d
 
 # release-info files
 mkdir -p -m755 %{buildroot}%{_datadir}/microshift/release
@@ -266,9 +272,14 @@ systemctl enable --now --quiet openvswitch || true
 %{_sysconfdir}/crio/crio.conf.d/microshift.conf
 %dir %{_sysconfdir}/microshift
 %dir %{_sysconfdir}/microshift/manifests
+%dir %{_sysconfdir}/microshift/manifests.d
 %config(noreplace) %{_sysconfdir}/microshift/config.yaml.default
 %config(noreplace) %{_sysconfdir}/microshift/lvmd.yaml.default
 %config(noreplace) %{_sysconfdir}/microshift/ovn.yaml.default
+
+%dir %{_prefix}/lib/microshift
+%dir %{_prefix}/lib/microshift/manifests
+%dir %{_prefix}/lib/microshift/manifests.d
 
 %files release-info
 %{_datadir}/microshift/release/release*.json
@@ -300,9 +311,13 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
-* Mon May 01 2023 Doug Hellmann <dhellmann@redhat.com> 4.14.0
+* Mon May 15 2023 Doug Hellmann <dhellmann@redhat.com> 4.14.0
 - Remove version specifier for container-selinux to let the system
   make the best choice.
+
+* Mon Apr 24 2023 Doug Hellmann <dhellmann@redhat.com> 4.14.0
+- Add /etc/microshift/manifests.d and /usr/lib/microshift/manifests.d
+  directories.
 
 * Wed Apr 12 2023 Zenghui Shi <zshi@redhat.com> 4.13.0
 - Upgrade openvswitch package version to 3.1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,7 +107,12 @@ func (c *Config) fillDefaults() error {
 		DefragCheckFreq:         5 * time.Minute,
 	}
 	c.Manifests = Manifests{
-		KustomizePaths: []string{defaultManifestDirLib, defaultManifestDirEtc},
+		KustomizePaths: []string{
+			defaultManifestDirLib,
+			defaultManifestDirLibGlob,
+			defaultManifestDirEtc,
+			defaultManifestDirEtcGlob,
+		},
 	}
 
 	c.MultiNode.Enabled = false

--- a/pkg/config/manifests.go
+++ b/pkg/config/manifests.go
@@ -1,5 +1,13 @@
 package config
 
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"k8s.io/klog/v2"
+)
+
 const (
 	// for files managed via management system in /etc, i.e. user applications
 	defaultManifestDirEtc = "/etc/microshift/manifests"
@@ -11,8 +19,37 @@ type Manifests struct {
 	// The locations on the filesystem to scan for kustomization.yaml
 	// files to use to load manifests. Set to a list of paths to scan
 	// only those paths. Set to an empty list to disable loading
-	// manifests.
+	// manifests. The entries in the list can be glob patterns to
+	// match multiple subdirectories.
 	//
 	// +kubebuilder:default={"/usr/lib/microshift/manifests","/etc/microshift/manifests"}
 	KustomizePaths []string `json:"kustomizePaths"`
+}
+
+func (m *Manifests) GetKustomizationPaths() ([]string, error) {
+	results := []string{}
+	for _, path := range m.KustomizePaths {
+		pattern := filepath.Join(path, "kustomization.yaml")
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("Could not understand kustomizePath value %v: %w", path, err)
+		}
+		if len(matches) == 0 {
+			klog.Infof("No kustomize path matches %v", pattern)
+			continue
+		}
+		// We add kustomization.yaml to the pattern so we only return
+		// directories where there is something to apply, but the
+		// results we need are the directory names, so convert the
+		// full match string back to a directory.
+		//
+		// Glob() does not explicitly say it sorts its return value,
+		// so we do it to ensure deterministic behavior.
+		sort.Strings(matches)
+		for _, match := range matches {
+			klog.Infof("Adding kustomize path %v", filepath.Dir(match))
+			results = append(results, filepath.Dir(match))
+		}
+	}
+	return results, nil
 }

--- a/pkg/config/manifests.go
+++ b/pkg/config/manifests.go
@@ -10,9 +10,11 @@ import (
 
 const (
 	// for files managed via management system in /etc, i.e. user applications
-	defaultManifestDirEtc = "/etc/microshift/manifests"
+	defaultManifestDirEtc     = "/etc/microshift/manifests"
+	defaultManifestDirEtcGlob = "/etc/microshift/manifests.d/*"
 	// for files embedded in ostree. i.e. cni/other component customizations
-	defaultManifestDirLib = "/usr/lib/microshift/manifests"
+	defaultManifestDirLib     = "/usr/lib/microshift/manifests"
+	defaultManifestDirLibGlob = "/usr/lib/microshift/manifests.d/*"
 )
 
 type Manifests struct {
@@ -22,7 +24,7 @@ type Manifests struct {
 	// manifests. The entries in the list can be glob patterns to
 	// match multiple subdirectories.
 	//
-	// +kubebuilder:default={"/usr/lib/microshift/manifests","/etc/microshift/manifests"}
+	// +kubebuilder:default={"/usr/lib/microshift/manifests","/usr/lib/microshift/manifests.d/*","/etc/microshift/manifests","/etc/microshift/manifests.d/*"}
 	KustomizePaths []string `json:"kustomizePaths"`
 }
 

--- a/pkg/config/manifests_test.go
+++ b/pkg/config/manifests_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetKustomizationPaths(t *testing.T) {
+	dataDir, cleanup := setupSuiteDataDir(t)
+	defer cleanup()
+
+	kustomizeDirName := func(path string) string {
+		return filepath.Join(dataDir, path)
+	}
+
+	makeTestKustomize := func(path string) error {
+		filename := filepath.Join(kustomizeDirName(path), "kustomization.yaml")
+		return os.WriteFile(filename, []byte{}, 0600)
+	}
+
+	makeTestKustomizeDir := func(path string) error {
+		return os.Mkdir(kustomizeDirName(path), 0700)
+	}
+
+	assert.NoError(t, makeTestKustomizeDir("empty"))
+	assert.NoError(t, makeTestKustomizeDir("one"))
+	assert.NoError(t, makeTestKustomize("one"))
+	assert.NoError(t, makeTestKustomizeDir("two"))
+	assert.NoError(t, makeTestKustomize("two"))
+
+	var ttests = []struct {
+		name        string
+		manifests   *Manifests
+		results     []string
+		expectError bool
+	}{
+		{
+			name: "empty",
+			manifests: &Manifests{
+				KustomizePaths: []string{},
+			},
+			results: []string{},
+		},
+		{
+			name: "all",
+			manifests: &Manifests{
+				KustomizePaths: []string{
+					kustomizeDirName("one"),
+					kustomizeDirName("two"),
+					kustomizeDirName("empty"),
+				},
+			},
+			results: []string{
+				kustomizeDirName("one"),
+				kustomizeDirName("two"),
+			},
+		},
+		{
+			name: "o*",
+			manifests: &Manifests{
+				KustomizePaths: []string{
+					kustomizeDirName("o*"),
+				},
+			},
+			results: []string{
+				kustomizeDirName("one"),
+			},
+		},
+		{
+			name: "*o*",
+			manifests: &Manifests{
+				KustomizePaths: []string{
+					kustomizeDirName("*o*"),
+				},
+			},
+			results: []string{
+				kustomizeDirName("one"),
+				kustomizeDirName("two"),
+			},
+		},
+		{
+			name: "nomatch",
+			manifests: &Manifests{
+				KustomizePaths: []string{
+					kustomizeDirName("nomatch"),
+				},
+			},
+			results: []string{},
+		},
+	}
+
+	for _, tt := range ttests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths, err := tt.manifests.GetKustomizationPaths()
+			if tt.expectError {
+				assert.EqualError(t, err, "")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, paths, tt.results)
+		})
+	}
+}

--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -3,6 +3,7 @@ package kustomize
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,13 +25,13 @@ const (
 )
 
 type Kustomizer struct {
-	paths      []string
+	cfg        *config.Config
 	kubeconfig string
 }
 
 func NewKustomizer(cfg *config.Config) *Kustomizer {
 	return &Kustomizer{
-		paths:      cfg.Manifests.KustomizePaths,
+		cfg:        cfg,
 		kubeconfig: cfg.KubeConfigPath(config.KubeAdmin),
 	}
 }
@@ -42,30 +43,37 @@ func (s *Kustomizer) Run(ctx context.Context, ready chan<- struct{}, stopped cha
 	defer close(stopped)
 	defer close(ready)
 
-	for _, path := range s.paths {
-		s.ApplyKustomizationPath(ctx, path)
+	kustomizationPaths, err := s.cfg.Manifests.GetKustomizationPaths()
+	if err != nil {
+		return fmt.Errorf("Could not find kustomization paths: %w", err)
+	}
+
+	for _, path := range kustomizationPaths {
+		s.applyKustomizationPath(ctx, path)
 	}
 
 	return ctx.Err()
 }
 
-func (s *Kustomizer) ApplyKustomizationPath(ctx context.Context, path string) {
+func (s *Kustomizer) applyKustomizationPath(ctx context.Context, path string) {
 	kustomization := filepath.Join(path, "kustomization.yaml")
-	if _, err := os.Stat(kustomization); !errors.Is(err, os.ErrNotExist) {
-		klog.Infof("Applying kustomization at %v ", kustomization)
-		if err := ApplyKustomizationWithRetries(ctx, path, s.kubeconfig); err != nil {
-			klog.Errorf("Applying kustomization at %v failed: %s. Giving up.", kustomization, err)
-		} else {
-			klog.Infof("Kustomization at %v applied successfully.", kustomization)
-		}
-	} else {
+
+	if _, err := os.Stat(kustomization); errors.Is(err, os.ErrNotExist) {
 		klog.Infof("No kustomization found at " + kustomization)
+		return
+	}
+
+	klog.Infof("Applying kustomization at %v ", kustomization)
+	if err := applyKustomizationWithRetries(ctx, path, s.kubeconfig); err != nil {
+		klog.Errorf("Applying kustomization at %v failed: %w. Giving up.", kustomization, err)
+	} else {
+		klog.Infof("Kustomization at %v applied successfully.", kustomization)
 	}
 }
 
-func ApplyKustomizationWithRetries(ctx context.Context, kustomization string, kubeconfig string) error {
+func applyKustomizationWithRetries(ctx context.Context, kustomization string, kubeconfig string) error {
 	return wait.PollUntilContextTimeout(ctx, retryInterval, retryTimeout, true, func(_ context.Context) (done bool, err error) {
-		if err := ApplyKustomization(kustomization, kubeconfig); err != nil {
+		if err := applyKustomization(kustomization, kubeconfig); err != nil {
 			klog.Infof("Applying kustomization failed: %s. Retrying in %s.", err, retryInterval)
 			return false, nil
 		}
@@ -73,7 +81,9 @@ func ApplyKustomizationWithRetries(ctx context.Context, kustomization string, ku
 	})
 }
 
-func ApplyKustomization(kustomization string, kubeconfig string) error {
+func applyKustomization(kustomization string, kubeconfig string) error {
+	klog.Infof("Applying kustomization at %s", kustomization)
+
 	cmds := &cobra.Command{
 		Use:   "kubectl",
 		Short: "kubectl",

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -40,3 +40,22 @@ Check Required Env Variables
     IF  "${USHIFT_USER}"=="${EMPTY}"
         Fatal Error    USHIFT_USER variable is required
     END
+
+Upload String To File  # robocop: disable=too-many-calls-in-keyword
+    [Documentation]  Write the string to a remote file
+    [Arguments]  ${content}  ${remote_filename}
+    ${rand}=    Generate Random String
+    ${local_tmp}=    Join Path    /tmp    ${rand}
+    Create File    ${local_tmp}    ${content}
+    ${rand}=    Generate Random String
+    ${remote_tmp}=    Join Path    /tmp    ${rand}
+    Put File  ${local_tmp}  ${remote_tmp}  mode=0644
+    Remove File  ${local_tmp}
+    ${stdout}  ${rc}=  Execute Command
+    ...    mv ${remote_tmp} ${remote_filename}
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}
+    ${stdout}  ${rc}=  Execute Command
+    ...    chown root:root ${remote_filename}
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}

--- a/test/resources/kubeconfig.resource
+++ b/test/resources/kubeconfig.resource
@@ -45,6 +45,13 @@ Create Namespace
     [Arguments]    ${ns}
     Run With Kubeconfig    oc create namespace ${ns}
 
+Create Random Namespace
+    [Documentation]    Creates a namespace with a random name and return the name.
+    ${rand}=    Generate Random String
+    ${rand}=    Convert To Lowercase  ${rand}
+    Run With Kubeconfig    oc create namespace test-${rand}
+    RETURN  test-${rand}
+
 Remove Namespace
     [Documentation]    Removes the given namespace.
     [Arguments]    ${ns}

--- a/test/resources/microshift-config.resource
+++ b/test/resources/microshift-config.resource
@@ -55,26 +55,7 @@ Clear MicroShift Config
     ...    rm -f /etc/microshift/config.yaml
     ...    sudo=True  return_rc=True
 
-Upload MicroShift Config  # robocop: disable=too-many-calls-in-keyword
+Upload MicroShift Config
     [Documentation]  Upload a new configuration file to the MicroShift host
     [Arguments]  ${config_content}
-
-    ${rand}=    Generate Random String
-    ${local_tmp}=    Join Path    /tmp    ${rand}
-    Create File    ${local_tmp}    ${config_content}
-
-    ${rand}=    Generate Random String
-    ${remote_tmp}=    Join Path    /tmp    ${rand}
-    Put File  ${local_tmp}  ${remote_tmp}  mode=0644
-
-    Remove File  ${local_tmp}
-
-    ${stdout}  ${rc}=  Execute Command
-    ...    mv ${remote_tmp} /etc/microshift/config.yaml
-    ...    sudo=True  return_rc=True
-    Should Be Equal As Integers  0  ${rc}
-
-    ${stdout}  ${rc}=  Execute Command
-    ...    chown root:root /etc/microshift/config.yaml
-    ...    sudo=True  return_rc=True
-    Should Be Equal As Integers  0  ${rc}
+    Upload String To File  ${config_content}  /etc/microshift/config.yaml

--- a/test/suites/kustomize.robot
+++ b/test/suites/kustomize.robot
@@ -1,0 +1,190 @@
+*** Settings ***
+Documentation     Tests for applying manifests automatically via the kustomize controller
+
+Resource    ../resources/common.resource
+Resource    ../resources/systemd.resource
+Resource    ../resources/microshift-config.resource
+Resource    ../resources/microshift-process.resource
+
+Test Tags         restart  slow
+
+
+*** Variables ***
+${CONFIGMAP_NAME}  test-configmap
+
+
+*** Test Cases ***
+Load From /etc/microshift/manifests
+    [Documentation]  /etc/microshift/manifests
+    [Setup]  Setup  /etc/microshift/manifests
+    ConfigMap Path Should Match
+    [Teardown]  Teardown
+
+Load From /etc/microshift/manifestsd
+    # Keyword names cannot have '.' in them
+    [Documentation]  Subdir of /etc/microshift/manifests.d
+    [Setup]  Setup With Subdir  /etc/microshift/manifests.d
+    ConfigMap Path Should Match
+    [Teardown]  Teardown With Subdir
+
+Load From /usr/lib/microshift/manifests
+    [Documentation]  /usr/lib/microshift/manifests
+    [Setup]  Setup  /usr/lib/microshift/manifests
+    ConfigMap Path Should Match
+    [Teardown]  Teardown
+
+Load From /usr/lib/microshift/manifestsd
+    # Keyword names cannot have '.' in them
+    [Documentation]  Subdir of /usr/lib/microshift/manifests.d
+    [Setup]  Setup With Subdir  /usr/lib/microshift/manifests.d
+    ConfigMap Path Should Match
+    [Teardown]  Teardown With Subdir
+
+Load From Configured Dir
+    [Documentation]  Non-default directory
+    [Setup]  Setup With Config  /usr/lib/microshift/test-manifests
+    ConfigMap Path Should Match
+    [Teardown]  Teardown With Config
+
+Do Not Load From Unonfigured Dir
+    [Documentation]  Remove default directory from config and ensure manifests are not loaded
+    [Setup]  Setup With Limited Config
+    ConfigMap Should Be Missing
+    [Teardown]  Teardown With Config
+
+
+*** Keywords ***
+Setup
+    [Documentation]  Set up for test
+    [Arguments]  ${path}
+    Set Suite Variable  \${MANIFEST_DIR}  ${path}
+    Check Required Env Variables
+    Login MicroShift Host
+    Setup Kubeconfig  # for readiness checks
+    ${ns}=  Create Random Namespace
+    Set Suite Variable  \${NAMESPACE}  ${ns}
+    Clear Manifest Directory
+    Write Manifests
+    Restart MicroShift
+
+Teardown
+    [Documentation]  Clean up after test
+    Clear Manifest Directory
+    Run With Kubeconfig  oc delete namespace ${NAMESPACE}  allow_fail=True
+    Logout MicroShift Host
+    Remove Kubeconfig
+
+Setup With Subdir
+    [Documentation]  Set up for test using dynamically created subdir
+    [Arguments]  ${path}
+    ${rand}=    Generate Random String
+    Setup  ${path}/${rand}
+
+Teardown With Subdir
+    [Documentation]  Remove MANIFEST_DIR and clean up
+    ${stdout}  ${rc}=  Execute Command
+    ...    rm -rf ${MANIFEST_DIR}
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}
+    Teardown
+
+Setup With Config  # robocop: disable=too-many-calls-in-keyword
+    [Documentation]  Set up for test using non-default directory
+    [Arguments]  ${path}
+    Set Suite Variable  \${MANIFEST_DIR}  ${path}
+    Check Required Env Variables
+    Login MicroShift Host
+    Setup Kubeconfig  # for readiness checks
+
+    # Extend the configuration setting to add the path
+    Save Default MicroShift Config
+    ${config_content}=  Catenate  SEPARATOR=\n
+    ...  manifests:
+    ...  \ \ kustomizePaths:
+    ...  \ \ \ \ - ${path}
+    ${merged}=  Extend MicroShift Config  ${config_content}
+    Upload MicroShift Config  ${merged}
+
+    ${ns}=  Create Random Namespace
+    Set Suite Variable  \${NAMESPACE}  ${ns}
+    Clear Manifest Directory
+    Write Manifests
+    Restart MicroShift
+
+Teardown With Config
+    [Documentation]  Restore default config and clean up
+    Restore Default Config
+    Teardown With Subdir
+
+Setup With Limited Config  # robocop: disable=too-many-calls-in-keyword
+    [Documentation]  Ensure the configuration does *not* include the manifest directory
+    Set Suite Variable  \${MANIFEST_DIR}    /usr/lib/microshift/manifests
+    Check Required Env Variables
+    Login MicroShift Host
+    Setup Kubeconfig  # for readiness checks
+
+    # Write a config that does not include our path
+    Save Default MicroShift Config
+    ${config_content}=  Catenate  SEPARATOR=\n
+    ...  manifests:
+    ...  \ \ kustomizePaths:
+    ...  \ \ \ \ - /etc/microshift/manifests
+    ${merged}=  Extend MicroShift Config  ${config_content}
+    Upload MicroShift Config  ${merged}
+
+    ${ns}=  Create Random Namespace
+    Set Suite Variable  \${NAMESPACE}  ${ns}
+    Clear Manifest Directory
+    Write Manifests
+    Restart MicroShift
+
+Restore Default Config
+    [Documentation]  Remove any custom config and restart MicroShift
+    Restore Default MicroShift Config
+    Restart MicroShift
+    Sleep  10 seconds  # Wait for systemd to catch up
+
+ConfigMap Path Should Match
+    [Documentation]  Ensure the config map path value matches the manifest dir
+    ${configmap}=  Oc Get  configmap  ${NAMESPACE}  ${CONFIGMAP_NAME}
+    Should Be Equal  ${MANIFEST_DIR}  ${configmap.data.path}
+
+ConfigMap Should Be Missing
+    [Documentation]  Ensure the config map was not created
+    ${result}=    Run Process    oc get configmap -n ${NAMESPACE} ${CONFIGMAP_NAME}
+    ...  env:KUBECONFIG=${KUBECONFIG}
+    ...  stderr=STDOUT
+    ...  shell=True
+    Should Be Equal As Integers  ${result.rc}  1
+
+Clear Manifest Directory
+    [Documentation]  Remove the contents of the manifest directory
+    ${stdout}  ${rc}=  Execute Command
+    ...    rm -rf ${MANIFEST_DIR}/*
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}
+
+Write Manifests
+    [Documentation]  Install manifests
+    # Make sure the manifest directory exists
+    ${stdout}  ${rc}=  Execute Command
+    ...    mkdir -p ${MANIFEST_DIR}
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}
+    # Configure kustomization to use the namespace created in Setup
+    ${kustomization}=  Catenate  SEPARATOR=\n
+    ...  resources:
+    ...  - configmap.yaml
+    ...  namespace: ${NAMESPACE}
+    ...
+    Upload String To File  ${kustomization}  ${MANIFEST_DIR}/kustomization.yaml
+    # Build a configmap with unique data for this scenario
+    ${configmap}=  Catenate  SEPARATOR=\n
+    ...  apiVersion: v1
+    ...  kind: ConfigMap
+    ...  metadata:
+    ...  \ \ name: ${CONFIGMAP_NAME}
+    ...  data:
+    ...  \ \ path: ${MANIFEST_DIR}
+    ...
+    Upload String To File  ${configmap}  ${MANIFEST_DIR}/configmap.yaml


### PR DESCRIPTION
- support glob patterns in the manifest paths config entry
- add manifests.d glob patterns to the defaults to allow packages with separate applications to write their own customization.yaml files

/assign @eggfoobar