### PR TITLE
NO-ISSUE: Fix lichen error due to go shim usage in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,8 @@ clean-cross-build:
 	if [ -d '$(CROSS_BUILD_BINDIR)' ]; then $(RM) -rf '$(CROSS_BUILD_BINDIR)'; fi
 	if [ -d '$(OUTPUT_DIR)/staging' ]; then $(RM) -rf '$(OUTPUT_DIR)/staging'; fi
 	if [ -d '$(OUTPUT_DIR)/venv' ]; then $(RM) -rf '$(OUTPUT_DIR)/venv'; fi
+	if [ -d '$(OUTPUT_DIR)/robotenv' ]; then $(RM) -rf '$(OUTPUT_DIR)/robotenv'; fi
+	if [ -d '$(OUTPUT_DIR)/goenv' ]; then $(RM) -rf '$(OUTPUT_DIR)/goenv'; fi
 	if [ -d '$(RPM_BUILD_DIR)' ]; then $(RM) -rf '$(RPM_BUILD_DIR)'; fi
 	if [ -d '$(ISO_DIR)' ]; then $(RM) -rf '$(ISO_DIR)'; fi
 	if [ -d '$(OUTPUT_DIR)' ]; then rmdir --ignore-fail-on-non-empty '$(OUTPUT_DIR)'; fi

--- a/scripts/verify/verify-licenses.sh
+++ b/scripts/verify/verify-licenses.sh
@@ -7,6 +7,21 @@ pushd "${ROOTDIR}" &> /dev/null
 # Install the tool
 ./scripts/fetch_tools.sh lichen
 
+# Work around lichen runtime errors when using go shim in CI.
+# The shim may produce debug output causing lichen processing error.
+# In this configuration, go.real executable is the name of the actual go compiler.
+if which go.real &>/dev/null ; then
+    TMP_GODIR=${ROOTDIR}/_output/goenv
+    mkdir -p "${TMP_GODIR}"
+
+    cat > "${TMP_GODIR}/go" <<EOF
+#!/bin/bash
+exec go.real "\$@"
+EOF
+    chmod 755 "${TMP_GODIR}/go"
+    export PATH=${TMP_GODIR}:${PATH}
+fi
+
 # Run the license check
 LICENSE_CHECK=./_output/bin/lichen
 for f in microshift microshift-etcd ; do


### PR DESCRIPTION
The OpenShift CI image may use a shim instead of the `go` compiler. Such shim producing debug output causes errors when run by `lichen`. 
Work around this problem by using the `go.real` driver for running `lichen` license verification.