### PR TITLE
USHIFT-1516: Fix build.sh to properly pick up embedded container references

### DIFF
--- a/scripts/image-builder/build.sh
+++ b/scripts/image-builder/build.sh
@@ -382,8 +382,8 @@ fi
 # Add container images
 if ${EMBED_CONTAINERS} ; then
     # Add the list of all the container images
-    jq -r '.images | .[] | ("[[containers]]\nsource = \"" + . + "\"\n")' \
-        "${ROOTDIR}/assets/release/release-$(uname -m).json" \
+    jq -r '.images | .[] | ("\n[[containers]]\nsource = \"" + . + "\"\n")' \
+        "./usr/share/microshift/release/release-$(uname -m).json" \
         >> blueprint_v0.0.1.toml
 fi
 


### PR DESCRIPTION
Also, fix Makefile to allow `build.sh` command line override when running `make iso` commands.

Closes [USHIFT-1516](https://issues.redhat.com//browse/USHIFT-1516)
