### PR TITLE
OCPBUGS-1892: Rebase - remove checking if job is a rehearsal

### DIFF
--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -8,11 +8,6 @@ set -x
 echo "Environment:"
 printenv
 
-if [[ "$JOB_NAME" == rehearse* ]]; then
-    echo "INFO: \$JOB_NAME starts with rehearse - running in DRY RUN mode"
-    export DRY_RUN=y
-fi
-
 cp /secrets/ci-pull-secret/.dockercfg "$HOME/.pull-secret.json" || {
     echo "WARN: Could not copy registry secret file"
 }


### PR DESCRIPTION
The same check is already present in the release repository.

Having two checks complicates manually retriggering rebase jobs, because both checks need to be disabled withing the same PR on the release repository.
By including this change, we'll be able to retrigger rebase jobs by simply commenting out check and rehearsing the job.