### PR TITLE
USHIFT-1519: hard-code source of LVMS manifests

### DIFF
--- a/scripts/auto-rebase/last_rebase.sh
+++ b/scripts/auto-rebase/last_rebase.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -x
-./scripts/auto-rebase/rebase.sh to "registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-07-27-172239" "registry.ci.openshift.org/ocp-arm64/release-arm64:4.14.0-0.nightly-arm64-2023-07-27-223712" "registry.access.redhat.com/lvms4/lvms-operator-bundle:v4.13.1-5"
+./scripts/auto-rebase/rebase.sh to "registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-07-27-172239" "registry.ci.openshift.org/ocp-arm64/release-arm64:4.14.0-0.nightly-arm64-2023-07-27-223712"


### PR DESCRIPTION
The production pipeline is passing an old value. We want that input
parameter to be controlled explicitly by the development, so ignore
the parameter and hard-code a value in the rebase script.

/assign @copejon @ggiguash @pmtk