### PR TITLE
OCPVE-614: feat: introduce CSI disable flag to allow for LVM initialization after microshift start

### DIFF
--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -2,6 +2,7 @@
   "type": "object",
   "required": [
     "apiServer",
+    "csi",
     "debugging",
     "dns",
     "etcd",
@@ -26,6 +27,19 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "csi": {
+      "description": "CSI provides configuration options for the inbuilt CSI infrastructure.",
+      "type": "object",
+      "required": [
+        "disable"
+      ],
+      "properties": {
+        "disable": {
+          "description": "Disable completely disables all internal CSI implementations and allows for Plug \u0026 Play of own CSI Plugins instead.",
+          "type": "boolean"
         }
       }
     },

--- a/docs/user/howto_config.md
+++ b/docs/user/howto_config.md
@@ -11,6 +11,8 @@ apiServer:
     advertiseAddress: ""
     subjectAltNames:
         - ""
+csi:
+    disable:
 debugging:
     logLevel: ""
 dns:
@@ -47,6 +49,8 @@ apiServer:
     advertiseAddress: ""
     subjectAltNames:
         - ""
+csi:
+    disable:
 debugging:
     logLevel: Normal
 dns:

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -4,6 +4,10 @@ apiServer:
     # SubjectAltNames added to API server certs
     subjectAltNames:
         - ""
+# CSI provides configuration options for the inbuilt CSI infrastructure.
+csi:
+    # Disable completely disables all internal CSI implementations and allows for Plug & Play of own CSI Plugins instead.
+    disable:
 debugging:
     # Valid values are: "Normal", "Debug", "Trace", "TraceAll". Defaults to "Normal".
     logLevel: Normal

--- a/pkg/components/storage.go
+++ b/pkg/components/storage.go
@@ -26,6 +26,16 @@ func getCSIPluginConfig() (*lvmd.Lvmd, error) {
 }
 
 func startCSIPlugin(ctx context.Context, cfg *config.Config, kubeconfigPath string) error {
+	if cfg.CSI.Disable {
+		klog.Info("inbuilt CSI is disabled, skipping initialization")
+		return nil
+	}
+
+	if err := lvmd.LvmSupported(); err != nil {
+		klog.Warningf("skipping CSI deployment: %v", err)
+		return nil
+	}
+
 	var (
 		ns = []string{
 			"components/lvms/topolvm-openshift-storage_namespace.yaml",
@@ -67,11 +77,6 @@ func startCSIPlugin(ctx context.Context, cfg *config.Config, kubeconfigPath stri
 			"components/lvms/topolvm-node-securitycontextconstraint.yaml",
 		}
 	)
-
-	if err := lvmd.LvmSupported(); err != nil {
-		klog.Warningf("skipping CSI deployment: %v", err)
-		return nil
-	}
 
 	// the lvmd file should be located in the same directory as the microshift config to minimize coupling with the
 	// csi plugin.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Etcd      EtcdConfig `json:"etcd"`
 	Debugging Debugging  `json:"debugging"`
 	Manifests Manifests  `json:"manifests"`
+	CSI       CSI        `json:"csi"`
 
 	// Internal-only fields
 	Ingress      IngressConfig `json:"-"`

--- a/pkg/config/csi.go
+++ b/pkg/config/csi.go
@@ -1,0 +1,8 @@
+package config
+
+// CSI provides configuration options for the inbuilt CSI infrastructure.
+type CSI struct {
+	// Disable completely disables all internal CSI implementations and allows for Plug & Play of own CSI
+	// Plugins instead.
+	Disable bool `json:"disable"`
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:

Completely stop CSI initialization with a config flag, even if LVM is supported. 
Allows Teams building with LVM or other CSI plugins to start running Microshift as their development base. Also allows pluggin in other CSI implementations.
