### PR TITLE
USHIFT-1725: warn the user when the logging level is unrecognized

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -77,6 +77,10 @@ func NewRunMicroshiftCommand() *cobra.Command {
 
 		cfg = config.ConfigMultiNode(cfg, multinode)
 
+		for _, w := range cfg.Warnings {
+			klog.Warningf("Configuration warning: %s", w)
+		}
+
 		// Things to very badly if the node's name has changed
 		// since the last time the server started.
 		err = cfg.EnsureNodeNameHasNotChanged()

--- a/pkg/cmd/showConfig.go
+++ b/pkg/cmd/showConfig.go
@@ -52,6 +52,10 @@ func NewShowConfigCommand(ioStreams genericclioptions.IOStreams) *cobra.Command 
 			cmdutil.CheckErr(err)
 
 			fmt.Fprintf(ioStreams.Out, "%s\n", string(marshalled))
+
+			for _, w := range cfg.Warnings {
+				fmt.Fprintf(ioStreams.Out, "# WARNING: %s\n", w)
+			}
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,6 +221,8 @@ func (c *Config) updateComputedValues() error {
 		c.ApiServer.AdvertiseAddress = firstValidIP.String()
 	}
 
+	c.computeLoggingSetting()
+
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	userSettings *Config       `json:"-"` // the values read from the config file
 
 	MultiNode MultiNodeConfig `json:"-"` // the value read from commond line
+
+	Warnings []string `json:"-"` // Warnings that should not prevent the service from starting.
 }
 
 // NewDefault creates a new Config struct populated with the
@@ -276,6 +278,11 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+// AddWarning saves a warning message to be reported later.
+func (c *Config) AddWarning(message string) {
+	c.Warnings = append(c.Warnings, message)
 }
 
 // UserNodeIP return the user configured NodeIP, or "" if it's unset.

--- a/pkg/config/debugging.go
+++ b/pkg/config/debugging.go
@@ -1,6 +1,13 @@
 package config
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// Use the upper-case version of the word to match the kubebuilder
+// default.
+const defaultLogLevel = "Normal"
 
 type Debugging struct {
 	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
@@ -9,15 +16,32 @@ type Debugging struct {
 	LogLevel string `json:"logLevel"`
 }
 
-// GetVerbosity returns the numerical value for LogLevel which is an enum
-func (c *Config) GetVerbosity() int {
-	var levelNames = map[string]int{
-		"normal":   2,
-		"debug":    4,
-		"trace":    6,
-		"traceall": 8,
+var logLevelNames = map[string]int{
+	"normal":   2,
+	"debug":    4,
+	"trace":    6,
+	"traceall": 8,
+}
+
+// computeLoggingSetting validates the logging setting and saves a
+// warning if there is an issue.
+func (c *Config) computeLoggingSetting() {
+	_, ok := logLevelNames[strings.ToLower(c.Debugging.LogLevel)]
+	if !ok {
+		if c.Debugging.LogLevel != "" {
+			c.AddWarning(fmt.Sprintf("Unrecognized log level %q, defaulting to %q",
+				c.Debugging.LogLevel, defaultLogLevel))
+		}
+		// Reset the value so that `show-config` reports the value
+		// being used instead of the value in the config file.
+		c.Debugging.LogLevel = defaultLogLevel
 	}
-	verbosity, ok := levelNames[strings.ToLower(c.Debugging.LogLevel)]
+}
+
+// GetVerbosity returns the numerical value for LogLevel which is an
+// enum.
+func (c *Config) GetVerbosity() int {
+	verbosity, ok := logLevelNames[strings.ToLower(c.Debugging.LogLevel)]
 	if !ok {
 		verbosity = 2
 	}

--- a/pkg/config/debugging_test.go
+++ b/pkg/config/debugging_test.go
@@ -8,52 +8,64 @@ import (
 
 func TestGetVerbosity(t *testing.T) {
 	var ttests = []struct {
-		setting string
-		level   int
+		setting  string
+		level    int
+		warnings int
 	}{
 		{
-			setting: "Normal",
-			level:   2,
+			setting:  "Normal",
+			level:    2,
+			warnings: 0,
 		},
 		{
-			setting: "normal",
-			level:   2,
+			setting:  "normal",
+			level:    2,
+			warnings: 0,
 		},
 		{
-			setting: "Debug",
-			level:   4,
+			setting:  "Debug",
+			level:    4,
+			warnings: 0,
 		},
 		{
-			setting: "debug",
-			level:   4,
+			setting:  "debug",
+			level:    4,
+			warnings: 0,
 		},
 		{
-			setting: "Trace",
-			level:   6,
+			setting:  "Trace",
+			level:    6,
+			warnings: 0,
 		},
 		{
-			setting: "trace",
-			level:   6,
+			setting:  "trace",
+			level:    6,
+			warnings: 0,
 		},
 		{
-			setting: "TraceAll",
-			level:   8,
+			setting:  "TraceAll",
+			level:    8,
+			warnings: 0,
 		},
 		{
-			setting: "traceall",
-			level:   8,
+			setting:  "traceall",
+			level:    8,
+			warnings: 0,
 		},
 		{
-			setting: "Unknown",
-			level:   2,
+			setting:  "Unknown",
+			level:    2,
+			warnings: 1,
 		},
 		{
-			setting: "unknown",
-			level:   2,
+			setting:  "unknown",
+			level:    2,
+			warnings: 1,
 		},
 		{
-			setting: "",
-			level:   2,
+			setting:  "",
+			level:    2,
+			warnings: 0,
 		},
 	}
 
@@ -61,8 +73,10 @@ func TestGetVerbosity(t *testing.T) {
 		t.Run(tt.setting, func(t *testing.T) {
 			config := NewDefault()
 			config.Debugging.LogLevel = tt.setting
+			config.computeLoggingSetting()
 			verbosity := config.GetVerbosity()
 			assert.Equal(t, tt.level, verbosity)
+			assert.Equal(t, tt.warnings, len(config.Warnings))
 		})
 	}
 }

--- a/test/suites/standard/configuration.robot
+++ b/test/suites/standard/configuration.robot
@@ -1,0 +1,72 @@
+*** Settings ***
+Documentation       Tests for configuration changes
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/microshift-config.resource
+Resource            ../../resources/microshift-process.resource
+Library             ../../resources/journalctl.py
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+Test Tags           restart    slow
+
+
+*** Variables ***
+${CURSOR}               ${EMPTY}    # The journal cursor before restarting MicroShift
+${BAD_LOG_LEVEL}        SEPARATOR=\n
+...                     ---
+...                     debugging:
+...                     \ \ logLevel: unknown-value
+${DEBUG_LOG_LEVEL}      SEPARATOR=\n
+...                     ---
+...                     debugging:
+...                     \ \ logLevel: debug
+
+
+*** Test Cases ***
+Unknown Log Level Produces Warning
+    [Documentation]    Logs should warn that the log level setting is unknown
+    Setup With Bad Log Level
+    Pattern Should Appear In Log Output    ${CURSOR}    Unrecognized log level "unknown-value", defaulting to "Normal"
+
+Debug Log Level Produces No Warning
+    [Documentation]    Logs should not warn that the log level setting is unknown
+    Setup With Debug Log Level
+    Pattern Should Not Appear In Log Output    ${CURSOR}    Unrecognized log level "debug", defaulting to "Normal"
+
+
+*** Keywords ***
+Setup
+    [Documentation]    Test suite setup
+    Check Required Env Variables
+    Login MicroShift Host
+    Setup Kubeconfig    # for readiness checks
+    Save Default MicroShift Config
+    Save Journal Cursor
+
+Teardown
+    [Documentation]    Test suite teardown
+    Restore Default MicroShift Config
+    Restart MicroShift
+    Logout MicroShift Host
+    Remove Kubeconfig
+
+Save Journal Cursor
+    [Documentation]
+    ...    Save the journal cursor then restart MicroShift so we capture the
+    ...    shutdown messages and startup messages.
+    ${cursor}=    Get Journal Cursor
+    Set Suite Variable    \${CURSOR}    ${cursor}
+
+Setup With Bad Log Level
+    [Documentation]    Set log level to an unknown value and restart
+    ${merged}=    Extend MicroShift Config    ${BAD_LOG_LEVEL}
+    Upload MicroShift Config    ${merged}
+    Restart MicroShift
+
+Setup With Debug Log Level
+    [Documentation]    Set log level to debug and restart
+    ${merged}=    Extend MicroShift Config    ${BAD_LOG_LEVEL}
+    Upload MicroShift Config    ${merged}
+    Restart MicroShift


### PR DESCRIPTION
Be more explicit about warning the user about a logging configuration
mistake.

/assign @eggfoobar