### PR TITLE
USHIFT-1436: capture composer logs when building images

### DIFF
--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -9,6 +9,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/common.sh"
 
 mkdir -p "${IMAGEDIR}"
+LOGDIR="${IMAGEDIR}/build-logs"
+mkdir -p "${LOGDIR}"
 
 if [ $# -ne 0 ]; then
     TEMPLATES="$*"
@@ -93,7 +95,8 @@ for template in ${TEMPLATES}; do
     sudo composer-cli blueprints push "${blueprint_file}"
 
     echo "Resolving dependencies for ${blueprint}"
-    sudo composer-cli blueprints depsolve "${blueprint}"
+    sudo composer-cli blueprints depsolve "${blueprint}" \
+         2>&1 | tee "${LOGDIR}/image-${blueprint}-depsolve.log"
 
     echo "Building edge-commit from ${blueprint}"
     buildid=$(sudo composer-cli compose start-ostree \

--- a/test/bin/download_images.sh
+++ b/test/bin/download_images.sh
@@ -12,12 +12,22 @@ mkdir -p "${VM_DISK_DIR}"
 
 download_image() {
     local buildid="${1}"
+    local status
+
+    status=$(sudo composer-cli compose status | grep "${buildid}" | awk '{print $2}')
+    if [ "${status}" != "FINISHED" ]; then
+        sudo composer-cli compose info "${buildid}"
+        return 1
+    fi
+
     # shellcheck disable=SC2086  # pass glob args without quotes
     rm -f ${buildid}-*.tar
     sudo composer-cli compose metadata "${buildid}"
     sudo composer-cli compose image "${buildid}"
     # shellcheck disable=SC2086  # pass glob args without quotes
     sudo chown "$(whoami)." ${buildid}-*
+
+    return 0
 }
 
 download_dir="${IMAGEDIR}/builds"
@@ -28,7 +38,10 @@ cd "${download_dir}"
 for blueprint_build in *.image-installer; do
     blueprint=$(basename "${blueprint_build}" .image-installer)
     buildid=$(cat "${blueprint_build}")
-    download_image "${buildid}"
+    if ! download_image "${buildid}"; then
+        echo "Did not download image"
+        continue
+    fi
     iso_file="${buildid}-installer.iso"
     echo "Moving ${iso_file} to ${VM_DISK_DIR}/${blueprint}.iso"
     mv -f "${iso_file}" "${VM_DISK_DIR}/${blueprint}.iso"
@@ -44,7 +57,10 @@ cd "${download_dir}"
 for blueprint_build in *.edge-commit; do
     blueprint=$(basename "${blueprint_build}" .edge-commit)
     buildid=$(cat "${blueprint_build}")
-    download_image "${buildid}"
+    if ! download_image "${buildid}"; then
+        echo "Did not download image"
+        continue
+    fi
     commit_file="${buildid}-commit.tar"
     echo "Unpacking ${commit_file} ${blueprint}"
     tar -C "${IMAGEDIR}" -xf "${commit_file}"

--- a/test/bin/download_images.sh
+++ b/test/bin/download_images.sh
@@ -12,11 +12,8 @@ mkdir -p "${VM_DISK_DIR}"
 
 download_image() {
     local buildid="${1}"
-    # FIXME: These logs should go to the artifacts directory instead
-    # of the build web server.
     # shellcheck disable=SC2086  # pass glob args without quotes
     rm -f ${buildid}-*.tar
-    sudo composer-cli compose logs "${buildid}"
     sudo composer-cli compose metadata "${buildid}"
     sudo composer-cli compose image "${buildid}"
     # shellcheck disable=SC2086  # pass glob args without quotes


### PR DESCRIPTION
Download the composer logs for all of the builds performed and stage them
with unique filenames so they can be collected by the CI system.

Remove the redundant log handling from the download script.

capture the depsolve logs for each blueprint separately

/assign @pacevedom @copejon