### PR TITLE
NO-ISSUE:  set the correct permission for osbuild-composer

### DIFF
--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -25,9 +25,14 @@ mkdir "${TEST_FILE}.dir"
 HOME_PERM=$(stat -c 0%a ~)
 FILE_PERM=$(stat -c 0%a "${TEST_FILE}.file")
 DIR_PERM=$(stat -c 0%a "${TEST_FILE}.dir")
-rm -rf "${TEST_FILE}"*
 
-if [ "${HOME_PERM}" -lt 0755 ] || [ "${FILE_PERM}" -lt 0644 ] || [ "${DIR_PERM}" -lt 0755 ] ; then
-    echo "Check home directory permissions and umask. The settings must allow read to group and others"
+# Set the Correct Permissions for osbuild-composer
+[ "${HOME_PERM}" -lt 0711 ]  && chmod go+x ~
+
+if [ "${FILE_PERM}" -lt 0644 ] || [ "${DIR_PERM}" -lt 0711 ] ; then
+    echo "Check ${TEST_FILE}.dir permissions. The umask setting must allow execute to group/others"
+    echo "Check ${TEST_FILE}.file permissions. The umask setting must allow read to group/others"    
     exit 1
 fi
+
+rm -rf "${TEST_FILE}"*


### PR DESCRIPTION
when /home/microshift  using default permissions (700)  `build.sh`  fails with an error: 
```bash
# Loading microshift blueprint v0.0.1
+ sudo composer-cli blueprints delete microshift
+ true
+ sudo composer-cli blueprints push /home/microshift/microshift/_output/image-builder/blueprint_v0.0.1.toml
+ sudo composer-cli blueprints depsolve microshift
ERROR: BlueprintsError: microshift: DNF error occurred: RepoError: There was a problem reading a repository: Failed to download metadata for repo 'de3d95914e632f2aee75dc0a200ac02106835607234a2ba2e4b3c2451b1efcad' [microshift-local: file:///home/microshift/microshift/_output/image-builder/microshift-local/]: Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
+ /home/microshift/microshift/scripts/image-builder/cleanup.sh

```
