### PR TITLE
USHIFT-1798: introduce fips periodic scenario on rpm based system

### DIFF
--- a/test/kickstart-templates/kickstart-liveimg.ks.template
+++ b/test/kickstart-templates/kickstart-liveimg.ks.template
@@ -105,4 +105,8 @@ done
 # and system needing much more time to roll back.
 ln -sf /dev/null /etc/systemd/user/grub-boot-success.timer
 
+
+# configure FIPs
+REPLACE_FIPS_COMMAND
+
 %end

--- a/test/scenarios-periodics/el92-src@fips.sh
+++ b/test/scenarios-periodics/el92-src@fips.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there. 
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart-liveimg.ks.template rhel-9.2-microshift-source-isolated true
+    launch_vm host1 "rhel-9.2-microshift-source-isolated" "" "" "" "" "" "1"
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_tests host1 suites/fips/
+}

--- a/test/suites/fips/validate-fips.robot
+++ b/test/suites/fips/validate-fips.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+Documentation       Tests related to FIPS Validation
+
+Resource            ../../resources/ostree-health.resource
+Resource            ../../resources/common.resource
+Resource            ../../resources/selinux.resource
+Library             Collections
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+
+*** Variables ***
+${USHIFT_HOST}      ${EMPTY}
+${USHIFT_USER}      ${EMPTY}
+
+
+*** Test Cases ***
+Verify Host Is FIPS Enabled
+    [Documentation]    Performs a FIPS validation against the host
+    Wait Until Greenboot Health Check Exited
+    Fips Should Be Enabled
+
+Verify Binary Is FIPS Compliant
+    [Documentation]    Performs a FIPS validation against the Microshift binary
+    Microshift Binary Should Dynamically Link FIPS Ossl Module
+
+
+*** Keywords ***
+Setup
+    [Documentation]    Test suite setup
+    Check Required Env Variables
+    Login MicroShift Host
+
+Teardown
+    [Documentation]    Test suite teardown
+    Logout MicroShift Host
+
+Microshift Binary Should Dynamically Link FIPS Ossl Module
+    [Documentation]    Check if Microshift binary is FIPS compliant.
+    ${stdout}    ${rc}=    Execute Command
+    ...    LD_DEBUG=symbols microshift run 2>&1 | grep ossl-modules/fips.so$
+    ...    sudo=False    return_rc=True
+    Should Be Equal As Integers    0    ${rc}
+
+Fips Should Be Enabled
+    [Documentation]    Check if FIPS is enabled on RHEL.
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    bash -x fips-mode-setup --check
+    ...    sudo=True    return_rc=True    return_stderr=True
+    Should Be Equal As Integers    0    ${rc}
+    Should Match    ${stdout}    FIPS mode is enabled.


### PR DESCRIPTION
This PR introduce FIPs support to the CI test framework:
- add fips_mode flag to the created  VMs 
- create new `fips` periodic scenario which run the standand suit test
- add RF FIPs compliance test on  RHEL and Microshift binary
- since osbuild  rpm based ISO images doesnt fully  support FIPs ,  `fips-mode-setup --enable` performed in kickstart.