### PR TITLE
USHIFT-1781: Add unprivileged router tests

### DIFF
--- a/origin/NOTES
+++ b/origin/NOTES
@@ -1,3 +1,6 @@
 Microshift origin fork.
 
 Current code synchronised with github.com/openshift/origin@90bcab071d
+
+List of changes that should be carried to openshift/origin:
+- https://github.com/openshift/microshift/pull/2497

--- a/origin/suite.txt
+++ b/origin/suite.txt
@@ -10,6 +10,7 @@
 "[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should serve the correct routes when running with the haproxy config manager [Suite:openshift/conformance/parallel]"
 "[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing conflicting status [Suite:openshift/conformance/parallel]"
 "[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router converges when multiple routers are writing status [Suite:openshift/conformance/parallel]"
+"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should run even if it has no access to update status [Skipped:Disconnected] [Suite:openshift/conformance/parallel]"
 "[sig-auth][Feature:PodSecurity] restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile [Suite:openshift/conformance/parallel]"
 "[sig-auth][Feature:PodSecurity][Feature:SCC] SCC admission fails for incorrect/non-existent required-scc annotation [Suite:openshift/conformance/parallel]"
 "[sig-auth][Feature:PodSecurity][Feature:SCC] creating pod controllers [Suite:openshift/conformance/parallel]"

--- a/origin/test/extended/router/unprivileged.go
+++ b/origin/test/extended/router/unprivileged.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should run even if it has no access to update status [apigroup:image.openshift.io]", func() {
+		g.It("should run even if it has no access to update status", func() {
 
 			routerPod := createScopedRouterPod(routerImage, "test-unprivileged", defaultPemData, "false")
 			g.By("creating a router")
@@ -62,7 +62,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
+			execPod := exutil.CreateAgnhostPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPod.Name, *metav1.NewDeleteOptions(1))
 			}()

--- a/origin/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/origin/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2,6 +2,7 @@ package generated
 
 import (
 	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 )
@@ -1357,7 +1358,7 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should override the route host with a custom value": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should run even if it has no access to update status [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should run even if it has no access to update status": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][Feature:Router][apigroup:route.openshift.io] The HAProxy router should serve the correct routes when running with the haproxy config manager": " [Suite:openshift/conformance/parallel]",
 

--- a/origin/test/extended/util/pods.go
+++ b/origin/test/extended/util/pods.go
@@ -19,6 +19,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"github.com/openshift/origin/test/extended/util/image"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -75,10 +76,22 @@ func RemovePodsWithPrefixes(oc *CLI, prefixes ...string) error {
 // The security context of this pod complies to the "restricted" profile.
 // If necessary this can be overriden in tweaks.
 func CreateExecPodOrFail(client kubernetes.Interface, ns, name string, tweak ...func(*v1.Pod)) *v1.Pod {
+	return createExecPodOrFail(client, ns, name, image.ShellImage(), tweak...)
+}
+
+// CreateAgnhostPodOrFail creates a pod used as a vessel for kubectl exec commands.
+// Pod name is uniquely generated.
+// The security context of this pod complies to the "restricted" profile.
+// If necessary this can be overriden in tweaks.
+func CreateAgnhostPodOrFail(client kubernetes.Interface, ns, name string, tweak ...func(*v1.Pod)) *v1.Pod {
+	return createExecPodOrFail(client, ns, name, podframework.GetTestImage(imageutils.Agnhost), tweak...)
+}
+
+func createExecPodOrFail(client kubernetes.Interface, ns, name, image string, tweak ...func(*v1.Pod)) *v1.Pod {
 	return podframework.CreateExecPodOrFail(context.TODO(), client, ns, name, func(pod *v1.Pod) {
 		pod.Name = name
 		pod.GenerateName = ""
-		pod.Spec.Containers[0].Image = image.ShellImage()
+		pod.Spec.Containers[0].Image = image
 		pod.Spec.Containers[0].Command = []string{"sh", "-c", "trap exit TERM; while true; do sleep 5; done"}
 		pod.Spec.Containers[0].Args = nil
 		pod.Spec.Containers[0].SecurityContext = podframework.GetRestrictedContainerSecurityContext()


### PR DESCRIPTION
Use agnhost image to bypass the `ShellImage` being hosted in the local registry from image operator.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
