### PR TITLE
USHIFT-1654: Fix openshift-route-controller RBAC failures

### DIFF
--- a/assets/controllers/route-controller-manager/ns.yaml
+++ b/assets/controllers/route-controller-manager/ns.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-controller-manager
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades

--- a/assets/controllers/route-controller-manager/route-controller-manager-clusterrole.yaml
+++ b/assets/controllers/route-controller-manager/route-controller-manager-clusterrole.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:openshift-route-controller-manager
+rules:
+# informers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+# emitting events
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+# used for detection of HA to configure leader election
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch

--- a/assets/controllers/route-controller-manager/route-controller-manager-clusterrolebinding.yaml
+++ b/assets/controllers/route-controller-manager/route-controller-manager-clusterrolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:openshift-route-controller-manager
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:openshift-route-controller-manager
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-route-controller-manager
+  name: route-controller-manager-sa

--- a/assets/controllers/route-controller-manager/sa.yaml
+++ b/assets/controllers/route-controller-manager/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: openshift-controller-manager
+  name: openshift-controller-manager-sa

--- a/pkg/controllers/openshift-route-controller-manager.go
+++ b/pkg/controllers/openshift-route-controller-manager.go
@@ -137,6 +137,7 @@ func (s *OCPRouteControllerManager) Run(ctx context.Context, ready chan<- struct
 
 	if err := assets.ApplyNamespaces(ctx, []string{
 		"controllers/route-controller-manager/route-controller-manager-ns.yaml",
+		"controllers/route-controller-manager/ns.yaml",
 	}, s.kubeadmconfig); err != nil {
 		klog.Fatalf("failed to apply openshift namespaces %v", err)
 	}
@@ -144,6 +145,7 @@ func (s *OCPRouteControllerManager) Run(ctx context.Context, ready chan<- struct
 		"controllers/route-controller-manager/informer-clusterrole.yaml",
 		"controllers/route-controller-manager/route-controller-manager-tokenreview-clusterrole.yaml",
 		"controllers/route-controller-manager/route-controller-manager-ingress-to-route-controller-clusterrole.yaml",
+		"controllers/route-controller-manager/route-controller-manager-clusterrole.yaml",
 	}, s.kubeadmconfig); err != nil {
 		klog.Fatalf("failed to apply route controller manager cluster roles %v", err)
 	}
@@ -152,6 +154,7 @@ func (s *OCPRouteControllerManager) Run(ctx context.Context, ready chan<- struct
 		"controllers/route-controller-manager/informer-clusterrolebinding.yaml",
 		"controllers/route-controller-manager/route-controller-manager-tokenreview-clusterrolebinding.yaml",
 		"controllers/route-controller-manager/route-controller-manager-ingress-to-route-controller-clusterrolebinding.yaml",
+		"controllers/route-controller-manager/route-controller-manager-clusterrolebinding.yaml",
 	}, s.kubeadmconfig); err != nil {
 		klog.Fatalf("failed to apply route controller manager cluster role bindings %v", err)
 	}
@@ -171,6 +174,7 @@ func (s *OCPRouteControllerManager) Run(ctx context.Context, ready chan<- struct
 
 	if err := assets.ApplyServiceAccounts(ctx, []string{
 		"controllers/route-controller-manager/route-controller-manager-sa.yaml",
+		"controllers/route-controller-manager/sa.yaml",
 	}, s.kubeadmconfig); err != nil {
 		klog.Fatalf("failed to apply route controller manager service account %v", err)
 	}

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -151,6 +151,10 @@ assets:
   - dir: controllers/route-controller-manager/
     src: cluster-openshift-controller-manager-operator/bindata/v3.11.0/openshift-controller-manager/
     files:
+      - file: ns.yaml
+      - file: sa.yaml
+      - file: route-controller-manager-clusterrole.yaml
+      - file: route-controller-manager-clusterrolebinding.yaml
       - file: informer-clusterrolebinding.yaml
       - file: informer-clusterrole.yaml
       - file: route-controller-manager-ingress-to-route-controller-clusterrolebinding.yaml


### PR DESCRIPTION
There were a handful of resources (ns, sa, rbac) missing that are required by the openshift-route-controller-manager.

Added files:
- Adds the openshift-controller-manager namespace and SA, which were referred by the informer-clusterrolebinding.yaml.
`ns.yaml`
`sa.yaml`

- There are the missing permissions for the openshift-route-controller-manager SA that is already deployed in microshift
`route-controller-manager-clusterrole.yaml`
`route-controller-manager-clusterrolebinding.yaml`
