### PR TITLE
USHIFT-2063: Display manage_build_cache.sh output for getlast command during CI builds

### DIFF
--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -132,9 +132,9 @@ CUR_WORKERS="$( [ "${CPU_CORES}" -lt  $(( MAX_WORKERS * 2 )) ] && echo $(( CPU_C
 $(dry_run) bash -x ./bin/start_osbuild_workers.sh "${CUR_WORKERS}"
 
 # Check if cache can be used for builds
-# This will fail when AWS S3 connection is not configured, or there is no cache bucket
+# This may fail when AWS S3 connection is not configured, or there is no cache bucket
 HAS_CACHE_ACCESS=false
-if ./bin/manage_build_cache.sh getlast -b "${SCENARIO_BUILD_BRANCH}" -t "${SCENARIO_BUILD_TAG}" &>/dev/null ; then
+if ./bin/manage_build_cache.sh getlast -b "${SCENARIO_BUILD_BRANCH}" -t "${SCENARIO_BUILD_TAG}" ; then
     HAS_CACHE_ACCESS=true
 fi
 


### PR DESCRIPTION
This is necessary to see the errors occasionally appearing when running the cache update procedure in CI