### PR TITLE
USHIFT-1218: Implement ostree updates from the local repository and edge commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,12 @@ image-build-iso: rpm
 iso: image-build-configure image-build-iso
 .PHONY: iso
 
+image-build-commit: rpm
+	./scripts/image-builder/build.sh $(IMAGE_BUILDER_ARGS) -build_edge_commit
+
+commit: image-build-configure image-build-commit
+.PHONY: commit
+
 rpm-podman:
 	RPM_BUILDER_IMAGE_TAG="rhel-8-release-golang-1.19-openshift-4.13"; \
 	podman build \

--- a/scripts/image-builder/config/blueprint_v0.0.1.toml
+++ b/scripts/image-builder/config/blueprint_v0.0.1.toml
@@ -1,4 +1,4 @@
-name = "microshift-container"
+name = "microshift"
 
 description = ""
 version = "0.0.1"
@@ -39,6 +39,10 @@ version = "*"
 
 [[packages]]
 name = "iotop"
+version = "*"
+
+[[packages]]
+name = "strace"
 version = "*"
 
 # other

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -34,8 +34,8 @@ ostreesetup --nogpg --osname=rhel --remote=edge --url=file:///run/install/repo/o
 
 %post --log=/var/log/anaconda/post-install.log --erroronfail
 
-# Replace the ostree server name
-echo -e 'url=http://REPLACE_OSTREE_SERVER_NAME/repo/' >> /etc/ostree/remotes.d/edge.conf
+# Replace the ostree server URL
+echo -e 'url=REPLACE_OSTREE_SERVER_URL' >> /etc/ostree/remotes.d/edge.conf
 
 # The pull secret is mandatory for MicroShift builds on top of OpenShift, but not OKD
 # The /etc/crio/crio.conf.d/microshift.conf references the /etc/crio/openshift-pull-secret file
@@ -80,5 +80,34 @@ for uuid in $(nmcli -f uuid,type,autoconnect connection | awk '$2 == "ethernet" 
     file=$(nmcli -f uuid,filename connection | awk -v uuid=${uuid} '$1 == uuid' | sed "s/${uuid}//g" | xargs)
     sed -i '/autoconnect=.*/d' "${file}"
 done
+
+# Configure an empty local ostree repository and server if the "edge" remote points to "localhost:8085"
+if grep -q '^url=http://127.0.0.1:8085' /etc/ostree/remotes.d/edge.conf ; then
+    ostree_repo=/var/lib/ostree-server-local
+    ostree_serv=ostree-server-local.service
+
+    # Create an empty repository with a summary
+    mkdir -p ${ostree_repo}/repo
+    ostree --repo=${ostree_repo}/repo init --mode=archive-z2
+    ostree summary --repo ${ostree_repo}/repo --update
+
+    # Create an HTTP server for the repository
+    cat > /etc/systemd/system/${ostree_serv} <<EOF
+[Unit]
+Description=Caddy HTTP server for the local ostree repository
+
+[Service]
+User=root
+WorkingDirectory=${ostree_repo}
+ExecStart=/bin/caddy file-server -listen 127.0.0.1:8085 -root ${ostree_repo} -browse
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctl enable ${ostree_serv}
+fi
 
 %end


### PR DESCRIPTION
* Add a special mode to the image-builder/build.sh script to generate edge commit archives
* Add an HTTP server to the ISO to allow local ostree updates
* Update documentation of Edge ISO with the new scenario

Closes [USHIFT-1218](https://issues.redhat.com//browse/USHIFT-1218)
