### PR TITLE
USHIFT-1297: Create image-builder VM as foreground process

### DIFF
--- a/scripts/image-builder/create-vm.sh
+++ b/scripts/image-builder/create-vm.sh
@@ -23,7 +23,7 @@ fi
 # Necessary to allow remote connections in the virt-viewer application
 sudo usermod -a -G libvirt "$(whoami)"
 
-sudo -b bash -c " \
+sudo bash -c " \
 virt-install \
     --name ${VMNAME} \
     --vcpus 2 \


### PR DESCRIPTION
Remove -b flag from sudo when creating the VM to allow active wait until the guest is completely installed and restarted.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
