### PR TITLE
OCPBUGS-22322: Don't create backups for current boot

### DIFF
--- a/pkg/admin/prerun/prerun.go
+++ b/pkg/admin/prerun/prerun.go
@@ -86,6 +86,20 @@ func (dm *dataManagement) backup() error {
 	}
 	klog.InfoS("Contents of version file", "contents", versionFile)
 
+	currentBootID, err := getCurrentBootID()
+	if err != nil {
+		return err
+	}
+	if currentBootID == versionFile.BootID {
+		// We don't want to create a backup if versionFile has current boot ID:
+		// backup would be created for current boot - in the middle of it.
+		// Because backups are not updated/overwritten, existence of such backup would prevent
+		// creation of proper backup, i.e. backup for previous boot after reboot.
+		klog.InfoS("Current boot ID and one stored in version file are the same - skipping backup",
+			"current", currentBootID)
+		return nil
+	}
+
 	existingBackups, err := getBackups(dm.dataManager)
 	if err != nil {
 		return err

--- a/test/resources/ostree-data.resource
+++ b/test/resources/ostree-data.resource
@@ -53,6 +53,13 @@ Backup Should Exist
     ${exists}=    Does Backup Exist    ${deployment_id}    ${boot_id}
     Should Be True    ${exists}
 
+Backup Should Not Exist
+    [Documentation]    Checks if backup identified by deployment ID
+    ...    and (optionally) boot ID does not exist
+    [Arguments]    ${deployment_id}    ${boot_id}=${EMPTY}
+    ${exists}=    Does Backup Exist    ${deployment_id}    ${boot_id}
+    Should Not Be True    ${exists}
+
 Remove Existing Backup For Current Deployment
     [Documentation]    Remove any existing backup for currently running deployment
     ${deploy_id}=    Get Booted Deployment Id

--- a/test/scenarios/el92-src@backups.sh
+++ b/test/scenarios/el92-src@backups.sh
@@ -12,5 +12,5 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/backup/backup-prune-old.robot
+    run_tests host1 suites/backup/backups.robot
 }

--- a/test/suites/backup/backups.robot
+++ b/test/suites/backup/backups.robot
@@ -5,6 +5,7 @@ Resource            ../../resources/common.resource
 Resource            ../../resources/ostree.resource
 Resource            ../../resources/ostree-data.resource
 Library             Collections
+Library             ../../resources/libostree.py
 
 Suite Setup         Setup
 Suite Teardown      Teardown
@@ -30,6 +31,15 @@ Rebooting Healthy System Should Not Delete Unknown Directories
     [Documentation]    Check that MicroShift backup logic does not delete unknown directories
 
     Validate Unknown Directories Exist
+
+Restarting MicroShift Should Not Result In Backup Creation
+    [Documentation]    Check that backup won't be created on MicroShift restart
+    ...    (which would block creating right backup after reboot)
+
+    ${deploy_id}=    Get Booted Deployment ID
+    ${boot_id}=    Get Current Boot Id
+    Restart MicroShift
+    Backup Should Not Exist    ${deploy_id}    ${boot_id}
 
 
 *** Keywords ***


### PR DESCRIPTION
Adds a check that prevents backup creation for current boot. Existence of such backup would prevent a proper backup (i.e. created on boot, with data compatible with previous boot) from being created (because microshift does not update backups - only creates new ones while deleting previous).