### PR TITLE
USHIFT-1551: only log gateway address when it changes

### DIFF
--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -59,8 +59,8 @@ func GetHostIP(nodeIP string) (string, error) {
 found:
 	if hostIP != previousGatewayIP {
 		previousGatewayIP = hostIP
+		klog.V(2).Infof("host gateway IP address: %s", hostIP)
 	}
-	klog.V(2).Infof("host gateway IP address: %s", hostIP)
 
 	return hostIP, nil
 }


### PR DESCRIPTION
We only want to log changes in state. This patch moves a log statement
into a conditional so that the message is only emitted when the
host gateway IP address changes.


/assign @pliurh @pacevedom