### PR TITLE
USHIFT-1292: Install GCC in dev VM

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -82,7 +82,7 @@ fi
 if ${INSTALL_BUILD_DEPS} || ${BUILD_AND_RUN}; then
     sudo dnf clean all -y
     sudo dnf update -y
-    sudo dnf install -y git cockpit make jq selinux-policy-devel rpm-build jq bash-completion
+    sudo dnf install -y gcc git cockpit make jq selinux-policy-devel rpm-build jq bash-completion
     sudo systemctl enable --now cockpit.socket
 fi
 


### PR DESCRIPTION
Installing microshift via configure-vm.sh was working before, but today it was failing because gcc wasn't installed:

```
# Building RPM packages
error: Failed build dependencies:
	gcc is needed by microshift-4.14.0_0.nightly_2023_05_29_174116_20230531233827_e4dff3d6-1.el9.x86_64
```