### PR TITLE
healthcheck deployments and daemonsets

### DIFF
--- a/scripts/verify/verify-shell.sh
+++ b/scripts/verify/verify-shell.sh
@@ -27,6 +27,7 @@ for f in ${CHECK_FILE_LIST} ; do
     # the list of checked files.
     "${SHELL_CHECK}" \
         --format=gcc \
+        --exclude=SC2317 \
         --external-sources \
         "${f}"
 done


### PR DESCRIPTION
Instead of checking individual pod state, including restart count, check the ready status of the deployment or daemonset that controls the pod. Let the controllers for deployment and daemonset be responsible for getting their pods into that ready state.

Because the old implementation applied the timeout to several different phases, introduce a retry loop for each namespace to allow each deployment or daemonset several attempts to get to ready.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
