### PR TITLE
NOISSUE: [release-4.13] Fix configure-vm.sh script to use release-4.13 branch by default

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -92,7 +92,7 @@ if ${BUILD_AND_RUN}; then
     # Build MicroShift
     # https://github.com/openshift/microshift/blob/main/docs/devenv_setup.md#build-microshift
     if [ ! -e ~/microshift ]; then
-        git clone https://github.com/openshift/microshift.git ~/microshift
+        git clone https://github.com/openshift/microshift.git -b release-4.13 ~/microshift
     fi
     cd ~/microshift
 


### PR DESCRIPTION
Necessary for QE procedures to build the right source code in the release-4.13 branch.