### PR TITLE
OCPBUGS-16339: Add explicit version dependencies among MicroShift RPM packages

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -60,8 +60,8 @@ BuildRequires: golang
 Requires: cri-o >= 1.25
 Requires: cri-tools >= 1.25
 Requires: iptables
-Requires: microshift-selinux
-Requires: microshift-networking
+Requires: microshift-selinux = %{version}
+Requires: microshift-networking = %{version}
 Requires: conntrack-tools
 Requires: sos
 Requires: crun
@@ -76,6 +76,7 @@ The microshift package provides an OpenShift Kubernetes distribution optimized f
 %package release-info
 Summary: Release information for MicroShift
 BuildArch: noarch
+Requires: microshift = %{version}
 
 %description release-info
 The microshift-release package provides release information files for this
@@ -89,6 +90,7 @@ BuildRequires: selinux-policy >= %{selinux_policyver}
 BuildRequires: selinux-policy-devel >= %{selinux_policyver}
 Requires: container-selinux
 BuildArch: noarch
+Requires: microshift = %{version}
 Requires: selinux-policy >= %{selinux_policyver}
 
 %description selinux
@@ -97,6 +99,7 @@ The microshift-selinux package provides the SELinux policy modules required by M
 
 %package networking
 Summary: Networking components for MicroShift
+Requires: microshift = %{version}
 Requires: openvswitch3.1
 Requires: NetworkManager
 Requires: NetworkManager-ovs
@@ -109,6 +112,7 @@ The microshift-networking package provides the networking components necessary f
 %package greenboot
 Summary: Greenboot components for MicroShift
 BuildArch: noarch
+Requires: microshift = %{version}
 Requires: greenboot
 
 %description greenboot
@@ -343,10 +347,13 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
-* Tue Jul  21 2023 Zenghui Shi <zshi@redhat.com> 4.14.0
+* Tue Jul 25 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.14.0
+- Add explicit version dependencies among MicroShift RPM packages
+
+* Fri Jul 21 2023 Zenghui Shi <zshi@redhat.com> 4.14.0
 - Add openvswitch user to hugetlbfs group
 
-* Tue Jun  6 2023 Doug Hellmann <dhellmann@redhat.com> 4.14.0
+* Tue Jun 06 2023 Doug Hellmann <dhellmann@redhat.com> 4.14.0
 - Restore golang BuildRequires setting
 
 * Mon May 15 2023 Doug Hellmann <dhellmann@redhat.com> 4.14.0


### PR DESCRIPTION
Two way version comparison is now in place:
* microshift depends on the exact version of microshift-networking / microshift-selinux
* all the sub-packages require the exact version of microshift

To test RPM dependencies, I used the following configurations
* rpm-413: vanilla RPM packages built by ART - no dependency fix
* rpm-nover: RPM packages from the main branch - no dependency fix
* rpm-ver: RPM packages with the current fix

*Scenario 1* - `4.13` allows mixing `nover` RPMs
```
$ sudo dnf localinstall microshift-4.13.5-202307141802.p0.g59bf35c.assembly.4.13.5.el9.x86_64.rpm ../rpm-nover/microshift-networking-4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9.x86_64.rpm ../rpm-nover/microshift-selinux-4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9.noarch.rpm
Dependencies resolved.
=============================================================================================
 Package                Arch   Version               Repository                         Size
=============================================================================================
Installing:
 microshift             x86_64 4.13.5-202307141802.p0.g59bf35c.assembly.4.13.5.el9
                                                     @commandline                       47 M
 microshift-networking  x86_64 4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9
                                                     @commandline                       18 k
 microshift-selinux     noarch 4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9
```

*Scenario 2* - `nover` allows mixing 4.13
```
$ sudo dnf localinstall microshift-4.14.0_0.nightly_2023_07
_20_215234_20230726140113_fa2a51bc9-1.el9.x86_64.rpm ../rpm-413/microshift-networking-4.13.5
-202307141802.p0.g59bf35c.assembly.4.13.5.el9.x86_64.rpm ../rpm-413/microshift-selinux-4.13.
5-202307141802.p0.g59bf35c.assembly.4.13.5.el9.noarch.rpm
Dependencies resolved.
============================================================================================
 Package                Arch   Version              Repository                         Size
============================================================================================
Installing:
 microshift             x86_64 4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9
                                                    @commandline                       55 M
 microshift-networking  x86_64 4.13.5-202307141802.p0.g59bf35c.assembly.4.13.5.el9
                                                    @commandline                       25 k
 microshift-selinux     noarch 4.13.5-202307141802.p0.g59bf35c.assembly.4.13.5.el9
                                                    @commandline                       24 k
```

*Scenario 3* - `ver` does not allow mixing `nover`
```
$ sudo dnf localinstall microshift-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64.rpm ../rpm-nover/microshift-networking-4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9.x86_64.rpm ../rpm-nover/microshift-selinux-4.14.0_0.nightly_2023_07_20_215234_20230726140113_fa2a51bc9-1.el9.noarch.rpm
Updating Subscription Management repositories.
Last metadata expiration check: 3:29:57 ago on Wed 26 Jul 2023 11:33:33 AM UTC.
Error:
 Problem: conflicting requests
  - nothing provides microshift-networking = 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508 needed by microshift-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64
  - nothing provides microshift-selinux = 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508 needed by microshift-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

*Scenario 4* -  4.13 cannot mix `ver` RPMS
```
$ sudo dnf localinstall microshift-4.13.5-202307141802.p0.g59bf35c.assembly.4.13.5.el9.x86_64.rpm ../rpm-ver/microshift-networking-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64.rpm ../rpm-ver/microshift-selinux-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.noarch.rpm
Updating Subscription Management repositories.
Last metadata expiration check: 3:30:58 ago on Wed 26 Jul 2023 11:33:33 AM UTC.
Error:
 Problem 1: conflicting requests
  - nothing provides microshift = 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508 needed by microshift-networking-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64
 Problem 2: conflicting requests
  - nothing provides microshift = 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508 needed by microshift-selinux-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.noarch
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)`
```

*Scenario 5* - `ver` RPM installation works
```
$ sudo dnf localinstall microshift-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64.rpm microshift-networking-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.x86_64.rpm microshift-selinux-4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9.noarch.rpm 
Updating Subscription Management repositories.
Last metadata expiration check: 3:41:05 ago on Wed 26 Jul 2023 11:33:33 AM UTC.
Dependencies resolved.
============================================================================================
 Package                Arch   Version              Repository                         Size
============================================================================================
Installing:
 microshift             x86_64 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9
                                                    @commandline                       55 M
 microshift-networking  x86_64 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9
                                                    @commandline                       18 k
 microshift-selinux     noarch 4.14.0_0.nightly_2023_07_20_215234_20230726061755_e849bc508-1.el9
                                                    @commandline                       23 k
```

Closes OCPBUGS-16339
