### PR TITLE
USHIFT-1429: set port values for new VMs by default

### DIFF
--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -17,10 +17,6 @@ echo "Logging to ${LOGFILE}"
 # Set fd 1 and 2 to write to the log file
 exec &> >(tee >(awk '{ print strftime("%Y-%m-%d %H:%M:%S"), $0; fflush() }' >"${LOGFILE}"))
 
-API_EXTERNAL_BASE_PORT="${1}"
-SSH_EXTERNAL_BASE_PORT="${2}"
-LB_EXTERNAL_BASE_PORT="${3}"
-
 cd ~/microshift/test
 
 # Start the web server to host the kickstart files and ostree commit
@@ -46,9 +42,6 @@ if [ ${FAIL} -ne 0 ]; then
     echo "Failed to boot all VMs"
     exit 1
 fi
-
-# Set up port forwarding
-bash -x ./bin/manage_vm_connections.sh remote -a "${API_EXTERNAL_BASE_PORT}" -s "${SSH_EXTERNAL_BASE_PORT}" -l "${LB_EXTERNAL_BASE_PORT}"
 
 # Kill the web server
 pkill caddy || true

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -175,6 +175,11 @@ launch_vm() {
         echo "${PUBLIC_IP}" > "${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/public_ip"
     else
         echo "${ip}" > "${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/public_ip"
+        # Set the defaults for the various ports so that connections
+        # from the hypervisor to the VM work.
+        echo "22" > "${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/ssh_port"
+        echo "6443" > "${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/api_port"
+        echo "5678" > "${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/lb_port"
     fi
 
     enable_ip_access "${full_vmname}" "${ip}"


### PR DESCRIPTION
When no PUBLIC_IP is set, assume connections will come from the
hypervisor to the VM ("local" mode) and configure the VM properties
accordingly.

/assign @pacevedom