### PR TITLE
chore: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // openshift-controller-manager
+	github.com/google/go-cmp v0.5.9
 	github.com/miekg/dns v1.1.35 // microshift
 	github.com/openshift/api v0.0.0-20230516201849-333bc194ef7a
 	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
@@ -16,14 +17,18 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
+	github.com/vishvananda/netlink v1.1.0
+	go.etcd.io/etcd/client/pkg/v3 v3.5.7
+	go.etcd.io/etcd/client/v3 v3.5.7
 	golang.org/x/sys v0.8.0
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.27.1
 	k8s.io/apiextensions-apiserver v0.27.1
 	k8s.io/apimachinery v0.27.1
 	k8s.io/apiserver v0.27.1
 	k8s.io/cli-runtime v0.27.1
 	k8s.io/client-go v0.27.1
+	k8s.io/cloud-provider v0.0.0
 	k8s.io/component-base v0.27.1
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/kube-aggregator v0.27.1
@@ -83,7 +88,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
-	github.com/ghodss/yaml v1.0.0
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.3 // indirect
@@ -103,7 +108,6 @@ require (
 	github.com/google/cadvisor v0.47.1 // indirect
 	github.com/google/cel-go v0.12.6 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -120,11 +124,13 @@ require (
 	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/libopenstorage/openstorage v1.0.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/moby/ipvs v1.1.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587 // indirect
@@ -156,13 +162,10 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
-	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.2 // indirect
 	github.com/vmware/govmomi v0.30.0 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.7 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.5.7
-	go.etcd.io/etcd/client/v3 v3.5.7
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.35.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0 // indirect
@@ -198,8 +201,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/warnings.v0 v0.1.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/cloud-provider v0.0.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/cluster-bootstrap v0.0.0 // indirect
 	k8s.io/component-helpers v0.27.1 // indirect
 	k8s.io/controller-manager v0.27.1 // indirect
@@ -222,11 +224,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.13.2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.14.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-)
-
-require (
-	github.com/lithammer/dedent v1.1.0 // indirect
-	github.com/moby/ipvs v1.1.0 // indirect
 )
 
 replace (

--- a/pkg/config/lvmd/lvmd.go
+++ b/pkg/config/lvmd/lvmd.go
@@ -6,8 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -34,8 +34,8 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	kubecm "k8s.io/kubernetes/cmd/kube-controller-manager/app"
 
-	"github.com/ghodss/yaml"
 	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 const (


### PR DESCRIPTION
The `github.com/ghodss/yaml` package is no longer being actively maintained. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, while `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. You can see the changes between the two versions here: [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), which mostly consists of bug fixes.

#### Note to the reviewer:

Please review and merge https://github.com/openshift/library-go/pull/1501 as well. Once that's done, I'll update `github.com/openshift/library-go` in this PR, allowing us to completely remove `github.com/ghodss/yaml`.

```
$ go mod why -m github.com/ghodss/yaml
# github.com/ghodss/yaml
github.com/openshift/microshift/pkg/assets
github.com/openshift/library-go/pkg/operator/resource/resourceapply
github.com/openshift/library-go/pkg/operator/v1helpers
github.com/ghodss/yaml
```