### PR TITLE
USHIFT-1591: Optimize VM creation process by creating multiple libvirt storage pools

### DIFF
--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -320,8 +320,8 @@ do_group() {
         elif [[ "${build_name}" =~ image-installer ]]; then
             blueprint=${build_name//-image-installer/}
             iso_file="${buildid}-installer.iso"
-            echo "Moving ${iso_file} to ${VM_DISK_DIR}/${blueprint}.iso"
-            mv -f "${iso_file}" "${VM_DISK_DIR}/${blueprint}.iso"
+            echo "Moving ${iso_file} to ${VM_DISK_BASEDIR}/${blueprint}.iso"
+            mv -f "${iso_file}" "${VM_DISK_BASEDIR}/${blueprint}.iso"
         else
             echo "Do not know how to handle build ${build_name}"
         fi
@@ -436,7 +436,7 @@ LOGDIR="${IMAGEDIR}/build-logs"
 mkdir -p "${LOGDIR}"
 mkdir -p "${IMAGEDIR}/blueprints"
 mkdir -p "${IMAGEDIR}/builds"
-mkdir -p "${VM_DISK_DIR}"
+mkdir -p "${VM_DISK_BASEDIR}"
 
 configure_package_sources
 

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -19,11 +19,11 @@ INSTALLER_IMAGE_BLUEPRINT="rhel-9.2"
 export IMAGEDIR="${ROOTDIR}/_output/test-images"
 
 # The storage pool name for VMs
-VM_STORAGE_POOL="vm-storage"
+VM_POOL_BASENAME="vm-storage"
 
 # The location for storage for the VMs.
 # shellcheck disable=SC2034  # used elsewhere
-VM_DISK_DIR="${IMAGEDIR}/${VM_STORAGE_POOL}"
+VM_DISK_BASEDIR="${IMAGEDIR}/${VM_POOL_BASENAME}"
 
 # The isolated network name used by some VMs.
 # shellcheck disable=SC2034  # used elsewhere


### PR DESCRIPTION
When running in CI, virtual machine creation hits the https://github.com/virt-manager/virt-manager/issues/498 libvirt bug.

```
sudo virt-install --noautoconsole --name rhel-9.2-microshift-source-rollback-host1 \
--vcpus 2 --memory 4092 --disk pool=vm-storage,size=20 --network network=default,model=virtio \
--events on_reboot=restart --location /home/microshift/microshift/_output/test-images/vm-storage/rhel-9.2.iso \
--extra-args inst.ks=http://192.168.122.1:8080/scenario-info/rhel-9.2-microshift-source-rollback/vms/host1/kickstart.ks \
--wait 15
ERROR    Error: --disk pool=vm-storage,size=20: internal error: pool 'vm-storage' has asynchronous jobs running.
```

Closes [USHIFT-1591](https://issues.redhat.com//browse/USHIFT-1591)
