### PR TITLE
USHIFT-1634: Pruning old backups: don't remove manual backups

### DIFF
--- a/pkg/admin/prerun/backups.go
+++ b/pkg/admin/prerun/backups.go
@@ -2,12 +2,21 @@ package prerun
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/openshift/microshift/pkg/admin/data"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+)
+
+var (
+	// backupNameRegexp is regexp schema of automated backup name:
+	// (osname)-(64 characters).(integer)_(32 characters)
+	// for example:
+	// rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2
+	backupNameRegexp = regexp.MustCompile(`^[\w-]+-[\d\w]{64}\.\d+_[\d\w]{32}$`)
 )
 
 type Backups []data.BackupName
@@ -104,16 +113,24 @@ func (bs Backups) getDangling(deploymentIDs []string) Backups {
 	}
 
 	if len(unknownDeployments) > 0 {
-		// Expecting to be "4.13"
+		// Expecting "4.13" or manual backups
 		klog.InfoS("Found backups not belonging to any deployment - they need to be deleted manually", "backups", unknownDeployments)
 	}
 
 	return backupsToRemove
 }
 
+func isAutomatedBackup(name data.BackupName) bool {
+	return backupNameRegexp.MatchString(string(name))
+}
+
 // getDeploymentIDForTheBackup returns a deployment ID from backup's name
 // according to the schema: deploy-id_boot-id
 func getDeploymentIDForTheBackup(backup data.BackupName) string {
+	if !isAutomatedBackup(backup) {
+		return ""
+	}
+
 	spl := strings.Split(string(backup), "_")
 	if len(spl) > 1 {
 		return spl[0]

--- a/pkg/admin/prerun/backups_test.go
+++ b/pkg/admin/prerun/backups_test.go
@@ -1,0 +1,108 @@
+package prerun
+
+import (
+	"testing"
+
+	"github.com/openshift/microshift/pkg/admin/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isAutomatedBackup(t *testing.T) {
+	testData := []struct {
+		name        string
+		backupName  data.BackupName
+		isAutomated bool
+	}{
+		{
+			name:        "Correct backup name",
+			backupName:  data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: true,
+		},
+		{
+			name:        "Serial number is missing at the end of deployment ID",
+			backupName:  data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048._80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: false,
+		},
+		{
+			name:        "Serial number is double digit",
+			backupName:  data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.11_80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: true,
+		},
+		{
+			name:        "Serial number is triple digit",
+			backupName:  data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.111_80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: true,
+		},
+		{
+			name:        "Deployment checksum is one char short",
+			backupName:  data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf9904.0_80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: false,
+		},
+		{
+			name:        "Boot ID is one char short",
+			backupName:  data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c"),
+			isAutomated: false,
+		},
+		{
+			name:        "Different osname",
+			backupName:  data.BackupName("fedora-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: true,
+		},
+		{
+			name:        "Different osname with extra dash",
+			backupName:  data.BackupName("fedora-silverblue-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2"),
+			isAutomated: true,
+		},
+		{
+			name:        "Former default manual name",
+			backupName:  data.BackupName("4.14.0_20230815000000"),
+			isAutomated: false,
+		},
+	}
+
+	for _, td := range testData {
+		t.Run(td.name, func(t *testing.T) {
+			assert.Equal(t, td.isAutomated, isAutomatedBackup(td.backupName))
+		})
+	}
+}
+
+func Test_getDeploymentIDForTheBackup(t *testing.T) {
+	testData := []struct {
+		backupName     data.BackupName
+		expectedResult string
+	}{
+		{
+			backupName:     data.BackupName("rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2"),
+			expectedResult: "rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0",
+		},
+		{
+			backupName:     data.BackupName("fedora-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2"),
+			expectedResult: "fedora-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0",
+		},
+		{
+			backupName:     data.BackupName("fedora-silverblue-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0_80364fcf3df54284a6902687e2cdd4c2"),
+			expectedResult: "fedora-silverblue-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0",
+		},
+		{
+			backupName:     data.BackupName("r-35d7b5c80f0f1378d6846f6dc1304bbf.0_80364fcf3df54284"),
+			expectedResult: "",
+		},
+		{
+			backupName:     data.BackupName("4.14.0_20230815000000"),
+			expectedResult: "",
+		},
+		{
+			backupName:     data.BackupName("custom001"),
+			expectedResult: "",
+		},
+		{
+			backupName:     data.BackupName("custom_001"),
+			expectedResult: "",
+		},
+	}
+
+	for _, td := range testData {
+		assert.Equal(t, td.expectedResult, getDeploymentIDForTheBackup(td.backupName))
+	}
+}

--- a/test/resources/libostree.py
+++ b/test/resources/libostree.py
@@ -62,18 +62,22 @@ def get_deployment_backup_prefix_path(deploy_id: str) -> str:
 
 def create_fake_backups(count: int, type_unknown: bool = False) -> None:
     """
-    Create n number of fake Backup directories, unknown types
-    are directories that are not named in the backup prefix convention
-    and are therefore unknown to MicroShift.
+    Create number of fake Backup directories.
+    Unknown types are directories that do not match automated backups naming
+    convention of 'deploymentID_bootID' which can be described more
+    specifically by (osname)-(64 chars).(int)_(32 chars).
+    Such backups should not be automatically pruned by MicroShift.
     """
     deploy_id = get_booted_deployment_id()
-    prefix_path = f"{get_deployment_backup_prefix_path(deploy_id)}_fake"
+    prefix_path = (
+        f"{get_deployment_backup_prefix_path(deploy_id)}_fake000000000000000000000000"
+    )
 
     if type_unknown:
-        prefix_path = os.path.join(BACKUP_STORAGE, "unknown")
+        prefix_path = os.path.join(BACKUP_STORAGE, "unknown_")
 
     for number in range(0, count):
-        remote_sudo(f"mkdir -p {prefix_path}{number}")
+        remote_sudo(f"mkdir -p {prefix_path}{number:0>4}")
 
 
 def remove_backups_for_deployment(deploy_id: str) -> None:


### PR DESCRIPTION
Verifies if name of a backup is matching schema of automated backup.
Manual backups that start with `X.Y.Z_` or any other manual backup
with underscore in its name should not be subject to automated
backup pruning.