### PR TITLE
USHIFT-1682: Update kickstart template to have GPT disk label

### DIFF
--- a/docs/config/microshift-starter.ks
+++ b/docs/config/microshift-starter.ks
@@ -7,10 +7,12 @@ reboot
 # Configure network to use DHCP and activate on boot
 network --bootproto=dhcp --device=link --activate --onboot=on
 
-# Partition disk with a 1GB boot XFS partition and a 10GB LVM volume containing system root
-# The remainder of the volume will be used by the CSI driver for storing data
+# Partition disk with a 1MB BIOS boot, 200M EFI, 800M boot XFS partition and
+# an LVM volume containing a 10GB+ system root. The remainder of the volume
+# will be used by the CSI driver for storing data
 zerombr
-clearpart --all --initlabel
+clearpart --all --disklabel gpt
+part biosboot --fstype=biosboot --size=1
 part /boot/efi --fstype=efi --size=200
 part /boot --fstype=xfs --asprimary --size=800
 part pv.01 --grow

--- a/docs/contributor/rhel4edge_iso.md
+++ b/docs/contributor/rhel4edge_iso.md
@@ -108,6 +108,8 @@ The artifact of the build is the `_output/image-builder/microshift-installer-${V
 The `kickstart.ks` file is configured to partition the main disk using `Logical Volume Manager` (LVM). Such partitioning is required for the data volume to be utilized by the MicroShift CSI driver and it allows for flexible file system customization if the disk space runs out.
 
 By default, the following partition layout is created and formatted with the `XFS` file system:
+* BIOS boot partition (1MB)
+  * It is required to boot ISO to systems with legacy BIOS while using GPT as the partitioning scheme.
 * EFI partition with EFI file system (200MB)
 * Boot partition is allocated on a 1GB volume
 * The rest of the disk is managed by the `LVM` in a single volume group named `rhel`
@@ -124,9 +126,10 @@ As an example, a 20GB disk is partitioned in the following manner by default.
 $ lsblk /dev/sda
 NAME          MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
 sda             8:0    0   20G  0 disk
-├─sda1          8:1    0  200M  0 part /boot/efi
-├─sda2          8:2    0  800M  0 part /boot
-└─sda3          8:3    0   19G  0 part
+├─sda1          8:1    0    1M  0 part
+├─sda2          8:2    0  200M  0 part /boot/efi
+├─sda3          8:3    0  800M  0 part /boot
+└─sda4          8:4    0   19G  0 part
   └─rhel-root 253:0    0   10G  0 lvm  /sysroot
 
 $ sudo vgdisplay -s

--- a/scripts/image-builder/config/kickstart.ks.template
+++ b/scripts/image-builder/config/kickstart.ks.template
@@ -7,20 +7,23 @@ reboot
 # Configure network to use DHCP and activate on boot
 network --bootproto=dhcp --device=link --activate --onboot=on
 
-# Partition disk with a 1GB boot XFS partition and an LVM volume containing a 10GB+ system root
-# The remainder of the volume will be used by the CSI driver for storing data
+# Partition disk with a 1MB BIOS boot, 200M EFI, 800M boot XFS partition and
+# an LVM volume containing a 10GB+ system root. The remainder of the volume
+# will be used by the CSI driver for storing data
 #
 # For example, a 20GB disk would be partitioned in the following way:
 #
 # NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
 # sda             8:0    0  20G  0 disk
-# ├─sda1          8:1    0 200M  0 part /boot/efi
-# ├─sda1          8:1    0 800M  0 part /boot
-# └─sda2          8:2    0  19G  0 part
+# ├─sda1          8:1    0   1M  0 part
+# ├─sda2          8:2    0 200M  0 part /boot/efi
+# ├─sda3          8:3    0 800M  0 part /boot
+# └─sda4          8:4    0  19G  0 part
 #  └─rhel-root  253:0    0  10G  0 lvm  /sysroot
 #
 zerombr
-clearpart --all --initlabel
+clearpart --all --disklabel gpt
+part biosboot --fstype=biosboot --size=1
 part /boot/efi --fstype=efi --size=200
 part /boot --fstype=xfs --asprimary --size=800
 # Uncomment this line to add a SWAP partition of the recommended size


### PR DESCRIPTION
ISO which is created using the image builder script is not able to run on the windows hyperv-gen2 which need gpt disk label instead msdos and UEFI support.

- https://learn.microsoft.com/en-us/windows-server/security/guarded-fabric-shielded-vm/guarded-fabric-create-a-linux-shielded-vm-template
