### PR TITLE
NO-ISSUE: Separate golang archive installation commands

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -107,13 +107,13 @@ if ${INSTALL_BUILD_DEPS} && [ ! -d "${GO_INSTALL_DIR}" ]; then
     echo "Installing go ${GO_VER}..."
     # This is installed into different location (/usr/local/bin/go) from dnf installed Go (/usr/bin/go) so it doesn't conflict
     # /usr/local/bin is before /usr/bin in $PATH so newer one is picked up
-    curl -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.linux-${GO_ARCH}.tar.gz" &&
-        sudo rm -rf "/usr/local/go${GO_VER}" && \
-            sudo mkdir -p "/usr/local/go${GO_VER}" && \
-            sudo tar -C "/usr/local/go${GO_VER}" -xzf "go${GO_VER}.linux-${GO_ARCH}.tar.gz" --strip-components 1 && \
-            sudo rm -rfv /usr/local/bin/{go,gofmt} && \
-            sudo ln --symbolic /usr/local/go${GO_VER}/bin/{go,gofmt} /usr/local/bin/ && \
-            rm -rfv "go${GO_VER}.linux-${GO_ARCH}.tar.gz"
+    curl -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.linux-${GO_ARCH}.tar.gz"
+    sudo rm -rf "/usr/local/go${GO_VER}"
+    sudo mkdir -p "/usr/local/go${GO_VER}"
+    sudo tar -C "/usr/local/go${GO_VER}" -xzf "go${GO_VER}.linux-${GO_ARCH}.tar.gz" --strip-components 1
+    sudo rm -rfv /usr/local/bin/{go,gofmt}
+    sudo ln --symbolic /usr/local/go${GO_VER}/bin/{go,gofmt} /usr/local/bin/
+    rm -rfv "go${GO_VER}.linux-${GO_ARCH}.tar.gz"
 fi
 
 if ${BUILD_AND_RUN}; then


### PR DESCRIPTION
If any of these commands fail when chained by `&&`, the script does not exit with error on the spot.

For example,  intermittent `curl` failure did not result in the top-level script failure.
```
+ curl -L -o go1.20.4.linux-amd64.tar.gz https://go.dev/dl/go1.20.4.linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100    75  100    75    0     0    735      0 --:--:-- --:--:-- --:--:--   735

 33 95.5M   33 31.5M    0     0  38.7M      0  0:00:02 --:--:--  0:00:02 38.7M
 67 95.5M   67 64.7M    0     0  53.2M      0  0:00:01  0:00:01 --:--:-- 82.7M
curl: (18) transfer closed with 32253670 bytes remaining to read
+ false
```