### PR TITLE
set DEST_DIR before fetch_tools.sh script

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -62,8 +62,10 @@ if [ ! -f "${RF_VARIABLES}" ]; then
     exit 1
 fi
 
-DEST_DIR="${RF_VENV}" "${ROOTDIR}/scripts/fetch_tools.sh" robotframework
-DEST_DIR="${RF_VENV}" "${ROOTDIR}/scripts/fetch_tools.sh" yq
+# DEST_DIR var is the python env dir used by fetch_tools.sh to install the tools
+export DEST_DIR="${RF_VENV}"
+"${ROOTDIR}/scripts/fetch_tools.sh" robotframework
+"${ROOTDIR}/scripts/fetch_tools.sh" yq
 
 RF_BINARY="${RF_VENV}/bin/robot"
 YQ_BINARY="${RF_VENV}/bin/yq"

--- a/test/run.sh
+++ b/test/run.sh
@@ -62,10 +62,8 @@ if [ ! -f "${RF_VARIABLES}" ]; then
     exit 1
 fi
 
-# shellcheck disable=SC2034
-DEST_DIR="${RF_VENV}" 
-"${ROOTDIR}/scripts/fetch_tools.sh" robotframework
-"${ROOTDIR}/scripts/fetch_tools.sh" yq
+DEST_DIR="${RF_VENV}" "${ROOTDIR}/scripts/fetch_tools.sh" robotframework
+DEST_DIR="${RF_VENV}" "${ROOTDIR}/scripts/fetch_tools.sh" yq
 
 RF_BINARY="${RF_VENV}/bin/robot"
 YQ_BINARY="${RF_VENV}/bin/yq"


### PR DESCRIPTION
Fix a bug introduced on https://github.com/openshift/microshift/pull/2647 PR: `DEST_DIR` must be set right before installing tools to set the proper path.

`DEST_DIR` specifies where to install the tool. robotframework is installed in `microshift/_output/robotenv` instead of `microshift/microshift-rf-tests@tmp/venv`. This causes robot framework execution to fail: `/home/jenkins/ws/workspace/microshift/microshift-rf-tests/microshift/test/run.sh: line 104: /home/jenkins/ws/workspace/microshift/microshift-rf-tests@tmp/venv/bin/robot: No such file or directory`

I found this bug last night Jenkins run: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/microshift/job/microshift-rf-tests/923/console