### PR TITLE
USHIFT-1493: The microshift-greenboot package is no longer optional

### DIFF
--- a/docs/contributor/greenboot.md
+++ b/docs/contributor/greenboot.md
@@ -2,8 +2,8 @@
 
 ## Motivation
 
-[Integrating MicroShift with Greenboot](./greenboot.md) allows for automatic
-software upgrade rollbacks in case of a failure.
+[Integrating MicroShift with Greenboot](../user/greenboot.md) allows for
+automatic software upgrade rollbacks in case of a failure.
 
 The current document describes a few techniques for:
 * Adding user workload health check procedures in a production environment

--- a/docs/user/greenboot.md
+++ b/docs/user/greenboot.md
@@ -20,11 +20,9 @@ interruption of service in case of a failed upgrade.
 ### Greenboot Configuration
 
 MicroShift includes the `40_microshift_running_check.sh` health check script to
-validate that all the required MicroShift services are up and running. There is
-no explicit dependency on the `greenboot` RPM from MicroShift core packages, or
-a requirement to use health check procedures. The health check script is packaged
-in the separate `microshift-greenboot` RPM, which may be installed on the system
-if the `greenboot` facilities are to be used.
+validate that all the required MicroShift services are up and running. The health
+check script is packaged in the separate mandatory `microshift-greenboot` RPM,
+which has an explicit dependency on the `greenboot` RPM.
 
 The health check script is installed into the `/etc/greenboot/check/required.d`
 directory and it is not executed during the system boot in case the `greenboot`

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -62,6 +62,7 @@ Requires: cri-tools >= 1.25
 Requires: iptables
 Requires: microshift-selinux = %{version}
 Requires: microshift-networking = %{version}
+Requires: microshift-greenboot = %{version}
 Requires: conntrack-tools
 Requires: sos
 Requires: crun
@@ -347,6 +348,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Thu Jul 27 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.14.0
+- The microshift-greenboot package is no longer optional
+
 * Tue Jul 25 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.14.0
 - Add explicit version dependencies among MicroShift RPM packages
 


### PR DESCRIPTION
Added explicit dependency on `microshift-greenboot` from the `microshift` RPM and updated the docs.

```
$ rpm -qpR ./_output/rpmbuild/RPMS/x86_64/microshift-4.14.0_0.nightly_2023_07_26_001154_20230727003726_560fed8c1_dirty-1.el9.x86_64.rpm | grep ^microshift
microshift-greenboot = 4.14.0_0.nightly_2023_07_26_001154_20230727003726_560fed8c1_dirty
microshift-networking = 4.14.0_0.nightly_2023_07_26_001154_20230727003726_560fed8c1_dirty
microshift-selinux = 4.14.0_0.nightly_2023_07_26_001154_20230727003726_560fed8c1_dirty
```

Closes [USHIFT-1493](https://issues.redhat.com//browse/USHIFT-1493)
