### PR TITLE
[USHIFT-1108] Add periodic scenario to test upgrade from latest release to head of next y-stream branch or main

### DIFF
--- a/test/scenarios-periodics/el92-src@upgrade-from-release-fails-and-rollsback.sh
+++ b/test/scenarios-periodics/el92-src@upgrade-from-release-fails-and-rollsback.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart.ks.template rhel-9.2-microshift-4."$(previous_minor_version)"
+    launch_vm host1
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+# CI will execute these tests on a set release branch, so source version will always be the latest code for that branch.
+# I.e. CI jobs testing release-4.14 will always compile the latest 4.14 code as the source_version.
+scenario_run_tests() {
+    run_tests host1 \
+        --variable "FAILING_REF:rhel-9.2-microshift-source" \
+        --variable "REASON:fail_greenboot" \
+        suites/upgrade/upgrade-fails-and-rolls-back.robot
+}


### PR DESCRIPTION
This PR is part of the implementation of [USHIFT-1108](https://issues.redhat.com//browse/USHIFT-1108), the rest of the work being in the openshift/release repo.

Changes here tried to reuse existing logic as much as possible.  
- A ./test/Makefile target is added to build the 4.y-1 branch.
- The PREVIOUS_MINOR_VERSION is reused.  More var related to building prior release were added where they were needed to complete the pipeline.
- 