### PR TITLE
USHIFT-1512: Increase the default devenv disk size to 70GB

### DIFF
--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -94,7 +94,7 @@ function action_create {
     export VMDISKDIR="${MICROSHIFT_VMDISKDIR}"
     export NCPUS="${NCPUS:-4}"
     export RAMSIZE="${RAMSIZE:-8}"
-    export DISKSIZE="${DISKSIZE:-60}"
+    export DISKSIZE="${DISKSIZE:-70}"
     export SWAPSIZE="${SWAPSIZE:-8}"
     export DATAVOLSIZE="${DATAVOLSIZE:-2}"
     if [ -z "${ISOFILE}" ]; then


### PR DESCRIPTION
After building an ISO with embedded containers (see #2179) using test harness environment, it because apparent that the default 50GB of disk space is not enough on the dev machine.