### PR TITLE
USHIFT-1972: Fix service restart race condition for services that exit

### DIFF
--- a/test/resources/microshift-process.resource
+++ b/test/resources/microshift-process.resource
@@ -80,7 +80,7 @@ Restart MicroShift
     [Documentation]    Restart the MicroShift service
     ${ushift_pid}=    MicroShift Process ID
     ${ushift_etcd_pid}=    MicroShift Etcd Process ID
-    Systemctl With Retry    restart    microshift.service
+    Systemctl    restart    microshift.service
     Wait Until MicroShift Process ID Changes    ${ushift_pid}
     Wait Until MicroShift Etcd Process ID Changes    ${ushift_etcd_pid}
     # Kubeconfig may change between restarts, ensure we are taking the latest one.
@@ -89,11 +89,11 @@ Restart MicroShift
 
 Stop MicroShift
     [Documentation]    Stop the MicroShift service
-    Systemctl With Retry    stop    microshift.service
+    Systemctl    stop    microshift.service
 
 Start MicroShift
     [Documentation]    Start the MicroShift service
-    Systemctl With Retry    start    microshift.service
+    Systemctl    start    microshift.service
     # Kubeconfig may change between restarts, ensure we are taking the latest one.
     Setup Kubeconfig
 

--- a/test/resources/ostree-health.resource
+++ b/test/resources/ostree-health.resource
@@ -16,10 +16,21 @@ Wait Until Greenboot Health Check Exited
 Greenboot Health Check Exited
     [Documentation]    Checks if greenboot-healthcheck finished running successfully (exited)
 
-    ${value}=    Get Systemd Setting    greenboot-healthcheck.service    SubState
-    Should Be Equal As Strings    ${value}    exited
+    Systemctl Check Service SubState    greenboot-healthcheck.service    exited
 
 Restart Greenboot And Wait For Success
     [Documentation]    Restart the greenboot-healthcheck service and check its status
-    Systemctl    restart    greenboot-healthcheck.service
+
+    ${unit_name}=    Set Variable    greenboot-healthcheck.service
+
+    # Note that the Systemctl keyword from systemd.resource cannot be used to
+    # restart the greenboot-healthcheck service due to the keyword expecting
+    # the 'running' state after the restart. This condition does not apply on
+    # services like greenboot that exit after their startup finishes.
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    systemctl restart ${unit_name}
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    IF    ${rc} != 0    Systemctl Print Service Status And Logs    ${unit_name}
+    Should Be Equal As Integers    0    ${rc}
+
     Wait Until Greenboot Health Check Exited

--- a/test/resources/systemd.resource
+++ b/test/resources/systemd.resource
@@ -23,16 +23,38 @@ Get Systemd Setting
     ${result}=    Strip String    ${stdout}
     RETURN    ${result}
 
-Systemctl    # robocop: disable=too-long-keyword
+Systemctl Print Service Status And Logs
+    [Documentation]    Dumps the status and latest logs for a specified service.
+    [Arguments]    ${unit_name}
+
+    ${status_text}=    Execute Command
+    ...    systemctl status ${unit_name}
+    ...    sudo=True    return_stdout=True
+    ${log_text}=    Execute Command
+    ...    journalctl -u ${unit_name} -o short | tail -c 32000
+    ...    sudo=True    return_stdout=True
+
+Systemctl Check Service SubState
+    [Documentation]    Check if the current sub-state of a service is the same
+    ...    as the expected sub-state.
+    [Arguments]    ${unit_name}    ${expected_state}
+
+    ${sub_state}=    Get Systemd Setting    ${unit_name}    SubState
+    Should Be Equal As Strings    ${sub_state}    ${expected_state}
+
+Systemctl
     [Documentation]    Run a systemctl command on the microshift host.
-    ...    The intent is to start, stop, or restart a service. Other
-    ...    commands should be implemented separately.    When the verb is
-    ...    "start" or "restart", this keyword will wait for the unit
+    ...    The intent is to enable, start, stop, or restart a service.
+    ...    Other commands should be implemented separately. When the verb
+    ...    is "start" or "restart", this keyword will wait for the unit
     ...    to report that it is "running". When the verb is "stop", this
     ...    keyword will wait for the unit to report that it is "dead".
     ...    When the verb is "enable", this keyword will only check success
-    ...    of the operation and not wait for any change to the service..
+    ...    of the operation and not wait for any change to the service.
     [Arguments]    ${verb}    ${unit_name}
+
+    # Verify the input
+    Should Be True    "${verb}" in {"restart", "start", "stop", "enable"}
 
     IF    "${verb}" in {"restart", "start"}
         ${state}=    Set Variable    running
@@ -42,20 +64,8 @@ Systemctl    # robocop: disable=too-long-keyword
 
     ${stdout}    ${stderr}    ${rc}=    Execute Command
     ...    systemctl ${verb} ${unit_name}
-    ...    sudo=True
-    ...    return_stdout=True
-    ...    return_stderr=True
-    ...    return_rc=True
-    IF    ${rc} != 0
-        ${status_text}=    Execute Command
-        ...    systemctl status ${unit_name}
-        ...    sudo=True
-        ...    return_stdout=True
-        ${log_text}=    Execute Command
-        ...    journalctl -u ${unit_name} -o short | tail -c 32000
-        ...    sudo=True
-        ...    return_stdout=True
-    END
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    IF    ${rc} != 0    Systemctl Print Service Status And Logs    ${unit_name}
     Should Be Equal As Integers    0    ${rc}
 
     IF    "${verb}" == "enable"    RETURN
@@ -66,18 +76,7 @@ Systemctl    # robocop: disable=too-long-keyword
     Sleep    5s
 
     Wait Until Keyword Succeeds    10x    10s
-    ...    Execute Command    [ $(systemctl show -p SubState --value ${unit_name}) = ${state} ]
-    ...        timeout=10s
-    ...        return_stdout=True
-    ...        return_stderr=True
-
-Systemctl With Retry
-    [Documentation]    Run Systemctl keyword but retry 10 times
-    [Arguments]    ${verb}    ${unit_name}
-    # Need to wait for more than 10s between the attempts not to
-    # trigger the service start limit condition (10s by default)
-    Wait Until Keyword Succeeds    6x    15s
-    ...    Systemctl    ${verb}    ${unit_name}
+    ...    Systemctl Check Service SubState    ${unit_name}    ${state}
 
 Systemctl Daemon Reload
     [Documentation]    Reload the systemd daemon.


### PR DESCRIPTION
When services are started synchronously using `systemctl start` or `systemctl restart`, they go through `start` and then `running` sub-state. 

The race condition was on services that do not have a "long" running phase, i.e. greenboot. Those services run until completion and exit. So, there is a `start`, very short `running` and `exited` sub-states for those services.

To fix the race condition with minimal changes to the existing infrastructure, a special `systemctl restart` logic was introduced for the `greenboot-healthcheck.service`.

In addition, the fixes include:
* Remove the `Systemctl With Retry` keyword
* Refactor the `Systemctl` keyword to shorten its length and address linter warning