### PR TITLE
USHIFT-1298: enable cgo to support loading local libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi 
 GO_TEST_FLAGS=$(GO_BUILD_FLAGS)
 GO_TEST_PACKAGES=./cmd/... ./pkg/...
 
-all: generate-config microshift etcd
+# Enable CGO when building microshift binary for access to local libraries.
+# Use an environment variable to allow CI to disable when cross-compiling.
+export CGO_ENABLED ?= 1
 
-# target "build:" defined in vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
-# Disable CGO when building microshift binary
-build: export CGO_ENABLED=0
+all: generate-config microshift etcd
 
 microshift: build
 

--- a/e2e/main.sh
+++ b/e2e/main.sh
@@ -153,12 +153,10 @@ run_test() {
 
     konfig=$(microshift_get_konfig)
     trap 'rm -f "${konfig}"' RETURN
-    
-    chmod +x "${SCRIPT_DIR}/tests/${test}"
 
     test_start=$(date +%s)
     set +e
-    KUBECONFIG="${konfig}" "${SCRIPT_DIR}/tests/${test}" &>"${output}/0010-test.log"
+    KUBECONFIG="${konfig}" bash "${SCRIPT_DIR}/tests/${test}" &>"${output}/0010-test.log"
     res=$?
     set -e
     test_dur=$(($(date +%s) - test_start))

--- a/e2e/tests/0050-pvc-resize.sh
+++ b/e2e/tests/0050-pvc-resize.sh
@@ -28,5 +28,5 @@ oc wait --for=condition=Ready --timeout=120s pod/test-pod
 
 RESIZE_TO=2Gi
 TIME_OUT=3m
-oc patch pvc my-pvc -p '{"spec":{"resources":{"requests":{"storage":"'${RESIZE_TO}'"}}}}'
-oc wait --timeout ${TIME_OUT} --for=jsonpath="{.spec.resources.requests.storage}"=${RESIZE_TO} pvc/my-pvc
+oc patch pvc test-claim -p '{"spec":{"resources":{"requests":{"storage":"'${RESIZE_TO}'"}}}}'
+oc wait --timeout ${TIME_OUT} --for=jsonpath="{.spec.resources.requests.storage}"=${RESIZE_TO} pvc/test-claim

--- a/etcd/Makefile
+++ b/etcd/Makefile
@@ -4,9 +4,9 @@ include ./vendor/github.com/openshift/build-machinery-go/make/targets/openshift/
 OUTPUT_DIR := ../_output
 GO_BUILD_BINDIR := $(OUTPUT_DIR)/bin
 
-all: export CGO_ENABLED=0
-
-build: export CGO_ENABLED=0
+# Enable CGO when building microshift binary for access to local libraries.
+# Use an environment variable to allow CI to disable when cross-compiling.
+export CGO_ENABLED ?= 1
 
 vendor:
 	go mod vendor


### PR DESCRIPTION
We had original disabled cgo, because it increases the binary size. We will need to accept that footprint increase.

```
# With CGO_ENABLED=0

$ du -sh _output/bin/microshift*
110M	_output/bin/microshift
42M	_output/bin/microshift-etcd

# With CGO_ENABLED=1

$ du -sh _output/bin/microshift*
141M	_output/bin/microshift
55M	_output/bin/microshift-etcd
```