### PR TITLE
USHIFT-1238: improvements to rebase script PR message handling

### DIFF
--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -245,7 +245,7 @@ def generate_pr_description(amd_tag, arm_tag, prow_job_url, rebase_script_succed
         logging.warning(f"Unable to read changelog file: {err}")
         changelog = ""
 
-    base = textwrap.dedent(f"""
+    template = textwrap.dedent("""
     amd64: {amd_tag}
     arm64: {arm_tag}
     prow job: {prow_job_url}
@@ -254,6 +254,7 @@ def generate_pr_description(amd_tag, arm_tag, prow_job_url, rebase_script_succed
 
     /label tide/merge-method-squash
     """)
+    base = template.format(amd_tag=amd_tag, arm_tag=arm_tag, prow_job_url=prow_job_url)
     return (base if rebase_script_succeded
             else "# rebase.sh failed - check committed rebase_sh.log\n\n" + base)
 

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -245,6 +245,13 @@ def generate_pr_description(amd_tag, arm_tag, prow_job_url, rebase_script_succed
         logging.warning(f"Unable to read changelog file: {err}")
         changelog = ""
 
+    # The GitHub API has a length limit for commit messages. It is
+    # longer than the limit imposed here, but this limit seems like
+    # the maximum that it would be reasonable to expect someone to
+    # actually try to read.
+    if len(changelog) > 5000:
+        changelog = f'{changelog}\n\nThe change list was truncated. See scripts/auto-rebase/changelog.txt in the PR for the full details.'
+
     template = textwrap.dedent("""
     amd64: {amd_tag}
     arm64: {arm_tag}


### PR DESCRIPTION
* Fix indentation

  Using an inline f-string to build the message means that the dedent() call
  is applied to the full text of the message, rather than just the template.
  The results therefore depend on the messages in the changelog, and come out
  misaligned. This change turns the dedent() results into a template string
  and fills in the template separately so that the results are more
  appealing.

* Truncate changelog when building rebase PR message

  The changelog for the rebase can grow quite long, especially when we are
  bringing in a new version of kubernetes. Truncate the changelog at a
  reasonable length when that happens.

/assign @pmtk