### PR TITLE
fix golang version compare

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -129,7 +129,7 @@ The microshift-greenboot package provides the Greenboot scripts used for verifyi
 # Dynamic detection of the available golang version also works for non-RPM golang packages
 golang_detected=$(go version | awk '{print $3}' | tr -d '[a-z]')
 golang_required=%{golang_version}
-if [[ "${golang_detected}" < "${golang_required}" ]] ; then
+if [[ `expr "${golang_detected}" < "${golang_required}"` -eq 0 ]] ; then
   echo "The detected go version ${golang_detected} is less than the required version ${golang_required}" > /dev/stderr
   exit 1
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
microshift failed to build on 4.15 when recent golang bumped to 1.20.10
https://download.eng.bos.redhat.com/brewroot/work/tasks/9029/56369029/build.log