### PR TITLE
USHIFT-1292: Remove unnecessary gcc dependency from MicroShift RPM

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -41,7 +41,6 @@ Source0: https://github.com/openshift/microshift/archive/%{commit}/microshift-%{
 
 ExclusiveArch: x86_64 aarch64
 
-BuildRequires: gcc
 BuildRequires: make
 BuildRequires: policycoreutils
 BuildRequires: systemd

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -82,7 +82,7 @@ fi
 if ${INSTALL_BUILD_DEPS} || ${BUILD_AND_RUN}; then
     sudo dnf clean all -y
     sudo dnf update -y
-    sudo dnf install -y gcc git cockpit make jq selinux-policy-devel rpm-build jq bash-completion
+    sudo dnf install -y git cockpit make jq selinux-policy-devel rpm-build jq bash-completion
     sudo systemctl enable --now cockpit.socket
 fi
 


### PR DESCRIPTION
Follow-up on #1862 

It looks like `gcc` build dependency was introduced 2 years ago and we may want to get rid of it to save on the installation time in CI, etc.
https://github.com/openshift/microshift/commit/29330ce3b3bd496c39336218ae88bf3bc76327db

Closes [USHIFT-1292](https://issues.redhat.com//browse/USHIFT-1292)
