### PR TITLE
OCPBUGS-12744: support all kustomization base filenames

### DIFF
--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -76,7 +76,7 @@
       ],
       "properties": {
         "kustomizePaths": {
-          "description": "The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.",
+          "description": "The locations on the filesystem to scan for kustomization files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.",
           "type": "array",
           "default": [
             "/usr/lib/microshift/manifests",

--- a/docs/howto_config.md
+++ b/docs/howto_config.md
@@ -118,9 +118,9 @@ Please note that values close to the floor may be more likely to impact etcd per
 
 # Auto-applying Manifests
 
-MicroShift leverages `kustomize` for Kubernetes-native templating and declarative management of resource objects. Upon start-up, it searches `/etc/microshift/manifests`, `/etc/microshift/manifests.d/*`, `/usr/lib/microshift/manifests`, and `/usr/lib/microshift/manifests.d/*` directories for a `kustomization.yaml` file. If it finds one, it automatically runs `kubectl apply -k` command to apply that manifest.
+MicroShift leverages `kustomize` for Kubernetes-native templating and declarative management of resource objects. Upon start-up, it searches `/etc/microshift/manifests`, `/etc/microshift/manifests.d/*`, `/usr/lib/microshift/manifests`, and `/usr/lib/microshift/manifests.d/*` directories for a `kustomization.yaml`, `kustomization.yml`, or `Kustomization` file. If it finds one, it automatically runs `kubectl apply -k` command to apply that manifest.
 
-The reason for providing multiple directories is to allow a flexible method to manage MicroShift workloads.
+Loading from multiple directories allows you to manage MicroShift workloads more flexibly. Different workloads can be independent of each other, instead of having to be loaded from a merged set of inputs.
 
 | Location                          | Intent |
 |-----------------------------------|--------|

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/manifests.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/kustomize/api/konfig"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 )
 
 type Manifests struct {
-	// The locations on the filesystem to scan for kustomization.yaml
+	// The locations on the filesystem to scan for kustomization
 	// files to use to load manifests. Set to a list of paths to scan
 	// only those paths. Set to an empty list to disable loading
 	// manifests. The entries in the list can be glob patterns to
@@ -29,29 +30,30 @@ type Manifests struct {
 }
 
 func (m *Manifests) GetKustomizationPaths() ([]string, error) {
+	kustomizationFileNames := konfig.RecognizedKustomizationFileNames()
 	results := []string{}
 	for _, path := range m.KustomizePaths {
-		pattern := filepath.Join(path, "kustomization.yaml")
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("failed to expand pattern in kustomizePath %v: %w", path, err)
-		}
-		if len(matches) == 0 {
-			klog.Infof("No kustomize path matches %v", pattern)
-			continue
-		}
-		// We add kustomization.yaml to the pattern so we only return
-		// directories where there is something to apply, but the
-		// results we need are the directory names, so convert the
-		// full match string back to a directory.
-		//
-		// Glob() does not explicitly say it sorts its return value,
-		// so we do it to ensure deterministic behavior.
-		sort.Strings(matches)
-		for _, match := range matches {
-			klog.Infof("Adding kustomize path %v", filepath.Dir(match))
-			results = append(results, filepath.Dir(match))
+		for _, filename := range kustomizationFileNames {
+			pattern := filepath.Join(path, filename)
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("Could not understand kustomizePath value %v: %w", path, err)
+			}
+			if len(matches) == 0 {
+				klog.Infof("No kustomize path matches %v", pattern)
+				continue
+			}
+			// We add the filename to the pattern so we only return
+			// directories where there is something to apply, but the
+			// results we need are the directory names, so convert the
+			// full match string back to a directory.
+			for _, match := range matches {
+				klog.Infof("Adding kustomize path %v", filepath.Dir(match))
+				results = append(results, filepath.Dir(match))
+			}
 		}
 	}
+	// Sort the results to ensure deterministic behavior.
+	sort.Strings(results)
 	return results, nil
 }

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -18,7 +18,7 @@ etcd:
     # Set a memory limit on the etcd process; etcd will begin paging memory when it gets to this value. 0 means no limit.
     memoryLimitMB: 0
 manifests:
-    # The locations on the filesystem to scan for kustomization.yaml files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
+    # The locations on the filesystem to scan for kustomization files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
     kustomizePaths:
         - /usr/lib/microshift/manifests
         - /usr/lib/microshift/manifests.d/*

--- a/pkg/config/manifests.go
+++ b/pkg/config/manifests.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/kustomize/api/konfig"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 )
 
 type Manifests struct {
-	// The locations on the filesystem to scan for kustomization.yaml
+	// The locations on the filesystem to scan for kustomization
 	// files to use to load manifests. Set to a list of paths to scan
 	// only those paths. Set to an empty list to disable loading
 	// manifests. The entries in the list can be glob patterns to
@@ -28,29 +29,36 @@ type Manifests struct {
 	KustomizePaths []string `json:"kustomizePaths"`
 }
 
+// GetKustomizationPaths returns the list of configured paths for
+// which there are actual kustomization files to be loaded. The paths
+// are returned in the order given in the configuration file. The
+// results of any glob patterns are sorted lexicographically.
 func (m *Manifests) GetKustomizationPaths() ([]string, error) {
+	kustomizationFileNames := konfig.RecognizedKustomizationFileNames()
 	results := []string{}
 	for _, path := range m.KustomizePaths {
-		pattern := filepath.Join(path, "kustomization.yaml")
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("failed to expand pattern in kustomizePath %v: %w", path, err)
-		}
-		if len(matches) == 0 {
-			klog.Infof("No kustomize path matches %v", pattern)
-			continue
-		}
-		// We add kustomization.yaml to the pattern so we only return
-		// directories where there is something to apply, but the
-		// results we need are the directory names, so convert the
-		// full match string back to a directory.
-		//
-		// Glob() does not explicitly say it sorts its return value,
-		// so we do it to ensure deterministic behavior.
-		sort.Strings(matches)
-		for _, match := range matches {
-			klog.Infof("Adding kustomize path %v", filepath.Dir(match))
-			results = append(results, filepath.Dir(match))
+		for _, filename := range kustomizationFileNames {
+			pattern := filepath.Join(path, filename)
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("Could not understand kustomizePath value %v: %w", path, err)
+			}
+			if len(matches) == 0 {
+				klog.Infof("No kustomize path matches %v", pattern)
+				continue
+			}
+			// We add the filename to the pattern so we only return
+			// directories where there is something to apply, but the
+			// results we need are the directory names, so convert the
+			// full match string back to a directory.
+			//
+			// Glob() does not explicitly say it sorts its return
+			// value, so we do it to ensure deterministic behavior.
+			sort.Strings(matches)
+			for _, match := range matches {
+				klog.Infof("Adding kustomize path %v", filepath.Dir(match))
+				results = append(results, filepath.Dir(match))
+			}
 		}
 	}
 	return results, nil

--- a/test/suites/kustomize.robot
+++ b/test/suites/kustomize.robot
@@ -6,198 +6,176 @@ Resource            ../resources/systemd.resource
 Resource            ../resources/microshift-config.resource
 Resource            ../resources/microshift-process.resource
 
+Suite Setup         Setup Suite
+Suite Teardown      Teardown Suite
+
 Test Tags           restart    slow
 
 
 *** Variables ***
 ${CONFIGMAP_NAME}       test-configmap
+${NON_DEFAULT_DIR}      /usr/lib/microshift/test-manifests
+${UNCONFIGURED_DIR}     /usr/lib/microshift/test-manifests.d/unconfigured
+${YAML_PATH}            /etc/microshift/manifests.d/yaml-ext
+${YML_PATH}             /etc/microshift/manifests.d/yml-ext
+${NOEXT_PATH}           /etc/microshift/manifests.d/no-ext
 
 
 *** Test Cases ***
 Load From /etc/microshift/manifests
     [Documentation]    /etc/microshift/manifests
-    [Setup]    Setup    /etc/microshift/manifests
-    ConfigMap Path Should Match
-    [Teardown]    Teardown
+    ConfigMap Path Should Match    ${ETC_NAMESPACE}    /etc/microshift/manifests
 
 Load From /etc/microshift/manifestsd
     # Keyword names cannot have '.' in them
     [Documentation]    Subdir of /etc/microshift/manifests.d
-    [Setup]    Setup With Subdir    /etc/microshift/manifests.d
-    ConfigMap Path Should Match
-    [Teardown]    Teardown With Subdir
+    ConfigMap Path Should Match    ${ETC_SUBDIR_NAMESPACE}    ${ETC_SUBDIR}
 
 Load From /usr/lib/microshift/manifests
     [Documentation]    /usr/lib/microshift/manifests
-    [Setup]    Setup    /usr/lib/microshift/manifests
-    ConfigMap Path Should Match
-    [Teardown]    Teardown
+    ConfigMap Path Should Match    ${USR_NAMESPACE}    /usr/lib/microshift/manifests
 
 Load From /usr/lib/microshift/manifestsd
     # Keyword names cannot have '.' in them
     [Documentation]    Subdir of /usr/lib/microshift/manifests.d
-    [Setup]    Setup With Subdir    /usr/lib/microshift/manifests.d
-    ConfigMap Path Should Match
-    [Teardown]    Teardown With Subdir
+    ConfigMap Path Should Match    ${USR_SUBDIR_NAMESPACE}    ${USR_SUBDIR}
 
 Load From Configured Dir
     [Documentation]    Non-default directory
-    [Setup]    Setup With Config    /usr/lib/microshift/test-manifests
-    ConfigMap Path Should Match
-    [Teardown]    Teardown With Config
+    ConfigMap Path Should Match    ${NON_DEFAULT_NAMESPACE}    /usr/lib/microshift/test-manifests
 
-Do Not Load From Unonfigured Dir
-    [Documentation]    Remove default directory from config and ensure manifests are not loaded
-    [Setup]    Setup With Limited Config
-    ConfigMap Should Be Missing
-    [Teardown]    Teardown With Config
+Do Not Load From Unconfigured Dir
+    [Documentation]    Manifests from a directory not in the config should not be loaded
+    ConfigMap Should Be Missing    ${UNCONFIGURED_NAMESPACE}
 
 Yaml Extension
-    [Documentation]    /etc/microshift/manifests/kustomization.yaml
-    [Setup]    Setup    /etc/microshift/manifests    kustomization.yaml
-    ConfigMap Path Should Match
-    [Teardown]    Teardown
+    [Documentation]    Root file kustomization.yaml
+    ConfigMap Path Should Match    ${YAML_NAMESPACE}    ${YAML_PATH}
 
 Yml Extension
-    [Documentation]    /etc/microshift/manifests/kustomization.yml
-    [Setup]    Setup    /etc/microshift/manifests    kustomization.yml
-    ConfigMap Path Should Match
-    [Teardown]    Teardown
+    [Documentation]    Root file kustomization.yml
+    ConfigMap Path Should Match    ${YML_NAMESPACE}    ${YML_PATH}
 
 No Extension
-    [Documentation]    /etc/microshift/manifests/Kustomization
-    [Setup]    Setup    /etc/microshift/manifests    Kustomization
-    ConfigMap Path Should Match
-    [Teardown]    Teardown
+    [Documentation]    Root file Kustomization
+    ConfigMap Path Should Match    ${NOEXT_NAMESPACE}    ${NOEXT_PATH}
 
 
 *** Keywords ***
-Setup
-    [Documentation]    Set up for test
-    [Arguments]    ${path}    ${kfile}=kustomization.yaml
-
-    Set Suite Variable    \${MANIFEST_DIR}    ${path}
+Setup Suite    # robocop: disable=too-long-keyword
+    [Documentation]    Set up all of the tests in this suite
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig    # for readiness checks
-    ${ns}=    Create Random Namespace
-    Set Suite Variable    \${NAMESPACE}    ${ns}
-    Clear Manifest Directory
-    Write Manifests    ${kfile}
-    Restart MicroShift
 
-Teardown
-    [Documentation]    Clean up after test
-    Clear Manifest Directory
-    Run With Kubeconfig    oc delete namespace ${NAMESPACE}    allow_fail=True
-    Logout MicroShift Host
-    Remove Kubeconfig
+    # Used by "Load From /etc/microshift/manifests"
+    ${ns}=    Generate Manifests    /etc/microshift/manifests
+    Set Suite Variable    \${ETC_NAMESPACE}    ${ns}
 
-Setup With Subdir
-    [Documentation]    Set up for test using dynamically created subdir
-    [Arguments]    ${path}
+    # Used by "Load From /etc/microshift/manifestsd"
     ${rand}=    Generate Random String
-    Setup    ${path}/${rand}
+    Set Suite Variable    \${ETC_SUBDIR}    /etc/microshift/manifests.d/${rand}
+    ${ns}=    Generate Manifests    ${ETC_SUBDIR}
+    Set Suite Variable    \${ETC_SUBDIR_NAMESPACE}    ${ns}
 
-Teardown With Subdir
-    [Documentation]    Remove MANIFEST_DIR and clean up
-    ${stdout}    ${rc}=    Execute Command
-    ...    rm -rf ${MANIFEST_DIR}
-    ...    sudo=True    return_rc=True
-    Should Be Equal As Integers    0    ${rc}
-    Teardown
+    # Used by "Load From /usr/lib/microshift/manifests"
+    ${ns}=    Generate Manifests    /usr/lib/microshift/manifests
+    Set Suite Variable    \${USR_NAMESPACE}    ${ns}
 
-Setup With Config    # robocop: disable=too-many-calls-in-keyword
-    [Documentation]    Set up for test using non-default directory
-    [Arguments]    ${path}
-    Set Suite Variable    \${MANIFEST_DIR}    ${path}
-    Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig    # for readiness checks
+    # Used by "Load From /usr/lib/microshift/manifestsd"
+    ${rand}=    Generate Random String
+    Set Suite Variable    \${USR_SUBDIR}    /usr/lib/microshift/manifests.d/${rand}
+    ${ns}=    Generate Manifests    ${USR_SUBDIR}
+    Set Suite Variable    \${USR_SUBDIR_NAMESPACE}    ${ns}
 
-    # Extend the configuration setting to add the path
-    Save Default MicroShift Config
-    ${config_content}=    Catenate    SEPARATOR=\n
-    ...    manifests:
-    ...    \ \ kustomizePaths:
-    ...    \ \ \ \ - ${path}
-    ${merged}=    Extend MicroShift Config    ${config_content}
-    Upload MicroShift Config    ${merged}
+    # Used by "Load From Configured Dir"
+    ${ns}=    Generate Manifests    ${NON_DEFAULT_DIR}
+    Set Suite Variable    \${NON_DEFAULT_NAMESPACE}    ${ns}
 
-    ${ns}=    Create Random Namespace
-    Set Suite Variable    \${NAMESPACE}    ${ns}
-    Clear Manifest Directory
-    Write Manifests
-    Restart MicroShift
+    # Used by "Do Not Load From Unconfigured Dir"
+    ${ns}=    Generate Manifests    ${UNCONFIGURED_DIR}
+    Set Suite Variable    \${UNCONFIGURED_NAMESPACE}    ${ns}
 
-Teardown With Config
-    [Documentation]    Restore default config and clean up
-    Restore Default Config
-    Teardown With Subdir
+    # Used by "Yaml Extension"
+    ${ns}=    Generate Manifests    ${YAML_PATH}    kustomization.yaml
+    Set Suite Variable    \${YAML_NAMESPACE}    ${ns}
 
-Setup With Limited Config    # robocop: disable=too-many-calls-in-keyword
-    [Documentation]    Ensure the configuration does *not* include the manifest directory
-    Set Suite Variable    \${MANIFEST_DIR}    /usr/lib/microshift/manifests
-    Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig    # for readiness checks
+    # Used by "Yml Extension"
+    ${ns}=    Generate Manifests    ${YML_PATH}    kustomization.yml
+    Set Suite Variable    \${YML_NAMESPACE}    ${ns}
 
-    # Write a config that does not include our path
+    # Used by "No Extension"
+    ${ns}=    Generate Manifests    ${NOEXT_PATH}    Kustomization
+    Set Suite Variable    \${NOEXT_NAMESPACE}    ${ns}
+
+    # Extend the configuration setting to add the unique path to the defaults
     Save Default MicroShift Config
     ${config_content}=    Catenate    SEPARATOR=\n
     ...    manifests:
     ...    \ \ kustomizePaths:
     ...    \ \ \ \ - /etc/microshift/manifests
+    ...    \ \ \ \ - /etc/microshift/manifests.d/*
+    ...    \ \ \ \ - /usr/lib/microshift/manifests
+    ...    \ \ \ \ - /usr/lib/microshift/manifests.d/*
+    ...    \ \ \ \ - ${NON_DEFAULT_DIR}
+    ...    \ \ \ \ # Add a directory _without_ the glob for unconfigured test
+    ...    \ \ \ \ - /usr/lib/microshift/test-manifests.d
     ${merged}=    Extend MicroShift Config    ${config_content}
     Upload MicroShift Config    ${merged}
 
+    Restart MicroShift
+
+Teardown Suite    # robocop: disable=too-many-calls-in-keyword
+    [Documentation]    Clean up all of the tests in this suite
+
+    Clear Manifest Directory    /etc/microshift/manifests
+    Remove Manifest Directory    ${ETC_SUBDIR}
+    Clear Manifest Directory    /usr/lib/microshift/manifests
+    Remove Manifest Directory    ${USR_SUBDIR}
+    Remove Manifest Directory    ${NON_DEFAULT_DIR}
+    Remove Manifest Directory    ${UNCONFIGURED_DIR}
+    Remove Manifest Directory    ${YAML_PATH}
+    Remove Manifest Directory    ${YML_PATH}
+    Remove Manifest Directory    ${NOEXT_PATH}
+
+    Run With Kubeconfig    oc delete namespace ${ETC_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${ETC_SUBDIR_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${USR_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${USR_SUBDIR_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${NON_DEFAULT_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${UNCONFIGURED_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${YAML_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${YML_NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${NOEXT_NAMESPACE}    allow_fail=True
+
+    Restore Default Config
+    Logout MicroShift Host
+    Remove Kubeconfig
+
+Generate Manifests
+    [Documentation]    Create a namespace and the manifests in the given path.
+    ...    Return the namespace.
+    [Arguments]    ${manifest_dir}    ${kfile}=kustomization.yaml
     ${ns}=    Create Random Namespace
-    Set Suite Variable    \${NAMESPACE}    ${ns}
-    Clear Manifest Directory
-    Write Manifests
-    Restart MicroShift
-
-Restore Default Config
-    [Documentation]    Remove any custom config and restart MicroShift
-    Restore Default MicroShift Config
-    Restart MicroShift
-    Sleep    10 seconds    # Wait for systemd to catch up
-
-ConfigMap Path Should Match
-    [Documentation]    Ensure the config map path value matches the manifest dir
-    ${configmap}=    Oc Get    configmap    ${NAMESPACE}    ${CONFIGMAP_NAME}
-    Should Be Equal    ${MANIFEST_DIR}    ${configmap.data.path}
-
-ConfigMap Should Be Missing
-    [Documentation]    Ensure the config map was not created
-    ${result}=    Run Process    oc get configmap -n ${NAMESPACE} ${CONFIGMAP_NAME}
-    ...    env:KUBECONFIG=${KUBECONFIG}
-    ...    stderr=STDOUT
-    ...    shell=True
-    Should Be Equal As Integers    ${result.rc}    1
-
-Clear Manifest Directory
-    [Documentation]    Remove the contents of the manifest directory
-    ${stdout}    ${rc}=    Execute Command
-    ...    rm -rf ${MANIFEST_DIR}/*
-    ...    sudo=True    return_rc=True
-    Should Be Equal As Integers    0    ${rc}
+    Clear Manifest Directory    ${manifest_dir}
+    Write Manifests    ${manifest_dir}    ${ns}    ${kfile}
+    RETURN    ${ns}
 
 Write Manifests
     [Documentation]    Install manifests
-    [Arguments]    ${kfile}=kustomization.yaml
+    [Arguments]    ${manifest_dir}    ${namespace}    ${kfile}
     # Make sure the manifest directory exists
     ${stdout}    ${rc}=    Execute Command
-    ...    mkdir -p ${MANIFEST_DIR}
+    ...    mkdir -p ${manifest_dir}
     ...    sudo=True    return_rc=True
     Should Be Equal As Integers    0    ${rc}
     # Configure kustomization to use the namespace created in Setup
     ${kustomization}=    Catenate    SEPARATOR=\n
     ...    resources:
     ...    - configmap.yaml
-    ...    namespace: ${NAMESPACE}
+    ...    namespace: ${namespace}
     ...
-    Upload String To File    ${kustomization}    ${MANIFEST_DIR}/${kfile}
+    Upload String To File    ${kustomization}    ${manifest_dir}/${kfile}
     # Build a configmap with unique data for this scenario
     ${configmap}=    Catenate    SEPARATOR=\n
     ...    apiVersion: v1
@@ -205,7 +183,43 @@ Write Manifests
     ...    metadata:
     ...    \ \ name: ${CONFIGMAP_NAME}
     ...    data:
-    ...    \ \ path: ${MANIFEST_DIR}
+    ...    \ \ path: ${manifest_dir}
     ...
-    Upload String To File    ${configmap}    ${MANIFEST_DIR}/configmap.yaml
+    Upload String To File    ${configmap}    ${manifest_dir}/configmap.yaml
 
+ConfigMap Path Should Match
+    [Documentation]    Ensure the config map path value matches the manifest dir
+    [Arguments]    ${namespace}    ${manifest_dir}
+    ${configmap}=    Oc Get    configmap    ${namespace}    ${CONFIGMAP_NAME}
+    Should Be Equal    ${manifest_dir}    ${configmap.data.path}
+
+ConfigMap Should Be Missing
+    [Documentation]    Ensure the config map was not created
+    [Arguments]    ${namespace}
+    ${result}=    Run Process    oc get configmap -n ${namespace} ${CONFIGMAP_NAME}
+    ...    env:KUBECONFIG=${KUBECONFIG}
+    ...    stderr=STDOUT
+    ...    shell=True
+    Should Be Equal As Integers    ${result.rc}    1
+
+Clear Manifest Directory
+    [Documentation]    Remove the contents of the manifest directory
+    [Arguments]    ${manifest_dir}
+    ${stdout}    ${rc}=    Execute Command
+    ...    rm -rf ${manifest_dir}/*
+    ...    sudo=True    return_rc=True
+    Should Be Equal As Integers    0    ${rc}
+
+Remove Manifest Directory
+    [Documentation]    Completely remove the directory
+    [Arguments]    ${manifest_dir}
+    ${stdout}    ${rc}=    Execute Command
+    ...    rm -rf ${manifest_dir}
+    ...    sudo=True    return_rc=True
+    Should Be Equal As Integers    0    ${rc}
+
+Restore Default Config
+    [Documentation]    Remove any custom config and restart MicroShift
+    Restore Default MicroShift Config
+    Restart MicroShift
+    Sleep    10 seconds    # Wait for systemd to catch up

--- a/test/suites/kustomize.robot
+++ b/test/suites/kustomize.robot
@@ -52,11 +52,30 @@ Do Not Load From Unonfigured Dir
     ConfigMap Should Be Missing
     [Teardown]    Teardown With Config
 
+Yaml Extension
+    [Documentation]    /etc/microshift/manifests/kustomization.yaml
+    [Setup]    Setup    /etc/microshift/manifests    kustomization.yaml
+    ConfigMap Path Should Match
+    [Teardown]    Teardown
+
+Yml Extension
+    [Documentation]    /etc/microshift/manifests/kustomization.yml
+    [Setup]    Setup    /etc/microshift/manifests    kustomization.yml
+    ConfigMap Path Should Match
+    [Teardown]    Teardown
+
+No Extension
+    [Documentation]    /etc/microshift/manifests/Kustomization
+    [Setup]    Setup    /etc/microshift/manifests    Kustomization
+    ConfigMap Path Should Match
+    [Teardown]    Teardown
+
 
 *** Keywords ***
 Setup
     [Documentation]    Set up for test
-    [Arguments]    ${path}
+    [Arguments]    ${path}    ${kfile}=kustomization.yaml
+
     Set Suite Variable    \${MANIFEST_DIR}    ${path}
     Check Required Env Variables
     Login MicroShift Host
@@ -64,7 +83,7 @@ Setup
     ${ns}=    Create Random Namespace
     Set Suite Variable    \${NAMESPACE}    ${ns}
     Clear Manifest Directory
-    Write Manifests
+    Write Manifests    ${kfile}
     Restart MicroShift
 
 Teardown
@@ -166,6 +185,7 @@ Clear Manifest Directory
 
 Write Manifests
     [Documentation]    Install manifests
+    [Arguments]    ${kfile}=kustomization.yaml
     # Make sure the manifest directory exists
     ${stdout}    ${rc}=    Execute Command
     ...    mkdir -p ${MANIFEST_DIR}
@@ -177,7 +197,7 @@ Write Manifests
     ...    - configmap.yaml
     ...    namespace: ${NAMESPACE}
     ...
-    Upload String To File    ${kustomization}    ${MANIFEST_DIR}/kustomization.yaml
+    Upload String To File    ${kustomization}    ${MANIFEST_DIR}/${kfile}
     # Build a configmap with unique data for this scenario
     ${configmap}=    Catenate    SEPARATOR=\n
     ...    apiVersion: v1
@@ -188,3 +208,4 @@ Write Manifests
     ...    \ \ path: ${MANIFEST_DIR}
     ...
     Upload String To File    ${configmap}    ${MANIFEST_DIR}/configmap.yaml
+


### PR DESCRIPTION
This change expands the search patterns for kustomization inputs to
include all of the forms supported by kubectl (kustomization.yaml,
kustomization.yml, and Kustomization).