### PR TITLE
USHIFT-1818: fix argument processing for login command

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -611,11 +611,11 @@ Settings
 
 Login
 
-  scenario.sh login <scenario-script> <host>
+  scenario.sh login <scenario-script> [<host>]
 EOF
 }
 
-if [ $# -ne 2 ]; then
+if [ $# -lt 2 ]; then
     usage
     exit 1
 fi


### PR DESCRIPTION
The script requires at least 2 arguments, but the login command
accepts an extra one.

/assign @ggiguash