### PR TITLE
[USHIFT-1444] Flakey snapshotting test on metal

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -10,6 +10,7 @@ source "${SCRIPTDIR}/common.sh"
 
 DEFAULT_BOOT_BLUEPRINT="rhel-9.2"
 LVM_SYSROOT_SIZE="10240"
+LVM_THINPOOL_SIZE="4096"
 WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
 PULL_SECRET="${PULL_SECRET:-${HOME}/.pull-secret.json}"
 PULL_SECRET_CONTENT="$(jq -c . "${PULL_SECRET}")"
@@ -69,6 +70,7 @@ prepare_kickstart() {
               -e "s|REPLACE_HOST_NAME|${vm_hostname}|g" \
               -e "s|REPLACE_REDHAT_AUTHORIZED_KEYS|${REDHAT_AUTHORIZED_KEYS}|g" \
               -e "s|REPLACE_PUBLIC_IP|${PUBLIC_IP}|g" \
+              -e "s|REPLACE_LVM_THINPOOL_SIZE|${LVM_THINPOOL_SIZE}|g" \
               > "${output_file}"
 }
 

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -58,7 +58,7 @@ device-classes:
 - name: thin
   thin-pool:
     name: ushift-thin
-    overprovision-ratio: 0
+    overprovision-ratio: 10
   type: thin
   volume-group: rhel
   spare-gb: 0

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -64,6 +64,21 @@ device-classes:
   spare-gb: 0
 EOF
 
+# Deploy a storageClass to enable provisioning on the thin-pool
+cat - >/etc/microshift/manifests/thin-sc.yaml <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: thin
+parameters:
+  csi.storage.k8s.io/fstype: xfs
+  "topolvm.io/device-class": "ushift-thin"
+provisioner: topolvm.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+EOF
+
 # Update the ostree server URL
 ostree remote delete edge
 ostree remote add --no-gpg-verify edge REPLACE_OSTREE_SERVER_URL

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -28,6 +28,7 @@ part /boot --fstype=xfs --asprimary --size=800
 part pv.01 --grow
 volgroup rhel pv.01
 logvol / --vgname=rhel --fstype=xfs --size=REPLACE_LVM_SYSROOT_SIZE --name=root
+logvol none --thinpool --size=REPLACE_LVM_THINPOOL_SIZE --fstype=None --name=thin --vgname=rhel
 
 # Lock root user account
 rootpw --lock
@@ -46,6 +47,22 @@ EOF
 if [ -n "REPLACE_PUBLIC_IP" ]; then
     echo "    - REPLACE_PUBLIC_IP" >>/etc/microshift/config.yaml
 fi
+
+# Set the /etc/microshift/lvmd.yaml file to expose the LVM configuration
+cat - >/etc/microshift/lvmd.yaml <<EOF
+device-classes:
+- default: true
+  name: default
+  volume-group: rhel
+  spare-gb: 0
+- name: thin
+  thin-pool:
+    name: thinpool
+    overprovision-ratio: 0
+  type: thin
+  volume-group: rhel
+  spare-gb: 0
+EOF
 
 # Update the ostree server URL
 ostree remote delete edge

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -28,7 +28,7 @@ part /boot --fstype=xfs --asprimary --size=800
 part pv.01 --grow
 volgroup rhel pv.01
 logvol / --vgname=rhel --fstype=xfs --size=REPLACE_LVM_SYSROOT_SIZE --name=root
-logvol none --thinpool --size=REPLACE_LVM_THINPOOL_SIZE --fstype=None --name=thin --vgname=rhel
+logvol none --thinpool --size=REPLACE_LVM_THINPOOL_SIZE --fstype=None --name=ushift-thin --vgname=rhel
 
 # Lock root user account
 rootpw --lock
@@ -57,7 +57,7 @@ device-classes:
   spare-gb: 0
 - name: thin
   thin-pool:
-    name: thinpool
+    name: ushift-thin
     overprovision-ratio: 0
   type: thin
   volume-group: rhel


### PR DESCRIPTION
[USHIFT-1444](https://issues.redhat.com//browse/USHIFT-1444)

Metal tests are flaking because the kickstart template is missing the thinpool creation command, an lvmd.yaml that reflects the actual storage config, and a storage class to expose the thin pool at the cluster layer.