### PR TITLE
USHIFT-1457: copy entire rpm source to local repo

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -303,8 +303,7 @@ if [[ "${MICROSHIFT_RPM_SOURCE}" == http* ]] ; then
     wget -q -nd -r -L -P microshift-local -A rpm "${MICROSHIFT_RPM_SOURCE}"
 else
     [ ! -d "${MICROSHIFT_RPM_SOURCE}" ] && echo "MicroShift RPM path '${MICROSHIFT_RPM_SOURCE}' does not exist" && exit 1
-    cp -TR "${MICROSHIFT_RPM_SOURCE}/RPMS" microshift-local
-    cp -TR "${MICROSHIFT_RPM_SOURCE}/SRPMS" microshift-local
+    cp -TR "${MICROSHIFT_RPM_SOURCE}" microshift-local
 fi
 
 # Exit if no RPM packages were found


### PR DESCRIPTION
Do not assume that the RPM source being copied is the result of a
local build, and copy everything we find. This ensures that if someone
points the script to a directory full of RPMs it can create a repo out
of them.

This partially reverts 75609ae5a251772e4d72e0c0ba9dd123d5ac02a1

/assign @ggiguash @jogeo