### PR TITLE
USHIFT-1438: Temporarily skip csi snapshot test

### DIFF
--- a/test/suites/snapshot.robot
+++ b/test/suites/snapshot.robot
@@ -27,7 +27,7 @@ ${LVMD_PATCH}           assets/lvmd.patch.yaml
 *** Test Cases ***
 Snapshotter Smoke Test
     [Documentation]    Write data to a volume, snapshot it, restore the snapshot and verify the data is present
-    [Tags]    smoke    snapshot
+    [Tags]    robot:skip-on-failure    smoke    snapshot
     [Setup]    Test Case Setup
 
     Oc Apply    -f ${SNAPSHOT} -n ${NAMESPACE}


### PR DESCRIPTION
Test seems to be flaky in the metal-tests workflow, temporarily disable until its passing.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
