### PR TITLE
USHIFT-1681: Inject target branch name into rebase branch name

### DIFF
--- a/docs/contributor/rebase.md
+++ b/docs/contributor/rebase.md
@@ -270,7 +270,7 @@ Primary consumer of release image references.
 Script responsible for updating MicroShift's manifests, image references, and go.mod references based on contents of release images.
 It's executed by `rebase.py` to capture output and exit code.
 
-It also creates a git branch which name consists of prefix `rebase-`, version and stream (e.g. `4.13.0-0.nightly`), and creation datetimes of AMD and ARM nightly releases (e.g. `_amd64-2023-01-31-072358_arm64-2023-01-31-233557`).
+It also creates a git branch which name consists of prefix `rebase-`, onto branch, version and stream (e.g. `4.13.0-0.nightly`), and creation datetimes of AMD and ARM nightly releases (e.g. `_amd64-2023-01-31-072358_arm64-2023-01-31-233557`).
 
 ### rebase.py
 

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -1098,7 +1098,7 @@ rebase_to() {
     # PULL_BASE_REF is expected in CI environments and should identify the active branch.
     if [[ "${PULL_BASE_REF:-}" == "" ]]; then
         >&2 echo 'Warning: env var PULL_BASE_REF not found or empty, falling back to local active branch.'
-        onto_branch=$(git branch rev-parse --abbrev-ref HEAD)
+        onto_branch=$(git rev-parse --abbrev-ref HEAD)
         if [[ "${onto_branch}" == 'HEAD' ]]; then
             >&2 echo 'Warning: detected HEAD in detached state, falling back to current abbreviated commit'
             onto_branch="$(git rev-parse --short HEAD)"

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -1094,7 +1094,20 @@ rebase_to() {
     amd64_date="$(cat ${STAGING_DIR}/release_amd64.json | jq -r .config.created | cut -f1 -dT)"
     arm64_date="$(cat ${STAGING_DIR}/release_arm64.json | jq -r .config.created | cut -f1 -dT)"
 
-    rebase_branch="rebase-${ver_stream}_amd64-${amd64_date}_arm64-${arm64_date}"
+    local onto_branch=""
+    # PULL_BASE_REF is expected in CI environments and should identify the active branch.
+    if [[ "${PULL_BASE_REF:-}" == "" ]]; then
+        >&2 echo 'Warning: env var PULL_BASE_REF not found or empty, falling back to local active branch.'
+        onto_branch=$(git branch rev-parse --abbrev-ref HEAD)
+        if [[ "${onto_branch}" == 'HEAD' ]]; then
+            >&2 echo 'Warning: detected HEAD in detached state, falling back to current abbreviated commit'
+            onto_branch="$(git rev-parse --short HEAD)"
+        fi
+    else
+        onto_branch="${PULL_BASE_REF}"
+    fi
+    # If onto_branch is not null, pad with "-", else onto_branch is empty so do not pad
+    rebase_branch="rebase${onto_branch:+"-$onto_branch"}-${ver_stream}_amd64-${amd64_date}_arm64-${arm64_date}"
     git branch -D "${rebase_branch}" || true
     git checkout -b "${rebase_branch}"
 


### PR DESCRIPTION
When the rebase script executes against the latest release-4.X branch and main, it does not generate a unique branch name. This creates a situation where, if 1 of the 2 is pushed, the rebase process running in parallel on the other may pull the remote rebase-branch.  This means that if a rebase onto branch A pushes rebase-branch A', the rebase process running in parallel on branch B can mistakenly pull branch A', rather than create a branch B', because the names of A' == B'. This effectively means branch A is being rebased onto branch B, and includes the commits of the parant branch.  Injecting the onto-branch's name (release-4.x | main) will detangle this situation.