### PR TITLE
USHIFT-1812: `make rpm-podman` only for x86_64

### DIFF
--- a/test/bin/build_rpms.sh
+++ b/test/bin/build_rpms.sh
@@ -15,8 +15,9 @@ rm -rf _output/rpmbuild*
 # Normal build of current branch from source
 BUILD_CMDS=('make rpm')
 
-# In CI, build the current branch from source with the build tools using used by OCP.
-if [ -v CI_JOB_NAME ] ; then
+# In CI, build the current branch from source with the build tools using used by OCP
+# (only for x86_64 - no FIPS support on ARM and no build image for ARM).
+if [ -v CI_JOB_NAME ] && [ "${UNAME_M}" == "x86_64" ]; then
     BUILD_CMDS=('make rpm-podman')
 fi
 


### PR DESCRIPTION
Because FIPS is not yet supported on ARM and there's no build image available for ARM, let's use `make rpm` to build RPMs for ARM.