### PR TITLE
USHIFT-1955: Implement microshift-olm plugin altering greenboot functionality

### DIFF
--- a/packaging/greenboot/microshift-running-check-olm.sh
+++ b/packaging/greenboot/microshift-running-check-olm.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# MicroShift OLM-specific functionality used in Greenboot health check procedures.
+#
+# If 'microshift-olm' RPM is installed, health check needs to include resources
+# from the 'openshift-operator-lifecycle-manager' namespace.
+#
+set -eu -o pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_PID=$$
+CHECK_DEPLOY_NS="openshift-operator-lifecycle-manager"
+LOG_POD_EVENTS=false
+
+# Source the MicroShift health check functions library
+# shellcheck source=packaging/greenboot/functions.sh
+source /usr/share/microshift/functions/greenboot.sh
+
+# Set the term handler to convert exit code to 1
+trap 'forced_termination' TERM SIGINT
+
+# Set the exit handler to log the exit status
+trap 'log_script_exit' EXIT
+
+# Handler that will be called when the script is terminated by sending TERM or
+# INT signals. To override default exit codes it forces returning 1 like the
+# rest of the error conditions throughout the health check.
+function forced_termination() {
+    echo "Signal received, terminating."
+    exit 1
+}
+
+#
+# Main
+#
+
+# Exit if the current user is not 'root'
+if [ "$(id -u)" -ne 0 ] ; then
+    echo "The '${SCRIPT_NAME}' script must be run with the 'root' user privileges"
+    exit 1
+fi
+
+echo "STARTED"
+
+# Print the boot variable status
+print_boot_status
+
+# Exit if the MicroShift service is not enabled
+if [ "$(systemctl is-enabled microshift.service 2>/dev/null)" != "enabled" ] ; then
+    echo "MicroShift service is not enabled. Exiting..."
+    exit 0
+fi
+
+# Set the wait timeout for the current check based on the boot counter
+WAIT_TIMEOUT_SECS=$(get_wait_timeout)
+
+# Starting pod-specific checks
+# Log list of pods and their events on failure
+LOG_POD_EVENTS=true
+
+# Wait for the deployments to be ready
+echo "Waiting ${WAIT_TIMEOUT_SECS}s for '${CHECK_DEPLOY_NS}' deployments to be ready"
+if ! wait_for "${WAIT_TIMEOUT_SECS}" namespace_deployment_ready ; then
+    echo "Error: Timed out waiting for '${CHECK_DEPLOY_NS}' deployments to be ready"
+    exit 1
+fi

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -281,6 +281,7 @@ install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshi
 # Copy all the OLM manifests except the arch specific ones
 install -p -m644 assets/optional/operator-lifecycle-manager/0000* %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-olm
 install -p -m644 assets/optional/operator-lifecycle-manager/kustomization.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-olm
+install -p -m755 packaging/greenboot/microshift-running-check-olm.sh %{buildroot}%{_sysconfdir}/greenboot/check/required.d/50_microshift_running_check_olm.sh
 
 %ifarch %{arm} aarch64
 cat assets/optional/operator-lifecycle-manager/kustomization.aarch64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-olm/kustomization.yaml
@@ -400,10 +401,14 @@ systemctl enable --now --quiet openvswitch || true
 %files olm
 %dir %{_prefix}/lib/microshift/manifests.d/001-microshift-olm
 %{_prefix}/lib/microshift/manifests.d/001-microshift-olm/*
+%{_sysconfdir}/greenboot/check/required.d/50_microshift_running_check_olm.sh
 
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Thu Dec 14 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.15.0
+- Implement greenboot check for microshift-olm RPM
+
 * Tue Dec 05 2023 Gregory Giguashvili <ggiguash@redhat.com> 4.15.0
 - The microshift-release-info RPM is no longer required
 - The microshift-release-info RPM contains sample blueprints including container image references


### PR DESCRIPTION
* Implement a new greenboot check script for the `microshift-olm` RPM, based on deployment readiness.
* Refactor the existing scripts to share some common functionality