### PR TITLE
OCPBUGS-11967: Use ovn-k masquerade nexthop address as gateway route's default gw

### DIFF
--- a/assets/components/ovn/common/configmap.yaml
+++ b/assets/components/ovn/common/configmap.yaml
@@ -29,6 +29,7 @@ data:
     [gateway]
     mode=local
     nodeport=true
+    next-hop=169.254.169.4
 
     [masterha]
     election-lease-duration=137


### PR DESCRIPTION
With this change, the gateway router of ovn-k can always forward egress traffic to host kernel.

It will fix the following scenarios:
1. no default gateway host
2. the connection to host default gateway is down

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
