### PR TITLE
USHIFT-1801: change build_rpms.sh to create rpm with podman in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ GO_PACKAGES=$(go list ./cmd/... ./pkg/...)
 # Build to a place we can ignore
 GO_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
 
+GO_CACHE :=$(shell go env GOCACHE)
+
 ifeq ($(DEBUG),true)
 	# throw all the debug info in!
 	LD_FLAGS =
@@ -293,15 +295,15 @@ commit: image-build-configure image-build-commit
 .PHONY: commit
 
 rpm-podman:
-	RPM_BUILDER_IMAGE_TAG="rhel-8-release-golang-1.19-openshift-4.13"; \
+	RPM_BUILDER_IMAGE_TAG="rhel-8-release-golang-1.20-openshift-4.14"; \
 	podman build \
 		--volume /etc/pki/entitlement/:/etc/pki/entitlement \
 		--build-arg TAG=$$RPM_BUILDER_IMAGE_TAG \
 		--tag microshift-builder:$$RPM_BUILDER_IMAGE_TAG - < ./packaging/images/Containerfile.rpm-builder ; \
 	podman run \
 		--rm -ti \
-		--volume $$(pwd):/opt/microshift \
-		--volume $$(go env GOCACHE):/go/.cache \
+		--volume $$(pwd):/opt/microshift:z \
+		--volume $(GO_CACHE):/go/.cache:z \
 		--env TARGET_ARCH=$(TARGET_ARCH) \
 		microshift-builder:$$RPM_BUILDER_IMAGE_TAG \
 		bash -ilc 'cd /opt/microshift && make rpm & pid=$$! ; trap "pkill $${pid}" INT ; wait $${pid}'

--- a/test/bin/build_rpms.sh
+++ b/test/bin/build_rpms.sh
@@ -12,9 +12,15 @@ source "${SCRIPTDIR}/common.sh"
 cd "${ROOTDIR}"
 rm -rf _output/rpmbuild*
 
-BUILD_CMDS=( \
-    # Normal build of current branch from source
-    'make rpm' \
+# Normal build of current branch from source
+BUILD_CMDS=('make rpm')
+
+# In CI, build the current branch from source with the build tools using used by OCP.
+if [ -v CI_JOB_NAME ] ; then
+    BUILD_CMDS=('make rpm-podman')
+fi
+
+BUILD_CMDS+=( 
     # Build RPMs with the version number of the next minor release,
     # but using the same source code as the normal build.
     'make -C test/ fake-next-minor-rpm' \


### PR DESCRIPTION
this change will  use openshift's  go container toolchain in CI  ,make the resulting binary/rpm FIPs compliant and consistent with ART .