### PR TITLE
USHIFT-1267: Allow for keeping container images when cleaning MicroShift data

### DIFF
--- a/e2e/main.sh
+++ b/e2e/main.sh
@@ -120,7 +120,7 @@ microshift_debug_info() {
 microshift_cleanup() {
     local output_dir="${1}"
     log "Cleaning MicroShift"
-    ssh_cmd "echo 1 | sudo microshift-cleanup-data --all" &>"${output_dir}/0000-cleanup.log"
+    ssh_cmd "echo 1 | sudo microshift-cleanup-data --all --keep-images" &>"${output_dir}/0000-cleanup.log"
 }
 
 microshift_reprovision() {

--- a/e2e/tests/assets/greenboot-test.sh
+++ b/e2e/tests/assets/greenboot-test.sh
@@ -10,7 +10,8 @@ function check_greenboot_exit_status() {
     local cleanup=$2
 
     if [ "${cleanup}" -ne 0 ]; then
-        echo 1 | microshift-cleanup-data --all
+        # Skip image deletion to speed up the test and make it more reliable
+        echo 1 | microshift-cleanup-data --all --keep-images
         systemctl enable --now microshift || true
     fi
 


### PR DESCRIPTION
* Add the `--keep-images` option to `microshift-cleanup-data` script
* Use this option in the greenboot tests to speed it up
* Fixed bug when deleting pods

```
$ ./scripts/microshift-cleanup-data.sh 
Stop all MicroShift services, also cleaning their data

Usage: microshift-cleanup-data.sh <--all [--keep-images] | --ovn>
   --all         Clean all MicroShift and OVN data
   --keep-images Keep container images when cleaning all data
   --ovn         Clean OVN data only
```

Closes [USHIFT-1267](https://issues.redhat.com//browse/USHIFT-1267)
