### PR TITLE
USHIFT-1778: Fix rpm spec version comparison

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -9,7 +9,8 @@
 }
 
 # golang specifics
-%global golang_version 1.20.3
+# Needs to match go.mod go directive
+%global golang_version 1.20
 #debuginfo not supported with Go
 %global debug_package %{nil}
 # modifying the Go binaries breaks the DWARF debugging
@@ -127,7 +128,7 @@ The microshift-greenboot package provides the Greenboot scripts used for verifyi
 
 %prep
 # Dynamic detection of the available golang version also works for non-RPM golang packages
-golang_detected=$(go version | awk '{print $3}' | tr -d '[a-z]')
+golang_detected=$(go version | awk '{print $3}' | tr -d '[a-z]' | cut -f1-2 -d.)
 golang_required=%{golang_version}
 if [[ "${golang_detected}" < "${golang_required}" ]] ; then
   echo "The detected go version ${golang_detected} is less than the required version ${golang_required}" > /dev/stderr


### PR DESCRIPTION
Since the go directive in go.mod is advisory only until 1.21 the enforcement happens when building the rpm.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
