### PR TITLE
NO-ISSUE: Simplify makefile clean target to remove the top-level directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,19 +304,8 @@ rpm-podman:
 # dev targets                 #
 ###############################
 
-clean-cross-build:
-	if [ -d '$(CROSS_BUILD_BINDIR)' ]; then $(RM) -rf '$(CROSS_BUILD_BINDIR)'; fi
-	if [ -d '$(OUTPUT_DIR)/staging' ]; then $(RM) -rf '$(OUTPUT_DIR)/staging'; fi
-	if [ -d '$(OUTPUT_DIR)/venv' ]; then $(RM) -rf '$(OUTPUT_DIR)/venv'; fi
-	if [ -d '$(OUTPUT_DIR)/robotenv' ]; then $(RM) -rf '$(OUTPUT_DIR)/robotenv'; fi
-	if ls $(OUTPUT_DIR)/e2e-* &>/dev/null ; then $(RM) -rf $(OUTPUT_DIR)/e2e-* ; fi
-	if [ -d '$(OUTPUT_DIR)/goenv' ]; then $(RM) -rf '$(OUTPUT_DIR)/goenv'; fi
-	if [ -d '$(RPM_BUILD_DIR)' ]; then $(RM) -rf '$(RPM_BUILD_DIR)'; fi
-	if [ -d '$(ISO_DIR)' ]; then $(RM) -rf '$(ISO_DIR)'; fi
-	if [ -d '$(OUTPUT_DIR)' ]; then rmdir --ignore-fail-on-non-empty '$(OUTPUT_DIR)'; fi
-.PHONY: clean-cross-build
-
-clean: clean-cross-build
+clean:
+	if [ -d '$(OUTPUT_DIR)' ]; then rm -rf '$(OUTPUT_DIR)'; fi
 .PHONY: clean
 
 vendor:


### PR DESCRIPTION
Deleting the top-level `_output` directory recursively rather then deleting sub-dirs one-by-one.