### PR TITLE
USHIFT-1512: Add isolated network test

### DIFF
--- a/test/assets/isolated-lb-service.yaml
+++ b/test/assets/isolated-lb-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: isolated-lb-service
+spec:
+  ports:
+  - port: 31111
+    targetPort: 80
+  selector:
+    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
+  type: LoadBalancer

--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -48,8 +48,8 @@ bash -x ./bin/start_webserver.sh
 
 # Build all of the images
 CPU_CORES="$(grep -c ^processor /proc/cpuinfo)"
-MAX_WORKERS=5
-CUR_WORKERS="$( [ "${CPU_CORES}" -lt  $(( MAX_WORKERS * 2 )) ] && echo $(( CPU_CORES / 2 )) || echo ${MAX_WORKERS} )"
+MAX_WORKERS=$(find "${ROOTDIR}/test/image-blueprints" -name \*.toml | wc -l)
+CUR_WORKERS="$( [ "${CPU_CORES}" -lt  $(( MAX_WORKERS * 2 )) ] && echo $(( CPU_CORES / 2 )) || echo "${MAX_WORKERS}" )"
 
 bash -x ./bin/start_osbuild_workers.sh "${CUR_WORKERS}"
 bash -x ./bin/build_images.sh

--- a/test/image-blueprints/group2/rhel92-source-isolated.toml
+++ b/test/image-blueprints/group2/rhel92-source-isolated.toml
@@ -1,0 +1,41 @@
+name = "rhel-9.2-microshift-source-isolated"
+description = "A RHEL 9.2 image with the RPMs built from source with embedded container images."
+version = "0.0.1"
+modules = []
+groups = []
+distro = "rhel-92"
+
+[[packages]]
+name = "microshift"
+version = "${SOURCE_VERSION}"
+
+[[packages]]
+name = "microshift-greenboot"
+version = "${SOURCE_VERSION}"
+
+[[packages]]
+name = "microshift-networking"
+version = "${SOURCE_VERSION}"
+
+[[packages]]
+name = "microshift-selinux"
+version = "${SOURCE_VERSION}"
+
+[[packages]]
+name = "microshift-test-agent"
+version = "*"
+
+[customizations.services]
+enabled = ["microshift", "microshift-test-agent"]
+
+[customizations.firewall]
+ports = ["22:tcp", "80:tcp", "443:tcp", "5353:udp", "6443:tcp", "30000-32767:tcp", "30000-32767:udp"]
+
+[customizations.firewall.services]
+enabled = ["mdns", "ssh", "http", "https"]
+
+[[customizations.firewall.zones]]
+name = "trusted"
+sources = ["10.42.0.0/16", "169.254.169.1"]
+
+RENDER_CONTAINER_IMAGES="${SOURCE_VERSION}"

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -42,8 +42,15 @@ mkdir -p /etc/microshift
 cat - >/etc/microshift/config.yaml <<EOF
 apiServer:
   subjectAltNames:
-    - $(ip route | grep default | awk '{print $9}')
 EOF
+
+DEFAULT_ROUTE_IP="$(ip route show default 2>/dev/null | head -1 | awk '{print $9}')"
+if [ -n "${DEFAULT_ROUTE_IP}" ] ; then
+    echo "    - ${DEFAULT_ROUTE_IP}" >>/etc/microshift/config.yaml
+else
+    MAIN_HOST_IP="$(hostname -I | awk '{print $1}')"
+    echo "    - ${MAIN_HOST_IP}" >>/etc/microshift/config.yaml
+fi
 if [ -n "REPLACE_PUBLIC_IP" ]; then
     echo "    - REPLACE_PUBLIC_IP" >>/etc/microshift/config.yaml
 fi

--- a/test/resources/microshift-host.resource
+++ b/test/resources/microshift-host.resource
@@ -2,6 +2,7 @@
 Documentation       Keywords for working with the MicroShift host
 
 Library             SSHLibrary
+Library             libostree.py
 
 
 *** Keywords ***
@@ -47,14 +48,16 @@ SSH Connection To MicroShift Host Should Be Functional
 
 Reboot MicroShift Host
     [Documentation]    Reboot the MicroShift host and wait until
-    ...    SSH connection is working again
+    ...    SSH connection is working again and boot identifier changes
     ...
-    ...    Expects that intial SSH connection to MicroShift host is active.
+    ...    Expects that initial SSH connection to MicroShift host is active.
 
+    ${bootid}=    Get Current Boot Id
     SSHLibrary.Start Command    reboot    sudo=True
     Sleep    30s
+
     Wait Until Keyword Succeeds    5m    15s
-    ...    SSH Connection To MicroShift Host Should Be Functional
+    ...    Is System Rebooted    ${bootid}
 
 Create Thin Storage Pool
     [Documentation]    Create a new thin storage pool
@@ -76,3 +79,17 @@ Is System OSTree
     ${rc}=    Execute Command    stat /run/ostree-booted
     ...    sudo=True    return_stderr=False    return_stdout=False    return_rc=True
     IF    ${rc} == 0    RETURN    ${TRUE}    ELSE    RETURN    ${FALSE}
+
+Is System Rebooted
+    [Documentation]    Check if the system rebooted comparing the current and provided boot identifier
+    [Arguments]    ${old_bootid}
+
+    Make New SSH Connection
+    ${cur_bootid}=    Get Current Boot Id
+    ${len}=    Get Length    ${cur_bootid}
+    IF    ${len} == 0
+        RETURN    False
+    ELSE
+        ${system_rebooted}=    Evaluate    '${old_bootid}' != '${cur_bootid}'
+        RETURN    ${system_rebooted}
+    END

--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -72,6 +72,10 @@ Stop MicroShift
     [Documentation]    Stop the MicroShift service
     Systemctl With Retry    stop    microshift.service
 
+Enable MicroShift
+    [Documentation]    Enable the MicroShift service
+    Systemctl    enable    microshift.service
+
 Cleanup MicroShift
     [Documentation]    Cleanup
     ...    opts=[--keep-images]

--- a/test/scenarios/el92-src@isolated-net.sh
+++ b/test/scenarios/el92-src@isolated-net.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# Redefine network-related settings to use the isolated network bridge
+VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
+# shellcheck disable=SC2034  # used elsewhere
+WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart.ks.template rhel-9.2-microshift-source-isolated
+    # Use the isolated network when creating a VM
+    launch_vm host1 "" "${VM_ISOLATED_NETWORK}"
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_tests host1 suites/isolated-net/isolated-network.robot
+}

--- a/test/suites/isolated-net/isolated-network.robot
+++ b/test/suites/isolated-net/isolated-network.robot
@@ -1,0 +1,79 @@
+*** Settings ***
+Documentation       Tests related to MicroShift running in an isolated network
+
+Resource            ../../resources/ostree-health.resource
+Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/microshift-host.resource
+Library             Collections
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+Test Tags           network
+
+
+*** Variables ***
+${USHIFT_HOST}      ${EMPTY}
+${LB_CONFIG}        assets/isolated-lb-service.yaml
+${LB_NSPACE}        openshift-ingress
+${LB_SRVNAME}       isolated-lb-service
+${LB_PORTNUM}       31111
+
+
+*** Test Cases ***
+Verify Load Balancer Services Are Running Correctly In Isolated Network
+    [Documentation]    Verifies that isolated network does not negatively
+    ...    impact Load Balancer Services.
+
+    Setup Kubeconfig
+    Create Load Balancer
+    Wait Until Keyword Succeeds    1m    5s
+    ...    Check Load Balancer Service Access
+
+    [Teardown]    Run Keywords
+    ...    Delete Load Balancer
+
+Verify MicroShift Is Healthy In Isolated Network After Clean And Reboot
+    [Documentation]    Makes sure that MicroShift running in an isolated network
+    ...    remains healthy after clean and reboot.
+
+    Cleanup MicroShift
+    Enable MicroShift
+    Reboot MicroShift Host
+
+    Verify No Internet Access
+    Wait For Healthy System
+
+
+*** Keywords ***
+Setup
+    [Documentation]    Test suite setup
+    Check Required Env Variables
+    Login MicroShift Host
+
+    Verify No Internet Access
+    Wait For Healthy System
+
+Teardown
+    [Documentation]    Test suite teardown
+    Logout MicroShift Host
+
+Verify No Internet Access
+    [Documentation]    Verifies that Internet is not accessible
+    ${rc}=    Execute Command
+    ...    curl -I redhat.com quay.io registry.access.redhat.com
+    ...    return_stdout=False    return_stderr=False    return_rc=True
+    Should Not Be Equal As Integers    ${rc}    0
+
+Create Load Balancer
+    [Documentation]    Creates a load balancer service backed by router pods.
+    Run With Kubeconfig    oc create -f ${LB_CONFIG} -n ${LB_NSPACE}
+
+Check Load Balancer Service Access
+    [Documentation]    Checks if a load balancer service can be accessed.
+    ${rc}=    Run And Return RC    curl -I ${USHIFT_HOST}:${LB_PORTNUM}
+    Should Be Equal As Integers    ${rc}    0
+
+Delete Load Balancer
+    [Documentation]    Deletes a load balancer service backed by router pods.
+    Run With Kubeconfig    oc delete svc/${LB_SRVNAME} -n ${LB_NSPACE}


### PR DESCRIPTION
Enable container image embedding and add the isolated network test.
**Note: this PR also fixes the race condition when rebooting the MicroShift host.**

This PR depends on the following to be merged:
- #2179 
- #2206 
- #2208
- #2209

Closes [USHIFT-1512](https://issues.redhat.com//browse/USHIFT-1512)
