### PR TITLE
USHIFT-1359: Rebase: write cluster registry credentials to custom path

### DIFF
--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -17,9 +17,11 @@ cp /secrets/ci-pull-secret/.dockercfg "$HOME/.pull-secret.json" || {
     echo "WARN: Could not copy registry secret file"
 }
 
-oc registry login
-release_amd64="$(oc image info $OPENSHIFT_RELEASE_IMAGE -o json | jq -r '.config.config.Labels."io.openshift.release"')"
-release_arm64="$(oc image info $OPENSHIFT_RELEASE_IMAGE_ARM -o json | jq -r '.config.config.Labels."io.openshift.release"')"
+# log in into cluster's registry
+oc registry login --to=/tmp/registry.json
+release_amd64="$(oc image info --registry-config=/tmp/registry.json $OPENSHIFT_RELEASE_IMAGE -o json | jq -r '.config.config.Labels."io.openshift.release"')"
+release_arm64="$(oc image info --registry-config=/tmp/registry.json $OPENSHIFT_RELEASE_IMAGE_ARM -o json | jq -r '.config.config.Labels."io.openshift.release"')"
+
 # LVMS is not tracked in the OCP release image.  Instead, rely on the latest X.Y stream as the release image.
 #  LVMS also does not cut nightly releases where ocp-release does.  This means that latest ocp-releases' y-stream
 #  can increment independently from LVMS, and will usually be 1 y-stream ahead of LVMS in-between OCP releases.


### PR DESCRIPTION
Periodic and presubmit jobs are set up differently. `oc registry login` fails to write registry config to default location in periodic jobs, no problem in presubmits.