### PR TITLE
USHIFT-1263: always use ushift to find active sprints

### DIFF
--- a/scripts/jira/start_ticket.py
+++ b/scripts/jira/start_ticket.py
@@ -182,9 +182,10 @@ def main():
 
     print(f'finding ticket {args.ticket_id}')
     ticket = server.issue(args.ticket_id)
+    print(f'found: "{ticket.fields.summary}"')
 
     jira_id = server.myself()['key']
-    print(f'  updating assignment to "{jira_id}"')
+    print(f'...updating assignment to "{jira_id}"')
     server.assign_issue(ticket, jira_id)
 
     if args.target_version:
@@ -194,14 +195,14 @@ def main():
                 break
         else:
             raise ValueError('Unknown version')
-        print(f'  setting the target version to "{args.target_version}"')
+        print(f'...setting the target version to "{args.target_version}"')
         setter(ticket, 'Target Version', [{'name': args.target_version}])
 
     if args.sprint:
         active_sprint = get_active_sprint(server, project_id)
         if not active_sprint:
             raise ValueError('No active sprint found')
-        print(f'  setting the sprint to "{active_sprint}"')
+        print(f'...setting the sprint to "{active_sprint}"')
         server.add_issues_to_sprint(active_sprint.id, [ticket.key])
 
     print(f'  setting ticket status to "{args.status}"')

--- a/scripts/jira/start_ticket.py
+++ b/scripts/jira/start_ticket.py
@@ -172,7 +172,10 @@ def main():
     )
     args = parser.parse_args()
 
-    project_id = get_project_id_from_ticket_id(args.ticket_id)
+    actual_project_id = get_project_id_from_ticket_id(args.ticket_id)
+    sprint_project_id = actual_project_id
+    if sprint_project_id == 'OCPBUGS':
+        sprint_project_id = 'USHIFT'
 
     server = jira.JIRA(
         server=SERVER_URL,
@@ -190,7 +193,7 @@ def main():
 
     if args.target_version:
         # Validate the version
-        for v in server.project(project_id).versions:
+        for v in server.project(actual_project_id).versions:
             if args.target_version == v.name:
                 break
         else:
@@ -199,17 +202,20 @@ def main():
         setter(ticket, 'Target Version', [{'name': args.target_version}])
 
     if args.sprint:
-        active_sprint = get_active_sprint(server, project_id)
+        active_sprint = get_active_sprint(server, sprint_project_id)
         if not active_sprint:
             raise ValueError('No active sprint found')
         print(f'...setting the sprint to "{active_sprint}"')
         server.add_issues_to_sprint(active_sprint.id, [ticket.key])
 
-    print(f'  setting ticket status to "{args.status}"')
-    server.transition_issue(
-        issue=ticket,
-        transition=args.status,
-    )
+    if actual_project_id == 'OCPBUGS':
+        print('...ticket status is managed automatically')
+    else:
+        print(f'...setting ticket status to "{args.status}"')
+        server.transition_issue(
+            issue=ticket,
+            transition=args.status,
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The OCPBUGS project has no sprints, so if the project for the ticket is
OCPBUGS use USHIFT to find sprints instead.