### PR TITLE
USHIFT-1228: [release-4.13] Temporarily downgrade container policy to 2.167.0-1 to avoid Image Builder errors

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -18,8 +18,8 @@
 # SELinux specifics
 %global selinuxtype targeted
 %define selinux_policyver 3.14.3-67
-%define container_policyver 2.208.0
-%define container_policy_epoch 3
+%define container_policyver 2.167.0-1
+%define container_policy_epoch 2
 %define microshift_relabel_files() \
    mkdir -p /var/hpvolumes; \
    mkdir -p /var/run/kubelet; \


### PR DESCRIPTION
Before this fix, the following errors were generated when running `make iso`
```
 Problem: package microshift-selinux-4.13.0_0.nightly_2023_04_21_084440_20230430213224_b9f09712-1.el9.noarch requires container-selinux >= 3:2.208.0, but none of the providers can be installed
  - package microshift-4.13.0_0.nightly_2023_04_21_084440_20230430213224_b9f09712-1.el9.x86_64 requires microshift-selinux, but none of the providers can be installed
  - cannot install both container-selinux-3:2.208.0-2.rhaos4.13.el9.noarch and container-selinux-3:2.199.0-1.el9.noarch
```

Here's where the conflicting packages are coming from
```
$ find _output/ -name container-selinux\*
_output/image-builder/openshift-local/rhocp-4.13-for-rhel-9-mirrorbeta-x86_64-rpms/container-selinux-2.208.0-2.rhaos4.13.el9.noarch.rpm

$ sudo dnf whatprovides --showduplicates container-selinux
container-selinux-3:2.199.0-1.el9.noarch : SELinux policies for container
                                         : runtimes
Repo        : rhel-9-for-x86_64-appstream-beta-rpms
Matched from:
Provide    : container-selinux = 3:2.199.0-1.el9

container-selinux-3:2.208.0-2.rhaos4.13.el9.noarch : SELinux policies for
                                                   : container runtimes
Repo        : @System
Matched from:
Provide    : container-selinux = 3:2.208.0-2.rhaos4.13.el9

container-selinux-3:2.208.0-2.rhaos4.13.el9.noarch : SELinux policies for
                                                   : container runtimes
Repo        : rhocp-4.13-for-rhel-9-mirrorbeta-x86_64-rpms
Matched from:
Provide    : container-selinux = 3:2.208.0-2.rhaos4.13.el9
```