### PR TITLE
USHIFT-2124: [release-4.15] Add test execution timeout to RF with 30m default

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -526,6 +526,14 @@ the primary host to use for connecting and any arguments to be given
 to `robot`, including the test suites and any unique variables that
 are not saved to the default variables file by the framework.
 
+The `robot` command uses the following options that can be overridden
+as an environment setting in scenario files:
+* `TEST_RANDOMIZATION=all` for running the tests in a random order
+* `TEST_EXECUTION_TIMEOUT=30m` for timing out on tests that run longer than expected
+
+> Execution timeout is disabled with running the scenario script in the
+> interactive mode to allow convenient interruption from the terminal.
+
 ## Troubleshooting
 
 ### Accessing VMs

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -26,6 +26,7 @@ SKIP_SOS=${SKIP_SOS:-false}  # may be overridden in global settings file
 SKIP_GREENBOOT=${SKIP_GREENBOOT:-false}  # may be overridden in scenario file
 VNC_CONSOLE=${VNC_CONSOLE:-false}  # may be overridden in global settings file
 TEST_RANDOMIZATION="all"  # may be overridden in scenario file
+TEST_EXECUTION_TIMEOUT="30m" # may be overriden in scenario file
 
 full_vm_name() {
     local base="${1}"
@@ -645,9 +646,19 @@ EOF
         record_junit "${vmname}" "pre_test_greenboot_check" "OK"
     fi
 
+    # Make sure the test execution times out after a predefined period.
+    # The 'timeout' command sends the HUP signal and, if the test does not
+    # exit after 5m, it sends the KILL signal to terminate the process.
     local var_arg=${variable_file:+-V "${variable_file}"}
+    local timeout_robot="timeout -v --kill-after=5m ${TEST_EXECUTION_TIMEOUT} ${rf_binary}"
+    if [ -t 0 ]; then
+        # Disable timeout for interactive mode when stdin is a terminal.
+        # This is necessary for proper handling of test interruption by user.
+        timeout_robot="${rf_binary}"
+    fi
+
     # shellcheck disable=SC2086
-    "${rf_binary}" \
+    if ! ${timeout_robot} \
         --name "${SCENARIO}" \
         --randomize "${TEST_RANDOMIZATION}" \
         --loglevel TRACE \
@@ -655,7 +666,13 @@ EOF
         --debugfile "${SCENARIO_INFO_DIR}/${SCENARIO}/rf-debug.log" \
         -x junit.xml \
         ${var_arg} \
-        "$@"
+        "$@" ; then
+        # Log junit message on the command timeout
+        if [ $? -ge 124 ] ; then
+            record_junit "${vmname}" "run_test_timed_out_${TEST_EXECUTION_TIMEOUT}" "FAILED"
+        fi
+        return 1
+    fi
 }
 
 load_global_settings() {

--- a/test/scenarios-periodics/el92-src@osconfig.sh
+++ b/test/scenarios-periodics/el92-src@osconfig.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Override the default test timeout of 30m
+# shellcheck disable=SC2034  # used elsewhere
+TEST_EXECUTION_TIMEOUT="1h"
+
 scenario_create_vms() {
     prepare_kickstart host1 kickstart.ks.template rhel-9.2-microshift-source
     launch_vm host1


### PR DESCRIPTION
Manual cherry-pick of #2794.