### PR TITLE
USHIFT-1547: Implement build ISO artifact caching in AWS S3 buckets

### DIFF
--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -203,6 +203,17 @@ get_robotframework() {
     fi
 }
 
+get_awscli() {
+    # Download AWS CLI
+    pushd "${WORK_DIR}" &>/dev/null
+
+    curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && \
+        unzip -q awscliv2.zip
+    ./aws/install --update --install-dir "$(realpath "${DEST_DIR}/../awscli")" --bin-dir "${DEST_DIR}"
+
+    popd &>/dev/null
+}
+
 tool_getters=$(declare -F |  cut -d' ' -f3 | grep "get_" | sed 's/get_//g')
 
 usage() {

--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script runs on the hypervisor, from the iso-build step.
+# This script runs on the hypervisor to boot all scenario VMs.
 
 set -xeuo pipefail
 PS4='+ $(date "+%T.%N")\011 '

--- a/test/bin/ci_phase_test.sh
+++ b/test/bin/ci_phase_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script runs on the CI cluster, from the metal-tests step.
+# This script runs on the hypervisor to execute all scenario tests.
 
 set -xeuo pipefail
 

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -153,3 +153,50 @@ get_vm_bridge_ip() {
 # default network for libvirt VMs.
 # shellcheck disable=SC2034  # used elsewhere
 VM_BRIDGE_IP="$(get_vm_bridge_ip "default")"
+
+get_build_branch() {
+    local -r ocp_ver="$(grep ^OCP_VERSION "${ROOTDIR}/Makefile.version.$(uname -m).var"  | awk '{print $NF}' | awk -F. '{print $1"."$2}')"
+    local -r cur_branch="$(git branch --show-current 2>/dev/null)"
+
+    # Check if the current branch is derived from "main"
+    local -r main_top=$(git rev-parse main 2>/dev/null)
+    local -r main_base="$(git merge-base "${cur_branch}" main 2>/dev/null)"
+    if [ "${main_top}" = "${main_base}" ] ; then
+        echo "main"
+        return
+    fi
+
+    # Check if the current branch is derived from "release-${ocp-ver}"
+    local -r rel_top=$(git rev-parse "release-${ocp_ver}" 2>/dev/null)
+    local -r rel_base="$(git merge-base "${cur_branch}" "release-${ocp_ver}" 2>/dev/null)"
+    if [ "${rel_top}" = "${rel_base}" ] ; then
+        echo "release-${ocp_ver}"
+        return
+    fi
+
+    # Fallback to main if none of the above works
+    echo "main"
+}
+
+# The branch identifier of the current scenario repository,
+# i.e. "main", "release-4.14", etc.
+# Used for top-level directory names when caching build artifacts,
+# i.e. <bucket_name>/<branch>
+# shellcheck disable=SC2034  # used elsewhere
+SCENARIO_BUILD_BRANCH="$(get_build_branch)"
+
+# The tag identifier of a scenario used in directory
+# names when caching today's build artifacts,
+# i.e. <bucket_name>/<branch>/<tag>
+# shellcheck disable=SC2034  # used elsewhere
+SCENARIO_BUILD_TAG="$(date '+%y%m%d')"
+
+# The tag identifier of a scenario used in directory
+# names when caching build artifacts from a day before,
+# i.e. <bucket_name>/<branch>/<tag>
+# shellcheck disable=SC2034  # used elsewhere
+SCENARIO_BUILD_TAG_PREV="$(date -d "yesterday" '+%y%m%d')"
+
+# The location of the awscli binary.
+# shellcheck disable=SC2034  # used elsewhere
+AWSCLI=${ROOTDIR}/_output/bin/aws

--- a/test/bin/manage_build_cache.sh
+++ b/test/bin/manage_build_cache.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+#
+# This script should be run on the build host to manage cache of build artifacts
+set -euo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=test/bin/common.sh
+source "${SCRIPTDIR}/common.sh"
+
+AWS_BUCKET_NAME="${AWS_BUCKET_NAME:-microshift-build-cache}"
+BCH_SUBDIR=
+TAG_SUBDIR=
+
+usage() {
+    cat - <<EOF
+${BASH_SOURCE[0]} (upload|download|verify|setlast|getlast|keep) [options]
+
+Manage build cache at the '${AWS_BUCKET_NAME}' AWS S3 bucket. The script
+assumes that the bucket exists and it is configured for read-write access
+using 'aws s3 (ls|sync|rm)' operations.
+
+The cache directory structure is '${AWS_BUCKET_NAME}/<branch>/<arch>/<tag>'.
+
+  -h        Show this help.
+
+  upload:   Upload build artifacts from the local disk to the specified
+            '${AWS_BUCKET_NAME}/<branch>/${UNAME_M}/<tag>' AWS S3 bucket.
+
+  download: Download build artifacts from the specified
+            '${AWS_BUCKET_NAME}/<branch>/${UNAME_M}/<tag>' AWS S3 bucket
+            to the local disk.
+
+  verify:   Exit with 0 status if the specified
+            '${AWS_BUCKET_NAME}/<branch>/${UNAME_M}/<tag>' sub-directory
+            exists and contains files, 1 otherwise.
+
+  setlast:  Update the '${AWS_BUCKET_NAME}/<branch>/${UNAME_M}/last' file
+            contents in the AWS S3 bucket with the specified '<tag>'.
+
+  getlast:  Retrieve the '${AWS_BUCKET_NAME}/<branch>/${UNAME_M}/last'
+            file contents from the AWS S3 bucket. The output format is
+            "LAST: <tag>" for easy parsing. The script returns the
+            specified '<tag>' as a fallback if the bucket file does
+            not exist.
+
+  keep:     Delete all data from the '${AWS_BUCKET_NAME}/<branch>/${UNAME_M}'
+            AWS S3 bucket, only keeping the 'last' and the specified
+            '<tag>' sub-directories.
+
+Options:
+
+  -b <branch>   The branch sub-directory in the AWS S3 bucket.
+
+  -t <tag>      The tag sub-directory in the AWS S3 bucket.
+
+EOF
+}
+
+action_upload() {
+    local -r src_dir="${IMAGEDIR}/${VM_POOL_BASENAME}"
+    local -r dst_dir="s3://${AWS_BUCKET_NAME}/${BCH_SUBDIR}/${UNAME_M}/${TAG_SUBDIR}/${VM_POOL_BASENAME}"
+    local -r src_size=$(du -csh "${IMAGEDIR}/${VM_POOL_BASENAME}" | awk 'END{print $1}')
+
+    echo "Uploading ${src_size} of data to '${dst_dir}'"
+    "${AWSCLI}" s3 sync --quiet --include '*.iso' "${src_dir}" "${dst_dir}"
+}
+
+action_download() {
+    local -r src_dir="s3://${AWS_BUCKET_NAME}/${BCH_SUBDIR}/${UNAME_M}/${TAG_SUBDIR}/${VM_POOL_BASENAME}"
+    local -r dst_dir="${IMAGEDIR}/${VM_POOL_BASENAME}"
+
+    echo "Downloading data from '${src_dir}'"
+    "${AWSCLI}" s3 sync --quiet --include '*.iso' "${src_dir}" "${dst_dir}"
+
+    local -r dst_size=$(du -csh "${IMAGEDIR}/${VM_POOL_BASENAME}" | awk 'END{print $1}')
+    echo "Downloaded ${dst_size} data"
+}
+
+action_verify() {
+    local -r src_dir="s3://${AWS_BUCKET_NAME}/${BCH_SUBDIR}/${UNAME_M}/${TAG_SUBDIR}/${VM_POOL_BASENAME}"
+
+    echo "Checking contents of '${src_dir}'"
+    if "${AWSCLI}" s3 ls "${src_dir}/" | awk '{print $NF}' | grep -Eq '.iso$' ; then
+        echo OK
+        exit 0
+    fi
+
+    echo KO
+    exit 1
+}
+
+action_setlast() {
+    local -r src_file="$(mktemp /tmp/setlast.XXXXXXXX)"
+    local -r dst_file="s3://${AWS_BUCKET_NAME}/${BCH_SUBDIR}/${UNAME_M}/last"
+
+    if [ "${TAG_SUBDIR}" = "last" ] ; then
+        echo "ERROR: Cannot set 'last' tag to itself"
+        exit 1
+    fi
+
+    echo "Updating '${dst_file}' with the '${TAG_SUBDIR}' tag"
+    echo -n "${TAG_SUBDIR}" > "${src_file}"
+    "${AWSCLI}" s3 cp --quiet "${src_file}" "${dst_file}"
+    rm -f "${src_file}"
+}
+
+action_getlast() {
+    local -r src_file="s3://${AWS_BUCKET_NAME}/${BCH_SUBDIR}/${UNAME_M}/last"
+    local -r dst_file="$(mktemp /tmp/getlast.XXXXXXXX)"
+
+    echo "Reading '${src_file}' tag contents"
+    "${AWSCLI}" s3 cp --quiet "${src_file}" "${dst_file}" || true
+    if [ -s "${dst_file}" ] ; then
+        echo "LAST: $(cat "${dst_file}")"
+    else
+        echo "LAST: ${TAG_SUBDIR}"
+    fi
+    rm -f "${dst_file}"
+}
+
+action_keep() {
+    local -r top_dir="s3://${AWS_BUCKET_NAME}/${BCH_SUBDIR}/${UNAME_M}"
+    # Get the last contents with the ${TAG_SUBDIR} default
+    local -r last_dir="$(action_getlast | awk '/LAST:/ {print $NF}')"
+
+    for sub_dir in $("${AWSCLI}" s3 ls "${top_dir}/" | awk '{print $NF}'); do
+        if [ "${sub_dir}" = "last" ] ; then
+            continue
+        fi
+        if [ "${sub_dir}" = "${TAG_SUBDIR}/" ] || [ "${sub_dir}" = "${last_dir}/" ] ; then
+            echo "Keeping '${sub_dir}' sub-directory"
+            continue
+        fi
+
+        echo "Deleting '${sub_dir}' sub-directory"
+        "${AWSCLI}" s3 rm --recursive "${top_dir}/${sub_dir}"
+    done
+}
+
+#
+# Main function
+#
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+action="${1}"
+shift
+
+# Parse options
+while getopts "b:t:h" opt; do
+    case "${opt}" in
+        h)
+            usage
+            exit 0
+            ;;
+        b)
+            BCH_SUBDIR="${OPTARG}"
+            ;;
+        t)
+            TAG_SUBDIR="${OPTARG}"
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "${BCH_SUBDIR}" ] || [ -z "${TAG_SUBDIR}" ] ; then
+    echo "ERROR: The <branch> and <tag> sub-directory values are mandatory"
+    echo
+    usage
+    exit 1
+fi
+
+# Install AWS CLI tools
+if [ ! -e "${AWSCLI}" ] ; then
+    "${ROOTDIR}/scripts/fetch_tools.sh" awscli
+fi
+
+# Verify the bucket can be accessed
+if ! "${AWSCLI}" s3 ls "${AWS_BUCKET_NAME}" &>/dev/null ; then
+    echo "ERROR: Cannot access the '${AWS_BUCKET_NAME}' AWS bucket"
+    exit 1
+fi
+
+# Run actions
+case "${action}" in
+    upload|download|verify|setlast|getlast|keep)
+        "action_${action}" "$@"
+        ;;
+    -h|help)
+        usage
+        exit 0
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
**Bottom line**: the current build times of `group1` and `group2` are ~40m. When testing cached builds on AWS metal host, the build times of `group1` and `group2` go down to ~25m.

> There are opportunities to also cache ostree commits in addition to ISO images, which will result in more savings
> of the overall build time.

The following changes were implemented in the test system:
- `scripts/fetch_tools.sh`
  - Installation of awscli for manipulating the buckets
-  `test/bin/common.sh`
   - Definition of the SCENARIO_BUILD_* denoting branch and current/previous tag
-  `test/bin/manage_build_cache.sh`
   - Cache manipulation script working with AWS S3 bucket

The main cache update and usage logic was implemented in `test/bin/ci_phase_iso_build.sh`. 
If access to a AWS S3 bucket is not configured, the builds should continue working normally, building everything locally.
- See [build_cache_update](https://github.com/openshift/microshift/pull/2522/files#diff-8852daecec3ead41a3def231ae3a3376cbae01858790680d6004dc1df2829b89R29) on how the cache is created
- See [build_with_cache](https://github.com/openshift/microshift/pull/2522/files#diff-8852daecec3ead41a3def231ae3a3376cbae01858790680d6004dc1df2829b89R43) on how the cache is used, optionally, when S3 bucket access is configured.

The cache creation should be scheduled as a separate periodic job using `test/bin/ci_phase_iso_build.sh -update_cache` command. This is to be implemented as a separate PR.