### PR TITLE
OCPBUGS-19296: Fix microshift-cleanup-data script and test its functionality

### DIFF
--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -101,11 +101,11 @@ Enable MicroShift
     Systemctl    enable    microshift.service
 
 Cleanup MicroShift
-    [Documentation]    Cleanup
-    ...    opts=[--keep-images]
-    [Arguments]    ${opts}=${EMPTY}
+    [Documentation]    Cleanup MicroShift data
+    [Arguments]    ${cmd}="--all"    ${opt}=${EMPTY}
+
     ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    echo 1 | sudo microshift-cleanup-data --all ${opts}
-    ...    sudo=True    return_stderr=True    return_rc=True
+    ...    echo 1 | sudo microshift-cleanup-data ${cmd} ${opt}
+    ...    return_stdout=True    return_stderr=True    return_rc=True
     Log Many    ${stdout}    ${stderr}    ${rc}
     Should Be Equal As Integers    ${rc}    0

--- a/test/resources/ostree-health.resource
+++ b/test/resources/ostree-health.resource
@@ -35,3 +35,8 @@ System Should Be Healthy
 
     ${health}=    Get Persisted System Health
     Should Be Equal As Strings    ${health}    healthy
+
+Restart Greenboot And Wait For Success
+    [Documentation]    Restart the greenboot-healthcheck service and check its status
+    Systemctl    restart    greenboot-healthcheck.service
+    Wait Until Greenboot Health Check Exited

--- a/test/suites/greenboot/greenboot.robot
+++ b/test/suites/greenboot/greenboot.robot
@@ -3,6 +3,7 @@ Documentation       Tests related to greenboot
 
 Resource            ../../resources/systemd.resource
 Resource            ../../resources/ostree.resource
+Resource            ../../resources/ostree-health.resource
 Resource            ../../resources/microshift-config.resource
 
 Suite Setup         Setup Suite
@@ -36,7 +37,7 @@ Simulate Service Failure
     [Documentation]    Simulate Service failure
     Restart Greenboot And Wait For Success
     Disrupt Service
-    Cleanup MicroShift    "--keep-images"
+    Cleanup MicroShift    --all    --keep-images
     Run Keyword And Expect Error    0 != 1
     ...    Systemctl    enable    --now microshift
     Run Keyword And Expect Error    0 != 1
@@ -88,11 +89,6 @@ Cleanup User Workload
     ...    sudo=True    return_rc=True
     Should Be Equal As Integers    0    ${rc}
 
-Restart Greenboot And Wait For Success
-    [Documentation]    Restart the greenboot-healthcheck service and check its status
-    Systemctl    restart    greenboot-healthcheck.service
-    Wait Until Greenboot Health Check Exited
-
 Disrupt Service
     [Documentation]    Prevent Microshift service from starting correctly.
     ${is_ostree}=    Is System OSTree
@@ -136,7 +132,7 @@ Disrupt Pod Network
 
 Cleanup And Start
     [Documentation]    Wipe Microshift data and start it.
-    Cleanup MicroShift    "--keep-images"
+    Cleanup MicroShift    --all    --keep-images
     Systemctl    enable    --now microshift
     Setup Kubeconfig
     Restart Greenboot And Wait For Success

--- a/test/suites/standard/cleanup-data.robot
+++ b/test/suites/standard/cleanup-data.robot
@@ -1,0 +1,185 @@
+*** Settings ***
+Documentation       Tests verifying microshift-cleanup-data script functionality
+
+Resource            ../../resources/systemd.resource
+Resource            ../../resources/ostree.resource
+Resource            ../../resources/ostree-health.resource
+Resource            ../../resources/microshift-config.resource
+
+Suite Setup         Setup Suite
+
+Test Tags           slow
+
+
+*** Test Cases ***
+Verify Invalid Command Line
+    [Documentation]    Verify invalid command line combinations
+
+    # Usage message
+    ${rc}=    Run MicroShift Cleanup Data    ${EMPTY}
+    Should Not Be Equal As Integers    ${rc}    0
+
+    # Invalid option combination
+    ${rc}=    Run MicroShift Cleanup Data    --ovn    --keep-images
+    Should Not Be Equal As Integers    ${rc}    0
+
+    ${rc}=    Run MicroShift Cleanup Data    --all    --ovn
+    Should Not Be Equal As Integers    ${rc}    0
+
+    ${rc}=    Run MicroShift Cleanup Data    --keep-images
+    Should Not Be Equal As Integers    ${rc}    0
+
+Verify Full Cleanup Data
+    [Documentation]    Verify full data clean scenarios
+
+    ${rc}=    Run MicroShift Cleanup Data    --all
+    Should Be Equal As Integers    ${rc}    0
+
+    MicroShift Processes Should Not Exist
+    SSHLibrary.Directory Should Not Exist    /var/lib/microshift
+    SSHLibrary.Directory Should Exist    /var/lib/microshift-backups
+
+    Crio Containers Should Not Exist
+    Crio Pods Should Not Exist
+    Crio Images Should Not Exist
+
+    OVN Processes Should Not Exist
+    OVN Data Should Not Exist
+    OVN Internal Bridge Should Not Exist
+
+    [Teardown]
+    ...    Start MicroShift And Wait Until Ready
+
+Verify Keep Images Cleanup Data
+    [Documentation]    Verify keep images data clean scenario
+
+    ${rc}=    Run MicroShift Cleanup Data    --keep-images    --all
+    Should Be Equal As Integers    ${rc}    0
+
+    MicroShift Processes Should Not Exist
+    SSHLibrary.Directory Should Not Exist    /var/lib/microshift
+    SSHLibrary.Directory Should Exist    /var/lib/microshift-backups
+
+    Crio Containers Should Not Exist
+    Crio Pods Should Not Exist
+    Crio Images Should Exist
+
+    OVN Processes Should Not Exist
+    OVN Data Should Not Exist
+    OVN Internal Bridge Should Not Exist
+
+    [Teardown]
+    ...    Start MicroShift And Wait Until Ready
+
+Verify OVN Cleanup Data
+    [Documentation]    Verify OVN data cleanup scenario
+
+    ${rc}=    Run MicroShift Cleanup Data    --ovn
+    Should Be Equal As Integers    ${rc}    0
+
+    MicroShift Processes Should Not Exist
+    SSHLibrary.Directory Should Exist    /var/lib/microshift
+    SSHLibrary.Directory Should Exist    /var/lib/microshift-backups
+
+    Crio Containers Should Not Exist
+    Crio Pods Should Not Exist
+    Crio Images Should Exist
+
+    OVN Processes Should Not Exist
+    OVN Data Should Not Exist
+    OVN Internal Bridge Should Not Exist
+
+    [Teardown]
+    ...    Start MicroShift And Wait Until Ready
+
+
+*** Keywords ***
+Setup Suite
+    [Documentation]    Set up all of the tests in this suite
+    Check Required Env Variables
+    Login MicroShift Host
+    Start MicroShift And Wait Until Ready
+
+Start MicroShift And Wait Until Ready
+    [Documentation]    Start the service and wait until full initialized
+    Systemctl    enable    --now microshift
+    Restart Greenboot And Wait For Success
+
+Run MicroShift Cleanup Data
+    [Documentation]    Run the microshift-cleanup-data script and
+    ...    return its exit code
+    [Arguments]    ${cmd}    ${opt}=${EMPTY}
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    echo 1 | sudo microshift-cleanup-data ${cmd} ${opt}
+    ...    return_stdout=True    return_stderr=True    return_rc=True
+    RETURN    ${rc}
+
+MicroShift Processes Should Not Exist
+    [Documentation]    Make sure that MicroShift and Etcd services are not running
+
+    # MicroShift service and Etcd process should be down
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    pidof microshift microshift-etcd
+    ...    return_stdout=True    return_stderr=True    return_rc=True
+    Should Not Be Equal As Integers    ${rc}    0
+
+Crio Containers Should Not Exist
+    [Documentation]    Make sure cri-o containers do not exist
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    crictl ps -a | wc -l
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Integers    ${stdout}    1
+
+Crio Pods Should Not Exist
+    [Documentation]    Make sure cri-o pods do not exist
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    crictl pods | wc -l
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Be Equal As Integers    ${stdout}    1
+
+Crio Images Should Exist
+    [Documentation]    Make sure cri-o images exist
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    crictl images | wc -l
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    Should Be Equal As Integers    ${rc}    0
+
+    ${stdout_int}=    Convert To Integer    ${stdout}
+    Should Be True    ${stdout_int} > 1
+
+Crio Images Should Not Exist
+    [Documentation]    Make sure cri-o images do not exist
+
+    ${status}=    Run Keyword And Return Status
+    ...    Crio Images Should Exist
+    Should Not Be True    ${status}
+
+OVN Processes Should Not Exist
+    [Documentation]    Make sure that OVN processes are not running
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    pidof conmon pause ovn-controller ovn-northd ovsdb-server
+    ...    return_stdout=True    return_stderr=True    return_rc=True
+    Should Not Be Equal As Integers    ${rc}    0
+
+OVN Data Should Not Exist
+    [Documentation]    Make sure that OVN data files and directories are deleted
+
+    # OVN data directories and files should be deleted
+    SSHLibrary.Directory Should Not Exist    /var/run/ovn
+    SSHLibrary.Directory Should Not Exist    /var/run/ovn-kubernetes
+    SSHLibrary.File Should Not Exist    /etc/cni/net.d/10-ovn-kubernetes.conf
+    SSHLibrary.File Should Not Exist    /opt/cni/bin/ovn-k8s-cni-overlay
+
+OVN Internal Bridge Should Not Exist
+    [Documentation]    Make sure that OVN internal bridge devices do not exist
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    ovs-vsctl br-exists br-int
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    Should Not Be Equal As Integers    ${rc}    0


### PR DESCRIPTION
Write an e2e test for testing the functionality of the `microshift-cleanup-data` script.
The following problems were found in the test and fixed:
* When deleting pods, no need to delete containers. Only delete images when `--keep-images` option is absent
* When cleaning OVN data, delete the `/var/run/ovn-kubernetes` directory instead of `/var/lib/ovnk` which does not exist

Closes [USHIFT-1509](https://issues.redhat.com//browse/USHIFT-1509)
