### PR TITLE
USHIFT-1422: use the regular RPM repositories for dependencies in image-builder script

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -305,14 +305,15 @@ fi
 # Set the cleanup and elapsed time traps only if command line parsing was successful
 trap '${SCRIPTDIR}/cleanup.sh; echo "Execution time: $(( ($(date +%s) - STARTTIME) / 60 )) minutes"' EXIT
 
-title "Downloading local OpenShift and MicroShift repositories"
+title "Setting up local MicroShift repository"
 # Copy MicroShift RPM packages
 rm -rf microshift-local 2>/dev/null || true
 if [[ "${MICROSHIFT_RPM_SOURCE}" == http* ]] ; then
     wget -q -nd -r -L -P microshift-local -A rpm "${MICROSHIFT_RPM_SOURCE}"
 else
     [ ! -d "${MICROSHIFT_RPM_SOURCE}" ] && echo "MicroShift RPM path '${MICROSHIFT_RPM_SOURCE}' does not exist" && exit 1
-    cp -TR "${MICROSHIFT_RPM_SOURCE}" microshift-local
+    cp -TR "${MICROSHIFT_RPM_SOURCE}/RPMS" microshift-local
+    cp -TR "${MICROSHIFT_RPM_SOURCE}/SRPMS" microshift-local
 fi
 
 # Exit if no RPM packages were found

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -324,6 +324,11 @@ fi
 createrepo microshift-local >/dev/null
 open_repo_permissions microshift-local
 
+# Determine the version of microshift we have, for use in blueprint templates later.
+MICROSHIFT_RELEASE_RPM=$(find "${MICROSHIFT_RPM_SOURCE}" -name 'microshift-release-info*.rpm' | tail -n 1)
+MICROSHIFT_VERSION=$(rpm -q --queryformat '%{version}' "${MICROSHIFT_RELEASE_RPM}")
+export MICROSHIFT_VERSION
+
 # Determine the image version from the RPM contents
 RELEASE_INFO_FILE=$(find . -name 'microshift-release-info-*.rpm' | tail -1)
 if [ -z "${RELEASE_INFO_FILE}" ] ; then
@@ -366,7 +371,10 @@ for f in microshift-local custom-rpms rhocp-4.13 fast-datapath; do
 done
 
 title "Preparing blueprints"
-cp -f "${SCRIPTDIR}"/config/{blueprint_v0.0.1.toml,installer.toml} .
+cp -f "${SCRIPTDIR}"/config/installer.toml .
+sed -e "s;REPLACE_MICROSHIFT_VERSION;${MICROSHIFT_VERSION};g" \
+    "${SCRIPTDIR}"/config/blueprint_v0.0.1.toml \
+    >blueprint_v0.0.1.toml
 if [ -n "${CUSTOM_RPM_FILES}" ] ; then
     for rpm in ${CUSTOM_RPM_FILES//,/ } ; do
         rpm_name=$(rpm -qp "${rpm}" --queryformat "%{NAME}")

--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -65,3 +65,4 @@ sudo systemctl stop --now osbuild-composer.socket osbuild-composer.service osbui
 sleep 5
 sudo rm -rf /var/cache/osbuild-worker/* /var/lib/osbuild-composer/*
 sudo systemctl start osbuild-composer.socket
+sudo systemctl start "osbuild-worker@1.service"

--- a/scripts/image-builder/config/blueprint_v0.0.1.toml
+++ b/scripts/image-builder/config/blueprint_v0.0.1.toml
@@ -9,15 +9,23 @@ groups = []
 
 [[packages]]
 name = "microshift"
-version = "*"
+version = "${MICROSHIFT_VERSION}"
 
 [[packages]]
 name = "microshift-greenboot"
-version = "*"
+version = "${MICROSHIFT_VERSION}"
+
+[[packages]]
+name = "microshift-networking"
+version = "${SOURCE_VERSION}"
+
+[[packages]]
+name = "microshift-selinux"
+version = "${SOURCE_VERSION}"
 
 [[packages]]
 name = "microshift-release-info"
-version = "*"
+version = "${MICROSHIFT_VERSION}"
 
 [[packages]]
 name = "openshift-clients"
@@ -43,12 +51,6 @@ version = "*"
 
 [[packages]]
 name = "strace"
-version = "*"
-
-# other
-
-[[packages]]
-name = "redhat-release"
 version = "*"
 
 # customizations

--- a/scripts/image-builder/config/blueprint_v0.0.1.toml
+++ b/scripts/image-builder/config/blueprint_v0.0.1.toml
@@ -9,23 +9,23 @@ groups = []
 
 [[packages]]
 name = "microshift"
-version = "${MICROSHIFT_VERSION}"
+version = "REPLACE_MICROSHIFT_VERSION"
 
 [[packages]]
 name = "microshift-greenboot"
-version = "${MICROSHIFT_VERSION}"
+version = "REPLACE_MICROSHIFT_VERSION"
 
 [[packages]]
 name = "microshift-networking"
-version = "${SOURCE_VERSION}"
+version = "REPLACE_MICROSHIFT_VERSION"
 
 [[packages]]
 name = "microshift-selinux"
-version = "${SOURCE_VERSION}"
+version = "REPLACE_MICROSHIFT_VERSION"
 
 [[packages]]
 name = "microshift-release-info"
-version = "${MICROSHIFT_VERSION}"
+version = "REPLACE_MICROSHIFT_VERSION"
 
 [[packages]]
 name = "openshift-clients"

--- a/scripts/image-builder/config/fast-datapath.toml.template
+++ b/scripts/image-builder/config/fast-datapath.toml.template
@@ -1,0 +1,8 @@
+id = "fast-datapath"
+name = "Fast Datapath for RHEL 9"
+type = "yum-baseurl"
+url = "https://cdn.redhat.com/content/dist/layered/rhel9/REPLACE_BUILD_ARCH/fast-datapath/os"
+check_gpg = true
+check_ssl = true
+system = false
+rhsm = true

--- a/scripts/image-builder/config/openshift-local.toml.template
+++ b/scripts/image-builder/config/openshift-local.toml.template
@@ -1,7 +1,0 @@
-id = "openshift-local"
-name = "OpenShift Local Repo"
-type = "yum-baseurl"
-url = "file://REPLACE_IMAGE_BUILDER_DIR/openshift-local/"
-check_gpg = false
-check_ssl = false
-system = false

--- a/scripts/image-builder/config/rhocp-4.13.toml.template
+++ b/scripts/image-builder/config/rhocp-4.13.toml.template
@@ -1,0 +1,8 @@
+id = "rhocp-4.13"
+name = "Red Hat OpenShift Container Platform 4.13 for RHEL 9"
+type = "yum-baseurl"
+url = "https://cdn.redhat.com/content/dist/layered/rhel9/REPLACE_BUILD_ARCH/rhocp/4.13/os"
+check_gpg = true
+check_ssl = true
+system = false
+rhsm = true


### PR DESCRIPTION
Instead of downloading dependencies and manipulating the local repo,
use the regular repositories normally. This allows composer to find the
pinned version of openvswitch3.1 needed right now.

Includes some other cleanup changes.

/assign @ggiguash @jogeo