### PR TITLE
USHIFT-788: Add AdvertiseAddress to kube-apiserver-service-network-signer SANs to fix OI…

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -288,6 +288,7 @@ func certSetup(cfg *config.Config) (*certchains.CertificateChains, error) {
 					"openshift.default.svc.cluster.local",
 					"api." + cfg.DNS.BaseDomain,
 					"api-int." + cfg.DNS.BaseDomain,
+					cfg.ApiServer.AdvertiseAddress,
 					apiServerServiceIP.String(),
 				},
 			},


### PR DESCRIPTION
Logs from test container before fix:

```
$ oc logs -n svcaccounts-8131           oidc-discovery-validator
I0531 23:09:03.332024       1 log.go:198] OK: Got token
I0531 23:09:03.332060       1 log.go:198] validating with in-cluster discovery
I0531 23:09:03.332298       1 log.go:198] OK: got issuer https://kubernetes.default.svc
I0531 23:09:03.332316       1 log.go:198] Full, not-validated claims:
openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://kubernetes.default.svc", Subject:"system:serviceaccount:svcaccounts-8131:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1685575138, NotBefore:1685574538, IssuedAt:1685574538, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-8131", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"079ab39d-d189-4446-a0b2-a08117b7aaf2"}}}
I0531 23:09:03.340812       1 log.go:198] OK: Constructed OIDC provider for issuer https://kubernetes.default.svc
I0531 23:09:03.343517       1 log.go:198] failed to validate with in-cluster discovery: failed to verify signature: fetching keys oidc: get keys failed Get "https://10.44.0.0:6443/openid/v1/jwks": x509: certificate is valid for 10.43.0.1, not 10.44.0.0
I0531 23:09:03.343558       1 log.go:198] falling back to validating with external discovery
I0531 23:09:03.343668       1 log.go:198] OK: got issuer https://kubernetes.default.svc
I0531 23:09:03.343715       1 log.go:198] Full, not-validated claims:
openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://kubernetes.default.svc", Subject:"system:serviceaccount:svcaccounts-8131:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1685575138, NotBefore:1685574538, IssuedAt:1685574538, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-8131", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"079ab39d-d189-4446-a0b2-a08117b7aaf2"}}}
I0531 23:09:03.360597       1 log.go:198] Get "https://kubernetes.default.svc/.well-known/openid-configuration": x509: certificate signed by unknown authority
```

After:

```
$ oc logs -n svcaccounts-4591           oidc-discovery-validator
I0601 00:09:45.763665       1 log.go:198] OK: Got token
I0601 00:09:45.763852       1 log.go:198] validating with in-cluster discovery
I0601 00:09:45.764126       1 log.go:198] OK: got issuer https://kubernetes.default.svc
I0601 00:09:45.764170       1 log.go:198] Full, not-validated claims:
openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://kubernetes.default.svc", Subject:"system:serviceaccount:svcaccounts-4591:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1685578780, NotBefore:1685578180, IssuedAt:1685578180, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-4591", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"80e186bf-c75d-4146-8714-2c433e852cf9"}}}
I0601 00:09:45.774191       1 log.go:198] OK: Constructed OIDC provider for issuer https://kubernetes.default.svc
I0601 00:09:45.779384       1 log.go:198] OK: Validated signature on JWT
I0601 00:09:45.779465       1 log.go:198] OK: Got valid claims from token!
I0601 00:09:45.779493       1 log.go:198] Full, validated claims:
&openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://kubernetes.default.svc", Subject:"system:serviceaccount:svcaccounts-4591:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1685578780, NotBefore:1685578180, IssuedAt:1685578180, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-4591", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"80e186bf-c75d-4146-8714-2c433e852cf9"}}}
```