### PR TITLE
USHIFT-1364: Don't overwrite health if backup wasn't created

### DIFF
--- a/packaging/greenboot/microshift_set_unhealthy.sh
+++ b/packaging/greenboot/microshift_set_unhealthy.sh
@@ -5,7 +5,10 @@ set -ex
 HEALTH=unhealthy
 
 SCRIPT_NAME=$(basename "$0")
-if [ "$(id -u)" -ne 0 ] ; then
+DIR=/var/lib/microshift-backups
+FILE="${DIR}/health.json"
+
+if [ "$(id -u)" -ne 0 ]; then
     echo "The '${SCRIPT_NAME}' script must be run with the 'root' user privileges"
     exit 1
 fi
@@ -15,13 +18,27 @@ if [ ! -f /run/ostree-booted ]; then
     exit 0
 fi
 
+# Define var FORCE to force overwrite
+if [[ ! -v FORCE ]] && [[ -e "${FILE}" ]]; then
+    h=$(jq -r '.health' "${FILE}")
+    b=$(jq -r '.boot_id' "${FILE}")
+    d=$(jq -r '.deployment_id' "${FILE}")
+
+    expected_backup="${DIR}/${d}_${b}"
+    if [[ "${h}" == "healthy" ]] && [[ ! -e "${expected_backup}" ]]; then
+        echo "State 'healthy' is persisted, but the backup was not created."
+        echo "Not overwriting the health.json, will retry backup on next boot"
+        exit 0
+    fi
+fi
+
 mkdir -p /var/lib/microshift-backups
 
-boot=$(tr -d '-' < /proc/sys/kernel/random/boot_id)
-deploy=$(rpm-ostree status --booted --jsonpath='$.deployments[0].id' | jq -r '.[0]')
+boot=$(tr -d '-' </proc/sys/kernel/random/boot_id)
+deploy=$(rpm-ostree status --booted --json | jq -r '.deployments[0].id')
 jq \
     --null-input \
     --arg health "${HEALTH}" \
     --arg deploy "${deploy}" \
     --arg boot "${boot}" \
-    '{ "health": $health, "deployment_id": $deploy, "boot_id": $boot }' > /var/lib/microshift-backups/health.json
+    '{ "health": $health, "deployment_id": $deploy, "boot_id": $boot }' >"${FILE}"


### PR DESCRIPTION
Taking a backup is very important and we don't want to lose information that it should be done.
This change adds handling of situation where MicroShift is unhealthy because it couldn't make a backup and it should attempt to do it after reboot and after rollback: "don't overwrite 'backup' request if it wasn't created".