### PR TITLE
USHIFT-1198: add tests for version API

### DIFF
--- a/test/resources/YAML.py
+++ b/test/resources/YAML.py
@@ -1,0 +1,10 @@
+"""Expose YAML parser to robot tests.
+"""
+import yaml
+from robot.utils import DotDict
+
+
+def yaml_parse(data):
+    """Parse input string as YAML and return DotDict instance."""
+    parsed = yaml.safe_load(data)
+    return DotDict(parsed)

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -12,6 +12,7 @@ Setup Suite
 Setup Suite With Namespace
     [Documentation]    Setup a test suite by creating a unique namespace and configuring Kubeconfig
     Check Required Env Variables
+    Login MicroShift Host
     Setup Kubeconfig
     ${rand}=    Generate Random String
     ${rand}=    Convert To Lower Case    ${rand}
@@ -22,6 +23,7 @@ Setup Suite With Namespace
 Teardown Suite
     [Documentation]    Teardown the namespace-less test suite by removing the Kubeconfig.
     Remove Kubeconfig
+    Login MicroShift Host
 
 Teardown Suite With Namespace
     [Documentation]    Teardown the namespaced test suite by removing the namespace and removing the Kubeconfig.

--- a/test/resources/kubeconfig.resource
+++ b/test/resources/kubeconfig.resource
@@ -37,6 +37,7 @@ Run With Kubeconfig
     IF    ${allow_fail} == False
         Should Be Equal As Integers    ${result.rc}    0
     END
+    RETURN  ${result.stdout}
 
 Create Namespace
     [Documentation]    Creates a namespace with the given name.

--- a/test/resources/kubeconfig.resource
+++ b/test/resources/kubeconfig.resource
@@ -34,6 +34,7 @@ Run With Kubeconfig
     [Arguments]    ${cmd}    ${allow_fail}=False
     ${result}=    Run Process    ${cmd}    env:KUBECONFIG=${KUBECONFIG}    stderr=STDOUT    shell=True
     Log    ${result.stdout}
+    Log    ${result.stderr}
     IF    ${allow_fail} == False
         Should Be Equal As Integers    ${result.rc}    0
     END

--- a/test/resources/kubeconfig.resource
+++ b/test/resources/kubeconfig.resource
@@ -7,11 +7,9 @@ Resource   ../resources/microshift-host.resource
 Get Kubeconfig
     [Documentation]    Get the kubeconfig file from the host argument and return contents
     [Arguments]    ${host}
-    Login MicroShift Host
     ${kubeconfig}    ${rc}=    Execute Command
     ...    cat /var/lib/microshift/resources/kubeadmin/${host}/kubeconfig
     ...    sudo=True    return_rc=True
-    Logout MicroShift Host
     Should Be Equal As Integers    ${rc}    0
     Should Not Be Empty            ${kubeconfig}
     [Return]    ${kubeconfig}

--- a/test/resources/microshift-host.resource
+++ b/test/resources/microshift-host.resource
@@ -5,7 +5,11 @@ Library    SSHLibrary
 *** Keywords ***
 Login MicroShift Host
     [Documentation]  Login to the MicroShift host via ssh and leave the connection open
-    [Arguments]
+    ...
+    ...  This keyword is meant to be used at the suite level. This ensures
+    ...  most tests already have an open connection. Any tests that will take
+    ...  action that disrupt that connection are responsible for restoring it.
+
     Log  Host: ${USHIFT_HOST}
     SSHLibrary.Open Connection    ${USHIFT_HOST}
     ${variables}=  Get Variables

--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -1,0 +1,22 @@
+*** Settings ***
+Library    Process
+Library    SSHLibrary
+Library    String
+Library    OperatingSystem
+Resource    ../resources/systemd.resource
+Resource    ../resources/microshift-host.resource
+Library    ../resources/YAML.py
+
+
+*** Keywords ***
+MicroShift Version
+    [Documentation]    Run the version command
+    Login MicroShift host
+    ${version_text}    ${rc}=    Execute Command
+    ...    microshift version -o yaml
+    ...    sudo=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Not Be Empty    ${version_text}
+    Logout MicroShift Host
+    ${version}=  Yaml Parse  ${version_text}
+    RETURN  ${version}

--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -3,7 +3,6 @@ Library    Process
 Library    SSHLibrary
 Library    String
 Library    OperatingSystem
-Resource    ../resources/systemd.resource
 Resource    ../resources/microshift-host.resource
 Library    ../resources/YAML.py
 
@@ -11,12 +10,10 @@ Library    ../resources/YAML.py
 *** Keywords ***
 MicroShift Version
     [Documentation]    Run the version command
-    Login MicroShift host
     ${version_text}    ${rc}=    Execute Command
     ...    microshift version -o yaml
     ...    sudo=True    return_rc=True
     Should Be Equal As Integers    ${rc}    0
     Should Not Be Empty    ${version_text}
-    Logout MicroShift Host
     ${version}=  Yaml Parse  ${version_text}
     RETURN  ${version}

--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -1,0 +1,13 @@
+*** Settings ***
+Resource    common.resource
+Library     YAML.py
+
+*** Keywords ***
+
+Oc Get
+    [Arguments]  ${type}  ${namespace}  ${resource}
+
+    ${yaml_text}=  Run With Kubeconfig  oc get -n ${namespace} -o yaml ${type} ${resource}
+    ${yaml_data}=  Yaml Parse  ${yaml_text}
+
+    RETURN  ${yaml_data}

--- a/test/run.sh
+++ b/test/run.sh
@@ -81,7 +81,7 @@ else
     # shellcheck disable=SC2086
     "${RF_BINARY}" \
         --randomize all \
-        --loglevel DEBUG \
+        --loglevel TRACE \
         -V "${RF_VARIABLES}" \
         -x junit.xml \
         --outputdir "${OUTDIR}" \

--- a/test/suites/version.robot
+++ b/test/suites/version.robot
@@ -1,0 +1,83 @@
+*** Settings ***
+Documentation       Tests related to the version of MicroShift
+
+Resource            ../resources/common.resource
+Resource            ../resources/oc.resource
+Resource            ../resources/microshift-process.resource
+Library             Collections
+Library             ../resources/YAML.py
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+
+*** Variables ***
+${USHIFT_HOST}      ${EMPTY}
+${USHIFT_USER}      ${EMPTY}
+
+
+*** Test Cases ***
+ConfigMap Contents
+    [Documentation]  Check the version of the server
+
+    ${configmap}=  Oc Get  configmap  kube-public  microshift-version
+    Should Be Equal As Integers    ${configmap.data.major}    ${MAJOR_VERSION}
+    Should Be Equal As Integers    ${configmap.data.minor}    ${MINOR_VERSION}
+
+CLI Output
+    [Documentation]  Check the version reported by the process
+
+    ${version}=  MicroShift Version
+    Should Be Equal As Integers    ${version.major}    ${MAJOR_VERSION}
+    Should Be Equal As Integers    ${version.minor}    ${MINOR_VERSION}
+    Should Start With  ${version.gitVersion}  ${Y_STREAM}
+
+ConfigMap Matches CLI
+    [Documentation]  Ensure the ConfigMap is being updated based on the actual binary version
+
+    ${configmap}=  Oc Get  configmap  kube-public  microshift-version
+    ${cli}=  MicroShift Version
+    Should Be Equal  ${configmap.data.version}  ${cli.gitVersion}
+
+
+*** Keywords ***
+Setup
+    [Documentation]  Test suite setup
+    Check Required Env Variables
+    Setup Kubeconfig
+    Read Expected Versions
+
+Teardown
+    [Documentation]  Test suite teardown
+    Remove Kubeconfig
+
+Read Expected Versions  # robocop: disable=too-many-calls-in-keyword
+    [Documentation]  Read ../Makefile.version.aarch64.var to find the expected versions
+    ...  Sets suite variables FULL_VERSION, MAJOR_VERSION, MINOR_VERSION, and Y_STREAM based on
+    ...  the content.
+
+    # The file contains content in this format:
+    #
+    #    OCP_VERSION := 4.14.0-0.nightly-arm64-2023-05-04-012046
+
+    ${unparsed}=  OperatingSystem.Get File  ../Makefile.version.aarch64.var
+
+    # 4.14.0-0.nightly-arm64-2023-05-04-012046
+    ${version_full_raw}=  Fetch From Right  ${unparsed}  :=
+    ${version_full}=  Strip String  ${version_full_raw}
+    Set Suite Variable  \${FULL_VERSION}  ${version_full}
+
+    # 4
+    ${major}=  Fetch From Left  ${version_full}  .
+    Set Suite Variable  \${MAJOR_VERSION}  ${major}
+
+    # 14.0-0.nightly-arm64-2023-05-04-012046
+    ${without_major}=  Get Substring  ${version_full}  2
+
+    # 14
+    ${minor}=  Fetch From Left  ${without_major}  .
+    Set Suite Variable  \${MINOR_VERSION}  ${minor}
+
+    # 4.14
+    ${ystream}=  Format String  {}.{}  ${major}  ${minor}
+    Set Suite Variable  \${Y_STREAM}  ${ystream}

--- a/test/suites/version.robot
+++ b/test/suites/version.robot
@@ -44,12 +44,14 @@ ConfigMap Matches CLI
 Setup
     [Documentation]  Test suite setup
     Check Required Env Variables
+    Login MicroShift Host
     Setup Kubeconfig
     Read Expected Versions
 
 Teardown
     [Documentation]  Test suite teardown
     Remove Kubeconfig
+    Logout MicroShift Host
 
 Read Expected Versions  # robocop: disable=too-many-calls-in-keyword
     [Documentation]  Read ../Makefile.version.aarch64.var to find the expected versions


### PR DESCRIPTION
- update the way commands are run to return stdout
- log the remote host used for tests when connecting
- add shell runner for robot framework tests
- add tests for version config map and command line output
- move variable file up one level and make the default an example file
- update ssh connection so if no key is provided the active agent is used instead