### PR TITLE
USHIFT-1433: pass repo to ostree refs command

### DIFF
--- a/test/bin/download_images.sh
+++ b/test/bin/download_images.sh
@@ -55,6 +55,7 @@ done
 
 echo "Updating references"
 cd "${IMAGEDIR}"
-ostree refs --force --create "rhel-9.2-microshift-failing" "rhel-9.2-microshift-source"
+ostree refs --repo=repo --force \
+       --create "rhel-9.2-microshift-failing" "rhel-9.2-microshift-source"
 ostree summary --update --repo=repo
 ostree summary --view --repo=repo


### PR DESCRIPTION
When creating an alias reference, `ostree refs` requires a `--repo`
argument to know where to create the reference.

/assign @pmtk