### PR TITLE
USHIFT-1941: Fix osconfig tests failing due to unplanned reboots and service failures

### DIFF
--- a/test/resources/systemd.resource
+++ b/test/resources/systemd.resource
@@ -52,7 +52,7 @@ Systemctl    # robocop: disable=too-long-keyword
         ...    sudo=True
         ...    return_stdout=True
         ${log_text}=    Execute Command
-        ...    journalctl -u ${unit_name} -o short | tail -n 100
+        ...    journalctl -u ${unit_name} -o short | tail -c 32000
         ...    sudo=True
         ...    return_stdout=True
     END
@@ -74,7 +74,9 @@ Systemctl    # robocop: disable=too-long-keyword
 Systemctl With Retry
     [Documentation]    Run Systemctl keyword but retry 10 times
     [Arguments]    ${verb}    ${unit_name}
-    Wait Until Keyword Succeeds    10x    10s
+    # Need to wait for more than 10s between the attempts not to
+    # trigger the service start limit condition (10s by default)
+    Wait Until Keyword Succeeds    6x    15s
     ...    Systemctl    ${verb}    ${unit_name}
 
 Systemctl Daemon Reload

--- a/test/suites/osconfig/cleanup-data.robot
+++ b/test/suites/osconfig/cleanup-data.robot
@@ -101,8 +101,9 @@ Setup Suite
     Start MicroShift And Wait Until Ready
 
 Start MicroShift And Wait Until Ready
-    [Documentation]    Start the service and wait until full initialized
-    Systemctl    enable    --now microshift
+    [Documentation]    Start the service and wait until fully initialized
+    Systemctl    enable    microshift
+    Systemctl    start    microshift
     Restart Greenboot And Wait For Success
 
 Run MicroShift Cleanup Data

--- a/test/suites/osconfig/systemd-resolved.robot
+++ b/test/suites/osconfig/systemd-resolved.robot
@@ -10,6 +10,8 @@ Resource            ../../resources/systemd.resource
 Suite Setup         Setup
 Suite Teardown      Teardown
 
+Test Tags           slow
+
 
 *** Variables ***
 ${KUBELET_CONFIG_FILE}      /var/lib/microshift/resources/kubelet/config/config.yaml
@@ -129,6 +131,7 @@ Stop Systemd-Resolved
 
     Systemctl    stop    systemd-resolved
     Reboot MicroShift Host
+    Wait Until Greenboot Health Check Exited
 
 Uninstall Systemd-Resolved
     [Documentation]    Remove the systemd-resolved package
@@ -141,6 +144,7 @@ Uninstall Systemd-Resolved
         Should Be Equal As Integers    0    ${rc}
 
         Reboot MicroShift Host
+        Wait Until Greenboot Health Check Exited
     ELSE
         ${stdout}    ${stderr}    ${rc}=    Execute Command
         ...    dnf remove -y systemd-resolved
@@ -159,6 +163,7 @@ Restore Systemd-Resolved
         Should Be Equal As Integers    0    ${rc}
 
         Reboot MicroShift Host
+        Wait Until Greenboot Health Check Exited
     ELSE
         ${stdout}    ${stderr}    ${rc}=    Execute Command
         ...    dnf install -y systemd-resolved


### PR DESCRIPTION
Besides adding `Wait Until Greenboot Health Check Exited` calls following the `Reboot MicroShift Host` function, the following fixes were implemented:
- Make the `systemctl` command retry less frequently (once in 15s instead of 10s) not to hit the 10s start limit
- Fixed the `Systemctl enable --now` call, which was wrong because `Systemctl` does not expect such usage
- Limited the journalctl output to 32K characters instead of 100 lines. The 32K characters is the max size of RF buffer anyway.