### PR TITLE
OCPBUGS-16192: Use no uplink br-ex in mutlinode mode

### DIFF
--- a/assets/components/ovn/multi-node/node/daemonset.yaml
+++ b/assets/components/ovn/multi-node/node/daemonset.yaml
@@ -145,6 +145,7 @@ spec:
             --sb-address "{{.OVN_SB_DB_LIST}}" \
             --config-file=/run/ovnkube-config/ovnkube.conf \
             --loglevel "${OVN_KUBE_LOG_LEVEL}" \
+            --allow-no-uplink \
             ${gateway_mode_flags} \
             ${gw_interface_flag} \
             --inactivity-probe="180000" \

--- a/scripts/multinode/configure-pri.sh
+++ b/scripts/multinode/configure-pri.sh
@@ -43,6 +43,11 @@ function configure_microshift() {
     sleep 5
     sudo systemctl start microshift-ovs-init.service
 
+    # OVN-K expects br-ex to have IP address assigned, add dummy IP to br-ex.
+    if ! ip addr show br-ex 2>/dev/null | grep -q '10.44.0.0/32'; then
+        sudo ip addr add 10.44.0.0/32 dev br-ex
+    fi
+
     # Configure MicroShift to allow API server access by an IP address
     cat <<EOF | sudo tee /etc/microshift/config.yaml &>/dev/null
 apiServer:

--- a/scripts/multinode/configure-sec.sh
+++ b/scripts/multinode/configure-sec.sh
@@ -40,6 +40,11 @@ function configure_microshift() {
     sleep 5
     sudo systemctl start microshift-ovs-init.service
 
+    # OVN-K expects br-ex to have IP address assigned, add dummy IP to br-ex.
+    if ! ip addr show br-ex 2>/dev/null | grep -q '10.44.0.0/32'; then
+        sudo ip addr add 10.44.0.0/32 dev br-ex
+    fi
+
     # Stop and unload the kubelet service, cleaning up its old data
     if [ "$(systemctl is-active kubelet.service)" = "active" ] ; then
         sudo systemctl stop --now kubelet


### PR DESCRIPTION
1. Enable no uplink mode for ovnkube.
2. Configure dummy IP for br-ex interface.