### PR TITLE
USHIFT-1456: use more complete version numbers in release tagging

### DIFF
--- a/scripts/release-notes/gen_ec_release_notes.py
+++ b/scripts/release-notes/gen_ec_release_notes.py
@@ -72,7 +72,7 @@ VERSION_RE = re.compile(
 # Include the major.minor version string in this list to ignore
 # processing very old versions for which we do not anticipate future
 # candidate builds.
-OLD_VERSIONS = ['4.12']
+OLD_VERSIONS = ['4.12', '4.13']
 
 
 # Representation of one release


### PR DESCRIPTION
We had 2 builds of 4.14.0~ec.3, which confused the release note tool. This
change adds the date and patch number values from the RPM version to the
tag and release name in case we have a similar issue in the future.

/assign @ggiguash