### PR TITLE
USHIFT-1383: Upgradeability: rename (un)healthy to "backup / restore" action

### DIFF
--- a/packaging/greenboot/microshift_set_backup.sh
+++ b/packaging/greenboot/microshift_set_backup.sh
@@ -2,10 +2,10 @@
 
 set -ex
 
-HEALTH=healthy
+ACTION=backup
 
 SCRIPT_NAME=$(basename "$0")
-if [ "$(id -u)" -ne 0 ] ; then
+if [ "$(id -u)" -ne 0 ]; then
     echo "The '${SCRIPT_NAME}' script must be run with the 'root' user privileges"
     exit 1
 fi
@@ -17,11 +17,11 @@ fi
 
 mkdir -p /var/lib/microshift-backups
 
-boot=$(tr -d '-' < /proc/sys/kernel/random/boot_id)
+boot=$(tr -d '-' </proc/sys/kernel/random/boot_id)
 deploy=$(rpm-ostree status --booted --jsonpath='$.deployments[0].id' | jq -r '.[0]')
 jq \
     --null-input \
-    --arg health "${HEALTH}" \
+    --arg action "${ACTION}" \
     --arg deploy "${deploy}" \
     --arg boot "${boot}" \
-    '{ "health": $health, "deployment_id": $deploy, "boot_id": $boot }' > /var/lib/microshift-backups/health.json
+    '{ "action": $action, "deployment_id": $deploy, "boot_id": $boot }' >/var/lib/microshift-backups/system.json

--- a/packaging/greenboot/microshift_set_restore.sh
+++ b/packaging/greenboot/microshift_set_restore.sh
@@ -2,10 +2,10 @@
 
 set -ex
 
-HEALTH=unhealthy
+ACTION=restore
 
 SCRIPT_NAME=$(basename "$0")
-if [ "$(id -u)" -ne 0 ] ; then
+if [ "$(id -u)" -ne 0 ]; then
     echo "The '${SCRIPT_NAME}' script must be run with the 'root' user privileges"
     exit 1
 fi
@@ -17,11 +17,11 @@ fi
 
 mkdir -p /var/lib/microshift-backups
 
-boot=$(tr -d '-' < /proc/sys/kernel/random/boot_id)
+boot=$(tr -d '-' </proc/sys/kernel/random/boot_id)
 deploy=$(rpm-ostree status --booted --jsonpath='$.deployments[0].id' | jq -r '.[0]')
 jq \
     --null-input \
-    --arg health "${HEALTH}" \
+    --arg action "${ACTION}" \
     --arg deploy "${deploy}" \
     --arg boot "${boot}" \
-    '{ "health": $health, "deployment_id": $deploy, "boot_id": $boot }' > /var/lib/microshift-backups/health.json
+    '{ "action": $action, "deployment_id": $deploy, "boot_id": $boot }' >/var/lib/microshift-backups/system.json

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -240,10 +240,10 @@ install -p -m755 packaging/greenboot/microshift-running-check.sh %{buildroot}%{_
 
 install -d -m755 %{buildroot}%{_sysconfdir}/greenboot/red.d
 install -p -m755 packaging/greenboot/microshift-pre-rollback.sh %{buildroot}%{_sysconfdir}/greenboot/red.d/40_microshift_pre_rollback.sh
-install -p -m755 packaging/greenboot/microshift_set_unhealthy.sh %{buildroot}%{_sysconfdir}/greenboot/red.d/40_microshift_set_unhealthy.sh
+install -p -m755 packaging/greenboot/microshift_set_restore.sh %{buildroot}%{_sysconfdir}/greenboot/red.d/40_microshift_set_restore.sh
 
 install -d -m755 %{buildroot}%{_sysconfdir}/greenboot/green.d
-install -p -m755 packaging/greenboot/microshift_set_healthy.sh %{buildroot}%{_sysconfdir}/greenboot/green.d/40_microshift_set_healthy.sh
+install -p -m755 packaging/greenboot/microshift_set_backup.sh %{buildroot}%{_sysconfdir}/greenboot/green.d/40_microshift_set_backup.sh
 
 %post
 
@@ -331,8 +331,8 @@ systemctl enable --now --quiet openvswitch || true
 %files greenboot
 %{_sysconfdir}/greenboot/check/required.d/40_microshift_running_check.sh
 %{_sysconfdir}/greenboot/red.d/40_microshift_pre_rollback.sh
-%{_sysconfdir}/greenboot/red.d/40_microshift_set_unhealthy.sh
-%{_sysconfdir}/greenboot/green.d/40_microshift_set_healthy.sh
+%{_sysconfdir}/greenboot/red.d/40_microshift_set_restore.sh
+%{_sysconfdir}/greenboot/green.d/40_microshift_set_backup.sh
 %{_datadir}/microshift/functions/greenboot.sh
 
 # Use Git command to generate the log and replace the VERSION string

--- a/test/resources/libostree.py
+++ b/test/resources/libostree.py
@@ -59,7 +59,7 @@ def remove_backups_for_deployment(deploy_id: str) -> None:
 def remove_backup_storage() -> None:
     """
     Removes entire backup storage directory (/var/lib/microshift-backups)
-    which contains backups and health data
+    which contains backups and system info
     """
     remote_sudo(f"rm -rf {BACKUP_STORAGE}")
 
@@ -74,11 +74,11 @@ def get_current_ref() -> str:
     return ref.split(":")[1]
 
 
-def get_persisted_system_health() -> str:
+def get_data_action() -> str:
     """
-    Get system health information from health.json file
+    Get action from system.json file
     """
-    return remote_sudo(f"jq -r '.health' {BACKUP_STORAGE}/health.json")
+    return remote_sudo(f"jq -r '.action' {BACKUP_STORAGE}/system.json")
 
 
 def rebase_ostree_system(ref: str) -> None:

--- a/test/resources/ostree.resource
+++ b/test/resources/ostree.resource
@@ -66,7 +66,8 @@ Rebase System And Verify
     Should Be Equal As Strings    ${ref_after_reboot}    ${ref}
 
 System Should Be Healthy
-    [Documentation]    Verifies if system is healthy by looking at health.json.
+    [Documentation]    Verifies if system is healthy by checking if
+    ...    'backup' action is persisted in system.json.
     ...    If this runs after greenboot-healthcheck finishes, it verifies
     ...    health of current boot.
 
@@ -74,8 +75,8 @@ System Should Be Healthy
     ${version}=    MicroShift Version
     IF    ${version.minor} == 13    RETURN
 
-    ${health}=    Get Persisted System Health
-    Should Be Equal As Strings    ${health}    healthy
+    ${action}=    Get Data Action
+    Should Be Equal As Strings    ${action}    backup
 
 MicroShift 413 Should Not Have Upgrade Artifacts
     [Documentation]    Verifies that host running MicroShift 4.13

--- a/test/suites-ostree/backup-restore.robot
+++ b/test/suites-ostree/backup-restore.robot
@@ -17,8 +17,9 @@ ${USHIFT_USER}      ${EMPTY}
 
 
 *** Test Cases ***
-Rebooting Healthy System Should Result In Data Backup
-    [Documentation]    Check if rebooting healthy system will result in backing up of MicroShift data
+MicroShift Backs Up Data On Boot
+    [Documentation]    Check if rebooting system will result in backing up
+    ...    MicroShift data when system.json has 'backup' action
 
     Wait Until Greenboot Health Check Exited
     System Should Be Healthy
@@ -30,17 +31,17 @@ Rebooting Healthy System Should Result In Data Backup
 
     Backup Should Exist    ${future_backup}
 
-Rebooting Unhealthy System Should Result In Restoring Data From A Backup
-    [Documentation]    Check if rebooting unhealthy system will result
-    ...    restoring MicroShift data from a backup
+MicroShift Restores Data On Boot
+    [Documentation]    Check if rebooting system will result in restoring
+    ...    MicroShift data when system.json has 'restore' action
 
-    Wait Until Greenboot Health Check Exited    # we don't want greenboot to overwrite health.json
+    Wait Until Greenboot Health Check Exited    # we don't want greenboot to overwrite system.json
     Remove Existing Backup For Current Deployment
 
     ${backup_name}=    Make Masquerading Backup
     Create Marker In Backup Dir    ${backup_name}
 
-    Mark System As Unhealthy    # to trigger restore after reboot
+    Write Restore Action
     Reboot MicroShift Host
     Wait For MicroShift Service
 
@@ -73,10 +74,10 @@ Make Masquerading Backup
 
     RETURN    ${backup_name}
 
-Mark System As Unhealthy
-    [Documentation]    Marks systems as unhealthy by executing microshift's red script
+Write Restore Action
+    [Documentation]    Writes a restore action to perform on next boot by running red script.
     ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    /etc/greenboot/red.d/40_microshift_set_unhealthy.sh
+    ...    /etc/greenboot/red.d/40_microshift_set_restore.sh
     ...    sudo=True    return_stderr=True    return_rc=True
     Should Be Equal As Integers    0    ${rc}
 


### PR DESCRIPTION
Reusing the same `health.json` across many boots with "boot health" persisted might be confusing.
Changing healthy to backup and unhealthy to restore might be beneficial for clearly describing the procedures.