### PR TITLE
USHIFT-1956: Add mirror registry options to test harness

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -322,6 +322,26 @@ MICROSHIFT_HOST=microshift-dev
 mkdir -p _output/test-images
 scp -r microshift@${MICROSHIFT_HOST}:microshift/_output/test-images/ _output/
 ```
+#### Mirroring the container registry
+In order to avoid possible disruptions from external sources such as container
+registries, there is an option to mirror the registry locally for all the
+images MicroShift requires.
+
+`ENABLE_REGISTRY_MIRROR` -- Boolean value controlling whether there will be a
+local mirror for all MicroShift container images configured in the hypervisor.
+
+The registry will contain all images extracted from previously built MicroShift
+RPMs in the `build` phase (taken from `microshift-release-info`).
+A quay mirror is configured in the hypervisor, all images are downloaded from
+their original registry and pushed into the new one. Each of the scenarios
+will inject the mirror's configuration automatically. Access to the mirror
+uses credentials and TLS.
+
+This is enabled by default in `./test/bin/ci_phase_iso_boot.sh`, as it makes
+pipelines more robust.
+It is disabled by default in each of the scenarios to ease development cycle.
+It is uncommon to run the full `./test/bin/ci_phase_iso_boot.sh` outside of
+CI as it requires a powerful machine.
 
 #### Global Settings
 

--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -39,6 +39,12 @@ bash -x ./bin/manage_hypervisor_config.sh create
 # repository.
 bash -x ./bin/start_webserver.sh
 
+# Setup a container registry and mirror images.
+if [ -f "${MIRROR_CONTAINERS_LIST}" ]; then
+    export ENABLE_MIRROR=true
+    bash -x ./bin/mirror_registry.sh
+fi
+
 # Show the summary of the output of the parallel jobs.
 if [ -t 0 ]; then
     progress="--progress"

--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -9,6 +9,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=test/bin/common.sh
 source "${SCRIPTDIR}/common.sh"
 
+ENABLE_MIRROR=${ENABLE_MIRROR:-true}
+
 # Log output automatically
 LOGDIR="${ROOTDIR}/_output/ci-logs"
 LOGFILE="${LOGDIR}/$(basename "$0" .sh).log"
@@ -40,8 +42,8 @@ bash -x ./bin/manage_hypervisor_config.sh create
 bash -x ./bin/start_webserver.sh
 
 # Setup a container registry and mirror images.
-if [ -f "${MIRROR_CONTAINERS_LIST}" ]; then
-    export ENABLE_MIRROR=true
+if [ "${ENABLE_MIRROR}" ]; then
+    export ENABLE_MIRROR
     bash -x ./bin/mirror_registry.sh
 fi
 

--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -9,7 +9,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=test/bin/common.sh
 source "${SCRIPTDIR}/common.sh"
 
-ENABLE_MIRROR=${ENABLE_MIRROR:-true}
+ENABLE_REGISTRY_MIRROR=${ENABLE_REGISTRY_MIRROR:-true}
 
 # Log output automatically
 LOGDIR="${ROOTDIR}/_output/ci-logs"
@@ -42,8 +42,8 @@ bash -x ./bin/manage_hypervisor_config.sh create
 bash -x ./bin/start_webserver.sh
 
 # Setup a container registry and mirror images.
-if [ "${ENABLE_MIRROR}" ]; then
-    export ENABLE_MIRROR
+if ${ENABLE_REGISTRY_MIRROR}; then
+    export ENABLE_REGISTRY_MIRROR
     bash -x ./bin/mirror_registry.sh
 fi
 

--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -43,8 +43,12 @@ bash -x ./bin/start_webserver.sh
 
 # Setup a container registry and mirror images.
 if ${ENABLE_REGISTRY_MIRROR}; then
-    export ENABLE_REGISTRY_MIRROR
-    bash -x ./bin/mirror_registry.sh
+    # Quay mirror does not provide an arm binary, temporarily run
+    # on x86 only.
+    if [ "$(uname -m)" == "x86_64" ]; then
+        export ENABLE_REGISTRY_MIRROR
+        bash -x ./bin/mirror_registry.sh
+    fi
 fi
 
 # Show the summary of the output of the parallel jobs.

--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -10,6 +10,15 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/common.sh"
 
 ENABLE_REGISTRY_MIRROR=${ENABLE_REGISTRY_MIRROR:-true}
+if ${ENABLE_REGISTRY_MIRROR}; then
+    # Quay mirror does not provide an arm binary, temporarily run
+    # on x86 only.
+    if [ "$(uname -m)" != "x86_64" ]; then
+        echo "Registry mirror disabled in non-x86 architectures. Quay mirror does not provide a binary for them"
+        ENABLE_REGISTRY_MIRROR=false
+    fi
+fi
+export ENABLE_REGISTRY_MIRROR
 
 # Log output automatically
 LOGDIR="${ROOTDIR}/_output/ci-logs"
@@ -43,12 +52,7 @@ bash -x ./bin/start_webserver.sh
 
 # Setup a container registry and mirror images.
 if ${ENABLE_REGISTRY_MIRROR}; then
-    # Quay mirror does not provide an arm binary, temporarily run
-    # on x86 only.
-    if [ "$(uname -m)" == "x86_64" ]; then
-        export ENABLE_REGISTRY_MIRROR
-        bash -x ./bin/mirror_registry.sh
-    fi
+    bash -x ./bin/mirror_registry.sh
 fi
 
 # Show the summary of the output of the parallel jobs.

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -8,12 +8,26 @@ source "${SCRIPTDIR}/common.sh"
 QUAY_VERSION=1.3.9
 REGISTRY_HOST=${REGISTRY_HOST:-$(hostname):8443}
 REGISTRY_ROOT=${REGISTRY_ROOT:-${HOME}/mirror-registry}
-REGISTRY_CONTAINERS=${REGISTRY_CONTAINERS:-${HOME}/containers}
+REGISTRY_CONTAINER_DIR=${REGISTRY_CONTAINER_DIR:-${REGISTRY_ROOT}/containers}
+REGISTRY_CONTAINER_LIST=${REGISTRY_CONTAINER_LIST:-${REGISTRY_ROOT}/mirror-list.txt}
 PULL_SECRET=${PULL_SECRET:-${HOME}/.pull-secret.json}
+
+get_container_images() {
+    containers=""
+    local -r release_info_rpm=$(find "${IMAGEDIR}/rpm-repos" -name "microshift-release-info-*.rpm" | sort)
+    if [ -z "${release_info_rpm}" ] ; then
+        echo "Error: missing microshift-release-info RPMs"
+        exit 1
+    fi
+    for package in ${release_info_rpm}; do
+        containers="$(rpm2cpio "${package}" | cpio  -i --to-stdout "*release-$(uname -m).json" 2> /dev/null | jq -r '[ .images[] ] | join("\n")')\n${containers}"
+    done
+    echo -n -e "${containers}" | sort -u
+}
 
 prereqs() {
     mkdir -p "${REGISTRY_ROOT}"
-    mkdir -p "${REGISTRY_CONTAINERS}"
+    mkdir -p "${REGISTRY_CONTAINER_DIR}"
     curl -L https://github.com/quay/mirror-registry/releases/download/v${QUAY_VERSION}/mirror-registry-offline.tar.gz -o /tmp/mirror-registry-offline.tar.gz
     tar xf /tmp/mirror-registry-offline.tar.gz -C "${REGISTRY_ROOT}"
     rm -f /tmp/mirror-registry-offline.tar.gz
@@ -30,11 +44,12 @@ setup_registry() {
 }
 
 mirror_images() {
-    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --reg-to-dir "${PULL_SECRET}" "${MIRROR_CONTAINERS_LIST}" "${REGISTRY_CONTAINERS}"
-    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --dir-to-reg "${REGISTRY_ROOT}/local-auth.json" "${REGISTRY_CONTAINERS}" "${REGISTRY_HOST}"
+    get_container_images > "${REGISTRY_CONTAINER_LIST}"
+    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --reg-to-dir "${PULL_SECRET}" "${REGISTRY_CONTAINER_LIST}" "${REGISTRY_CONTAINER_DIR}"
+    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --dir-to-reg "${REGISTRY_ROOT}/local-auth.json" "${REGISTRY_CONTAINER_DIR}" "${REGISTRY_HOST}"
     jq -s '.[0] * .[1]' "${PULL_SECRET}" "${REGISTRY_ROOT}/local-auth.json" > "${PULL_SECRET}.tmp"
     mv "${PULL_SECRET}.tmp" "${PULL_SECRET}"
-    rm -rf "${REGISTRY_CONTAINERS}"
+    rm -rf "${REGISTRY_CONTAINER_DIR}"
 }
 
 prereqs

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -21,12 +21,12 @@ prereqs() {
 }
 
 setup_registry() {
-    cd "${REGISTRY_ROOT}"
+    pushd "${REGISTRY_ROOT}" &>/dev/null
     ./mirror-registry install -r "${REGISTRY_ROOT}" --initUser microshift --initPassword microshift
     sudo cp "${REGISTRY_ROOT}/quay-rootCA/rootCA.pem" /etc/pki/ca-trust/source/anchors/mirror-registry.pem
     sudo update-ca-trust
     podman login -u microshift -p microshift "${REGISTRY_HOST}" --authfile "${REGISTRY_ROOT}/local-auth.json"
-    cd -
+    popd &>/dev/null
 }
 
 mirror_images() {
@@ -34,7 +34,7 @@ mirror_images() {
     "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --dir-to-reg "${REGISTRY_ROOT}/local-auth.json" "${REGISTRY_CONTAINERS}" "${REGISTRY_HOST}"
     jq -s '.[0] * .[1]' "${PULL_SECRET}" "${REGISTRY_ROOT}/local-auth.json" > "${PULL_SECRET}.tmp"
     mv "${PULL_SECRET}.tmp" "${PULL_SECRET}"
-    rm -r "${REGISTRY_CONTAINERS}"
+    rm -rf "${REGISTRY_CONTAINERS}"
 }
 
 prereqs

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=test/bin/common.sh
+source "${SCRIPTDIR}/common.sh"
+
+QUAY_VERSION=1.3.9
+REGISTRY_HOST=${REGISTRY_HOST:-$(hostname):8443}
+REGISTRY_ROOT=${REGISTRY_ROOT:-${HOME}/mirror-registry}
+REGISTRY_CONTAINERS=${REGISTRY_CONTAINERS:-${HOME}/containers}
+PULL_SECRET=${PULL_SECRET:-${HOME}/.pull-secret.json}
+
+prereqs() {
+    mkdir -p "${REGISTRY_ROOT}"
+    mkdir -p "${REGISTRY_CONTAINERS}"
+    curl -L https://github.com/quay/mirror-registry/releases/download/v${QUAY_VERSION}/mirror-registry-offline.tar.gz -o /tmp/mirror-registry-offline.tar.gz
+    tar xf /tmp/mirror-registry-offline.tar.gz -C "${REGISTRY_ROOT}"
+    rm -f /tmp/mirror-registry-offline.tar.gz
+    sudo dnf install -y podman skopeo jq
+}
+
+setup_registry() {
+    cd "${REGISTRY_ROOT}"
+    ./mirror-registry install -r "${REGISTRY_ROOT}" --initUser microshift --initPassword microshift
+    sudo cp "${REGISTRY_ROOT}/quay-rootCA/rootCA.pem" /etc/pki/ca-trust/source/anchors/mirror-registry.pem
+    sudo update-ca-trust
+    podman login -u microshift -p microshift "${REGISTRY_HOST}" --authfile "${REGISTRY_ROOT}/local-auth.json"
+    cd -
+}
+
+mirror_images() {
+    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --reg-to-dir "${PULL_SECRET}" "${MIRROR_CONTAINERS_LIST}" "${REGISTRY_CONTAINERS}"
+    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --dir-to-reg "${REGISTRY_ROOT}/local-auth.json" "${REGISTRY_CONTAINERS}" "${REGISTRY_HOST}"
+    jq -s '.[0] * .[1]' "${PULL_SECRET}" "${REGISTRY_ROOT}/local-auth.json" > "${PULL_SECRET}.tmp"
+    mv "${PULL_SECRET}.tmp" "${PULL_SECRET}"
+    rm -r "${REGISTRY_CONTAINERS}"
+}
+
+prereqs
+setup_registry
+mirror_images

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -39,6 +39,8 @@ setup_registry() {
     ./mirror-registry install -r "${REGISTRY_ROOT}" --initUser microshift --initPassword microshift
     sudo cp "${REGISTRY_ROOT}/quay-rootCA/rootCA.pem" /etc/pki/ca-trust/source/anchors/mirror-registry.pem
     sudo update-ca-trust
+    # The mirror does not allow anonymous access, therefore we need the user and password configured in the
+    # pull secrets.
     podman login -u microshift -p microshift "${REGISTRY_HOST}" --authfile "${REGISTRY_ROOT}/local-auth.json"
     popd &>/dev/null
 }

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -21,6 +21,7 @@ PULL_SECRET="${PULL_SECRET:-${HOME}/.pull-secret.json}"
 PULL_SECRET_CONTENT="$(jq -c . "${PULL_SECRET}")"
 PUBLIC_IP=${PUBLIC_IP:-""}  # may be overridden in global settings file
 VM_BOOT_TIMEOUT=900
+ENABLE_MIRROR=${ENABLE_MIRROR:-false}
 SKIP_SOS=${SKIP_SOS:-false}  # may be overridden in global settings file
 SKIP_GREENBOOT=${SKIP_GREENBOOT:-false}  # may be overridden in scenario file
 VNC_CONSOLE=${VNC_CONSOLE:-false}  # may be overridden in global settings file
@@ -170,6 +171,8 @@ prepare_kickstart() {
     local output_file
     local vm_hostname
     local fips_command=""
+    local -r hostname=$(hostname)
+    local -r cert=/etc/pki/ca-trust/source/anchors/mirror-registry.pem
 
     full_vmname="$(full_vm_name "${vmname}")"
     output_file="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/kickstart.ks"
@@ -196,7 +199,15 @@ prepare_kickstart() {
               -e "s|REPLACE_REDHAT_AUTHORIZED_KEYS|${REDHAT_AUTHORIZED_KEYS}|g" \
               -e "s|REPLACE_PUBLIC_IP|${PUBLIC_IP}|g" \
               -e "s|REPLACE_FIPS_COMMAND|${fips_command}|g" \
+              -e "s|REPLACE_ENABLE_MIRROR|${ENABLE_MIRROR}|g" \
               > "${output_file}"
+    if [ "${ENABLE_MIRROR}" ]; then
+        mirror_cert_content=$(awk '{printf "%s\\n", $0}' "${cert}")
+        sed -i \
+          -e "s|REPLACE_MIRROR_CERTIFICATE|${mirror_cert_content}|g" \
+          -e "s|REPLACE_HOSTNAME|${hostname}|g" \
+          "${output_file}"
+    fi
     record_junit "${vmname}" "prepare_kickstart" "OK"
 }
 

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -278,10 +278,8 @@ wait_for_greenboot() {
 
     local -r start_time=$(date +%s)
     local -r ssh_cmd="ssh -oConnectTimeout=10 -oBatchMode=yes -oStrictHostKeyChecking=accept-new redhat@${ip}"
-    local retry_count=2
     while [ $(( $(date +%s) - start_time )) -lt "${VM_BOOT_TIMEOUT}" ] ; do
         local svc_state
-
         svc_state="$(${ssh_cmd} systemctl show --property=SubState --value greenboot-healthcheck || true)"
         if [ "${svc_state}" = "exited" ] ; then
             record_junit "${vmname}" "greenboot-check" "OK"
@@ -290,26 +288,6 @@ wait_for_greenboot() {
 
         # Print the last log and check for terminal failure
         ${ssh_cmd} "sudo journalctl -n 10 -u greenboot-healthcheck" || true
-        if [ "${svc_state}" = "failed" ] ; then
-            # FIXME: See OCPBUGS-24222
-            # Workaround for TopoLVM images getting stuck
-            # Delete the pods (TopoLVM included) and retry greenboot check
-            # Remove this code when the problem is addressed
-            if [ ${retry_count} -gt 0 ] ; then
-                echo "Deleting MicroShift pods and retrying the greenboot checks (${retry_count} attempts remaining)"
-                (( retry_count-- ))
-                # The '--ovn' option keeps the data, but deletes all pods and networking components
-                if ! ${ssh_cmd} "sudo microshift-cleanup-data --ovn ; sudo systemctl enable --now microshift" ; then
-                    echo "WARNING: MicroShift data cleanup returned an error"
-                fi
-                if ! ${ssh_cmd} "sudo systemctl restart --no-block greenboot-healthcheck.service" ; then
-                    echo "WARNING: Greenboot service restart returned an error"
-                fi
-            else
-                echo "The greenboot service reported a failed state, no need to wait any longer"
-                break
-            fi
-        fi
 
         date
         sleep 10

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -205,7 +205,7 @@ prepare_kickstart() {
         mirror_cert_content=$(awk '{printf "%s\\n", $0}' "${cert}")
         sed -i \
           -e "s|REPLACE_MIRROR_CERTIFICATE|${mirror_cert_content}|g" \
-          -e "s|REPLACE_HOSTNAME|${hostname}|g" \
+          -e "s|REPLACE_MIRROR_HOSTNAME|${hostname}|g" \
           "${output_file}"
     fi
     record_junit "${vmname}" "prepare_kickstart" "OK"

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -57,6 +57,62 @@ if [ -n "REPLACE_PUBLIC_IP" ]; then
     echo "    - REPLACE_PUBLIC_IP" >>/etc/microshift/config.yaml
 fi
 
+if REPLACE_ENABLE_MIRROR; then
+    # Setup mirror registries configuration here, as the hostname is dynamic and the file is verbose.
+    cat > /etc/containers/registries.conf.d/999-microshift-mirror.conf <<EOF
+[[registry]]
+    prefix = ""
+    location = "REPLACE_HOSTNAME:8443"
+    mirror-by-digest-only = true
+
+[[registry]]
+    prefix = ""
+    location = "quay.io"
+    mirror-by-digest-only = true
+[[registry.mirror]]
+    location = "REPLACE_HOSTNAME:8443"
+
+[[registry]]
+    prefix = ""
+    location = "registry.redhat.io"
+    mirror-by-digest-only = true
+[[registry.mirror]]
+    location = "REPLACE_HOSTNAME:8443"
+
+[[registry]]
+    prefix = ""
+    location = "registry.access.redhat.com"
+    mirror-by-digest-only = true
+[[registry.mirror]]
+    location = "REPLACE_HOSTNAME:8443"
+EOF
+
+    # Skip signature verifying for red hat registries, since the signatures are bound the original
+    # registry name and mirroring images changes that.
+    cat > /etc/containers/policy.json <<EOF
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports":
+        {
+            "docker-daemon":
+                {
+                    "": [{"type":"insecureAcceptAnything"}]
+                }
+        }
+}
+EOF
+
+    # setup TLS certs for the registry
+    cat > /etc/pki/ca-trust/source/anchors/mirror-registry.pem <<EOF
+REPLACE_MIRROR_CERTIFICATE
+EOF
+    sudo update-ca-trust
+fi
+
 # The pull secret is mandatory for MicroShift builds on top of OpenShift, but not OKD
 # The /etc/crio/crio.conf.d/microshift.conf references the /etc/crio/openshift-pull-secret file
 mkdir -p /etc/crio

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -62,7 +62,7 @@ if REPLACE_ENABLE_MIRROR; then
     cat > /etc/containers/registries.conf.d/999-microshift-mirror.conf <<EOF
 [[registry]]
     prefix = ""
-    location = "REPLACE_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:8443"
     mirror-by-digest-only = true
 
 [[registry]]
@@ -70,21 +70,21 @@ if REPLACE_ENABLE_MIRROR; then
     location = "quay.io"
     mirror-by-digest-only = true
 [[registry.mirror]]
-    location = "REPLACE_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:8443"
 
 [[registry]]
     prefix = ""
     location = "registry.redhat.io"
     mirror-by-digest-only = true
 [[registry.mirror]]
-    location = "REPLACE_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:8443"
 
 [[registry]]
     prefix = ""
     location = "registry.access.redhat.com"
     mirror-by-digest-only = true
 [[registry.mirror]]
-    location = "REPLACE_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:8443"
 EOF
 
     # Skip signature verifying for red hat registries, since the signatures are bound the original
@@ -110,7 +110,7 @@ EOF
     cat > /etc/pki/ca-trust/source/anchors/mirror-registry.pem <<EOF
 REPLACE_MIRROR_CERTIFICATE
 EOF
-    sudo update-ca-trust
+    update-ca-trust
 fi
 
 # The pull secret is mandatory for MicroShift builds on top of OpenShift, but not OKD


### PR DESCRIPTION
- Adds the possibility of mirroring the registry so that it is hosted in the hypervisor.
- Activated automatically in CI, it needs ENABLE_REGISTRY_MIRROR=true env var when executed locally.
- Provides a registry where all the images from built RPMs are mirrored.
- VMs are configured to use the mirror for all possible image sources in a secure way.
- Image signature validation for images coming from registry.redhat.io and registry.access.redhat.com is disabled.
- Registry is started and filled with images in boot phase.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
