### PR TITLE
OCPBUGS-14678: microshift-etcd shuts down independently

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	gracefulShutdownTimeout = 60
+	gracefulShutdownTimeout = 15
 )
 
 var (

--- a/pkg/controllers/etcd.go
+++ b/pkg/controllers/etcd.go
@@ -74,6 +74,7 @@ func (s *EtcdService) Run(ctx context.Context, ready chan<- struct{}, stopped ch
 			"--uid=root",
 			"--scope",
 			"--unit", "microshift-etcd",
+			"--property", "Before=microshift.service",
 			"--property", "BindsTo=microshift.service",
 		)
 
@@ -113,16 +114,6 @@ func (s *EtcdService) Run(ctx context.Context, ready chan<- struct{}, stopped ch
 		// Exit microshift to trigger microshift-etcd restart
 		klog.Warning("microshift-etcd process terminated prematurely, restarting MicroShift")
 		os.Exit(0)
-	}()
-
-	// Handle microshift-etcd termination after microshift process exits
-	defer func() {
-		if err := cmd.Process.Signal(os.Interrupt); err != nil {
-			klog.Warningf("%v failed interrupting the process: %+v", s.Name(), err)
-			if err := cmd.Process.Kill(); err != nil {
-				klog.Warningf("%v failed killing the process: %+v", s.Name(), err)
-			}
-		}
 	}()
 
 	if err := checkIfEtcdIsReady(ctx); err != nil {


### PR DESCRIPTION
microshift is running microshift-etcd binary as systemd [transient](https://github.com/openshift/microshift/blob/14adeba0d460b38c898d9b730806eb4f011b49cd/pkg/controllers/etcd.go#L73) unit ,

current behavior after microshift.service is stopped:

1. systemd sends its term signal  to the microshift.service,
2. microshift ServiceManager  stopping  the microshift-etcd.transient unit https://github.com/openshift/microshift/blob/14adeba0d460b38c898d9b730806eb4f011b49cd/pkg/controllers/etcd.go#L119-L126
3. microshift  exits prematurely: https://github.com/openshift/microshift/blob/14adeba0d460b38c898d9b730806eb4f011b49cd/pkg/controllers/etcd.go#L107-L116

this behaviour causes  unclean microshift services shutdown (see also [USHIFT-1533](https://issues.redhat.com//browse/USHIFT-1533)),

which is  evident in the journal log:
```microshift-etcd process terminated prematurely, restarting MicroShift```
it is also  explains why the shutdown happens so quickly .

the proposed change enforces the dependency order from systemd perspective, 
delegate the etcd shutdown to systemd  instead of ServiceManager.

side effect of this  change: the shutdown becomes  much slower.  

before the change:
```
> time systemctl stop microshift

real    0m0.087s
user    0m0.013s
sys     0m0.021s

> journalctl -u microshift.service | grep systemd
Sep 02 22:17:18 microshift-lenovo systemd[1]: Stopping MicroShift...
Sep 02 22:17:18 microshift-lenovo systemd[1]: microshift.service: Deactivated successfully.
Sep 02 22:17:18 microshift-lenovo systemd[1]: Stopped MicroShift.
Sep 02 22:17:18 microshift-lenovo systemd[1]: microshift.service: Consumed 28.903s CPU time.

>journalctl -u microshift-etcd.scope | grep systemd
Sep 02 22:17:18 microshift-lenovo systemd[1]: microshift-etcd.scope: Deactivated successfully.
Sep 02 22:17:18 microshift-lenovo systemd[1]: Stopped /usr/bin/microshift-etcd run.
Sep 02 22:17:18 microshift-lenovo systemd[1]: microshift-etcd.scope: Consumed 5.071s CPU time.


```


after the change:
```
> time systemctl stop microshift
real    1m0.098s
user    0m0.017s
sys     0m0.018s

> journalctl -u microshift.service | grep systemd
Sep 02 22:06:53 microshift-lenovo systemd[1]: Stopping MicroShift...
Sep 02 22:07:53 microshift-lenovo systemd[1]: microshift.service: Deactivated successfully.
Sep 02 22:07:53 microshift-lenovo systemd[1]: Stopped MicroShift.
Sep 02 22:07:53 microshift-lenovo systemd[1]: microshift.service: Consumed 24.946s CPU time.

> journalctl -u microshift-etcd.scope | grep systemd
Sep 02 22:07:53 microshift-lenovo systemd[1]: Stopping /usr/bin/microshift-etcd run...
Sep 02 22:07:53 microshift-lenovo systemd[1]: microshift-etcd.scope: Deactivated successfully.
Sep 02 22:07:53 microshift-lenovo systemd[1]: Stopped /usr/bin/microshift-etcd run.
Sep 02 22:07:53 microshift-lenovo systemd[1]: microshift-etcd.scope: Consumed 4.268s CPU time.
```
