### PR TITLE
[release-4.13] USHIFT-1241: Fix RHEL 9.2 DVD name following the operating system GA

### DIFF
--- a/docs/devenv_cloud.md
+++ b/docs/devenv_cloud.md
@@ -131,7 +131,7 @@ Follow the instructions in the [Create Virtual Machine](./devenv_setup_auto.md#c
 ```bash
 ./scripts/devenv-builder/create-vm.sh microshift-bench \
     /var/lib/libvirt/images \
-    /var/lib/libvirt/images/rhel-baseos-9.*-$(uname -i)-dvd.iso \
+    /var/lib/libvirt/images/rhel-9.2-$(uname -m)-dvd.iso \
     2 2 10 0 1
 ```
 

--- a/docs/devenv_setup.md
+++ b/docs/devenv_setup.md
@@ -19,7 +19,7 @@ sudo dnf install -y libvirt virt-manager virt-install virt-viewer libvirt-client
 Move the ISO image to `/var/lib/libvirt/images` directory and run the following commands to create a virtual machine.
 ```bash
 VMNAME="microshift-dev"
-ISONAME=rhel-baseos-9.1-$(uname -i)-boot.iso
+ISONAME=rhel-9.2-$(uname -m)-boot.iso
 
 sudo -b bash -c " \
 cd /var/lib/libvirt/images/ && \

--- a/docs/devenv_setup_auto.md
+++ b/docs/devenv_setup_auto.md
@@ -89,7 +89,7 @@ As an example, run the following command to create a virtual machine named `micr
 > See the [Recommended system swap size](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/getting-started-with-swap_managing-storage-devices#recommended-system-swap-space_getting-started-with-swap) document for more information.
 
 ```bash
-ISONAME=rhel-baseos-9.1-$(uname -i)-dvd.iso
+ISONAME=rhel-9.2-$(uname -m)-dvd.iso
 
 ./scripts/devenv-builder/create-vm.sh microshift-dev \
     /var/lib/libvirt/images \
@@ -100,7 +100,7 @@ ISONAME=rhel-baseos-9.1-$(uname -i)-dvd.iso
 or
 
 ```bash
-ISONAME=rhel-baseos-9.1-$(uname -i)-dvd.iso
+ISONAME=rhel-9.2-$(uname -m)-dvd.iso
 
 export VMNAME=microshift-dev
 export VMDISKDIR=/var/lib/libvirt/images

--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -42,16 +42,16 @@ function get_base_isofile {
 
     case $rhel_version in
         8)
-            echo "rhel-8.7-x86_64-dvd.iso"
+            echo "rhel-8.7-$(uname -m)-dvd.iso"
             ;;
         8.*)
-            echo "rhel-${rhel_version}-x86_64-dvd.iso"
+            echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         9)
-            echo "rhel-baseos-9.1-x86_64-dvd.iso"
+            echo "rhel-9.2-$(uname -m)-dvd.iso"
             ;;
         9.*)
-            echo "rhel-baseos-${rhel_version}-x86_64-dvd.iso"
+            echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         *)
             echo "unknown RHEL version $rhel_version" 1>&2


### PR DESCRIPTION
Backport of #1785
Closes [USHIFT-1241](https://issues.redhat.com//browse/USHIFT-1241)
