### PR TITLE
[NO-ISSUE] use kustomize to generate smoke-test resources

### DIFF
--- a/e2e/main.sh
+++ b/e2e/main.sh
@@ -107,6 +107,30 @@ apiServer:
   subjectAltNames:
   - '"${USHIFT_IP}"'
 EOF' &>"${output_dir}/0001-setup.log"
+
+    ssh_cmd 'cat <<EOF | sudo tee /etc/microshift/lvmd.yaml
+# The fields here reflect LVM state of the CI smoke-testing instance.
+device-classes:
+  # The name of a device-class
+  - name: default
+
+    # The group where this device-class creates the logical volumes
+    volume-group: rhel
+
+    # Storage capacity in GiB to be spared
+    spare-gb: 0
+
+    # A flag to indicate that this device-class is used by default
+    default: true
+  - name: thin
+    volume-group: rhel
+    spare-gb: 0
+    default: false
+    type: thin
+    thin-pool:
+      name: thin
+      overprovision-ratio: 10.0
+EOF' &>>"${output_dir}/0001-setup.log"
     ssh_cmd "sudo systemctl enable --now microshift" &>>"${output_dir}/0001-setup.log"
 }
 

--- a/e2e/tests/0050-pvc-resize.sh
+++ b/e2e/tests/0050-pvc-resize.sh
@@ -5,28 +5,35 @@ PS4='+ $(date "+%T.%N")\011 '
 set -x
 
 SCRIPT_PATH="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+POD_MANIFEST="${SCRIPT_PATH}/assets/kustomizations/patches/pvc-thick"
 
 RETRIES=5
-BACKOFF=20
+RETRY_WAIT=20
 
 wait_until() {
     local cmd=$*
     for _ in $(seq "${RETRIES}"); do
         ${cmd} && return 0
-        sleep "${BACKOFF}"
+        sleep "${RETRY_WAIT}"
     done
     return 1
 }
 
+MANIFEST="$(mktemp -d)/manifest.yaml"
+oc kustomize "${POD_MANIFEST}" | tee "${MANIFEST}"
+
+CLAIM_NAME="$(yq 'select(.kind == "PersistentVolumeClaim") | .metadata.name' "${MANIFEST}")"
+POD_NAME="$(yq 'select(.kind == "Pod") | .metadata.name' "${MANIFEST}")"
+
 cleanup() {
-    oc delete -f "${SCRIPT_PATH}/assets/pod-with-pvc.yaml"
+    oc delete -f "${MANIFEST}"
 }
 trap 'cleanup' EXIT
 
-oc create -f "${SCRIPT_PATH}/assets/pod-with-pvc.yaml"
-oc wait --for=condition=Ready --timeout=120s pod/test-pod
+oc apply -f "${MANIFEST}"
+oc wait --for=condition=Ready --timeout=120s pod/"${POD_NAME}"
 
 RESIZE_TO=2Gi
 TIME_OUT=3m
-oc patch pvc test-claim -p '{"spec":{"resources":{"requests":{"storage":"'${RESIZE_TO}'"}}}}'
-oc wait --timeout ${TIME_OUT} --for=jsonpath="{.spec.resources.requests.storage}"=${RESIZE_TO} pvc/test-claim
+oc patch pvc "${CLAIM_NAME}" -p '{"spec":{"resources":{"requests":{"storage":"'${RESIZE_TO}'"}}}}'
+oc wait --timeout ${TIME_OUT} --for=jsonpath="{.spec.resources.requests.storage}"=${RESIZE_TO} pvc/"${CLAIM_NAME}"

--- a/e2e/tests/assets/kustomizations/base/kustomization.yaml
+++ b/e2e/tests/assets/kustomizations/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./pod-base.yaml

--- a/e2e/tests/assets/kustomizations/base/pod-base.yaml
+++ b/e2e/tests/assets/kustomizations/base/pod-base.yaml
@@ -1,25 +1,10 @@
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  namespace: default
-  name: test-claim
-spec:
-  accessModes:
-  - ReadWriteOnce
-  storageClassName: topolvm-provisioner
-  resources:
-    requests:
-      storage: 1Gi
----
 kind: Pod
 apiVersion: v1
 metadata:
-  name: test-pod
-  namespace: default
+  name: base
 spec:
   securityContext:
     runAsNonRoot: true
-    privileged: false
     seccompProfile:
       type: RuntimeDefault
   containers:
@@ -39,5 +24,3 @@ spec:
       name: test-vol
   volumes:
   - name: test-vol
-    persistentVolumeClaim:
-      claimName: test-claim

--- a/e2e/tests/assets/kustomizations/patches/pvc-thick/kustomization.yaml
+++ b/e2e/tests/assets/kustomizations/patches/pvc-thick/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base/
+- pvc.yaml
+
+patches:
+  - path: pod.patch.yaml

--- a/e2e/tests/assets/kustomizations/patches/pvc-thick/pod.patch.yaml
+++ b/e2e/tests/assets/kustomizations/patches/pvc-thick/pod.patch.yaml
@@ -1,0 +1,9 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: base
+spec:
+  volumes:
+    - name: test-vol
+      persistentVolumeClaim:
+        claimName: test-claim-thick

--- a/e2e/tests/assets/kustomizations/patches/pvc-thick/pvc.yaml
+++ b/e2e/tests/assets/kustomizations/patches/pvc-thick/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-claim-thick
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: topolvm-provisioner
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
This was originally part of #1933.  This changes the way smoke-test assets are managed.  As a standalone change it's not that impactful (only the resize test is affected).

The snapshotting feature will add a handful more smoke-test assets and it will be more manageable to use a base pod definition and patch in varying PVC definitions.  The alternative is to use manifests that are almost completely identical, except for the claim.

This PR also fixes a script bug in the e2e/main.sh file by removing the indentation in the here-doc.