### PR TITLE
OCPBUGS-13239: Remove CPU Pinning

### DIFF
--- a/packaging/crio.conf.d/microshift-ovn.conf
+++ b/packaging/crio.conf.d/microshift-ovn.conf
@@ -2,8 +2,3 @@
 # ovn-kubernetes is the name configured by OVN-K in /etc/cni/net.d/ config file
 # by declaring this CRI-O will wait until that network is configured.
 cni_default_network = "ovn-kubernetes"
-
-[crio.runtime.workloads.management]
-activation_annotation = "target.workload.openshift.io/management"
-annotation_prefix = "resources.workload.openshift.io"
-resources = { "cpushares" = 0, "cpuset" = "0" }


### PR DESCRIPTION
Due to limitations on AWS ARM, we are removing this CPU pinning to elivate confromance testing failing on ARM. This feature will be revisited, see https://issues.redhat.com/browse/USHIFT-1239 
