### PR TITLE
USHIFT-1448: remove redundant ostree setup in kickstart

### DIFF
--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -47,10 +47,6 @@ if [ -n "REPLACE_PUBLIC_IP" ]; then
     echo "    - REPLACE_PUBLIC_IP" >>/etc/microshift/config.yaml
 fi
 
-# Update the ostree server URL
-ostree remote delete edge
-ostree remote add --no-gpg-verify edge REPLACE_OSTREE_SERVER_URL
-
 # The pull secret is mandatory for MicroShift builds on top of OpenShift, but not OKD
 # The /etc/crio/crio.conf.d/microshift.conf references the /etc/crio/openshift-pull-secret file
 cat > /etc/crio/openshift-pull-secret <<EOF


### PR DESCRIPTION
The call to ostreesetup creates an edge remote with the correct URL,
so there is no need to delete it and re-create it.

/assign @ggiguash