### PR TITLE
OCPBUGS-19719: Use cgo net for name resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ debug:
 	@echo PATCH:"$(PATCH)"
 
 # These tags make sure we can statically link and avoid shared dependencies
-GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi providerless netgo osusergo'
+GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi providerless netcgo osusergo'
 
 # Set variables for test-unit target
 GO_TEST_FLAGS=$(GO_BUILD_FLAGS)

--- a/test/resources/microshift-host.resource
+++ b/test/resources/microshift-host.resource
@@ -93,3 +93,19 @@ Is System Rebooted
         ${system_rebooted}=    Evaluate    '${old_bootid}' != '${cur_bootid}'
         RETURN    ${system_rebooted}
     END
+
+Change Hostname
+    [Documentation]    Changes hostname to the argument. Returns old hostname
+    [Arguments]    ${hostname}
+
+    ${old_hostname}    ${stderr}    ${rc}=    SSHLibrary.Execute Command    hostname
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+
+    ${stderr}    ${rc}=    SSHLibrary.Execute Command    hostnamectl hostname ${hostname}
+    ...    sudo=True    return_rc=True    return_stderr=True    return_stdout=False
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+
+    RETURN    ${old_hostname}

--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -47,10 +47,10 @@ Oc Wait For
     ...    ${wait_for}    expects a key=value. See 'oc wait --help' for examples
     ...    ${timeout}    Takes an integer and a single character time-unit identifier, e.g.: 30s
     ...    If no timeout value is provided, defaults to 30s.
-    [Arguments]    ${type_name}    ${wait_for}    ${timeout}=30s
+    [Arguments]    ${type_name}    ${wait_for}    ${timeout}=30s    ${ns}=${NAMESPACE}
 
     ${timeout_opt}=    Set Variable    --timeout\=${timeout}
-    ${output}=    Run With Kubeconfig    oc wait -n ${NAMESPACE} ${type_name} --for=${wait_for} ${timeout_opt}
+    ${output}=    Run With Kubeconfig    oc wait -n ${ns} ${type_name} --for=${wait_for} ${timeout_opt}
     RETURN    ${output}
 
 Oc Create
@@ -72,4 +72,11 @@ Oc Patch
     ...    Returns the combined STDOUT/STDER output of the command.
     [Arguments]    ${type_name}    ${opts}
     ${output}=    Run With Kubeconfig    oc patch -n ${NAMESPACE} ${type_name} -p ${opts}
+    RETURN    ${output}
+
+Oc Logs
+    [Documentation]    Run 'oc logs' on a specific resource in the given namespace.
+    ...    Returns the combined STDOUT/STDER output of the command.
+    [Arguments]    ${opts}    ${namespace}
+    ${output}=    Run With Kubeconfig    oc logs -n ${namespace} ${opts}
     RETURN    ${output}

--- a/test/suites/standard/hostname.robot
+++ b/test/suites/standard/hostname.robot
@@ -12,8 +12,8 @@ Test Tags           restart    slow
 
 
 *** Variables ***
-${NEW_HOSTNAME}    microshift.local
-${OLD_HOSTNAME}    ${EMPTY}
+${NEW_HOSTNAME}     microshift.local
+${OLD_HOSTNAME}     ${EMPTY}
 
 
 *** Test Cases ***
@@ -25,6 +25,7 @@ Verify local name resolution
     Oc Logs    namespace="openshift-ingress"    opts="deployment/router-default"
 
     [Teardown]    Restore Old Hostname
+
 
 *** Keywords ***
 Setup

--- a/test/suites/standard/hostname.robot
+++ b/test/suites/standard/hostname.robot
@@ -1,0 +1,57 @@
+*** Settings ***
+Documentation       Tests verifying hostname resolution
+
+Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/microshift-host.resource
+Resource            ../../resources/oc.resource
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+Test Tags           restart    slow
+
+
+*** Variables ***
+${NEW_HOSTNAME}    microshift.local
+${OLD_HOSTNAME}    ${EMPTY}
+
+
+*** Test Cases ***
+Verify local name resolution
+    [Documentation]    Verify correct name resolution through mDNS
+    [Setup]    Configure New Hostname
+
+    Oc Wait For    deployment/router-default    condition\=Available    120s    ns=openshift-ingress
+    Oc Logs    namespace="openshift-ingress"    opts="deployment/router-default"
+
+    [Teardown]    Restore Old Hostname
+
+*** Keywords ***
+Setup
+    [Documentation]    Set up all of the tests in this suite
+    Check Required Env Variables
+    Login MicroShift Host
+    Setup Kubeconfig
+
+Teardown
+    [Documentation]    Test suite teardown
+    Remove Kubeconfig
+    Logout MicroShift Host
+
+Configure New Hostname
+    [Documentation]    Configures ${NEW_HOSTNAME} in the MicroShift host.
+    ${old}=    Setup Hostname    ${NEW_HOSTNAME}
+    Set Suite Variable    \${OLD_HOSTNAME}    ${old}
+
+Restore Old Hostname
+    [Documentation]    Configure old hostname again in the MicroShift host.
+    Setup Hostname    ${OLD_HOSTNAME}
+
+Setup Hostname
+    [Documentation]    Setup a new hostname and return the old one.
+    [Arguments]    ${hostname}
+    IF    "${hostname}"=="${EMPTY}"    RETURN
+    ${old}=    Change Hostname    ${hostname}
+    Cleanup MicroShift    --all    --keep-images
+    Restart MicroShift
+    RETURN    ${old}


### PR DESCRIPTION
When using .local hostnames and mDNS the native golang resolver does not work properly as it only reads the /etc/resolv.conf The cgo based resolver calls the C library routines instead. See https://pkg.go.dev/net#hdr-Name_Resolution

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
