### PR TITLE
NO-ISSUE: Increase greenboot test timeout to 4m

### DIFF
--- a/e2e/tests/assets/greenboot-test.sh
+++ b/e2e/tests/assets/greenboot-test.sh
@@ -31,7 +31,7 @@ function check_greenboot_exit_status() {
 # Initial check must succeed (set timeout of 180s to speed up the process)
 #
 tee /etc/greenboot/greenboot.conf &>/dev/null <<EOF
-MICROSHIFT_WAIT_TIMEOUT_SEC=180
+MICROSHIFT_WAIT_TIMEOUT_SEC=240
 EOF
 check_greenboot_exit_status 0 1
 


### PR DESCRIPTION
After the CI move to AWS, greenboot tests seem to time out frequently waiting for cluster to become available.
Trying to increase the timeout to see if this makes the test more predictable. 
