### PR TITLE
OCPBUGS-12977: Fix log message when CSI is disabled

### DIFF
--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -84,7 +84,7 @@ func startCSIPlugin(ctx context.Context, cfg *config.Config, kubeconfigPath stri
 		return err
 	}
 	if !lvmdCfg.IsEnabled() {
-		klog.V(2).Info("CSI is disabled. %s", lvmdCfg.Message)
+		klog.V(2).Infof("CSI is disabled. %s", lvmdCfg.Message)
 		return nil
 	}
 	lvmdRenderParams, err := renderLvmdParams(lvmdCfg)


### PR DESCRIPTION
Minor fix in the message formatting.
Closes OCPBUGS-12977
