### PR TITLE
OCPBUGS-18351: fix: update rpm spec file

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -27,6 +27,8 @@
    restorecon -R /var/lib/kubelet/pods; \
    restorecon -R /var/run/secrets/kubernetes.io/serviceaccount; \
    restorecon -R /var/lib/microshift-backups; \
+   restorecon -R /etc/microshift; \
+   restorecon -R /usr/lib/microshift; \
    restorecon -v /usr/bin/microshift; \
    restorecon -v /usr/bin/microshift-etcd
 

--- a/packaging/selinux/microshift.fc
+++ b/packaging/selinux/microshift.fc
@@ -3,6 +3,7 @@
 /var/lib/microshift.saved(/.*)?                                 gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/microshift(/.*)?                                       gen_context(system_u:object_r:container_var_lib_t,s0)
 /etc/microshift(/.*)?                                           gen_context(system_u:object_r:kubernetes_file_t,s0)
+/usr/lib/microshift(/.*)?                                       gen_context(system_u:object_r:kubernetes_file_t,s0)
 /usr/local/bin/microshift                                   --  gen_context(system_u:object_r:kubelet_exec_t,s0)
 /usr/bin/microshift                                         --  gen_context(system_u:object_r:kubelet_exec_t,s0)
 /usr/local/bin/microshift-etcd                              --  gen_context(system_u:object_r:kubelet_exec_t,s0)


### PR DESCRIPTION
added restorecon command to spec file for /etc/microshift and /usr/lib/microshift during upgrades from 4.13 added rule for /usr/lib/microshift folder
