### PR TITLE
OCPBUGS-18706: Don't wait before applying a CRD

### DIFF
--- a/pkg/assets/crd.go
+++ b/pkg/assets/crd.go
@@ -161,7 +161,7 @@ func ApplyCRDs(ctx context.Context, cfg *config.Config) error {
 			return fmt.Errorf("error getting asset %s: %v", crd, err)
 		}
 		c := readCRDOrDie(crdBytes)
-		if err = wait.PollUntilContextTimeout(ctx, customResourceReadyInterval, customResourceReadyTimeout, false, func(ctx context.Context) (done bool, err error) {
+		if err = wait.PollUntilContextTimeout(ctx, customResourceReadyInterval, customResourceReadyTimeout, true, func(ctx context.Context) (done bool, err error) {
 			if err := applyCRD(ctx, client, c); err != nil {
 				klog.Warningf("failed to apply openshift CRD %s: %v", crd, err)
 				return false, nil


### PR DESCRIPTION
By changing `immediate` from `false` to `true`, `PollUntilContextTimeout` will no longer wait for specified interval (5 seconds in this case) before running given `func` for the first time.

This results in drastic speed up of MicroShift's start up: 40 seconds because currently we have 8 CRDs to apply.
