### PR TITLE
USHIFT-1250: Add an option to build.sh to customize open firewall ports

### DIFF
--- a/docs/rhel4edge_iso.md
+++ b/docs/rhel4edge_iso.md
@@ -67,6 +67,9 @@ Optional arguments:
   -authorized_keys_file path_to_file
           Path to an SSH authorized_keys file to allow SSH access
           into the default 'redhat' account
+  -open_firewall_ports port1[:protocol1],...,portN[:protocolN]
+          One or more comma-separated ports (optionally with protocol)
+          to be allowed by firewall (default: none)
   -prometheus
           Add Prometheus process exporter to the image. See
           https://github.com/ncabatoff/process-exporter for more information


### PR DESCRIPTION
A more flexible approach for opening firewall ports when building R4E ISO images. 
By default, no ports are open.

A follow-up on the discussion in #1792 

Closes [USHIFT-1250](https://issues.redhat.com//browse/USHIFT-1250)
