### PR TITLE
OCPBUGS-15740: Fix show-config command output

### DIFF
--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -33,6 +33,10 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 				if err != nil {
 					cmdutil.CheckErr(err)
 				}
+				err = cfg.EnsureNodeNameHasNotChanged()
+				if err != nil {
+					cmdutil.CheckErr(err)
+				}
 			case "default":
 				cfg = config.NewDefault()
 			default:


### PR DESCRIPTION
Command `microshift show-config` must show the running configuration. This command loaded the configuration from /etc/microshift/config.yaml if it existed, possibly showing wrong information (editing the file without restarting microshift yields wrong data).
Having no configuration file fills the config with defaults. This might also be wrong in the event of a hostname change, when this is automatically fixed to use the previous name. This command would show the new name when MicroShift is using the previous one.

New approach stores the running configuration upon start and returns it when asked for it.
If MicroShift is not running this command returns the last active config.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
