### PR TITLE
USHIFT-1628 [BUG] Custom qemu-guest-agent library mishandles non-0 virsh status

### DIFF
--- a/test/resources/qemu-guest-agent.py
+++ b/test/resources/qemu-guest-agent.py
@@ -47,13 +47,15 @@ def _do_guest_exec(vm_name: str, cmd: str, *args) -> int:
     #    }
     #  }
     result: ExecutionResult = Process().run_process('virsh', *virsh_args)
-    content = json.loads(result.stdout)['return']
-
-    BuiltIn().log(f'guest-exec result: {content}')
+    # check that the "virsh" process exited cleanly.  This is not the same as the guest process's exit code.
     if result.rc != 0:
-        raise RuntimeError(f'virsh command failed:\nstdout={result.stdout}'
+        raise RuntimeError(f'virsh command failed:'
+                           f'\nstdout={result.stdout}'
                            f'\nstderr={result.stderr}'
                            f'\nrc={result.rc}')
+    content = json.loads(result.stdout)['return']
+    BuiltIn().log(f'guest-exec result: {content}')
+
     return content['pid']
 
 
@@ -84,12 +86,14 @@ def _do_guest_exec_status(vm_name: str, pid: int) -> (dict, bool):
     #    }
     #  }
     result: ExecutionResult = Process().run_process('virsh', *virsh_args)
-    content = json.loads(result.stdout)['return']
-    BuiltIn().log(f'guest-exec-status result: {content}')
+    # check that the "virsh" process exited cleanly.  This is not the same as the guest process's exit code.
     if result.rc != 0:
-        raise RuntimeError(f'virsh command failed:\nstdout={result.stdout}'
+        raise RuntimeError(f'virsh command failed:'
+                           f'\nstdout={result.stdout}'
                            f'\nstderr={result.stderr}'
                            f'\nrc={result.rc}')
+    content = json.loads(result.stdout)['return']
+    BuiltIn().log(f'guest-exec-status result: {content}')
     return {
         'rc': content['exitcode'] if 'exitcode' in content else None,
         'stdout': base64.decodebytes(content['out-data'].encode('utf-8')) if 'out-data' in content else '',


### PR DESCRIPTION
As it is, the virsh processes's return data is accessed before checking the virsh exit status.  If the exit code is non-0, `result.stdout['return']` is unassigned, causing a json decoding error.

This fix checks the `result.rc` before `result.stdout['return']` to protect against accessing a non-existent key.