### PR TITLE
USHIFT-1426: remove openvswitch pin in test image blueprint

### DIFF
--- a/test/image-blueprints/group2/rhel92-microshift-previous-minor.toml
+++ b/test/image-blueprints/group2/rhel92-microshift-previous-minor.toml
@@ -5,11 +5,6 @@ modules = []
 groups = []
 distro = "rhel-92"
 
-# FIXME: Temporarily pin the openvswitch version.
-[[packages]]
-name = "openvswitch3.1"
-version = "3.1.0-14.el9fdp"
-
 [[packages]]
 name = "microshift"
 version = "4.${PREVIOUS_MINOR_VERSION}*"


### PR DESCRIPTION
This depends on #2114

/assign @ggiguash @zshi-redhat