### PR TITLE
USHIFT-1942: Upgrade pyyaml version to 6.0.1 in RF

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,7 @@ robotframework==6.0.2
 robotframework-requests==0.9.4
 robotframework-scplibrary==1.2.0
 robotframework-sshlibrary==3.8.0
-pyyaml==6.0
+pyyaml==6.0.1
 robotframework-robocop==3.1.1
 robotframework-tidy==4.3.0
 packaging==23.2


### PR DESCRIPTION
This fixes a dependency problem on Fedora 39, while remaining functional on RHEL 9.x