### PR TITLE
USHIFT-1676: Add missing dependencies for LoadbalancerServiceController

### DIFF
--- a/pkg/loadbalancerservice/controller.go
+++ b/pkg/loadbalancerservice/controller.go
@@ -45,7 +45,11 @@ func (c *LoadbalancerServiceController) Name() string {
 }
 
 func (c *LoadbalancerServiceController) Dependencies() []string {
-	return []string{}
+	return []string{
+		"network-configuration",
+		"kube-apiserver",                  // needed for informers
+		"infrastructure-services-manager", // starts CNI
+	}
 }
 
 func (c *LoadbalancerServiceController) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {


### PR DESCRIPTION
This change does not impact actual runtime, because order in which services are added to ServiceManager is more important than the dependencies itself and LBSvcCtrl starts so late its dependencies are already up and running.