### PR TITLE
NO-ISSUE: Remove "greenboot-complete" from scenario.sh junit

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -401,10 +401,7 @@ SSH_PRIV_KEY: "${SSH_PRIVATE_KEY:-}"
 SSH_PORT: ${ssh_port}
 EOF
 
-    if wait_for_greenboot "${full_vmname}" "${vm_ip}"; then
-        record_junit "${vmname}" "greenboot-complete" "OK"
-    else
-        record_junit "${vmname}" "greenboot-complete" "FAILED"
+    if ! wait_for_greenboot "${full_vmname}" "${vm_ip}"; then
         return 1
     fi
 


### PR DESCRIPTION
junit is recorded during "create" phase and waiting for greenboot was moved to "run" phase.

That resulted in adding an extra <testcase> after the </testsuite> which violates XML spec which says that XML document can only have one root element.

Malformed XML is available in `artifacts/microshift-metal-tests/openshift-microshift-e2e-metal-tests/artifacts/scenario-info/$SCENARIO/vms/junit.xml`