### PR TITLE
USHIFT-1555: add timeout for long running command

### DIFF
--- a/packaging/greenboot/functions.sh
+++ b/packaging/greenboot/functions.sh
@@ -98,7 +98,7 @@ function wait_for() {
     shift 1
 
     local -r start=$(date +%s)
-    until ("$@"); do
+    until (timeout "${timeout}" "$@"); do
         sleep 1
 
         local now


### PR DESCRIPTION
This change safeguards the  wait_for function  against long running commands.
if the  command is not finished within the arg_1 `timeout`  , command (arg_2)  will be killed   and `return 1`.
