### PR TITLE
USHIFT-1538: Verify contents of a backup before restoring

### DIFF
--- a/pkg/admin/data/data_manager_test.go
+++ b/pkg/admin/data/data_manager_test.go
@@ -1,0 +1,54 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func Test_checkDirectoryContents(t *testing.T) {
+	testData := []struct {
+		name    string
+		input   sets.Set[string]
+		isValid bool
+	}{
+		{
+			name:    "Perfect backup",
+			input:   sets.New[string]("certs", "etcd", "kubelet-plugins", "resources", "version"),
+			isValid: true,
+		},
+		{
+			name:    "Backup with some extra files - still valid",
+			input:   sets.New[string]("certs", "etcd", "kubelet-plugins", "resources", "version", "extra", "random", "dirs"),
+			isValid: true,
+		},
+		{
+			name:    "version file is missing",
+			input:   sets.New[string]("certs", "etcd", "kubelet-plugins", "resources"),
+			isValid: false,
+		},
+		{
+			name:    "certs dir is missing",
+			input:   sets.New[string]("etcd", "kubelet-plugins", "resources", "version"),
+			isValid: false,
+		},
+		{
+			name:    "None of the directories match",
+			input:   sets.New[string]("1", "2", "3", "4"),
+			isValid: false,
+		},
+	}
+
+	for _, td := range testData {
+		td := td
+		t.Run(td.name, func(t *testing.T) {
+			err := checkDirectoryContents(td.input)
+			if td.isValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/admin.go
+++ b/pkg/cmd/admin.go
@@ -97,10 +97,6 @@ func NewRestoreCommand() *cobra.Command {
 				return err
 			}
 
-			// TODO: Verify content of provided path
-			// Check if provided path points to a directory that is really
-			// a backup of MicroShift's data.
-
 			return dataManager.Restore(name)
 		},
 	}


### PR DESCRIPTION
Adds a naive verification if provided path is
in fact a backup of MicroShift data.
It should prevent some accidental overwrites of
MicroShift data with contents of random directories.