### PR TITLE
OCPBUGS-22854: The microshift-release-info RPM is no longer required and it contains sample blueprints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ rpm-podman:
 		--authfile $(PULLSECRET) \
 		--tag microshift-builder:$(RPM_BUILDER_IMAGE_TAG) - < ./packaging/images/Containerfile.rpm-builder ; \
 	podman run \
-		--rm -ti \
+		--rm -i \
 		--volume $$(pwd):/opt/microshift:z \
 		--volume $(GO_CACHE):/go/.cache:z \
 		--env TARGET_ARCH=$(TARGET_ARCH) \

--- a/packaging/blueprint/blueprint.toml.template
+++ b/packaging/blueprint/blueprint.toml.template
@@ -1,0 +1,35 @@
+name = "microshift-${REPLACE_USHIFT_VERSION}-${REPLACE_USHIFT_ARCH}"
+description = "MicroShift ${REPLACE_USHIFT_VERSION} on ${REPLACE_USHIFT_ARCH} platform"
+version = "0.0.1"
+modules = []
+groups = []
+
+[[packages]]
+name = "microshift"
+version = "${REPLACE_USHIFT_VERSION}"
+
+[[packages]]
+name = "microshift-greenboot"
+version = "${REPLACE_USHIFT_VERSION}"
+
+[[packages]]
+name = "microshift-networking"
+version = "${REPLACE_USHIFT_VERSION}"
+
+[[packages]]
+name = "microshift-selinux"
+version = "${REPLACE_USHIFT_VERSION}"
+
+[customizations.services]
+enabled = ["microshift"]
+
+[customizations.firewall]
+ports = ["22:tcp", "80:tcp", "443:tcp", "5353:udp", "6443:tcp", "30000-32767:tcp", "30000-32767:udp"]
+
+[customizations.firewall.services]
+enabled = ["mdns", "ssh", "http", "https"]
+
+[[customizations.firewall.zones]]
+name = "trusted"
+sources = ["10.42.0.0/16", "169.254.169.1"]
+

--- a/packaging/images/Containerfile.rpm-builder
+++ b/packaging/images/Containerfile.rpm-builder
@@ -6,7 +6,7 @@ RUN rm -rfv /etc/yum.repos.d/ci-rpm-mirrors.repo /etc/yum.repos.d/localdev* && \
         --setopt=tsflags=nodocs \
         --setopt=install_weak_deps=False \
         -y \
-          selinux-policy-devel rpmdevtools \
+        selinux-policy-devel rpmdevtools jq gettext \
     && \
     dnf clean all && \
     rm -rf /var/cache/dnf/*


### PR DESCRIPTION
Also added code to the spec file to declare all the directories under `/usr/share/microshift` to make sure they are cleaned up on uninstall.

```
$ ls -Rl /usr/share/microshift/
/usr/share/microshift/:
total 0
drwxr-xr-x. 2 root root 65 Nov 21 14:04 blueprint
drwxr-xr-x. 2 root root 26 Nov 21 14:04 functions
drwxr-xr-x. 2 root root 61 Nov 21 14:04 release
drwxr-xr-x. 2 root root 38 Nov 21 14:04 spec

/usr/share/microshift/blueprint:
total 8
-rw-r--r--. 1 root root 3443 Nov 21 14:00 blueprint-aarch64.toml
-rw-r--r--. 1 root root 3441 Nov 21 14:00 blueprint-x86_64.toml

/usr/share/microshift/functions:
total 12
-rw-r--r--. 1 root root 8855 Nov 21 11:33 greenboot.sh

/usr/share/microshift/release:
total 8
-rw-r--r--. 1 root root 2469 Nov 21 11:19 release-aarch64.json
-rw-r--r--. 1 root root 2463 Nov 21 11:19 release-x86_64.json

/usr/share/microshift/spec:
total 8
-rw-r--r--. 1 root root 5002 Nov 21 11:54 config-openapi-spec.json
```