### PR TITLE
USHIFT-1590: Event cache configuration update

### DIFF
--- a/pkg/controllers/cluster-policy-controller.go
+++ b/pkg/controllers/cluster-policy-controller.go
@@ -21,6 +21,7 @@ import (
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	clusterpolicycontroller "github.com/openshift/cluster-policy-controller/pkg/cmd/cluster-policy-controller"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/microshift/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	unstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -81,7 +82,8 @@ func (s *ClusterPolicyController) configure(cfg *config.Config) error {
 			Kind:       "Namespace",
 			Name:       namespace,
 			Namespace:  namespace,
-		})
+		}).
+		WithEventRecorderOptions(events.RecommendedClusterSingletonCorrelatorOptions())
 
 	s.run = func(ctx context.Context) error {
 		return builder.Run(ctx, ctrlConfig)


### PR DESCRIPTION
Default configuration for event cache allows only 1 event every 5min. This triggers event aggregation which collapses several events into a single one, losing information about the event (aggregation happens when the reason is the same, regardless of the message). By allowing 1 event per second this problem is greatly reduced (if not completely).

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
