### PR TITLE
NO-ISSUE: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ sshfile
 ansible/*.txt
 test/variables.yaml
 test/scenario_settings.sh
+__pycache__


### PR DESCRIPTION
It's a directory created when running robot framework tests, but we don't want to commit it to the repo.