### PR TITLE
OCPBUGS-18548: Stop all MicroShift components when signaled to exit

### DIFF
--- a/pkg/controllers/infra-services-controller.go
+++ b/pkg/controllers/infra-services-controller.go
@@ -41,6 +41,7 @@ func (s *InfrastructureServicesManager) Dependencies() []string {
 }
 
 func (s *InfrastructureServicesManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+	defer close(stopped)
 	defer close(ready)
 
 	if err := applyDefaultRBACs(ctx, s.cfg); err != nil {

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -160,6 +160,7 @@ func (s *KubeAPIServer) configure(cfg *config.Config) error {
 			},
 			"enable-admission-plugins":              {},
 			"send-retry-after-while-not-ready-once": {"true"},
+			"shutdown-delay-duration":               {"5s"},
 		},
 		GenericAPIServerConfig: configv1.GenericAPIServerConfig{
 			AdmissionConfig: configv1.AdmissionConfig{

--- a/pkg/controllers/openshift-default-scc-manager.go
+++ b/pkg/controllers/openshift-default-scc-manager.go
@@ -41,6 +41,7 @@ func (s *OpenShiftDefaultSCCManager) Dependencies() []string {
 }
 
 func (s *OpenShiftDefaultSCCManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+	defer close(stopped)
 	defer close(ready)
 	// TO-DO add readiness check
 	if err := ApplyDefaultSCCs(ctx, s.cfg); err != nil {

--- a/scripts/auto-rebase/rebase_patches/0030-kube-controller-manager-command-context.patch
+++ b/scripts/auto-rebase/rebase_patches/0030-kube-controller-manager-command-context.patch
@@ -16,7 +16,7 @@ index 087b5f50b..092a1bdb5 100644
  
 -			stopCh := server.SetupSignalHandler()
 -			return Run(context.Background(), c.Complete(), stopCh)
-+			return Run(context.Background(), c.Complete(), cmd.Context().Done())
++			return Run(cmd.Context(), c.Complete(), cmd.Context().Done())
  		},
  		Args: func(cmd *cobra.Command, args []string) error {
  			for _, arg := range args {

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -155,7 +155,7 @@ controller, and serviceaccounts controller.`,
 			// add feature enablement metrics
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
 
-			return Run(context.Background(), c.Complete(), cmd.Context().Done())
+			return Run(cmd.Context(), c.Complete(), cmd.Context().Done())
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {


### PR DESCRIPTION
### make KCM use context we give to command 

By using `cmd.Context()`, KCM will use a context MicroShift passes down through all the components.

When using `context.Background()` it won't ever stop, because it's never cancelled, and result in blocking `ServiceManager` which waits for all components to stop and make MicroShift use its whole internal `gracefulShutdownTimer`.

---

### override KAS' `shutdown-delay-duration` to `5s` (from `70s`)

`shutdown-delay-duration` tells KAS how long to serve after receiving a stop signal.

Its value is provided to `time.Sleep()`, so it's used in full; there is not short-circuit mechanism that would let KAS exit earlier.

Default value of `70s` is set in `assets/controllers/kube-apiserver/defaultconfig.yaml`