### PR TITLE
USHIFT-1829: add debug log for robotframework

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -528,6 +528,7 @@ EOF
         --randomize all \
         --loglevel TRACE \
         --outputdir "${SCENARIO_INFO_DIR}/${SCENARIO}" \
+        --debugfile "${SCENARIO_INFO_DIR}/${SCENARIO}/rf-debug.log" \
         -x junit.xml \
         -V "${variable_file}" \
         "$@"


### PR DESCRIPTION
The debug log shows each command being executed in detail, and is very
useful when debugging a test locally.