### PR TITLE
USHIFT-1876: enable directory listing in test harness webserver

### DIFF
--- a/test/bin/start_webserver.sh
+++ b/test/bin/start_webserver.sh
@@ -24,6 +24,7 @@ http {
     server {
         listen 0.0.0.0:${WEB_SERVER_PORT};
         root   ${IMAGEDIR};
+        autoindex on;
     }
 }
 pid ${IMAGEDIR}/nginx.pid;


### PR DESCRIPTION
Turn on autoindex so that on development hosts it is easier to
navigate to RF log files.