### PR TITLE
OCPQE-17114: Stress Testing

### DIFF
--- a/scripts/image-builder/config/blueprint_v0.0.1.toml
+++ b/scripts/image-builder/config/blueprint_v0.0.1.toml
@@ -53,6 +53,10 @@ version = "*"
 name = "strace"
 version = "*"
 
+[[packages]]
+name = "iproute-tc"
+version = "*"
+
 # customizations
 
 [customizations]

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -557,7 +557,7 @@ stress_testing() {
     local -r condition="${3}"
     local -r value="${4}"
 
-    local -r ssh_host="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/public_ip"
+    local -r ssh_host="$(get_vm_property "${vmname}" public_ip)"
     local -r ssh_user=redhat
     local -r ssh_port="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/ssh_port"
     local -r ssh_pkey="${SSH_PRIVATE_KEY:-}"

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -550,6 +550,31 @@ next_minor_version() {
     echo $(( $(current_minor_version) + 1 ))
 }
 
+# Enable/Disable Stress Condition
+stress_testing() {
+    local -r vmname="${1}"
+    local -r action="${2}"
+    local -r condition="${3}"
+    local -r value="${4}"
+
+    local -r ssh_host="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/public_ip"
+    local -r ssh_user=redhat
+    local -r ssh_port="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/ssh_port"
+    local -r ssh_pkey="${SSH_PRIVATE_KEY:-}"
+
+
+	if [ "${action}" == "enable" ]; then
+        echo "${action}d stress condition: ${condition} ${value}"
+        "${SCRIPTDIR}/stress_testing.sh" -e "${condition}" -v "${value}" -h "${ssh_host}" -u "${ssh_user}" -p "${ssh_port}" -k "${ssh_pkey}"
+    elif [ "${action}" == "disable" ]; then
+        echo "${action}d stress condition: ${condition}"
+        "${SCRIPTDIR}/stress_testing.sh" -d "${condition}" -h "${ssh_host}" -u "${ssh_user}" -p "${ssh_port}" -k "${ssh_pkey}"
+    else
+        error "Invalid Stress Testing action"
+        exit 1
+    fi
+}
+
 # Run the tests for the current scenario
 run_tests() {
     local -r vmname="${1}"

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -559,7 +559,7 @@ stress_testing() {
 
     local -r ssh_host="$(get_vm_property "${vmname}" public_ip)"
     local -r ssh_user=redhat
-    local -r ssh_port="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/ssh_port"
+    local -r ssh_port="$(get_vm_property "${vmname}" ssh_port)"
     local -r ssh_pkey="${SSH_PRIVATE_KEY:-}"
     
     if [ "${action}" == "enable" ]; then

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -550,7 +550,17 @@ next_minor_version() {
     echo $(( $(current_minor_version) + 1 ))
 }
 
-# Enable/Disable Stress Condition
+# Public function to enable or disable a Stress Condition
+#
+# Enables or disables a Condition to limit a resource
+# at OS level limiting resources (latency, bandwidth, packet loss, memory, disk...)
+# to a given value for development and testing purposes.
+#
+# Arguments
+#  vmname -- The short name of the VM in the scenario (e.g., "host1")
+#  action -- "enable" or "disable"
+#  condition -- The name of the resource to be be limited
+#  value  -- The target value for the Stress Condition
 stress_testing() {
     local -r vmname="${1}"
     local -r action="${2}"

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -561,9 +561,8 @@ stress_testing() {
     local -r ssh_user=redhat
     local -r ssh_port="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/ssh_port"
     local -r ssh_pkey="${SSH_PRIVATE_KEY:-}"
-
-
-	if [ "${action}" == "enable" ]; then
+    
+    if [ "${action}" == "enable" ]; then
         echo "${action}d stress condition: ${condition} ${value}"
         "${SCRIPTDIR}/stress_testing.sh" -e "${condition}" -v "${value}" -h "${ssh_host}" -u "${ssh_user}" -p "${ssh_port}" -k "${ssh_pkey}"
     elif [ "${action}" == "disable" ]; then

--- a/test/bin/stress_testing.sh
+++ b/test/bin/stress_testing.sh
@@ -190,9 +190,9 @@ CONDITION: { cpu | memory | disk | bandwidth | packet_loss | latency }
     latency: limit minimun latency to the value in ms\n
 EXAMPLE: 
     ${SCRIPT_NAME} --help
-    ${SCRIPT_NAME} --e latency 100 -h 192.168.1.1 -u root -p 22 -k ~/key.pem
-    ${SCRIPT_NAME} --d latency -h 192.168.1.1 -u root -p 22 -k ~/key.pem
-    ${SCRIPT_NAME} --g latency
+    ${SCRIPT_NAME} -e latency 100 -h 192.168.1.1 -u root -p 22 -k ~/key.pem
+    ${SCRIPT_NAME} -d latency -h 192.168.1.1 -u root -p 22 -k ~/key.pem
+    ${SCRIPT_NAME} -g latency
 EOF
 }
 

--- a/test/bin/stress_testing.sh
+++ b/test/bin/stress_testing.sh
@@ -164,34 +164,36 @@ function post_check {
 
 # usage
 function help {
-  echo -e "USAGE: "
-  echo -e "       ${SCRIPT_NAME} -e CONDITION -v value [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]"
-  echo -e "       ${SCRIPT_NAME} -d CONDITION [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]"
-  echo -e "       ${SCRIPT_NAME} -g CONDITION [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]"
-  echo -e "       ${SCRIPT_NAME} --help\n"
-  echo -e "PARAMS:"
-  echo -e "       -e,     Enable condition"
-  echo -e "       -d,     Disable condition"
-  echo -e "       -g,     Returns the current real value for the condition"
-  echo -e "       -v,     Target value when enable a condition"
-  echo -e "       -i,     Network interface for network conditions, default one is set if ommited"
-  echo -e "       -h,     Hostname to perform action in a remote host"
-  echo -e "       -u,     ssh user to perform action in a remote host"
-  echo -e "       -p,     ssh port to perform in a remote host"
-  echo -e "       -k,     ssh private key path"
-  echo -e "       --help, Shows this help\n"
-  echo -e "CONDITION: { cpu | memory | disk | bandwidth | packet_loss | latency }"
-  echo -e "        cpu: limit the usage cpu % to the value"
-  echo -e "        memory: limit the available memory to the value"
-  echo -e "        disk: limit the free space to the value"
-  echo -e "        bandwidth: limit the max download and upload bandwidth to the value in Kbps"
-  echo -e "        packet_loss: set packet loss % to the value"
-  echo -e "        latency: limit minimun latency to the value in ms\n"
-  echo -e "EXAMPLE: "
-  echo -e "        ${SCRIPT_NAME} --help"
-  echo -e "        ${SCRIPT_NAME} --e latency 100 -h 192.168.1.1 -u root -p 22 -k ~/key.pem"
-  echo -e "        ${SCRIPT_NAME} --d latency -h 192.168.1.1 -u root -p 22 -k ~/key.pem"
-  echo -e "        ${SCRIPT_NAME} --g latency"
+  cat - <<EOF
+USAGE: 
+    ${SCRIPT_NAME} -e CONDITION -v value [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]
+    ${SCRIPT_NAME} -d CONDITION [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]
+    ${SCRIPT_NAME} -g CONDITION [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]
+    ${SCRIPT_NAME} --help\n
+PARAMS:
+    -e,     Enable condition
+    -d,     Disable condition
+    -g,     Returns the current real value for the condition
+    -v,     Target value when enable a condition
+    -i,     Network interface for network conditions, default one is set if ommited
+    -h,     Hostname to perform action in a remote host
+    -u,     ssh user to perform action in a remote host
+    -p,     ssh port to perform in a remote host
+    -k,     ssh private key path
+    --help, Shows this help\n
+CONDITION: { cpu | memory | disk | bandwidth | packet_loss | latency }
+    cpu: limit the usage cpu % to the value
+    memory: limit the available memory to the value
+    disk: limit the free space to the value
+    bandwidth: limit the max download and upload bandwidth to the value in Kbps
+    packet_loss: set packet loss % to the value
+    latency: limit minimun latency to the value in ms\n
+EXAMPLE: 
+    ${SCRIPT_NAME} --help
+    ${SCRIPT_NAME} --e latency 100 -h 192.168.1.1 -u root -p 22 -k ~/key.pem
+    ${SCRIPT_NAME} --d latency -h 192.168.1.1 -u root -p 22 -k ~/key.pem
+    ${SCRIPT_NAME} --g latency
+EOF
 }
 
 pre_check "$@"

--- a/test/bin/stress_testing.sh
+++ b/test/bin/stress_testing.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+#
+# This script enable Stress conditions at OS level in local or remote host
+# limiting resources (latency, bandwidth, packet loss, memory, disk...)
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+WONDERSHAPER="/usr/local/bin/wondershaper"
+SPEEDTEST_CLI="/usr/local/bin/speedtest-cli"
+
+# run commands
+function run {
+  if [ "${SSH_PORT:-}" ]; then
+    SSH_PORT_PARAM+="-p ${SSH_PORT}"
+  fi
+
+  if [ "${SSH_PKEY:-}" ]; then
+    SSH_PKEY_PARAM="-i ${SSH_PKEY}"
+  fi
+
+  if [ "${SSH_USER:-}" ]; then
+    SSH_USER_PARAM="${SSH_USER}@"
+  fi
+
+  if [ "${SSH_HOSTNAME:-}" ]; then
+    # shellcheck disable=SC2086
+    ssh -o LogLevel=ERROR ${SSH_PORT_PARAM:-} ${SSH_PKEY_PARAM:-} ${SSH_USER_PARAM:-}${SSH_HOSTNAME} "$@"
+  else
+    "$@"
+  fi
+}
+
+# bandwidth condition
+function bandwidth_condition {
+  bandwidth_condition_ready
+  if [ "${ACTION}" == "enable" ]; then
+    enable_bandwidth
+  elif [ "${ACTION}" == "disable" ]; then
+    disable_bandwidth
+  elif [ "${ACTION}" == "get" ]; then
+    get_bandwidth
+  fi
+}
+
+function bandwidth_condition_ready { 
+  # tc command
+  check_command "tc -V"
+
+  # wondershaper
+  if ( ! sudo ${WONDERSHAPER} -v  &> /dev/null);  then
+    run sudo curl -Lo ${WONDERSHAPER} https://raw.githubusercontent.com/magnific0/wondershaper/master/wondershaper &> /dev/null
+    run sudo chmod +x ${WONDERSHAPER} &> /dev/null
+    check_command "sudo ${WONDERSHAPER} -v"
+  fi
+
+  # speedtest-cli
+  if ( ! ${SPEEDTEST_CLI} --version &> /dev/null);  then
+    run sudo curl -Lo ${SPEEDTEST_CLI} https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py &> /dev/null
+    run sudo chmod +x ${SPEEDTEST_CLI} &> /dev/null
+    check_command "${SPEEDTEST_CLI} --version"
+  fi
+}
+
+function enable_bandwidth {
+  echo -e "Bandwidth condition enabled: max download and upload rate is ${VALUE} Kbps on ${INTERFACE} interface"
+  run sudo ${WONDERSHAPER} -a "${INTERFACE}" -d "${VALUE}" -u "${VALUE}"
+}
+
+function disable_bandwidth {
+  echo -e "Bandwidth condition disabled on ${INTERFACE} interface"
+  run sudo ${WONDERSHAPER} -a "${INTERFACE}" -c || true
+}
+
+function get_bandwidth {
+  run ${SPEEDTEST_CLI} --simple | tail -n2
+}
+
+# latency condition
+function latency_condition {
+  latency_condition_ready
+  if [ "${ACTION}" == "enable" ]; then
+    enable_latency
+  elif [ "${ACTION}" == "disable" ]; then
+    disable_latency
+  elif [ "${ACTION}" == "get" ]; then
+    get_latency
+  fi
+}
+
+function latency_condition_ready {
+  # tc command
+  check_command "tc -V"
+}
+
+function enable_latency {
+  echo -e "Latency condition enabled: min latency is ${VALUE} ms on ${INTERFACE} interface"
+  run sudo tc qdisc replace dev "${INTERFACE}" root netem delay "${VALUE}ms"
+}
+
+function disable_latency {
+  echo -e "Latency condition disabled on ${INTERFACE} interface"
+  run sudo tc qdisc delete dev "${INTERFACE}" root
+}
+
+function get_latency {
+  AVG_LATENCY=$(run ping -c 3 8.8.8.8 | awk '/avg/{print $4}' | awk -F"/" '{printf "%d\n",$2}')
+  echo "${AVG_LATENCY}ms"
+}
+
+function tbd {
+  echo -e "This action is not implemented yet"
+}
+
+function check_command {
+  if ( ! run $1 &> /dev/null ) ; then
+    echo -e "ERROR: $1: command not found"
+    exit 1
+  fi
+}
+
+# set interface
+function set_network_interface {
+  if [ -z "${INTERFACE:-}" ]; then
+    IP=$(run hostname -I | awk '{print $1}')
+    INTERFACE=$(run ip route | grep default | awk -v ip="${IP}" '$0~ip{print $5}')
+  fi
+}
+
+# check args
+function pre_check {
+  # empty or help
+  if [ $# -eq 0 ] || [[ "$*" == *"--help"* ]]; then 
+    help
+    exit 0
+  fi
+}
+
+function post_check {
+  # check action is set  
+  if [ -z "${ACTION}" ]; then
+    echo -e "ERROR: action must be set"
+    exit 1
+  fi
+
+  # check enable action value arg
+  if [ "${ACTION}" == "enable" ] && [ -z "${VALUE:-}" ]; then
+    echo -e "ERROR: value param is missing"
+    exit 1
+  elif [ "${ACTION}" == "enable" ] && [ "${VALUE:-}" ]; then
+    # check if value is a integer
+    if ! [[ "${VALUE:-}" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: value param must be an integer" 
+      exit 1
+    fi
+  fi
+
+  # check disable and get actions must not have a value
+  if [ "${ACTION}" == "disable" ] || [ "${ACTION}" == "get" ] && [ ! "${VALUE:-}" == "" ]; then
+    echo -e "ERROR: value param must be removed"
+    exit 1
+  fi
+}
+
+# usage
+function help {
+  echo -e "USAGE: "
+  echo -e "       ${SCRIPT_NAME} -e CONDITION -v value [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]"
+  echo -e "       ${SCRIPT_NAME} -d CONDITION [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]"
+  echo -e "       ${SCRIPT_NAME} -g CONDITION [-i interface] [-h hostname [-u ssh_user] [-p ssh_port]]"
+  echo -e "       ${SCRIPT_NAME} --help\n"
+  echo -e "PARAMS:"
+  echo -e "       -e,     Enable condition"
+  echo -e "       -d,     Disable condition"
+  echo -e "       -g,     Returns the current real value for the condition"
+  echo -e "       -v,     Target value when enable a condition"
+  echo -e "       -i,     Network interface for network conditions, default one is set if ommited"
+  echo -e "       -h,     Hostname to perform action in a remote host"
+  echo -e "       -u,     ssh user to perform action in a remote host"
+  echo -e "       -p,     ssh port to perform in a remote host"
+  echo -e "       -k,     ssh private key path"
+  echo -e "       --help, Shows this help\n"
+  echo -e "CONDITION: { cpu | memory | disk | bandwidth | packet_loss | latency }"
+  echo -e "        cpu: limit the usage cpu % to the value"
+  echo -e "        memory: limit the available memory to the value"
+  echo -e "        disk: limit the free space to the value"
+  echo -e "        bandwidth: limit the max download and upload bandwidth to the value in Kbps"
+  echo -e "        packet_loss: set packet loss % to the value"
+  echo -e "        latency: limit minimun latency to the value in ms\n"
+  echo -e "EXAMPLE: "
+  echo -e "        ${SCRIPT_NAME} --help"
+  echo -e "        ${SCRIPT_NAME} --e latency 100 -h 192.168.1.1 -u root -p 22 -k ~/key.pem"
+  echo -e "        ${SCRIPT_NAME} --d latency -h 192.168.1.1 -u root -p 22 -k ~/key.pem"
+  echo -e "        ${SCRIPT_NAME} --g latency"
+}
+
+pre_check "$@"
+
+# main loop
+while getopts ":e:d:g:v:i:h:u:p:k:" param; do
+  case ${param} in
+    e)  ACTION="enable" CONDITION="${OPTARG}";;
+    d)  ACTION="disable" CONDITION="${OPTARG}";;
+    g)  ACTION="get" CONDITION="${OPTARG}";;
+    v)  VALUE="${OPTARG}";;
+    i)  INTERFACE="${OPTARG}";;
+    h)  SSH_HOSTNAME="${OPTARG}";;
+    u)  SSH_USER="${OPTARG}";;
+    p)  SSH_PORT="${OPTARG}";;
+    k)  SSH_PKEY="${OPTARG}";;
+    *)   echo -e "ERROR: invalid option '$*'" && exit 1;;
+  esac
+done
+shift $((OPTIND-1))
+
+post_check
+
+# condition loop
+case ${CONDITION:-} in
+  c | cpu)          tbd ;;
+  m | memory)       tbd ;;
+  d | disk)         tbd ;;
+  b | bandwidth)    set_network_interface; bandwidth_condition ;;
+  p | packet_loss)  tbd ;;
+  l | latency)      set_network_interface; latency_condition;;
+  "")               echo -e "ERROR: condition is missing"; exit 1;;
+  *)                echo -e "ERROR: condition is not valid '${CONDITION}'"; exit 1;;
+esac
+

--- a/test/image-blueprints/layer1-base/group1/rhel92.toml
+++ b/test/image-blueprints/layer1-base/group1/rhel92.toml
@@ -9,6 +9,10 @@ groups = []
 name = "microshift-test-agent"
 version = "*"
 
+[[packages]]
+name = "iproute-tc"
+version = "*"
+
 [customizations.services]
 enabled = ["microshift-test-agent"]
 

--- a/test/image-blueprints/layer1-base/group1/rhel93.toml
+++ b/test/image-blueprints/layer1-base/group1/rhel93.toml
@@ -9,6 +9,10 @@ groups = []
 name = "microshift-test-agent"
 version = "*"
 
+[[packages]]
+name = "iproute-tc"
+version = "*"
+
 [customizations.services]
 enabled = ["microshift-test-agent"]
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -62,6 +62,7 @@ if [ ! -f "${RF_VARIABLES}" ]; then
     exit 1
 fi
 
+# shellcheck disable=SC2034
 DEST_DIR="${RF_VENV}" 
 "${ROOTDIR}/scripts/fetch_tools.sh" robotframework
 "${ROOTDIR}/scripts/fetch_tools.sh" yq

--- a/test/run.sh
+++ b/test/run.sh
@@ -56,16 +56,18 @@ while getopts "hno:v:i:s:" opt; do
 done
 shift $((OPTIND-1))
 
-RF_BINARY="${RF_VENV}/bin/robot"
-
 if [ ! -f "${RF_VARIABLES}" ]; then
     echo "Please create or provide a variables file at ${RF_VARIABLES}" 1>&2
     echo "See ${SCRIPTDIR}/variables.yaml.example for the expected content." 1>&2
     exit 1
 fi
 
+DEST_DIR="${RF_VENV}" 
 "${ROOTDIR}/scripts/fetch_tools.sh" robotframework
 "${ROOTDIR}/scripts/fetch_tools.sh" yq
+
+RF_BINARY="${RF_VENV}/bin/robot"
+YQ_BINARY="${RF_VENV}/bin/yq"
 
 cd "${SCRIPTDIR}" || (echo "Did not find ${SCRIPTDIR}" 1>&2; exit 1)
 
@@ -80,10 +82,10 @@ if [ "${STRESS_TESTING:-}" ]; then
     CONDITION="${STRESS_TESTING%-*}"
     VALUE="${STRESS_TESTING#*-}"
 
-    SSH_HOST=$(yq '.USHIFT_HOST' "${SCRIPTDIR}"/rf_variables.yaml)
-    SSH_USER=$(yq '.USHIFT_USER' "${SCRIPTDIR}"/rf_variables.yaml)
-    SSH_PORT=$(yq '.SSH_PORT' "${SCRIPTDIR}"/rf_variables.yaml)
-    SSH_PKEY=$(yq '.SSH_PRIV_KEY' "${SCRIPTDIR}"/rf_variables.yaml)
+    SSH_HOST=$("${YQ_BINARY}" '.USHIFT_HOST' "${SCRIPTDIR}"/rf_variables.yaml)
+    SSH_USER=$("${YQ_BINARY}" '.USHIFT_USER' "${SCRIPTDIR}"/rf_variables.yaml)
+    SSH_PORT=$("${YQ_BINARY}" '.SSH_PORT' "${SCRIPTDIR}"/rf_variables.yaml)
+    SSH_PKEY=$("${YQ_BINARY}" '.SSH_PRIV_KEY' "${SCRIPTDIR}"/rf_variables.yaml)
 
     "${SCRIPTDIR}"/bin/stress_testing.sh -e "${CONDITION}" -v "${VALUE}" -h "${SSH_HOST}" -u "${SSH_USER}" -p "${SSH_PORT}" -k "${SSH_PKEY}"
 fi

--- a/test/run.sh
+++ b/test/run.sh
@@ -14,7 +14,7 @@ OUTDIR="${ROOTDIR}/_output/e2e-$(date +%Y%m%d-%H%M%S)"
 function usage {
     local -r script_name=$(basename "$0")
     cat - <<EOF
-${script_name} [-h] [-n] [-o output_dir] [-v venv_dir] [-i var_file] [-s name-value] [test suite files]
+${script_name} [-h] [-n] [-o output_dir] [-v venv_dir] [-i var_file] [-s name=value] [test suite files]
 
 Options:
 
@@ -23,7 +23,7 @@ Options:
   -o DIR             The output directory. (${OUTDIR})
   -v DIR             The venv directory. (${RF_VENV})
   -i PATH            The variables file. (${RF_VARIABLES})
-  -s NAME-VALUE      To enable an stress condition.
+  -s NAME=VALUE      To enable an stress condition.
 EOF
 }
 
@@ -79,8 +79,8 @@ fi
 
 # enable stress condition
 if [ "${STRESS_TESTING:-}" ]; then
-    CONDITION="${STRESS_TESTING%-*}"
-    VALUE="${STRESS_TESTING#*-}"
+    CONDITION="${STRESS_TESTING%=*}"
+    VALUE="${STRESS_TESTING#*=}"
 
     SSH_HOST=$("${YQ_BINARY}" '.USHIFT_HOST' "${SCRIPTDIR}"/rf_variables.yaml)
     SSH_USER=$("${YQ_BINARY}" '.USHIFT_USER' "${SCRIPTDIR}"/rf_variables.yaml)


### PR DESCRIPTION
Stress Testing script to enable/disable conditions (limiting resources) on local or remote host:
- New `stress_testing.sh` script added.
- `run.sh` add a new `-s` option to set the Stress Condition
- `scenario.sh` add new `stress_testing` function to enable/disable Stress condition before/after `run_tests`
- Add a new package `iproute-tc` to blueprints
    - This package is needed to run `tc qdisc` commands for networking Stress conditions.