### PR TITLE
Upgrade the devenv and image build scripts to use 4.14 release dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ verify-licenses: microshift etcd
 
 .PHONY: verify-assets
 verify-assets:
-	./scripts/auto-rebase/presubmit.py
+	./scripts/verify/verify-assets.sh
 
 .PHONY: verify-go
 verify-go: verify-golangci

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -9,7 +9,7 @@
 }
 
 # golang specifics
-%global golang_version 1.19
+%global golang_version 1.20.3
 #debuginfo not supported with Go
 %global debug_package %{nil}
 # modifying the Go binaries breaks the DWARF debugging
@@ -42,7 +42,6 @@ Source0: https://github.com/openshift/microshift/archive/%{commit}/microshift-%{
 ExclusiveArch: x86_64 aarch64
 
 BuildRequires: gcc
-BuildRequires: golang >= %{golang_version}
 BuildRequires: make
 BuildRequires: policycoreutils
 BuildRequires: systemd
@@ -105,6 +104,13 @@ Requires: greenboot
 The microshift-greenboot package provides the Greenboot scripts used for verifying that MicroShift is up and running.
 
 %prep
+# Dynamic detection of the available golang version also works for non-RPM golang packages
+golang_detected=$(go version | awk '{print $3}' | tr -d '[a-z]')
+golang_required=%{golang_version}
+if [[ "${golang_detected}" < "${golang_required}" ]] ; then
+  echo "The detected go version ${golang_detected} is less than the required version ${golang_required}" > /dev/stderr
+  exit 1
+fi
 
 %setup -n microshift-%{commit}
 

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -273,8 +273,7 @@ createrepo microshift-local >/dev/null
 # Download openshift local RPM packages (noarch for python and selinux packages)
 rm -rf openshift-local 2>/dev/null || true
 
-# TODO: Start using 'rhocp-4.13' repository when OCP 4.13 is released
-OCP_REPO_NAME="rhocp-4.12-for-rhel-${OSVERSION}-$(uname -m)-rpms"
+OCP_REPO_NAME="rhocp-4.13-for-rhel-${OSVERSION}-$(uname -m)-rpms"
 reposync -n -a "${BUILD_ARCH}" -a noarch --download-path openshift-local \
     --repo="${OCP_REPO_NAME}" \
     --repo="fast-datapath-for-rhel-${OSVERSION}-${BUILD_ARCH}-rpms" >/dev/null

--- a/scripts/verify/verify-assets.sh
+++ b/scripts/verify/verify-assets.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOTDIR=$(git rev-parse --show-toplevel)
+VENV_DIR="${ROOTDIR}/_output"
+VENV="${VENV_DIR}/venv"
+REQ_FILE=${ROOTDIR}/scripts/requirements.txt
+
+create_venv() {
+    local vpython="${VENV}/bin/python3"
+
+    [ -f "${REQ_FILE}" ] || { echo "${REQ_FILE} is not present"; exit 1; }
+    [ -d "${VENV_DIR}" ] || mkdir -p "${VENV_DIR}"
+
+    echo "Creating venv in '${VENV}' and installing packages..."
+    python3 -m venv "${VENV}"
+    ${vpython} -m pip install --upgrade pip
+    ${vpython} -m pip install -r "${REQ_FILE}"
+    echo "Done!"
+}
+
+run_script() {
+    local python="${VENV}/bin/python3"
+
+    if ! command -v "${python}" &>/dev/null; then
+        echo "Installing tools..."
+        create_venv
+    fi
+
+    ${python} "${ROOTDIR}/scripts/auto-rebase/presubmit.py"
+}
+
+run_script


### PR DESCRIPTION
- Use configure-vm.sh script for configuring devenv
- Remove the duplication of information and dependency between the devenv configuration doc and configure-vm.sh
- Start using Go 1.20.3 in devenv
- Remove Go `BuildRequires` dependency from MicroShift spec file, using `go version` dynamic check

See an example of `make rpm` output generated on the go version incompatibility
```
# Building RPM packages
The detected go version 1.20.2 is less than the required version 1.20.3
error: Bad exit status from /var/tmp/rpm-tmp.scxA6z (%prep)
    Bad exit status from /var/tmp/rpm-tmp.scxA6z (%prep)
make: *** [Makefile:236: rpm] Error 1
```

Closes:
[USHIFT-1265](https://issues.redhat.com//browse/USHIFT-1265)
[USHIFT-1266](https://issues.redhat.com//browse/USHIFT-1266)
