### PR TITLE
USHIFT-1510: Enhance multinode configuration scripts to be more resilient

### DIFF
--- a/scripts/multinode/configure-pri.sh
+++ b/scripts/multinode/configure-pri.sh
@@ -37,11 +37,11 @@ function configure_system() {
 
 function configure_microshift() {
     # Clean the current MicroShift configuration and stop the service
-    echo 1 | sudo microshift-cleanup-data --all
+    echo 1 | sudo microshift-cleanup-data --all --keep-images
 
     # Run OVN initialization script
     sleep 5
-    sudo systemctl start microshift-ovs-init.service
+    sudo systemctl start --wait microshift-ovs-init.service
 
     # OVN-K expects br-ex to have IP address assigned, add dummy IP to br-ex.
     if ! ip addr show br-ex 2>/dev/null | grep -q '10.44.0.0/32'; then


### PR DESCRIPTION
The secondary node is now tagged with "worker" label.
```
NAME             STATUS   ROLES                         AGE   VERSION
microshift-pri   Ready    control-plane,master,worker   79s   v1.27.1
microshift-sec   Ready    worker                        31s   v1.27.1
```

The following additional changes were also implemented:
- Keep images when cleaning MicroShift data to speed up pod reboot
- Wait until microshift-ovs-init.service is started to avoid race condition with IP setting
- Verify kubelet process is killed on the secondary node
- Unmount /var/lib/kubelet on the secondary node to allow directory deletion
- Wait until all MicroShift nodes are ready
- Wait until the pods are ready using the multinode pod counts

Closes [USHIFT-1510](https://issues.redhat.com//browse/USHIFT-1510)
