### PR TITLE
[USHIFT-2378] CI: Build group3 images unconditionally

### DIFF
--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -58,9 +58,10 @@ if [ -v CI_JOB_NAME ] ; then
     bash -x ./bin/build_images.sh -g ./image-blueprints/group1
     bash -x ./bin/build_images.sh -g ./image-blueprints/group2
     # Group 3 only contains images used in periodic CI jobs
-    if [[ "${CI_JOB_NAME}" =~ .*periodic.* ]]; then
-        bash -x ./bin/build_images.sh -g ./image-blueprints/group3
-    fi
+#  FIXME - re-enable branch logic after merging PR 2378 which cannot pass tests b/c the ISO is not built.
+#    if [[ "${CI_JOB_NAME}" =~ .*periodic.* ]]; then
+    bash -x ./bin/build_images.sh -g ./image-blueprints/group3
+#    fi
 else
     # Fall back to full build when not running in CI
     bash -x ./bin/build_images.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
This is a temporary workaround to allow #2378 to pass pre-submits.  The PR's jobs cannot pass because the scenario image doesn't exist.  After merging 2378, we should revert this PR (or maybe enhance the logic to permit presubmit builds when changes are made to group3 files).