### PR TITLE
NO-ISSUE: fixing typo with crio package in kickstart file - from criu -> crio

### DIFF
--- a/docs/config/microshift-starter.ks
+++ b/docs/config/microshift-starter.ks
@@ -32,7 +32,7 @@ conntrack-tools
 containernetworking-plugins
 containers-common
 container-selinux
-criu
+crio
 git
 jq
 make


### PR DESCRIPTION
This is just simple fix for typo in the kickstarter file.

https://github.com/openshift/microshift/blob/main/docs/config/microshift-starter.ks#L35

