### PR TITLE
NO-ISSUE Update python scripts to use python3

### DIFF
--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This Python script automates the process of rebasing a Git branch

--- a/scripts/jira/start_ticket.py
+++ b/scripts/jira/start_ticket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Tool for bringing a ticket into the current sprint and updating its status.
 


### PR DESCRIPTION
Recently we updated `build_root` image to one based on RHEL9 which ships python3 instead of python2. Change is needed to fix rebase procedure