### PR TITLE
USHIFT-1235: Fix RHEL 9.2 DVD name following the operating system GA

### DIFF
--- a/ansible/roles/create-vm/defaults/main.yml
+++ b/ansible/roles/create-vm/defaults/main.yml
@@ -3,7 +3,7 @@
 
 vm_name: microshift-dev
 vm_disk_dir: /var/lib/libvirt/images
-iso_file: /var/lib/libvirt/images/rhel-baseos-9.1-x86_64-dvd.iso
+iso_file: /var/lib/libvirt/images/rhel-9.2-x86_64-dvd.iso
 num_cpu: 4
 ram_size: 6
 disk_size: 50

--- a/docs/devenv_cloud.md
+++ b/docs/devenv_cloud.md
@@ -131,7 +131,7 @@ Follow the instructions in the [Create Virtual Machine](./devenv_setup_auto.md#c
 ```bash
 ./scripts/devenv-builder/create-vm.sh microshift-bench \
     /var/lib/libvirt/images \
-    /var/lib/libvirt/images/rhel-baseos-9.2-$(uname -m)-dvd.iso \
+    /var/lib/libvirt/images/rhel-9.2-$(uname -m)-dvd.iso \
     2 2 10 0 1
 ```
 

--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -19,7 +19,7 @@ sudo dnf install -y libvirt virt-manager virt-install virt-viewer libvirt-client
 Move the ISO image to `/var/lib/libvirt/images` directory and run the following commands to create a virtual machine.
 ```bash
 VMNAME="microshift-dev"
-ISONAME=rhel-baseos-9.2-$(uname -m)-boot.iso
+ISONAME=rhel-9.2-$(uname -m)-boot.iso
 
 sudo -b bash -c " \
 cd /var/lib/libvirt/images/ && \

--- a/docs/devenv_setup_auto.md
+++ b/docs/devenv_setup_auto.md
@@ -89,7 +89,7 @@ As an example, run the following command to create a virtual machine named `micr
 > See the [Recommended system swap size](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/getting-started-with-swap_managing-storage-devices#recommended-system-swap-space_getting-started-with-swap) document for more information.
 
 ```bash
-ISONAME=rhel-baseos-9.2-$(uname -m)-dvd.iso
+ISONAME=rhel-9.2-$(uname -m)-dvd.iso
 
 ./scripts/devenv-builder/create-vm.sh microshift-dev \
     /var/lib/libvirt/images \
@@ -100,7 +100,7 @@ ISONAME=rhel-baseos-9.2-$(uname -m)-dvd.iso
 or
 
 ```bash
-ISONAME=rhel-baseos-9.2-$(uname -m)-dvd.iso
+ISONAME=rhel-9.2-$(uname -m)-dvd.iso
 
 export VMNAME=microshift-dev
 export VMDISKDIR=/var/lib/libvirt/images

--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -41,19 +41,16 @@ function get_base_isofile {
 
     case ${rhel_version} in
         8)
-            echo "rhel-8.7-x86_64-dvd.iso"
+            echo "rhel-8.7-$(uname -m)-dvd.iso"
             ;;
         8.*)
-            echo "rhel-${rhel_version}-x86_64-dvd.iso"
+            echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         9)
-            echo "rhel-9.2-beta-x86_64-dvd.iso"
+            echo "rhel-9.2-$(uname -m)-dvd.iso"
             ;;
-        9.1)
-            echo "rhel-baseos-9.1-x86_64-dvd.iso"
-            ;;
-        9.2-beta)
-            echo "rhel-9.2-beta-x86_64-dvd.iso"
+        9.*)
+            echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         *)
             echo "unknown RHEL version ${rhel_version}" 1>&2


### PR DESCRIPTION
Follow-up on #1770 
Closes [USHIFT-1235](https://issues.redhat.com//browse/USHIFT-1235)

