### PR TITLE
USHIFT-2067: Use registry mirror in all architectures

### DIFF
--- a/test/bin/ci_phase_iso_boot.sh
+++ b/test/bin/ci_phase_iso_boot.sh
@@ -10,14 +10,6 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/common.sh"
 
 ENABLE_REGISTRY_MIRROR=${ENABLE_REGISTRY_MIRROR:-true}
-if ${ENABLE_REGISTRY_MIRROR}; then
-    # Quay mirror does not provide an arm binary, temporarily run
-    # on x86 only.
-    if [ "$(uname -m)" != "x86_64" ]; then
-        echo "Registry mirror disabled in non-x86 architectures. Quay mirror does not provide a binary for them"
-        ENABLE_REGISTRY_MIRROR=false
-    fi
-fi
 export ENABLE_REGISTRY_MIRROR
 
 # Log output automatically

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -11,6 +11,7 @@ REGISTRY_ROOT=${REGISTRY_ROOT:-${HOME}/mirror-registry}
 REGISTRY_CONTAINER_DIR=${REGISTRY_CONTAINER_DIR:-${REGISTRY_ROOT}/containers}
 REGISTRY_CONTAINER_LIST=${REGISTRY_CONTAINER_LIST:-${REGISTRY_ROOT}/mirror-list.txt}
 PULL_SECRET=${PULL_SECRET:-${HOME}/.pull-secret.json}
+LOCAL_REGISTRY_NAME="microshift-local-registry"
 
 get_container_images() {
     containers=""
@@ -30,7 +31,9 @@ prereqs() {
     mkdir -p "${REGISTRY_ROOT}"
     mkdir -p "${REGISTRY_CONTAINER_DIR}"
     sudo dnf install -y podman skopeo jq
-    podman run -d -p 5000:5000 --restart always --name registry "quay.io/microshift/distribution:${DISTRIBUTION_VERSION}"
+    podman stop "${LOCAL_REGISTRY_NAME}" || true
+    podman rm "${LOCAL_REGISTRY_NAME}" || true
+    podman run -d -p 5000:5000 --restart always --name "${LOCAL_REGISTRY_NAME}" "quay.io/microshift/distribution:${DISTRIBUTION_VERSION}"
 }
 
 setup_registry() {

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -30,7 +30,7 @@ prereqs() {
     mkdir -p "${REGISTRY_ROOT}"
     mkdir -p "${REGISTRY_CONTAINER_DIR}"
     sudo dnf install -y podman skopeo jq
-    podman run -d -p 5000:5000 --restart always --name registry "docker.io/distribution/distribution:${DISTRIBUTION_VERSION}"
+    podman run -d -p 5000:5000 --restart always --name registry "quay.io/microshift/distribution:${DISTRIBUTION_VERSION}"
 }
 
 setup_registry() {

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -39,7 +39,7 @@ prereqs() {
 setup_registry() {
     # Docker distribution does not support TLS authentication. The mirror-images.sh helper uses skopeo without tls options
     # and it defaults to https. Since this is not supported we need to configure registries.conf so that skopeo tries http instead.
-    sudo bash -c 'cat >> /etc/containers/registries.conf' << EOF
+    sudo bash -c 'cat > /etc/containers/registries.conf.d/900-microshift-mirror.conf' << EOF
 [[registry]]
 location = "$(hostname)"
 insecure = true

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -172,7 +172,6 @@ prepare_kickstart() {
     local vm_hostname
     local fips_command=""
     local -r hostname=$(hostname)
-    local -r cert=/etc/pki/ca-trust/source/anchors/mirror-registry.pem
 
     full_vmname="$(full_vm_name "${vmname}")"
     output_file="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}/kickstart.ks"
@@ -200,19 +199,8 @@ prepare_kickstart() {
               -e "s|REPLACE_PUBLIC_IP|${PUBLIC_IP}|g" \
               -e "s|REPLACE_FIPS_COMMAND|${fips_command}|g" \
               -e "s|REPLACE_ENABLE_MIRROR|${ENABLE_REGISTRY_MIRROR}|g" \
+              -e "s|REPLACE_MIRROR_HOSTNAME|${hostname}|g" \
               > "${output_file}"
-    if ${ENABLE_REGISTRY_MIRROR}; then
-        if [ ! -f "${cert}" ]; then
-            error "No ${cert} was found. Did you run mirror_registry.sh?"
-            record_junit "${vmname}" "prepare_kickstart" "no-mirror-cert"
-            exit 1
-        fi
-        local -r mirror_cert_content=$(awk '{printf "%s\\n", $0}' "${cert}")
-        sed -i \
-          -e "s|REPLACE_MIRROR_CERTIFICATE|${mirror_cert_content}|g" \
-          -e "s|REPLACE_MIRROR_HOSTNAME|${hostname}|g" \
-          "${output_file}"
-    fi
     record_junit "${vmname}" "prepare_kickstart" "OK"
 }
 

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -62,7 +62,7 @@ if REPLACE_ENABLE_MIRROR; then
     cat > /etc/containers/registries.conf.d/999-microshift-mirror.conf <<EOF
 [[registry]]
     prefix = ""
-    location = "REPLACE_MIRROR_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:5000"
     mirror-by-digest-only = true
 
 [[registry]]
@@ -70,21 +70,21 @@ if REPLACE_ENABLE_MIRROR; then
     location = "quay.io"
     mirror-by-digest-only = true
 [[registry.mirror]]
-    location = "REPLACE_MIRROR_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:5000"
 
 [[registry]]
     prefix = ""
     location = "registry.redhat.io"
     mirror-by-digest-only = true
 [[registry.mirror]]
-    location = "REPLACE_MIRROR_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:5000"
 
 [[registry]]
     prefix = ""
     location = "registry.access.redhat.com"
     mirror-by-digest-only = true
 [[registry.mirror]]
-    location = "REPLACE_MIRROR_HOSTNAME:8443"
+    location = "REPLACE_MIRROR_HOSTNAME:5000"
 EOF
 
     # Skip signature verifying for red hat registries, since the signatures are bound the original
@@ -105,12 +105,6 @@ EOF
         }
 }
 EOF
-
-    # setup TLS certs for the registry
-    cat > /etc/pki/ca-trust/source/anchors/mirror-registry.pem <<EOF
-REPLACE_MIRROR_CERTIFICATE
-EOF
-    update-ca-trust
 fi
 
 # The pull secret is mandatory for MicroShift builds on top of OpenShift, but not OKD


### PR DESCRIPTION
- Enable registry mirror in x86 and aarch64.
- Use docker distribution instead of quay.
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
