### PR TITLE
USHIFT-1413: Update prerun after storage migration design changes

### DIFF
--- a/pkg/admin/prerun/health.go
+++ b/pkg/admin/prerun/health.go
@@ -1,0 +1,50 @@
+package prerun
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openshift/microshift/pkg/admin/data"
+	"github.com/openshift/microshift/pkg/util"
+)
+
+var (
+	healthFilepath            = "/var/lib/microshift-backups/health.json"
+	errHealthFileDoesNotExist = errors.New("health file does not exist")
+)
+
+type HealthInfo struct {
+	Health       string `json:"health"`
+	DeploymentID string `json:"deployment_id"`
+	BootID       string `json:"boot_id"`
+}
+
+func (hi *HealthInfo) BackupName() data.BackupName {
+	return data.BackupName(fmt.Sprintf("%s_%s", hi.DeploymentID, hi.BootID))
+}
+
+func (hi *HealthInfo) IsHealthy() bool {
+	return hi.Health == "healthy"
+}
+
+func getHealthInfo() (*HealthInfo, error) {
+	if exists, err := util.PathExistsAndIsNotEmpty(healthFilepath); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, errHealthFileDoesNotExist
+	}
+
+	content, err := os.ReadFile(healthFilepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read health data from %q: %w", healthFilepath, err)
+	}
+
+	health := &HealthInfo{}
+	if err := json.Unmarshal(content, &health); err != nil {
+		return nil, fmt.Errorf("failed to parse health data %q: %w", strings.TrimSpace(string(content)), err)
+	}
+	return health, nil
+}

--- a/pkg/admin/prerun/upgrade_blocking_test.go
+++ b/pkg/admin/prerun/upgrade_blocking_test.go
@@ -35,43 +35,47 @@ func Test_IsBlocked(t *testing.T) {
 	}
 
 	testData := []struct {
-		dataVersion    string
-		execVersion    string
-		expectedResult bool
+		dataVersion string
+		execVersion string
+		errExpected bool
 	}{
 		{
-			dataVersion:    "4.14.4",
-			execVersion:    "4.14.10",
-			expectedResult: false,
+			dataVersion: "4.14.4",
+			execVersion: "4.14.10",
+			errExpected: false,
 		},
 		{
-			dataVersion:    "4.14.5",
-			execVersion:    "4.14.10",
-			expectedResult: true,
+			dataVersion: "4.14.5",
+			execVersion: "4.14.10",
+			errExpected: true,
 		},
 		{
-			dataVersion:    "4.14.6",
-			execVersion:    "4.14.10",
-			expectedResult: true,
+			dataVersion: "4.14.6",
+			execVersion: "4.14.10",
+			errExpected: true,
 		},
 		{
-			dataVersion:    "4.14.7",
-			execVersion:    "4.14.10",
-			expectedResult: false,
+			dataVersion: "4.14.7",
+			execVersion: "4.14.10",
+			errExpected: false,
 		},
 		{
-			dataVersion:    "4.14.7",
-			execVersion:    "4.15.0",
-			expectedResult: false,
+			dataVersion: "4.14.7",
+			execVersion: "4.15.0",
+			errExpected: false,
 		},
 		{
-			dataVersion:    "4.15.2",
-			execVersion:    "4.15.5",
-			expectedResult: true,
+			dataVersion: "4.15.2",
+			execVersion: "4.15.5",
+			errExpected: true,
 		},
 	}
 
 	for _, td := range testData {
-		assert.Equal(t, td.expectedResult, isBlocked(edges, td.execVersion, td.dataVersion))
+		if td.errExpected {
+			assert.Error(t, isBlocked(edges, td.execVersion, td.dataVersion))
+		} else {
+			assert.NoError(t, isBlocked(edges, td.execVersion, td.dataVersion))
+		}
 	}
 }

--- a/pkg/admin/prerun/version_test.go
+++ b/pkg/admin/prerun/version_test.go
@@ -8,55 +8,48 @@ import (
 
 func TestCheckVersionDiff(t *testing.T) {
 	testData := []struct {
-		name                      string
-		execVer                   versionMetadata
-		dataVer                   versionMetadata
-		expectedMigrationRequired bool
-		errExpected               bool
+		name        string
+		execVer     versionMetadata
+		dataVer     versionMetadata
+		errExpected bool
 	}{
 		{
-			name:                      "equal versions: no migration, no error",
-			execVer:                   versionMetadata{Major: 4, Minor: 14},
-			dataVer:                   versionMetadata{Major: 4, Minor: 14},
-			expectedMigrationRequired: false,
-			errExpected:               false,
+			name:        "equal versions: no migration, no error",
+			execVer:     versionMetadata{Major: 4, Minor: 14},
+			dataVer:     versionMetadata{Major: 4, Minor: 14},
+			errExpected: false,
 		},
 		{
-			name:                      "X versions must be the same",
-			execVer:                   versionMetadata{Major: 4, Minor: 14},
-			dataVer:                   versionMetadata{Major: 5, Minor: 14},
-			expectedMigrationRequired: false,
-			errExpected:               true,
+			name:        "X versions must be the same",
+			execVer:     versionMetadata{Major: 4, Minor: 14},
+			dataVer:     versionMetadata{Major: 5, Minor: 14},
+			errExpected: true,
 		},
 		{
-			name:                      "binary must not be older than data",
-			execVer:                   versionMetadata{Major: 4, Minor: 14},
-			dataVer:                   versionMetadata{Major: 4, Minor: 15},
-			expectedMigrationRequired: false,
-			errExpected:               true,
+			name:        "binary must not be older than data",
+			execVer:     versionMetadata{Major: 4, Minor: 14},
+			dataVer:     versionMetadata{Major: 4, Minor: 15},
+			errExpected: true,
 		},
 		{
-			name:                      "binary must be newer only by one minor version",
-			execVer:                   versionMetadata{Major: 4, Minor: 15},
-			dataVer:                   versionMetadata{Major: 4, Minor: 14},
-			expectedMigrationRequired: true,
-			errExpected:               false,
+			name:        "binary must be newer only by one minor version",
+			execVer:     versionMetadata{Major: 4, Minor: 15},
+			dataVer:     versionMetadata{Major: 4, Minor: 14},
+			errExpected: false,
 		},
 		{
-			name:                      "binary newer more than one minor version is not supported",
-			execVer:                   versionMetadata{Major: 4, Minor: 15},
-			dataVer:                   versionMetadata{Major: 4, Minor: 13},
-			expectedMigrationRequired: false,
-			errExpected:               true,
+			name:        "binary newer more than one minor version is not supported",
+			execVer:     versionMetadata{Major: 4, Minor: 15},
+			dataVer:     versionMetadata{Major: 4, Minor: 13},
+			errExpected: true,
 		},
 	}
 
 	for _, td := range testData {
 		td := td
 		t.Run(td.name, func(t *testing.T) {
-			migrationRequired, err := checkVersionDiff(td.execVer, td.dataVer)
+			err := checkVersionCompatibility(td.execVer, td.dataVer)
 
-			assert.Equal(t, td.expectedMigrationRequired, migrationRequired)
 			if td.errExpected {
 				assert.Error(t, err)
 			} else {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -119,7 +119,7 @@ func RunMicroshift(cfg *config.Config) error {
 		return fmt.Errorf("failed to create dir %q: %w", config.DataDir, err)
 	}
 
-	if err := prerun.CreateOrValidateDataVersion(); err != nil {
+	if err := prerun.CheckAndUpdateDataVersion(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We won't aim toward running migration in prerun phase (instead it'll run in full cluster).
Therefore, removing all references to migration from prerun.
It can be now thought of as two, almost distinct, areas:
- data management (backup, restore, removal), and
- version metadata management