### PR TITLE
USHIFT-1284: make test login to microshift host more reliable

### DIFF
--- a/test/resources/microshift-host.resource
+++ b/test/resources/microshift-host.resource
@@ -13,8 +13,10 @@ Login MicroShift Host
 
     Log  Host: ${USHIFT_HOST}
     SSHLibrary.Open Connection    ${USHIFT_HOST}
-    ${variables}=  Get Variables
-    IF  "\${SSH_PRIV_KEY}" in "${variables}"
+    # If there is an ssh key set in the global configuration, use that to
+    # login to the host. Otherwise assume that the ssh agent is running
+    # and configured properly.
+    IF  '${SSH_PRIV_KEY}'
         SSHLibrary.Login With Public Key    ${USHIFT_USER}    ${SSH_PRIV_KEY}
     ELSE
         SSHLibrary.Login    ${USHIFT_USER}  allow_agent=True

--- a/test/variables.yaml.example
+++ b/test/variables.yaml.example
@@ -3,5 +3,6 @@ USHIFT_HOST: microshift
 # USHIFT_USER: User to log into MicroShift's host
 USHIFT_USER: microshift
 # SSH Private key to use when logging into MicroShift's host.
-# Unset this variable to use ssh agent.
+# Set this variable to "" to use ssh agent.
+#SSH_PRIV_KEY: ""
 SSH_PRIV_KEY: /home/microshift/.ssh/id_rsa


### PR DESCRIPTION
Use 'Get Varible Value' to see if an ssh key has been provided instead
of looking for the name in all of the variables ourselves.