### PR TITLE
OCPBUGS-13078: Remove config flag externalGatewayInterface from ovn.yaml

### DIFF
--- a/docs/network/default_cni_plugin.md
+++ b/docs/network/default_cni_plugin.md
@@ -67,7 +67,6 @@ The following configs are supported in ovn-kubernetes config file:
 |:--------------------------------|:--------|:-------|:-------|:----------------------------------------------------------------------------|:------|
 |ovsInit.disableOVSInit           |N        |bool    |false   |Skip configuring OVS bridge "br-ex" in microshift-ovs-init.service           |true   |
 |ovsInit.gatewayInterface         |N        |string  |""      |Interface to be added in OVS gateway bridge "br-ex"                          |eth0   |
-|ovsInit.externalGatewayInterface |N        |string  |""      |Interface to be added in external OVS gateway bridge "br-ex1"                |eth1   |
 |mtu                              |N        |int     |*auto*  |MTU value to be used for the Pods, must be less than or equal to the MTU of default route interface|1500|
 
 > When `disableOVSInit` is true, OVS bridge "br-ex" needs to be configured manually. This OVS bridge is required by ovn-kubernetes CNI. See section [OVS bridge](#ovs-bridge) for guidance on configuring the OVS gateway bridge manually.
@@ -80,7 +79,6 @@ Below is an example of `ovn.yaml`:
 ovsInit:
   disableOVSInit: true
   gatewayInterface: eth0
-  externalGatewayInterface: eth1
 mtu: 1500
 ```
 **NOTE:* The change of `mtu` configuration in `ovn.yaml` requires node reboot to take effect. <br>
@@ -146,12 +144,6 @@ Upon restarting, it recreates ovnkube-master daemonset with updated IP address i
 microshift-ovs-init.service is able to use user specified host interface for cluster network.
 This is done by specifying the `gatewayInterface` in the CNI config file `/etc/microshift/ovn.yaml`.
 The specified interface will be added in OVS bridge `br-ex` which acts as gateway bridge for ovn-kubernetes CNI network.
-
-### Second gateway interface
-
-microshift-ovs-init.service is able to setup one additional host interface for cluster ingress/egress traffic.
-This is done by specifying the `externalGatewayInterface` in the CNI config file `/etc/microshift/ovn.yaml`.
-The external gateway interface will be added in a second OVS bridge `br-ex1`. Cluster pod traffic destinated to additional host subnet will be routed through `br-ex1`.
 
 ### Blocking external access to NodePort service on specific host interfaces
 

--- a/docs/network/host_networking.md
+++ b/docs/network/host_networking.md
@@ -43,7 +43,6 @@ The following physical network interfaces are created or modified by ovn-kuberne
 |name               |type              |description            |comment                                                                                             |
 |:------------------|:-----------------|:----------------------|:---------------------------------------------------------------------------------------------------|
 |br-ex              |OVS bridge        |gateway bridge         |created by microshift-ovs-init.service or manually                                                  |
-|br-ex1             |OVS bridge        |external gateway bridge|created by microshift-ovs-init.service when externalGatewayInterface is configured                  |
 |br-int             |OVS bridge        |integration bridge     |created by ovnkube-master container                                                                 |
 |patch-br-ex        |OVS patch port    |                       |created by ovnkube-master container, connect br-ex to br-int                                        |
 |patch-br-int       |OVS patch port    |                       |created by ovnkube-master container, connect br-int to br-ex                                        |
@@ -52,7 +51,6 @@ The following physical network interfaces are created or modified by ovn-kuberne
 |7ea12e348b34f1e    |veth              |pod veth interface     |created and plugged to br-int by ovnkube-master container, the other end connects to pod namespace  |
 
 - `7ea12e348b34f1e` is one end of veth pair that connects pod to br-int, it is named after the first 15 bits of pod sandbox ID. The other end of veth pair is in pod network namespace (named `eth0` inside pod). There could be as many veth pairs as the number of pods. <br>
-- `br-ex1` is created by `microshift-ovs.init.service` when `externalGatewayInterface` is configured in `/etc/microshift/ovn.yaml`. `externalGatewayInterface` is added into `br-ex1` as its uplink port whose IP is also moved to `br-ex1`. Cluster egress traffic destinated to `externalGatewayInterface` subnet will be routed through `br-ex1`. <br>
 
 A snapshot of OVS interfaces from running MicroShift cluster:
 

--- a/packaging/microshift/ovn.yaml
+++ b/packaging/microshift/ovn.yaml
@@ -5,9 +5,6 @@ ovsInit:
   # Interface to be added in OVS gateway bridge "br-ex"
   #gatewayInterface: ""
 
-  # Interface to be added in external OVS gateway bridge "br-ex1"
-  #externalGatewayInterface: ""
-
 # MTU value to be used for the Pods, must be less than or equal to the MTU of
 # default route interface.
 #mtu: 1500

--- a/pkg/config/ovn/ovn.go
+++ b/pkg/config/ovn/ovn.go
@@ -15,7 +15,6 @@ import (
 const (
 	ovnConfigFileName           = "ovn.yaml"
 	OVNGatewayInterface         = "br-ex"
-	OVNExternalGatewayInterface = "br-ex1"
 	defaultMTU                  = 1500
 	OVNKubernetesV4MasqueradeIP = "169.254.169.2"
 	OVNKubernetesV6MasqueradeIP = "fd69::2"
@@ -43,8 +42,6 @@ type OVSInitConfig struct {
 	DisableOVSInit bool `json:"disableOVSInit,omitempty"`
 	// Uplink interface for OVS bridge "br-ex"
 	GatewayInterface string `json:"gatewayInterface,omitempty"`
-	// Uplink interface for OVS bridge "br-ex1"
-	ExternalGatewayInterface string `json:"externalGatewayInterface,omitempty"`
 }
 
 func (o *OVNKubernetesConfig) Validate() error {
@@ -73,17 +70,6 @@ func (o *OVNKubernetesConfig) validateConfig() error {
 		_, err := net.InterfaceByName(o.OVSInit.GatewayInterface)
 		if err != nil {
 			return fmt.Errorf("gateway interface %s not found", o.OVSInit.GatewayInterface)
-		}
-	}
-	if o.OVSInit.ExternalGatewayInterface != "" {
-		_, err := net.InterfaceByName(o.OVSInit.ExternalGatewayInterface)
-		if err != nil {
-			return fmt.Errorf("external gateway interface %s not found", o.OVSInit.ExternalGatewayInterface)
-		}
-		_, err = net.InterfaceByName(OVNExternalGatewayInterface)
-		if err != nil {
-			return fmt.Errorf("external gateway interface %s is configured, but external gateway bridge %s not found",
-				o.OVSInit.ExternalGatewayInterface, OVNExternalGatewayInterface)
 		}
 	}
 


### PR DESCRIPTION
This flag is for building a secondary bridge br-ex1 for OVN-K. The br-ex1 bridge is used by the multiple external gateway feature that we don't support in microshift.
