### PR TITLE
USHIFT-1445: fix: prune test

### DIFF
--- a/test/resources/libostree.py
+++ b/test/resources/libostree.py
@@ -67,13 +67,13 @@ def create_fake_backups(count: int, type_unknown: bool = False) -> None:
     and are therefore unknown to MicroShift.
     """
     deploy_id = get_booted_deployment_id()
-    prefix_path = get_deployment_backup_prefix_path(deploy_id)
+    prefix_path = f"{get_deployment_backup_prefix_path(deploy_id)}_fake"
 
     if type_unknown:
         prefix_path = os.path.join(BACKUP_STORAGE, "unknown")
 
     for number in range(0, count):
-        remote_sudo(f"mkdir -p {prefix_path}_fake{number}")
+        remote_sudo(f"mkdir -p {prefix_path}{number}")
 
 
 def remove_backups_for_deployment(deploy_id: str) -> None:

--- a/test/suites-ostree/backup-prune.robot
+++ b/test/suites-ostree/backup-prune.robot
@@ -20,22 +20,19 @@ ${UNKOWN_DIR_REG}       unknown_fake*
 
 
 *** Test Cases ***
-Rebooting Healthy System Should Result In Pruning Old Backups
-    [Documentation]    Check that MicroShift backup logic prunes old backups
+Rebooting Healthy System Should Result In Pruning Old Backups And Keeping Unknown Directories
+    [Documentation]    Check that MicroShift backup logic prunes old backups and keeps unknown directories
 
     Create Fake Backup Directories
     Validate Fake Backups Exist
-    Reboot MicroShift Host
-    Wait For MicroShift Service
-    Validate Fake Backups Have Been Deleted
 
-Rebooting Healthy System Should Not Delete Unknown Directories
-    [Documentation]    Check that MicroShift backup logic does not delete unknown directories
-
-    Create Fake Unknown Backup Directories
+    Create Unknown Fake Backup Directories
     Validate Unknown Fake Backups Exist
+
     Reboot MicroShift Host
-    Wait For MicroShift Service
+    Wait For Healthy System
+
+    Validate Fake Backups Have Been Deleted
     Validate Unknown Fake Backups Exist
 
 
@@ -52,7 +49,7 @@ Validate Fake Backups Have Been Deleted
     [Documentation]    Listing the fake backups should return an error code of 2 if no longer exists
     List Backups With Expected RC    2    ${FAKE_DIR_REG}
 
-Create Fake Unknown Backup Directories
+Create Unknown Fake Backup Directories
     [Documentation]    Create unknown fake backup folders
     Create Fake Backups    2    True
 

--- a/test/suites-ostree/backup-prune.robot
+++ b/test/suites-ostree/backup-prune.robot
@@ -23,15 +23,6 @@ ${UNKOWN_DIR_REG}       unknown_fake*
 Rebooting Healthy System Should Result In Pruning Old Backups And Keeping Unknown Directories
     [Documentation]    Check that MicroShift backup logic prunes old backups and keeps unknown directories
 
-    Create Fake Backup Directories
-    Validate Fake Backups Exist
-
-    Create Unknown Fake Backup Directories
-    Validate Unknown Fake Backups Exist
-
-    Reboot MicroShift Host
-    Wait For Healthy System
-
     Validate Fake Backups Have Been Deleted
     Validate Unknown Fake Backups Exist
 
@@ -77,6 +68,15 @@ Setup
     [Documentation]    Test suite setup
     Check Required Env Variables
     Login MicroShift Host
+
+    Create Fake Backup Directories
+    Validate Fake Backups Exist
+
+    Create Unknown Fake Backup Directories
+    Validate Unknown Fake Backups Exist
+
+    Reboot MicroShift Host
+    Wait For Healthy System
 
 Teardown
     [Documentation]    Test suite teardown

--- a/test/suites-ostree/backup-prune.robot
+++ b/test/suites-ostree/backup-prune.robot
@@ -2,6 +2,7 @@
 Documentation       Tests related to MicroShift backup functionality on OSTree-based systems
 
 Resource            ../resources/common.resource
+Resource            ../resources/ostree.resource
 Resource            ../resources/ostree-data.resource
 Library             Collections
 
@@ -16,15 +17,19 @@ ${USHIFT_HOST}          ${EMPTY}
 ${USHIFT_USER}          ${EMPTY}
 
 ${FAKE_DIR_REG}         *_fake*
-${UNKOWN_DIR_REG}       unknown_fake*
+${UNKOWN_DIR_REG}       unknown*
 
 
 *** Test Cases ***
-Rebooting Healthy System Should Result In Pruning Old Backups And Keeping Unknown Directories
-    [Documentation]    Check that MicroShift backup logic prunes old backups and keeps unknown directories
+Rebooting Healthy System Should Result In Pruning Old Backups
+    [Documentation]    Check that MicroShift backup logic prunes old backups
 
     Validate Fake Backups Have Been Deleted
-    Validate Unknown Fake Backups Exist
+
+Rebooting Healthy System Should Not Delete Unknown Directories
+    [Documentation]    Check that MicroShift backup logic does not delete unknown directories
+
+    Validate Unknown Directories Exist
 
 
 *** Keywords ***
@@ -40,15 +45,15 @@ Validate Fake Backups Have Been Deleted
     [Documentation]    Listing the fake backups should return an error code of 2 if no longer exists
     List Backups With Expected RC    2    ${FAKE_DIR_REG}
 
-Create Unknown Fake Backup Directories
-    [Documentation]    Create unknown fake backup folders
+Create Unknown Directories
+    [Documentation]    Create unknown fake folders that the pruning logic should not touch
     Create Fake Backups    2    True
 
-Validate Unknown Fake Backups Exist
+Validate Unknown Directories Exist
     [Documentation]    Make sure the unknown fake backups exist
     List Backups With Expected RC    0    ${UNKOWN_DIR_REG}
 
-Delete Unkown Fake Backups
+Delete Unknown Directories
     [Documentation]    Remove unknown directories
 
     ${stdout}    ${rc}=    Execute Command
@@ -72,13 +77,13 @@ Setup
     Create Fake Backup Directories
     Validate Fake Backups Exist
 
-    Create Unknown Fake Backup Directories
-    Validate Unknown Fake Backups Exist
+    Create Unknown Directories
+    Validate Unknown Directories Exist
 
     Reboot MicroShift Host
     Wait For Healthy System
 
 Teardown
     [Documentation]    Test suite teardown
-    Delete Unkown Fake Backups
+    Delete Unknown Directories
     Logout MicroShift Host


### PR DESCRIPTION
This is to avoid errors in timing between file creation and when the system comes up, since the prune logic skips touching the directory if backup exists, this tests could fail sometimes if ran out of order.

Moving to one test to avoid issue.

/assign @pmtk 
