### PR TITLE
USHIFT-1665: Fix show-config command to require root priviledges

### DIFF
--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/spf13/cobra"
@@ -26,6 +27,10 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 		Run: func(cmd *cobra.Command, args []string) {
 			var cfg *config.Config
 			var err error
+
+			if os.Geteuid() > 0 {
+				cmdutil.CheckErr(fmt.Errorf("command requires root privileges"))
+			}
 
 			switch opts.Mode {
 			case "effective":

--- a/test/suites/standard/show-config.robot
+++ b/test/suites/standard/show-config.robot
@@ -19,6 +19,13 @@ ${MEMLIMIT128}      SEPARATOR=\n
 
 
 *** Test Cases ***
+No Sudo Command
+    [Documentation]    Test without priviledge elevation
+    ${output}    ${rc}=    Execute Command
+    ...    microshift show-config
+    ...    sudo=False    return_rc=True
+    Should Not Be Equal As Integers    0    ${rc}
+
 No Mode Argument
     [Documentation]    Test without any explicit --mode
     ${output}    ${rc}=    Execute Command


### PR DESCRIPTION
Closes [USHIFT-1665](https://issues.redhat.com//browse/USHIFT-1665)
