### PR TITLE
OCPBUGS-11967: Use dummy next-hop masquerade address as OVN-K default gateway

### DIFF
--- a/assets/components/ovn/common/configmap.yaml
+++ b/assets/components/ovn/common/configmap.yaml
@@ -29,6 +29,9 @@ data:
     [gateway]
     mode=local
     nodeport=true
+{{- if not .DefaultGatewayExist}}
+    next-hop=169.254.169.4
+{{- end}}
 
     [masterha]
     election-lease-duration=137


### PR DESCRIPTION
When there is no default gateway available for the host, use '169.254.169.4' as the OVN-K default gateway.

We will revisit this in 4.14, if we decide to use this setting for all scenarios.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
