### PR TITLE
USHIFT-1705: hostname/kustomize tests: re-enable microshift.service after cleanup

### DIFF
--- a/test/suites/standard/hostname.robot
+++ b/test/suites/standard/hostname.robot
@@ -54,5 +54,6 @@ Setup Hostname
     IF    "${hostname}"=="${EMPTY}"    RETURN
     ${old}=    Change Hostname    ${hostname}
     Cleanup MicroShift    --all    --keep-images
+    Systemctl    enable    microshift
     Restart MicroShift
     RETURN    ${old}


### PR DESCRIPTION
Because `hostname.robot` was cleaning up MicroShift, but not re-enabling it, when kustomize.robot rebooted the ostree host MicroShift was not starting