### PR TITLE
USHIFT-1949: Require openvswitch3.1 or openvswitch to allow installation on Fedora

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -109,7 +109,7 @@ The microshift-selinux package provides the SELinux policy modules required by M
 %package networking
 Summary: Networking components for MicroShift
 Requires: microshift = %{version}
-Requires: openvswitch3.1
+Requires: (openvswitch3.1 or openvswitch >= 3.1)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq


### PR DESCRIPTION
The version number is not part of the openvswitch package name in Fedora. This PR proposes changing the networking rpmspec requirement to either openvswitch3.1 (RHEL or CS9) or openvswitch (Fedora). 