### PR TITLE
USHIFT-643: Add system:router cluster role

### DIFF
--- a/assets/components/openshift-router/cluster-role-system-router.yaml
+++ b/assets/components/openshift-router/cluster-role-system-router.yaml
@@ -1,0 +1,40 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:router
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/status
+  verbs:
+  - update

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -110,6 +110,7 @@ func startIngressController(ctx context.Context, cfg *config.Config, kubeconfigP
 		clusterRole = []string{
 			"components/openshift-router/cluster-role.yaml",
 			"components/openshift-router/cluster-role-aggregate-route.yaml",
+			//TODO another one here. see if the rebase will overwrite it!
 		}
 		apps = []string{
 			"components/openshift-router/deployment.yaml",

--- a/pkg/components/controllers.go
+++ b/pkg/components/controllers.go
@@ -110,7 +110,7 @@ func startIngressController(ctx context.Context, cfg *config.Config, kubeconfigP
 		clusterRole = []string{
 			"components/openshift-router/cluster-role.yaml",
 			"components/openshift-router/cluster-role-aggregate-route.yaml",
-			//TODO another one here. see if the rebase will overwrite it!
+			"components/openshift-router/cluster-role-system-router.yaml",
 		}
 		apps = []string{
 			"components/openshift-router/deployment.yaml",

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -22,10 +22,13 @@ assets:
       - file: update-node-resolver.sh
 
   - dir: components/openshift-router/
+    no_clean: true
     src: cluster-ingress-operator/pkg/manifests/assets/router/
     files:
       - file: cluster-role-binding.yaml
       - file: cluster-role.yaml
+      - file: cluster-role-system-router.yaml
+        ignore: "it's manually copied from OAS bootstrap policy. Not available in any repo rebase is using"
       - file: configmap.yaml
         git_restore: True
       - file: deployment.yaml

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -22,13 +22,12 @@ assets:
       - file: update-node-resolver.sh
 
   - dir: components/openshift-router/
-    no_clean: true
     src: cluster-ingress-operator/pkg/manifests/assets/router/
     files:
       - file: cluster-role-binding.yaml
       - file: cluster-role.yaml
       - file: cluster-role-system-router.yaml
-        ignore: "it's manually copied from OAS bootstrap policy. Not available in any repo rebase is using"
+        git_restore: True
       - file: configmap.yaml
         git_restore: True
       - file: deployment.yaml


### PR DESCRIPTION
Add cluster role system:router to allow creating additional routers besides the default. Default router uses a different cluster role with wider system permissions that are not applicable to application/namespace-bound routers.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
