### PR TITLE
USHIFT-1859: Kustomization: enable server-side apply to avoid big resources failing

### DIFF
--- a/pkg/kustomize/apply.go
+++ b/pkg/kustomize/apply.go
@@ -125,6 +125,11 @@ func applyKustomization(kustomization string, kubeconfig string) error {
 		return err
 	}
 
+	// Enable server-side apply to ensure big resources are applied successfully.
+	o.ServerSideApply = true
+	// Force conflicts to ensure that resources are applied even if they have changed on kube.
+	o.ForceConflicts = true
+
 	if err := o.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->

Enables server-side apply for kustomize at startup. related to https://github.com/openshift/microshift/issues/2535

**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes https://github.com/openshift/microshift/issues/2535
