### PR TITLE
USHIFT-1246: Enable custom variables file and venv dir in RF

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -9,9 +9,7 @@ ROOTDIR=$(git rev-parse --show-toplevel)
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 RF_VENV="${ROOTDIR}/_output/robotenv"
-RF_BINARY="${RF_VENV}/bin/robot"
 RF_VARIABLES="${SCRIPTDIR}/variables.yaml"
-
 DRYRUN=false
 OUTDIR="${ROOTDIR}/_output/e2e-$(date +%Y%m%d-%H%M%S)"
 
@@ -29,10 +27,14 @@ Options:
 
   -o DIR   The output directory. (${OUTDIR})
 
+  -v DIR   The venv directory. (${RF_VENV})
+
+  -i PATH  The variables file. (${RF_VARIABLES})
+
 EOF
 }
 
-while getopts "hno:" opt; do
+while getopts "hno:v:i:" opt; do
     case ${opt} in
         h)
             usage
@@ -44,6 +46,12 @@ while getopts "hno:" opt; do
         o)
             OUTDIR=${OPTARG}
             ;;
+        v)
+            RF_VENV=${OPTARG}
+            ;;
+        i)
+            RF_VARIABLES=${OPTARG}
+            ;;
         *)
             usage
             exit 1
@@ -52,9 +60,11 @@ while getopts "hno:" opt; do
 done
 shift $((OPTIND-1))
 
+RF_BINARY="${RF_VENV}/bin/robot"
+
 if [ ! -f "${RF_VARIABLES}" ]; then
-    echo "Please create a variables file at ${RF_VARIABLES}" 1>&2
-    echo "See ${RF_VARIABLES}.example for the expected content." 1>&2
+    echo "Please create or provide a variables file at ${RF_VARIABLES}" 1>&2
+    echo "See ${SCRIPTDIR}/variables.yaml.example for the expected content." 1>&2
     exit 1
 fi
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -5,8 +5,8 @@ IFS=$'\n\t'
 
 # shellcheck disable=SC2086
 
-ROOTDIR=$(git rev-parse --show-toplevel)
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR="${SCRIPTDIR}/.."
 
 RF_VENV="${ROOTDIR}/_output/robotenv"
 RF_VARIABLES="${SCRIPTDIR}/variables.yaml"


### PR DESCRIPTION
Avoid having fixed locations for some of the practicalities of running RF both locally and on CI. Allow changing both the dir for venv for python dependencies and also the variables file. This also allows QE have multiple files locally and select when running the tests.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
