### PR TITLE
USHIFT-1528: Don't throw an error when there is no rollback deploy

### DIFF
--- a/pkg/admin/prerun/system.go
+++ b/pkg/admin/prerun/system.go
@@ -90,7 +90,8 @@ func getRollbackDeploymentID() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("could not find rollback deployment in %#v", deployments)
+	// missing rollback deployment is valid scenario
+	return "", nil
 }
 
 func getAllDeploymentIDs() ([]string, error) {


### PR DESCRIPTION
System without rollback deployment is valid system.
By not throwing an error in this situation, MicroShift will continue start up (without restoring anything) to give cluster a chance to recover instead of just failing.