### PR TITLE
USHIFT-1737: fix: add wait for microshift serice to make sure health check succeeds

### DIFF
--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -35,6 +35,7 @@ MicroShift Is Live
 
 Wait For MicroShift
     [Documentation]    Wait for various checks to ensure MicroShift is online.
+    Wait For MicroShift Service
     Wait Until Keyword Succeeds    30x    10s
     ...    MicroShift Is Ready
     Wait Until Keyword Succeeds    30x    10s

--- a/test/suites/standard/kustomize.robot
+++ b/test/suites/standard/kustomize.robot
@@ -241,6 +241,7 @@ Restore Default Config
     ${is_ostree}=    Is System OSTree
     IF    ${is_ostree}
         Reboot MicroShift Host
+        Wait For MicroShift Service
         Wait For MicroShift
     ELSE
         Restart MicroShift

--- a/test/suites/standard/kustomize.robot
+++ b/test/suites/standard/kustomize.robot
@@ -241,7 +241,6 @@ Restore Default Config
     ${is_ostree}=    Is System OSTree
     IF    ${is_ostree}
         Reboot MicroShift Host
-        Wait For MicroShift Service
         Wait For MicroShift
     ELSE
         Restart MicroShift


### PR DESCRIPTION
Seems like we might have a timing problem between when the teardown of kustomize happens and when we validate microshift is up