### PR TITLE
USHIFT-1741: Ansible script bump golang version to 1.20.3 for MicroShift 4.14

### DIFF
--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -9,7 +9,7 @@ etcd_repo: https://github.com/openshift/etcd.git
 microshift_dir: "{{ ansible_env.HOME }}/microshift"
 microshift_repo: https://github.com/openshift/microshift.git
 microshift_rpms: []
-microshift_version: 4.13.0-rc-5
+microshift_version: 4.14.0-ec.4-202308011235.p0
 
 du_dirs:
   - /

--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -5,7 +5,7 @@ go_arch: arm64
 go_files:
   - go
   - gofmt
-go_version: 1.19.6
+go_version: 1.20.3
 go_install_dir: /usr/local/go{{ go_version }}
 
 install_packages:


### PR DESCRIPTION

**Which issue(s) this PR addresses**:
Closes #[USHIFT-1741](https://issues.redhat.com//browse/USHIFT-1741)
