### PR TITLE
USHIFT-1234: globally disable a few pylint rules that are commonly an issue

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -101,6 +101,9 @@ disable=raw-checker-failed,
         no-self-use,
         # Too many false-positives
         no-member,
+        logging-fstring-interpolation,
+        logging-not-lazy,
+        line-too-long,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/scripts/auto-rebase/handle_assets.py
+++ b/scripts/auto-rebase/handle_assets.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-# pylint: disable=logging-fstring-interpolation,logging-not-lazy,line-too-long
-
 """
 This script updates assets based on a YAML recipe (`assets.yaml`)
 The recipe specifies what files and directories should be copied, ignored, and restored.
@@ -10,9 +8,10 @@ File: handle_assets.py
 
 import logging
 import os
-import sys
 import shutil
 import subprocess
+import sys
+
 import yaml
 
 try:

--- a/scripts/auto-rebase/presubmit.py
+++ b/scripts/auto-rebase/presubmit.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# pylint: disable=line-too-long
 
 """
 This script verifies all the assets for auto-rebase.
@@ -8,10 +7,11 @@ It checks that all files in the assets directory are listed in the assets.yaml f
 File: presubmit.py
 """
 
-from functools import reduce
 import glob
 import os
 import sys
+from functools import reduce
+
 import yaml
 
 # pylint: disable=R0801

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # pylint: disable=fixme,global-statement,too-many-statements,too-many-locals,broad-except
-# pylint: disable=logging-fstring-interpolation,logging-not-lazy,line-too-long
 
 """
 This Python script automates the process of rebasing a Git branch

--- a/scripts/jira/cloner.py
+++ b/scripts/jira/cloner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=too-few-public-methods, broad-except, line-too-long
+# pylint: disable=too-few-public-methods, broad-except
 """
 This script provides various functions for Automatic MicroShift bug JIRA cloner.
 
@@ -17,9 +17,11 @@ File : cloner.py
 import argparse
 import os
 import sys
-import jira
+
 from tabulate import tabulate
 from tqdm import tqdm
+
+import jira
 
 JQL_FILTER_QUERY = 'filter = "MicroShift - Bugs in Project" and status in (New, Assigned, Post, "To Do", "In Progress", "Code Review")'
 JQL_FILTER_ISSUE = 'key in ({})'

--- a/scripts/release-notes/gen_ec_release_notes.py
+++ b/scripts/release-notes/gen_ec_release_notes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=too-many-locals, line-too-long
+# pylint: disable=too-many-locals
 
 """Release Note Tool
 


### PR DESCRIPTION
Disable logging-fstring-interpolation, logging-not-lazy, line-too-long
because we have valid code that violates those rules in a few places
where we disable the rules locally.