### PR TITLE
Revert "USHIFT-1555: add timeout for long running command"

### DIFF
--- a/packaging/greenboot/functions.sh
+++ b/packaging/greenboot/functions.sh
@@ -98,7 +98,7 @@ function wait_for() {
     shift 1
 
     local -r start=$(date +%s)
-    until (timeout "${timeout}" "$@"); do
+    until ("$@"); do
         sleep 1
 
         local now


### PR DESCRIPTION
This reverts commit 733477ccd92a670866d5fff52aae3110d6b75a78.
This change introduced an issue on greenboot  while VM is booting.