### PR TITLE
USHIFT-1286: Use exit code 1 in greenboot failures

### DIFF
--- a/packaging/greenboot/microshift-running-check.sh
+++ b/packaging/greenboot/microshift-running-check.sh
@@ -10,8 +10,17 @@ PODS_CT_LIST=(2                        1                    1                 2 
 # shellcheck source=packaging/greenboot/functions.sh
 source /usr/share/microshift/functions/greenboot.sh
 
+# Set the term handler to convert exit code to 1
+trap 'return_failure' TERM
+
 # Set the exit handler to log the exit status
 trap 'script_exit' EXIT
+
+# The term handler to override the default behavior and have a uniform and
+# homogeneous exit code in all controlled situations.
+function return_failure() {
+    exit 1
+}
 
 # The script exit handler logging the FAILURE or FINISHED message depending
 # on the exit status of the last command


### PR DESCRIPTION
All MicroShift failures return 1 except for the service not being able to start. This happens because it shortcuts error checking by sending a SIGTERM to itself so that it exits immediately. The default handler for this signal returns exit code 143, whereas all the other known failure conditions return 1.
When testing this behavior the greenboot script is not consistent when something fails. This change creates a specific handler for TERM so that the exit code is also 1.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
