### PR TITLE
USHIFT-1509: Enhance microshift-cleanup-data script UX and functionality

### DIFF
--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -79,7 +79,7 @@ Enable MicroShift
 Cleanup MicroShift
     [Documentation]    Cleanup
     ...    opts=[--keep-images]
-    [Arguments]    ${opts}=""
+    [Arguments]    ${opts}=${EMPTY}
     ${stdout}    ${stderr}    ${rc}=    Execute Command
     ...    echo 1 | sudo microshift-cleanup-data --all ${opts}
     ...    sudo=True    return_stderr=True    return_rc=True


### PR DESCRIPTION
The following enhancements were implemented:
- Enhanced usability by allowing positiion independent options and more flexible answer when prompted
- Added error messages when command line parsing fails
- Added `set -euo pipefail` option to the script
- Fixed crio container and image removal by using commands that actually work
- Added the missing `kube-system` namespace to the clean list

Closes [USHIFT-1509](https://issues.redhat.com//browse/USHIFT-1509)
