### PR TITLE
USHIFT-1470: Add subcommand to restore a backup

### DIFF
--- a/cmd/microshift/main.go
+++ b/cmd/microshift/main.go
@@ -38,6 +38,7 @@ func newCommand() *cobra.Command {
 	cmd.AddCommand(cmds.NewRunMicroshiftCommand())
 	cmd.AddCommand(cmds.NewVersionCommand(ioStreams))
 	cmd.AddCommand(cmds.NewShowConfigCommand(ioStreams))
-	cmd.AddCommand(cmds.NewAdminCommand())
+	cmd.AddCommand(cmds.NewBackupCommand())
+	cmd.AddCommand(cmds.NewRestoreCommand())
 	return cmd
 }

--- a/test/suites-ostree/backup-restore.robot
+++ b/test/suites-ostree/backup-restore.robot
@@ -67,7 +67,7 @@ Make Masquerading Backup
     ${backup_name}=    Set Variable    ${deploy_id}_manual
 
     ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    microshift admin data backup --name "${backup_name}"
+    ...    microshift backup --name "${backup_name}"
     ...    sudo=True    return_stderr=True    return_rc=True
     Should Be Equal As Integers    0    ${rc}
 


### PR DESCRIPTION
* Adds `restore` subcommand that takes fullpath to a backup: `sudo microshift admin restore /var/lib/microshift-backups/some-manual-backup/`
* Flattens the subcommand structure from `admin data backup,restore` to `admin backup,restore`.
