### PR TITLE
OCPBUGS-19363: Not update the CoreDNS configmap for systemd-resolved

### DIFF
--- a/assets/components/openshift-dns/dns/configmap.yaml
+++ b/assets/components/openshift-dns/dns/configmap.yaml
@@ -16,7 +16,7 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         prometheus 127.0.0.1:9153
-        forward . {{with .UpstreamResolver}}{{.}}{{else}}/etc/resolv.conf{{end}} {
+        forward . /etc/resolv.conf {
             policy sequential
         }
         cache 900 {

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -232,13 +232,6 @@ func startDNSController(ctx context.Context, cfg *config.Config, kubeconfigPath 
 		klog.Warningf("Failed to apply serviceAccount %v %v", sa, err)
 		return err
 	}
-	// set DNS forward to systemd-resolved resolver if exists
-	// https://github.com/coredns/coredns/blob/master/plugin/loop/README.md#troubleshooting-loops-in-kubernetes-clusters
-	if _, err := os.Stat(config.DefaultSystemdResolvedFile); err == nil {
-		extraParams["UpstreamResolver"] = config.DefaultSystemdResolvedFile
-	} else {
-		extraParams["UpstreamResolver"] = ""
-	}
 	if err := assets.ApplyConfigMaps(ctx, cm, renderTemplate, renderParamsFromConfig(cfg, extraParams), kubeconfigPath); err != nil {
 		klog.Warningf("Failed to apply configMap %v %v", cm, err)
 		return err

--- a/test/suites/standard/systemd-resolved.robot
+++ b/test/suites/standard/systemd-resolved.robot
@@ -1,0 +1,54 @@
+*** Settings ***
+Documentation       verify microshift with systemd-resolved installed
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/microshift-host.resource
+Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/ostree-health.resource
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+
+*** Test Cases ***
+Systemd-resolved installed
+    [Documentation]    Verify kubelet uses the upstream resolve file of systemd-resolved
+    Install Systemd-resolved RPM Packages
+    Restart MicroShift
+    Wait Until Greenboot Health Check Exited
+    ${output}    ${rc}=    Execute Command
+    ...    grep -q "resolvConf: /run/systemd/resolve/resolv.conf" \
+    ...    /var/lib/microshift/resources/kubelet/config/config.yaml
+    ...    sudo=True    return_rc=True
+    Should Be Equal As Integers    0    ${rc}
+    Uninstall Systemd-resolved RPM Packages
+    Restart MicroShift
+
+
+*** Keywords ***
+Setup
+    [Documentation]    Test suite setup
+    Check Required Env Variables
+    Login MicroShift Host
+
+Teardown
+    [Documentation]    Test suite teardown
+    Logout MicroShift Host
+
+Install Systemd-resolved RPM Packages
+    [Documentation]    Installs Systemd-resolved RPM packages from the specified URL
+
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    dnf install -y systemd-resolved
+    ...    sudo=True    return_rc=True    return_stderr=True    return_stdout=True
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+
+Uninstall Systemd-resolved RPM Packages
+    [Documentation]    Uninstalls Systemd-resolved RPM packages
+
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    dnf remove -y systemd-resolved
+    ...    sudo=True    return_rc=True    return_stderr=True    return_stdout=True
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}


### PR DESCRIPTION
If systemd-resolved is enable in host, microshift will add the `--resolv-conf` flag for kubelet. Then kubelet will copy the host /run/systemd/resolve/resolv.conf to the CoreDNS pod /etc/resolv.conf automatically. Therefore we don't need to update the CoreDNS configmap.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
