### PR TITLE
USHIFT-1623: add support for vnc consoles to scenario vms

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -344,6 +344,10 @@ use ssh-agent.
 in a local environment where sos can be run manually when
 necessary. Do not enable this option in CI.
 
+`VNC_CONSOLE` -- Whether to add a VNC graphics console to hosts. This
+is useful in local developer settings where cockpit can be used to
+login to the host. Set to `true` to enable. Defaults to `false`.
+
 #### Configuring Hypervisor
 
 Use `./test/bin/manage_hypervisor_config.sh` to manage the following

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -17,6 +17,7 @@ PULL_SECRET_CONTENT="$(jq -c . "${PULL_SECRET}")"
 PUBLIC_IP=${PUBLIC_IP:-""}  # may be overridden in global settings file
 VM_BOOT_TIMEOUT=900
 SKIP_SOS=${SKIP_SOS:-false}  # may be overridden in global settings file
+VNC_CONSOLE=${VNC_CONSOLE:-false}  # may be overridden in global settings file
 
 full_vm_name() {
     local base="${1}"
@@ -218,12 +219,19 @@ launch_vm() {
         # FIXME: variable for memory?
         # FIXME: variable for ISO
 
+        local graphics_args
+        graphics_args="none"
+        if "${VNC_CONSOLE}"; then
+            graphics_args="vnc,listen=0.0.0.0"
+        fi
+
         # When bash creates a background job (using `&`),
         # the bg job does not get its own TTY.
         # If the TTY is not provided, virt-install refuses
         # to attach to the console. `unbuffer` provides the TTY.
         if ! sudo unbuffer virt-install \
             --autoconsole text \
+            --graphics "${graphics_args}" \
             --name "${full_vmname}" \
             --vcpus 2 \
             --memory 4092 \


### PR DESCRIPTION
It can be useful to access test VMs through the console. This patch
adds an option to the scenario test harness to add a VNC console that
can be used with cockpit to monitor or login to the VM.

/assign @ggiguash @pmtk @pacevedom