### PR TITLE
USHIFT-1229: fix the location of kube-apiserver configuration assets

### DIFF
--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -126,7 +126,7 @@ assets:
       - file: podsecurity-admission-label-syncer-controller-clusterrolebinding.yaml
 
   - dir: controllers/kube-apiserver/
-    src: cluster-kube-apiserver-operator/bindata/cmd/generate-config/config/
+    src: cluster-kube-apiserver-operator/bindata/assets/config/
     files:
       - file: config-overrides.yaml
       - file: defaultconfig.yaml


### PR DESCRIPTION
Undo change from 5ae782b0eb