### PR TITLE
USHIFT-1961: remove golang cache when building from ART container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,6 @@ rpm-podman:
 	podman run \
 		--rm -i \
 		--volume $$(pwd):/opt/microshift:z \
-		--volume $(GO_CACHE):/go/.cache:z \
 		--env TARGET_ARCH=$(TARGET_ARCH) \
 		microshift-builder:$(RPM_BUILDER_IMAGE_TAG) \
 		bash -ilc 'cd /opt/microshift && make rpm & pid=$$! ; trap "pkill $${pid}" INT ; wait $${pid}'


### PR DESCRIPTION
since we are running concurrent  builds with different golang compilers and shared cache,  it may produce  FIPS incompateble RPMS,   which may lead  to FIPS test failures.