### PR TITLE
USHIFT-1816: use the package as source of truth for version of microshift in tests

### DIFF
--- a/test/resources/microshift-rpm.resource
+++ b/test/resources/microshift-rpm.resource
@@ -2,6 +2,7 @@
 Documentation       Keywords for working with the MicroShift on a non-ostree system
 
 Resource            common.resource
+Library             String
 Library             SSHLibrary
 
 
@@ -52,3 +53,18 @@ Update Dnf Cache
     ...    sudo=True    return_rc=True    return_stderr=True    return_stdout=False
     Log    ${stderr}
     Should Be Equal As Integers    0    ${rc}
+
+Get Version Of MicroShift RPM
+    [Documentation]    Returns the version of the installed MicroShift RPM as a string
+    ${rpm_cmd_output}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    rpm -q microshift
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+    # rpm_cmd_output will look like:
+    # microshift-4.15.0_0.nightly_2023_11_01_080931_20231103152813_3f5593fca_dirty-1.el9.x86_64
+    ${ignored}    ${version_string_raw}=    Split String    ${rpm_cmd_output}    -    1
+    # version_string_raw should be:
+    # 4.15.0_0.nightly_2023_11_01_080931_20231103152813_3f5593fca_dirty-1.el9.x86_64
+    ${version_string}=    Strip String    ${version_string_raw}
+    RETURN    ${version_string}

--- a/test/suites/standard/version.robot
+++ b/test/suites/standard/version.robot
@@ -4,6 +4,7 @@ Documentation       Tests related to the version of MicroShift
 Resource            ../../resources/common.resource
 Resource            ../../resources/oc.resource
 Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/microshift-rpm.resource
 Library             Collections
 Library             ../../resources/DataFormats.py
 
@@ -74,19 +75,13 @@ Teardown
     Logout MicroShift Host
 
 Read Expected Versions    # robocop: disable=too-many-calls-in-keyword
-    [Documentation]    Read ../Makefile.version.aarch64.var to find the expected versions
+    [Documentation]    Ask dnf for the version of the MicroShift package to
+    ...    find the expected versions
+    ...
     ...    Sets suite variables FULL_VERSION, MAJOR_VERSION, MINOR_VERSION, and Y_STREAM based on
     ...    the content.
-
-    # The file contains content in this format:
-    #
-    #    OCP_VERSION := 4.14.0-0.nightly-arm64-2023-05-04-012046
-
-    ${unparsed}=    OperatingSystem.Get File    ../Makefile.version.aarch64.var
-
-    # 4.14.0-0.nightly-arm64-2023-05-04-012046
-    ${version_full_raw}=    Fetch From Right    ${unparsed}    :=
-    ${version_full}=    Strip String    ${version_full_raw}
+    # This returns a string like 4.14.0-0.nightly-arm64-2023-05-04-012046
+    ${version_full}=    Get Version Of MicroShift RPM
     Set Suite Variable    \${FULL_VERSION}    ${version_full}
     # 4.14.0
     ${version_short_matches}=    Get Regexp Matches    ${version_full}    ^(\\d+.\\d+.\\d+)


### PR DESCRIPTION
Instead of reading the local source tree to determine what version
MicroShift should report, look at the dnf info for the package.

/assign @ggiguash @jogeo