### PR TITLE
USHIFT-1666: Selinux domain transition test 

### DIFF
--- a/test/assets/selinux-test-exec.sh
+++ b/test/assets/selinux-test-exec.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+process_context_switch() {
+    echo "Forked process running under context $(id -Z)"
+    "$@"
+}
+
+# We fork a process here to try and escape
+echo "Executing Command: $*"
+process_context_switch "$@" &
+wait $!

--- a/test/resources/selinux.py
+++ b/test/resources/selinux.py
@@ -14,6 +14,9 @@ CONTEXT_CHECK_MAP = {
         "/var/lib/microshift",
         "/var/lib/microshift-backups",
     ],
+    "system_u:object_r:container_log_t:s0": [
+        "/var/log/kube-apiserver",
+    ],
     "system_u:object_r:kubelet_exec_t:s0": [
         "/usr/bin/microshift",
         "/usr/bin/microshift-etcd",

--- a/test/resources/selinux.py
+++ b/test/resources/selinux.py
@@ -226,13 +226,14 @@ def sources_have_less_permission_than_parent(parent: str, all_sources: List[str]
         BuiltIn().should_be_equal_as_integers(rc, 0)
 
         if source_number_of_permissions != parent_number_of_permissions:
-            file_path, rc = remote_sudo_rc(f"{semanage_cmd} | grep {source} | awk '{{ print $1 }}'")
+            file_paths, rc = remote_sudo_rc(f"{semanage_cmd} | grep {source} | awk '{{ print $1 }}'")
             BuiltIn().should_be_equal_as_integers(rc, 0)
-            file_exists, rc = remote_sudo_rc(f"[ -e {file_path} ] && echo found || echo safe")
-            BuiltIn().should_be_equal_as_integers(rc, 0)
+            for file_path in file_paths.splitlines():
+                file_exists, rc = remote_sudo_rc(f"[ -e {file_path} ] && echo found || echo safe")
+                BuiltIn().should_be_equal_as_integers(rc, 0)
 
-            if file_exists == "found":
-                error_list.append(f"source: {source} has differnt permission count than parent: {parent} with file({file_path}), needs investigation.")
+                if file_exists == "found":
+                    error_list.append(f"source: {source} has differnt permission count than parent: {parent} with file({file_path}), needs investigation.")
 
     return error_list
 

--- a/test/resources/selinux.resource
+++ b/test/resources/selinux.resource
@@ -3,6 +3,7 @@ Documentation       Keywords for OSTree-based systems
 
 Resource            ostree-data.resource
 Library             Collections
+Library             SSHLibrary
 Library             selinux.py
 
 
@@ -31,6 +32,16 @@ Containers Should Not Have Access To Container Var Lib Labels
 
     ${default_result}=    Run Default Access Check
     Should Be Empty    ${default_result}
+
+    # Copy over a test file that forks and execs the given command
+    SSHLibrary.Put File    ./assets/selinux-test-exec.sh    /tmp/selinux-test-exec.sh
+
+    # Here we check that given a priveleged context, it can not domain transition to a context with privelage.
+    #
+    # Validate that the given path `kubelet_exec_t -> kubelet_t -> container_var_lib_t` should not be possible
+    # when running under context container_t
+    ${default_transition_result}=    Run Default Access Binary Transition Check    /tmp/selinux-test-exec.sh
+    Should Be Empty    ${default_transition_result}
 
 Folders Should Have Expected Fcontext Types
     [Documentation]    Performs a check to make sure the folders created during rpm install

--- a/test/resources/selinux.resource
+++ b/test/resources/selinux.resource
@@ -21,7 +21,7 @@ Validate SELinux
     [Documentation]    Wrapper call for all SELinux checks
 
     Containers Should Not Have Access To Container Var Lib Labels
-    Run Default Traversal Access Check
+    Context Traversal Should Not Gain More Access
     Folders Should Have Expected Fcontext Types
     Semanage Fcontext Should Have Combined List Of OCP And MicroShift Rules
     Audit Log Should Be Empty For MicroShift
@@ -63,6 +63,12 @@ Audit Log Should Be Empty For MicroShift
     [Documentation]    Checks that no permission denials have occured during running MicroShift
 
     ${result}=    Get Denial Audit Log
+    Should Be Empty    ${result}
+
+Context Traversal Should Not Gain More Access
+    [Documentation]    Checks that no extra permissions are gained via domain and context changes.
+
+    ${result}=    Run Default Traversal Access Check
     Should Be Empty    ${result}
 
 # Helper Functions

--- a/test/resources/selinux.resource
+++ b/test/resources/selinux.resource
@@ -21,6 +21,7 @@ Validate SELinux
     [Documentation]    Wrapper call for all SELinux checks
 
     Containers Should Not Have Access To Container Var Lib Labels
+    Run Default Traversal Access Check
     Folders Should Have Expected Fcontext Types
     Semanage Fcontext Should Have Combined List Of OCP And MicroShift Rules
     Audit Log Should Be Empty For MicroShift


### PR DESCRIPTION
Updated our context check to include /var/log/kube-apiserver

Adds a domain transition test to our selinux tests to validate that executing a binary can't transition to more privileged files.