### PR TITLE
USHIFT-974: fix docs and default config file for manifest locations

### DIFF
--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -79,7 +79,7 @@
           "description": "The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests.",
           "type": "array",
           "default": [
-            "/var/lib/microshift/manifests",
+            "/usr/lib/microshift/manifests",
             "/etc/microshift/manifests"
           ],
           "items": {

--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -55,7 +55,7 @@ etcd:
     memoryLimitMB: 0
 manifests:
     kustomizePaths:
-        - /var/lib/microshift/manifests
+        - /usr/lib/microshift/manifests
         - /etc/microshift/manifests
 network:
     clusterNetwork:

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
@@ -13,6 +13,6 @@ type Manifests struct {
 	// only those paths. Set to an empty list to disable loading
 	// manifests.
 	//
-	// +kubebuilder:default={"/var/lib/microshift/manifests","/etc/microshift/manifests"}
+	// +kubebuilder:default={"/usr/lib/microshift/manifests","/etc/microshift/manifests"}
 	KustomizePaths []string `json:"kustomizePaths"`
 }

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -20,7 +20,7 @@ etcd:
 manifests:
     # The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests.
     kustomizePaths:
-        - /var/lib/microshift/manifests
+        - /usr/lib/microshift/manifests
         - /etc/microshift/manifests
 network:
     # IP address pool to use for pod IPs. This field is immutable after installation.

--- a/pkg/config/manifests.go
+++ b/pkg/config/manifests.go
@@ -13,6 +13,6 @@ type Manifests struct {
 	// only those paths. Set to an empty list to disable loading
 	// manifests.
 	//
-	// +kubebuilder:default={"/var/lib/microshift/manifests","/etc/microshift/manifests"}
+	// +kubebuilder:default={"/usr/lib/microshift/manifests","/etc/microshift/manifests"}
 	KustomizePaths []string `json:"kustomizePaths"`
 }


### PR DESCRIPTION
The docs incorrectly said /var/lib instead of /usr/lib.