### PR TITLE
USHIFT-1504: add more labels to rebase PRs automatically

### DIFF
--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -383,7 +383,7 @@ def create_pr_title(branch_name, successful_rebase):
     Given a branch name, creates a pull request title. If the rebase was successful,
     the title is just the branch name, else "**FAILURE**" followed by the branch name.
     """
-    return branch_name if successful_rebase else f"**FAILURE** {branch_name}"
+    return f"NO-ISSUE: {branch_name}" if successful_rebase else f"**FAILURE** {branch_name}"
 
 
 def get_expected_branch_name(amd, arm):

--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -266,6 +266,9 @@ def generate_pr_description(amd_tag, arm_tag, prow_job_url, rebase_script_succed
     {changelog}
 
     /label tide/merge-method-squash
+    /label cherry-pick-approved
+    /label backport-risk-assessed
+    /label bugzilla/valid-bug
     """)
     base = template.format(**locals())
     return (base if rebase_script_succeded


### PR DESCRIPTION
We've agreed that the dev team can add cherry-pick-approved to rebase PRs,
so have the bot do it when the PR is submitted.

We do not use jira issues to track rebase PRs, so instead of forcing 
reviewers to add the label manually put `NO-ISSUE` in the PR title to have
the bot label it for us.

/assign @ggiguash @pmtk @jogeo