### PR TITLE
USHIFT-1270: The ISO image version should be deduced from the microshift RPM

### DIFF
--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-ROOTDIR=$(git rev-parse --show-toplevel)
+ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
 BUILDDIR="${ROOTDIR}/_output/image-builder/"
 
 title() {

--- a/scripts/image-builder/create-vm.sh
+++ b/scripts/image-builder/create-vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-ROOTDIR=$(git rev-parse --show-toplevel)
+ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
 ISODIR=${ROOTDIR}/_output/image-builder
 
 if [ $# -ne 2 ] ; then


### PR DESCRIPTION
Tested using the following sequence
```
BUILD_ARCH=$(uname -m)
OCP_REPO_NAME="rhocp-4.13-for-rhel-9-${BUILD_ARCH}-rpms"
reposync -n -a "${BUILD_ARCH}" -a noarch --download-path ~/openshift-local --repo="${OCP_REPO_NAME}"
find ~/openshift-local -type f -not -name microshift\* -exec rm -f {} \;

~/microshift/scripts/image-builder/build.sh -microshift_rpms ~/openshift-local -pull_secret_file ~/.pull-secret.json
```

Closes [USHIFT-1270](https://issues.redhat.com//browse/USHIFT-1270)
