### PR TITLE
USHIFT-1411: Fix openvswitch3.1 version comparison not to use exact pattern

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -97,7 +97,7 @@ The microshift-selinux package provides the SELinux policy modules required by M
 
 %package networking
 Summary: Networking components for MicroShift
-Requires: openvswitch3.1 == 3.1.0-14.el9fdp
+Requires: openvswitch3.1 <= 3.1.0-14.el9fdp
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq


### PR DESCRIPTION
Exact pattern comparison does not work in osbuilder, generating the following error.
```
# Loading microshift blueprint v0.0.1
ERROR: BlueprintsError: microshift: DNF error occurred: DepsolveError: There was a problem depsolving microshift, microshift-greenboot, microshift-release-info, openshift-clients, iputils, bind-utils, net-tools, iotop, strace, redhat-release, caddy-2.4.6, kernel: 
 Problem: package microshift-4.14.0_0.nightly_2023_07_05_191022_20230710193040_5aa2178c3_dirty-1.el9.x86_64 requires microshift-networking, but none of the providers can be installed
  - conflicting requests
  - nothing provides openvswitch3.1 = 3.1.0-14.el9fdp needed by microshift-networking-4.14.0_0.nightly_2023_07_05_191022_20230710193040_5aa2178c3_dirty-1.el9.x86_64
```
Closes [USHIFT-1411](https://issues.redhat.com//browse/USHIFT-1411)
