### PR TITLE
USHIFT-1401: rebase should only clean up files it creates

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -993,7 +993,7 @@ rebase_to() {
     fi
 
     title "# Removing staging directory"
-    rm -rf "$REPOROOT/_output"
+    rm -rf "${STAGING_DIR}"
 }
 
 


### PR DESCRIPTION
We use the _output directory for tools and test files, which should
not be deleted when running a rebase.

/assign @pmtk