### PR TITLE
USHIFT-1458: update build scripts to make rpm builds consistent

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -157,13 +157,18 @@ rhel-9.2-microshift-source | A RHEL 9.2 image with the RPMs built from source.
 
 ## Preparing to run test scenarios
 
-### Creating the local RPM repository
+### Building RPMs
+
+The upgrade and rollback test scenarios use multiple builds of
+MicroShift to create images with different versions. Use
+`./bin/build_rpms.sh` to build all of the necessary packages.
+
+### Creating the local RPM repositories
 
 After running `make rpm` at the top of the source tree, run
 `./bin/create_local_repo.sh` from this directory to copy the necessary
-files into a location that can be used as an RPM repository by
-Composer. If you build new RPMs, you need to re-run
-`create_local_repo.sh` *and* build new images.
+files into locations that can be used as a RPM repositories by
+Composer.
 
 ### Creating the images
 
@@ -179,6 +184,14 @@ blueprints available.
 Use `./bin/download_images.sh` to download all of the images from
 Composer's cache and set up the directory for the web server to host
 the files needed to launch VMs and run test scenarios.
+
+### Rebuilding from source easily
+
+If you build new RPMs, you need to re-run several steps (build the
+RPMs, build the local repos, build the images, download the
+images). Use `./bin/rebuild_source_images.sh` to automate all of those
+steps with 1 script while only rebuilding the images that use RPMs
+created from source (not already published releases).
 
 ### Global settings
 

--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -50,6 +50,7 @@ export PREVIOUS_MINOR_VERSION  # defined earlier
 
 # Add our sources. It is OK to run these steps repeatedly, if the
 # details change they are updated in the service.
+title "Expanding package source templates to ${IMAGEDIR}/package-sources"
 mkdir -p "${IMAGEDIR}/package-sources"
 # shellcheck disable=SC2231  # allow glob expansion without quotes in for loop
 for template in ${TESTDIR}/package-sources/*.toml; do
@@ -83,6 +84,7 @@ get_blueprint_name() {
 BUILDIDS=""
 
 # Upload the blueprint definitions
+title "Expanding blueprint templates to ${IMAGEDIR}/blueprints and starting image builds"
 mkdir -p "${IMAGEDIR}/blueprints"
 mkdir -p "${IMAGEDIR}/builds"
 # shellcheck disable=SC2231  # allow glob expansion without quotes in for loop
@@ -133,11 +135,11 @@ if ${BUILD_INSTALLER}; then
     BUILDIDS="${BUILDIDS} ${buildid}"
 fi
 
-echo "Waiting for builds to complete..."
+title "Waiting for builds to complete..."
 # shellcheck disable=SC2086  # pass command arguments quotes to allow word splitting
 time "${SCRIPTDIR}/wait_images.py" ${BUILDIDS}
 
-echo "Downloading build logs..."
+title "Downloading build logs to ${LOGDIR}"
 cd "${IMAGEDIR}/builds"
 for buildid in ${BUILDIDS}; do
     blueprint=$(grep "${buildid}" -- *.image-installer *.edge-commit | cut -f1 -d:)

--- a/test/bin/build_rpms.sh
+++ b/test/bin/build_rpms.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This script should be run on the image build server (usually the
+# same as the hypervisor).
+
+set -euo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPTDIR}/common.sh"
+
+cd "${ROOTDIR}"
+rm -rf _output/rpmbuild*
+
+# Normal build of current branch from source
+title "Building from current branch"
+make rpm
+
+# Build some RPMs with the version number of the next minor release,
+# but using the same source code as the normal build.
+title "Building fake next minor version"
+make -C test/ fake-next-minor-rpm

--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -48,13 +48,9 @@ cd ~/microshift/test/
 bash -x ./bin/configure_hypervisor_firewall.sh
 
 # Re-build from source.
-cd ~/microshift/
-rm -rf ./_output/rpmbuild*
-time make rpm
-time make -C test/ fake-next-minor-rpm
+bash -x ./bin/build_rpms.sh
 
 # Set up for scenario tests
-cd ~/microshift/test/
 timeout 20m bash -x ./bin/create_local_repo.sh
 timeout 20m bash -x ./bin/start_osbuild_workers.sh 5
 timeout 20m bash -x ./bin/build_images.sh

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -59,6 +59,15 @@ RF_VENV=${RF_VENV:-${ROOTDIR}/_output/robotenv}
 # Which port the web server should run on.
 WEB_SERVER_PORT=${WEB_SERVER_PORT:-8080}
 
+title() {
+    # Only use color when reporting to a terminal
+    if [ -t 1 ]; then
+        echo -e "\E[34m\n# $1\E[00m"
+    else
+        echo "$1"
+    fi
+}
+
 error() {
     local message="$*"
     echo "ERROR: ${message} [$(caller)]" 1>&2

--- a/test/bin/create_local_repo.sh
+++ b/test/bin/create_local_repo.sh
@@ -13,6 +13,7 @@ make_repo() {
     local repodir="$1"
     local builddir="$2"
 
+    title "Creating RPM repo at ${repodir}"
     if [ -d "${repodir}" ]; then
         echo "Cleaning up existing repository"
         rm -rf "${repodir}"
@@ -24,7 +25,6 @@ make_repo() {
     # shellcheck disable=SC2086  # no quotes for command arguments to allow word splitting
     cp -R ${builddir}/{RPMS,SPECS,SRPMS} "${repodir}/"
 
-    echo "Creating RPM repo at ${repodir}"
     createrepo "${repodir}"
 
     echo "Fixing permissions of RPM repo contents"

--- a/test/bin/download_images.sh
+++ b/test/bin/download_images.sh
@@ -33,7 +33,7 @@ download_image() {
 download_dir="${IMAGEDIR}/builds"
 mkdir -p "${download_dir}"
 
-echo "Downloading installer images to ${download_dir}"
+title "Downloading installer images to ${download_dir}"
 cd "${download_dir}"
 for blueprint_build in *.image-installer; do
     blueprint=$(basename "${blueprint_build}" .image-installer)
@@ -52,7 +52,7 @@ if [ -d "${IMAGEDIR}/repo" ]; then
     rm -rf "${IMAGEDIR}/repo"
 fi
 
-echo "Downloading ostree commits and metadata to ${download_dir}"
+title "Downloading ostree commits and metadata to ${download_dir}"
 cd "${download_dir}"
 for blueprint_build in *.edge-commit; do
     blueprint=$(basename "${blueprint_build}" .edge-commit)
@@ -66,7 +66,7 @@ for blueprint_build in *.edge-commit; do
     tar -C "${IMAGEDIR}" -xf "${commit_file}"
 done
 
-echo "Updating references"
+title "Updating ostree references in ${IMAGEDIR}/repo"
 cd "${IMAGEDIR}"
 ostree refs --repo=repo --force \
        --create "rhel-9.2-microshift-failing" "rhel-9.2-microshift-source"

--- a/test/bin/rebuild_source_images.sh
+++ b/test/bin/rebuild_source_images.sh
@@ -9,10 +9,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/common.sh"
 
 # Rebuild the RPM from source
-cd "${ROOTDIR}"
-rm -rf _output/rpmbuild
-make rpm
-make -C test/ fake-next-minor-rpm
+"${SCRIPTDIR}/build_rpms.sh"
 
 cd "${TESTDIR}"
 
@@ -27,6 +24,7 @@ get_blueprint_name() {
     tomcli-get "${filename}" name
 }
 
+title "Determining images to rebuild"
 TO_BUILD=""
 
 # shellcheck disable=SC2231  # allow glob expansion without quotes in for loop


### PR DESCRIPTION
Consolidate several places where we build RPMs into a single script that
can be reused.

/assign @pmtk @jogeo @copejon