### PR TITLE
NO-ISSUE: MicroShift release info RPM should be queried from the local directory

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -316,9 +316,8 @@ createrepo microshift-local >/dev/null
 open_repo_permissions microshift-local
 
 # Determine the version of microshift we have, for use in blueprint templates later.
-MICROSHIFT_RELEASE_RPM=$(find "${MICROSHIFT_RPM_SOURCE}" -name 'microshift-release-info*.rpm' | tail -n 1)
+MICROSHIFT_RELEASE_RPM=$(find microshift-local -name 'microshift-release-info*.rpm' | tail -n 1)
 MICROSHIFT_VERSION=$(rpm -q --queryformat '%{version}' "${MICROSHIFT_RELEASE_RPM}")
-export MICROSHIFT_VERSION
 
 # Determine the image version from the RPM contents
 RELEASE_INFO_FILE=$(find . -name 'microshift-release-info-*.rpm' | tail -1)


### PR DESCRIPTION
When running the script with a remote RPM repository, it did not work correctly.
```
$ bash -x ./scripts/image-builder/build.sh -pull_secret_file ~/.pull-secret.json -microshift_rpms https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/microshift/ocp-dev-preview/latest-4.14/el9/os/
...
...
+ createrepo microshift-local
+ open_repo_permissions microshift-local
+ find microshift-local -type f -exec chmod a+r '{}' ';'
+ find microshift-local -type d -exec chmod a+rx '{}' ';'
++ find https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/latest-4.14/el9/os/ -name 'microshift-release-info*.rpm'
find: ‘https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/latest-4.14/el9/os/’: No such file or directory
```