### PR TITLE
OCPBUGS-13221: show the effective config by default

### DIFF
--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -17,7 +17,7 @@ type showConfigOptions struct {
 
 func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
 	opts := showConfigOptions{
-		Mode: "default",
+		Mode: "effective",
 	}
 
 	cmd := &cobra.Command{
@@ -27,13 +27,16 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 			var cfg *config.Config
 			var err error
 
-			if opts.Mode == "effective" {
+			switch opts.Mode {
+			case "effective":
 				cfg, err = config.ActiveConfig()
 				if err != nil {
 					cmdutil.CheckErr(err)
 				}
-			} else {
+			case "default":
 				cfg = config.NewDefault()
+			default:
+				cmdutil.CheckErr(fmt.Errorf("Unrecognized mode %q", opts.Mode))
 			}
 
 			marshalled, err := yaml.Marshal(cfg)

--- a/test/suites/show-config.robot
+++ b/test/suites/show-config.robot
@@ -1,0 +1,71 @@
+*** Settings ***
+Documentation   show-config command tests
+
+Resource    ../resources/common.resource
+Resource    ../resources/microshift-config.resource
+Resource    ../resources/microshift-host.resource
+Resource    ../resources/microshift-process.resource
+Library     ../resources/YAML.py
+
+Suite Setup     Setup
+Suite Teardown  Teardown
+
+
+*** Variables ***
+${MEMLIMIT128}      SEPARATOR=\n
+...  ---
+...  etcd:
+...  \ \ memoryLimitMB: 128
+
+
+*** Test Cases ***
+No Mode Argument
+    [Documentation]  Test without any explicit --mode
+    ${output}  ${rc}=  Execute Command
+    ...    microshift show-config
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}
+    ${config}=  Yaml Parse  ${output}
+    Should Be Equal As Integers  128  ${config.etcd.memoryLimitMB}
+
+Explicit Mode Default
+    [Documentation]  Test with explicit '--mode default'
+    ${config}=  Show Config  default
+    Should Be Equal As Integers  0  ${config.etcd.memoryLimitMB}
+
+Explicit Mode Effective
+    [Documentation]  Test with explicit '--mode effective'
+    ${config}=  Show Config  effective
+    Should Be Equal As Integers  128  ${config.etcd.memoryLimitMB}
+
+Mode Unknown
+    [Documentation]  Test with explicit '--mode no-such-mode'
+    ${output}  ${rc}=  Execute Command
+    ...    microshift show-config --mode no-such-mode
+    ...    sudo=True  return_rc=True
+    Should Not Be Equal As Integers  0  ${rc}
+
+
+*** Keywords ***
+Setup
+    [Documentation]  Test suite setup
+    Check Required Env Variables
+    Login MicroShift Host
+    Save Default MicroShift Config
+    ${newconfig}=  Extend MicroShift Config  ${MEMLIMIT128}
+    Upload MicroShift Config  ${newconfig}
+
+Teardown
+    [Documentation]  Test suite teardown
+    Restore Default MicroShift Config
+    Logout MicroShift Host
+
+Show Config
+    [Documentation]  Run microshift show-config with ${mode}
+    [Arguments]  ${mode}
+    ${output}  ${rc}=  Execute Command
+    ...    microshift show-config --mode ${mode}
+    ...    sudo=True  return_rc=True
+    Should Be Equal As Integers  0  ${rc}
+    ${yaml_data}=  Yaml Parse  ${output}
+    RETURN  ${yaml_data}


### PR DESCRIPTION
Change the default for the mode option to show-config so that the effective
configuration is displayed when no mode is specified and the user has to
ask explicitly for the default values.