### PR TITLE
USHIFT-1395: Use file protocol for local ostree updates instead of Caddy HTTP server

### DIFF
--- a/docs/contributor/rhel4edge_iso.md
+++ b/docs/contributor/rhel4edge_iso.md
@@ -60,7 +60,7 @@ Optional arguments:
   -embed_containers
           Embed the MicroShift container dependencies in the image
   -ostree_server_url URL
-          URL of the ostree server (default: http://127.0.0.1:8085/repo)
+          URL of the ostree server (default: file:///var/lib/ostree-local/repo)
   -build_edge_commit
           Build edge commit archive instead of an ISO image. The
           archive contents can be used for serving ostree updates.
@@ -175,7 +175,7 @@ Run the following commands to create a virtual machine using the installer image
 ```bash
 VMNAME="microshift-edge"
 NETNAME="default"
-sudo -b bash -c " \
+sudo bash -c " \
 cd /var/lib/libvirt/images/ && \
 virt-install \
     --name ${VMNAME} \
@@ -213,28 +213,19 @@ oc get pods -A
 
 **Default Configuration**
 
-The default ISO image is configured to run a Caddy HTTP server for the `ostree`
-updates at the `http://127.0.0.1:8085` URL, serving the contents of the local
-`/var/lib/ostree-server-local` directory containing an empty `ostree` update
-repository.
+The default ISO image is configured to use the local `/var/lib/ostree-local`
+directory as the source for `ostree` updates. This directory contains an empty
+`ostree` update repository.
 
 Log into the MicroShift server using `redhat:redhat` credentials and run the
 following commands to check the local `ostree` server configuration.
 
 ```bash
-$ systemctl is-active ostree-server-local.service
-active
-
-$ sudo journalctl -u ostree-server-local.service --output cat
-Started Caddy HTTP server for the local ostree repository.
-...
-...
-
 $ ostree remote list
 edge
 
 $ ostree remote show-url edge
-http://127.0.0.1:8085/repo
+file:///var/lib/ostree-local/repo
 
 $ ostree remote summary edge
 Repository Mode (ostree.summary.mode): archive-z2
@@ -275,9 +266,9 @@ $ sudo rpm-ostree deploy <YOUR_OSTREE_COMMIT_REV>
 
 **Local Updates**
 
-When the default Caddy HTTP server is configured for the `ostree` updates, users
-can overwrite the contents of the `/var/lib/ostree-server-local` directory and
-install the updates locally.
+When the local `ostree` repository is configured for the `ostree` updates, users
+can overwrite the contents of the `/var/lib/ostree-local` directory and install
+the updates locally.
 
 One of the techniques for generating `ostree` updates is supported by the
 `scripts/image-builder/build.sh` script. When the `-build_edge_commit` command
@@ -299,14 +290,14 @@ The contents of the archive can be used for serving ostree updates:
 > `-embed_containers` arguments to customize the edge commit archive contents.
 
 Copy the produced `microshift-0.0.1-commit.tar` archive to the
-MicroShift server and unpack it at the `/var/lib/ostree-server-local` directory,
+MicroShift server and unpack it at the `/var/lib/ostree-local` directory,
 deleting the previous contents.
 
 Run the following commands to generate the update summary, check the new
 `ostree` commit revision and install the update.
 
 ```bash
-$ sudo ostree summary --repo /var/lib/ostree-server-local/repo --update
+$ sudo ostree summary --repo /var/lib/ostree-local/repo --update
 
 $ ostree remote summary edge
 * rhel/9/x86_64/edge

--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -7,7 +7,7 @@ IMGNAME=microshift
 IMAGE_VERSION=undefined
 BUILD_ARCH=$(uname -m)
 OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
-OSTREE_SERVER_URL=http://127.0.0.1:8085/repo
+OSTREE_SERVER_URL=file:///var/lib/ostree-local/repo
 LVM_SYSROOT_SIZE_MIN=10240
 LVM_SYSROOT_SIZE=${LVM_SYSROOT_SIZE_MIN}
 OCP_PULL_SECRET_FILE=
@@ -162,15 +162,6 @@ install_prometheus_rpm() {
         title "Downloading Prometheus exporter(s)"
         wget -q "${url}${file}"
         CUSTOM_RPM_FILES+="$(pwd)/${file},"
-    fi
-}
-
-install_caddy_rpm() {
-    if [ "${OSTREE_SERVER_URL}" = "http://127.0.0.1:8085/repo" ] ; then
-        title "Downloading Caddy package"
-        # The package comes from the EPEL repository
-        sudo dnf download -y -q caddy
-        CUSTOM_RPM_FILES+="$(pwd)/caddy-*.rpm,"
     fi
 }
 
@@ -356,9 +347,6 @@ open_repo_permissions openshift-local
 
 # Install prometheus process exporter
 install_prometheus_rpm
-
-# Install Caddy HTTP server
-install_caddy_rpm
 
 # Copy user-specific RPM packages
 rm -rf custom-rpms 2>/dev/null || true

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -85,33 +85,14 @@ done
 # installed at /etc/pki/ca-trust/source/anchors directory
 update-ca-trust
 
-# Configure an empty local ostree repository and server if the "edge" remote points to "localhost:8085"
-if grep -q '^url=http://127.0.0.1:8085' /etc/ostree/remotes.d/edge.conf ; then
-    ostree_repo=/var/lib/ostree-server-local
-    ostree_serv=ostree-server-local.service
+# Configure an empty ostree repository if the "edge" remote points to a local directory
+if grep -q '^url=file:///var/lib/ostree-local' /etc/ostree/remotes.d/edge.conf ; then
+    ostree_repo=/var/lib/ostree-local
 
     # Create an empty repository with a summary
     mkdir -p ${ostree_repo}/repo
     ostree --repo=${ostree_repo}/repo init --mode=archive-z2
     ostree summary --repo ${ostree_repo}/repo --update
-
-    # Create an HTTP server for the repository
-    cat > /etc/systemd/system/${ostree_serv} <<EOF
-[Unit]
-Description=Caddy HTTP server for the local ostree repository
-
-[Service]
-User=root
-WorkingDirectory=${ostree_repo}
-ExecStart=/bin/caddy file-server -listen 127.0.0.1:8085 -root ${ostree_repo} -browse
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-    systemctl daemon-reload
-    systemctl enable ${ostree_serv}
 fi
 
 %end


### PR DESCRIPTION
Using HTTP server for local `ostree` upgrades is not necessary, hence the simplification of the default ISO configuration.

Closes [USHIFT-1395](https://issues.redhat.com//browse/USHIFT-1395)
