### PR TITLE
USHIFT-1778: Remove broken golang version check in spec file

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -125,15 +125,6 @@ Requires: greenboot
 %description greenboot
 The microshift-greenboot package provides the Greenboot scripts used for verifying that MicroShift is up and running.
 
-%prep
-# Dynamic detection of the available golang version also works for non-RPM golang packages
-golang_detected=$(go version | awk '{print $3}' | tr -d '[a-z]')
-golang_required=%{golang_version}
-if [[ "${golang_detected}" < "${golang_required}" ]] ; then
-  echo "The detected go version ${golang_detected} is less than the required version ${golang_required}" > /dev/stderr
-  exit 1
-fi
-
 %setup -n microshift-%{commit}
 
 %build


### PR DESCRIPTION
Remove the golang version check that fails because it thinks 1.20.10
is less than 1.20.3. This failure prevents the ART build pipeline from
producing RPMs, because that pipeline uses 1.20.10.

/assign @ggiguash @pmtk @pacevedom