### PR TITLE
USHIFT-1926: Implement certificate cleanup option in microshift-cleanup-data script

### DIFF
--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -3,6 +3,7 @@ Documentation       Keywords common to many test suites
 
 Library             OperatingSystem
 Library             String
+Library             SSHLibrary
 Resource            ../resources/kubeconfig.resource
 
 
@@ -60,3 +61,39 @@ Upload String To File    # robocop: disable=too-many-calls-in-keyword
     ...    chown root:root ${remote_filename}
     ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
     Should Be Equal As Integers    0    ${rc}
+
+Verify Remote Directory Exists With Sudo
+    [Documentation]    Use sudo to verify that the specified directory exists
+    [Arguments]    ${remote_dir}
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    test -d ${remote_dir}
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Should Be Equal As Integers    0    ${rc}
+
+Verify Remote Directory Does Not Exist With Sudo
+    [Documentation]    Use sudo to verify that the specified directory does not exist
+    [Arguments]    ${remote_dir}
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    test -d ${remote_dir}
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Should Not Be Equal As Integers    0    ${rc}
+
+Verify Remote File Exists With Sudo
+    [Documentation]    Use sudo to verify that the specified file exists
+    [Arguments]    ${remote_file}
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    test -f ${remote_file}
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Should Be Equal As Integers    0    ${rc}
+
+Verify Remote File Does Not Exist With Sudo
+    [Documentation]    Use sudo to verify that the specified file does not exist
+    [Arguments]    ${remote_file}
+
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    test -f ${remote_file}
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Should Not Be Equal As Integers    0    ${rc}


### PR DESCRIPTION
The new script usage is as follows.
```
Stop all MicroShift services, also cleaning their data

Usage: microshift-cleanup-data.sh <--all [--keep-images] | --ovn | --cert>
   --all         Clean all MicroShift and OVN data
   --keep-images Keep container images when cleaning all data
   --ovn         Clean OVN data only
   --cert        Clean certificates only
```

Note: the changes in `systemd.resource` file come to make the logs more verbose and explicit, which assists with troubleshooting. The previous implementation did not show the returned values.