### PR TITLE
OCPBUGS-19563: Move healthcheck script to /usr/lib/greenboot

### DIFF
--- a/docs/contributor/greenboot.md
+++ b/docs/contributor/greenboot.md
@@ -23,9 +23,9 @@ at this time.
 
 Proceed by creating a health check script in the `/etc/greenboot/check/required.d`
 directory.
-> The name prefix of the user script should be chosen to make sure it runs after
-> the `40_microshift_running_check.sh` script, which implements the MicroShift
-> health check procedure for its core services.
+> The name prefix of the user script should be chosen appropriately.
+> Because MicroShift's healthcheck resides in `/usr/lib/greenboot/check/require.d`,
+> it will run before any checks in `/etc/greenboot/check/require.d`.
 
 ```
 SCRIPT_FILE=/etc/greenboot/check/required.d/50_busybox_running_check.sh

--- a/docs/contributor/updateability.md
+++ b/docs/contributor/updateability.md
@@ -175,7 +175,8 @@ with it see following enhancements:
 [MicroShift updateability in ostree based systems: integration with greenboot](https://github.com/openshift/enhancements/blob/master/enhancements/microshift/microshift-updateability-ostree.md#integration-with-greenboot)
 
 In short, on system boot, greenboot will run health check scripts
-(residing in `/etc/greenboot/check/{required.d,wanted.d}/`)
+(residing in `/usr/lib/greenboot/check/{required.d,wanted.d}/` and
+`/etc/greenboot/check/{required.d,wanted.d}/`)
 and, depending on result of *required* scripts, will run either "green" 
 (healthy) or "red" (unhealthy) scripts. 
 

--- a/docs/user/greenboot.md
+++ b/docs/user/greenboot.md
@@ -24,7 +24,7 @@ validate that all the required MicroShift services are up and running. The healt
 check script is packaged in the separate mandatory `microshift-greenboot` RPM,
 which has an explicit dependency on the `greenboot` RPM.
 
-The health check script is installed into the `/etc/greenboot/check/required.d`
+The health check script is installed into the `/usr/lib/greenboot/check/required.d`
 directory and it is not executed during the system boot in case the `greenboot`
 package is not present.
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -244,8 +244,8 @@ install -m644 packaging/selinux/microshift.pp.bz2 %{buildroot}%{_datadir}/selinu
 install -d -m755 %{buildroot}%{_datadir}/microshift/functions
 install -p -m644 packaging/greenboot/functions.sh %{buildroot}%{_datadir}/microshift/functions/greenboot.sh
 
-install -d -m755 %{buildroot}%{_sysconfdir}/greenboot/check/required.d
-install -p -m755 packaging/greenboot/microshift-running-check.sh %{buildroot}%{_sysconfdir}/greenboot/check/required.d/40_microshift_running_check.sh
+install -d -m755 %{buildroot}%{_prefix}/lib/greenboot/check/required.d
+install -p -m755 packaging/greenboot/microshift-running-check.sh %{buildroot}%{_prefix}/lib/greenboot/check/required.d/40_microshift_running_check.sh
 
 install -d -m755 %{buildroot}%{_sysconfdir}/greenboot/red.d
 install -p -m755 packaging/greenboot/microshift-pre-rollback.sh %{buildroot}%{_sysconfdir}/greenboot/red.d/40_microshift_pre_rollback.sh
@@ -345,7 +345,7 @@ systemctl enable --now --quiet openvswitch || true
 %{_bindir}/configure-ovs-microshift.sh
 
 %files greenboot
-%{_sysconfdir}/greenboot/check/required.d/40_microshift_running_check.sh
+%{_prefix}/lib/greenboot/check/required.d/40_microshift_running_check.sh
 %{_sysconfdir}/greenboot/red.d/40_microshift_pre_rollback.sh
 %{_sysconfdir}/greenboot/red.d/40_microshift_set_unhealthy.sh
 %{_sysconfdir}/greenboot/green.d/40_microshift_set_healthy.sh
@@ -354,6 +354,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Fri Sep 22 2023 Patryk Matuszak <pmatusza@redhat.com> 4.14.0
+- Move healthcheck script to /usr/lib/greenboot
+
 * Wed Sep 06 2023 Pablo Acevedo Montserrat <pacevedo@redhat.com> 4.14.0
 - Add microshift-sos-report binary
 


### PR DESCRIPTION
When greenboot runs scripts, it considers two locations `/usr/lib/greenboot` and `/etc/greenboot`. It also runs `required.d` and `wanted.d` scripts from each path in
sequence, that is:
- (1) `/usr/lib/greenboot/checks/required.d`
- (2) `/usr/lib/greenboot/checks/wanted.d`
- (3) `/etc/greenboot/checks/required.d`
- (4) `/etc/greenboot/checks/wanted.d`

At the moment of writing this commit, greenboot shipped in RHEL unconditionally exits with rc=1 when required.d scripts failed.

Because MicroShift's scripts were placed in the (3) directory, they would not run if any script from (1) failed.

In upstream greenboot the behavior has already changed: all scripts will run, regardless of the path or importance (required vs wanted), and then greenboot will exit with appropriate return code.

Only healthcheck script is moved, because greenboot considers two mentioned paths for checks, it only uses `/etc/greenboot` for green and red scripts (that is until fix to run all checks before exiting makes into package for RHEL, as it also extends possible paths for green and red scripts to `/usr/lib/greenboot`).

Related greenboot PR: https://github.com/fedora-iot/greenboot/pull/97

Additional checks used in tests are not relocated, because `/usr/lib/` is immutable endpoint and would require remounting the filesystem to place files there. For that reason, these test assets will continue to reside in `/etc/greenboot/checks` as it's root writable.