### PR TITLE
USHIFT-2090: Introduce MicroShift cluster ID

### DIFF
--- a/assets/version/microshift-version.yaml
+++ b/assets/version/microshift-version.yaml
@@ -9,3 +9,4 @@ data:
   minor: ""
   patch: ""
   version: ""
+  clusterid: ""

--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -17,10 +17,15 @@ package controllers
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/openshift/microshift/pkg/assets"
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/version"
+
+	"github.com/google/uuid"
 	"k8s.io/klog/v2"
 )
 
@@ -46,11 +51,14 @@ func (s *VersionManager) Run(ctx context.Context, ready chan<- struct{}, stopped
 	defer close(ready)
 
 	versionInfo := version.Get()
+	// cluster ID read from <config.DataDir>/cluster-id file
+	clusterIDFromDB := initClusterID()
 	var data = map[string]string{
-		"major":   versionInfo.Major,
-		"minor":   versionInfo.Minor,
-		"patch":   versionInfo.Patch,
-		"version": versionInfo.String(),
+		"major":     versionInfo.Major,
+		"minor":     versionInfo.Minor,
+		"patch":     versionInfo.Patch,
+		"version":   versionInfo.String(),
+		"clusterid": clusterIDFromDB,
 	}
 
 	kubeConfigPath := s.cfg.KubeConfigPath(config.KubeAdmin)
@@ -60,4 +68,56 @@ func (s *VersionManager) Run(ctx context.Context, ready chan<- struct{}, stopped
 	}
 
 	return ctx.Err()
+}
+
+func createClusterIDFile(fileName string) {
+	uuidBytes, err := uuid.New().MarshalText()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	// Write the UUID to a new file
+	err = os.WriteFile(fileName, uuidBytes, 0400)
+	if err != nil {
+		klog.Fatal(err)
+	}
+}
+
+func initClusterID() string {
+	// The location of the cluster ID file
+	fileName := filepath.Join(config.DataDir, "cluster-id")
+
+	// The default cluster ID is empty, all zeros
+	uuidBytes, err := uuid.Nil.MarshalText()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	// Cluster ID can only be initialized or read when running as root
+	if os.Geteuid() != 0 {
+		return string(uuidBytes)
+	}
+
+	// Cannot create cluster ID file if the MicroShift DB directory does not exist
+	var info os.FileInfo
+	info, err = os.Stat(config.DataDir)
+	if err != nil || !info.IsDir() {
+		klog.Fatalf(
+			"Cannot create MicroShift Cluster ID file before the '%s' directory is created",
+			config.DataDir)
+	}
+
+	// Create the cluster ID file if it does not already exist
+	_, err = os.Stat(fileName)
+	if os.IsNotExist(err) {
+		createClusterIDFile(fileName)
+	}
+
+	// Read the cluster ID from the disk
+	uuidBytes, err = os.ReadFile(fileName)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	return strings.TrimSpace(string(uuidBytes))
 }

--- a/test/suites/standard/clusterid.robot
+++ b/test/suites/standard/clusterid.robot
@@ -1,0 +1,75 @@
+*** Settings ***
+Documentation       Tests verifying MicroShift cluster ID functionality
+
+Resource            ../../resources/microshift-host.resource
+Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/oc.resource
+Resource            ../../resources/ostree-health.resource
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+Test Tags           restart    slow
+
+
+*** Variables ***
+${CLUSTERID_FILE}           /var/lib/microshift/cluster-id
+${CLUSTERID_NS}             kube-public
+${CLUSTERID_RESOURCE}       microshift-version
+
+
+*** Test Cases ***
+Compare Cluster ID From File And ConfigMap
+    [Documentation]    Verify that cluster ID is the same when read
+    ...    from file and configmap
+    ${file_id}=    Get MicroShift Cluster ID From File
+    ${conf_id}=    Get MicroShift Cluster ID From ConfigMap
+    Should Be Equal As Strings    ${file_id}    ${conf_id}
+
+Verify Cluster ID Change For New Database
+    [Documentation]    Verify that cluster ID changes after MicroShift
+    ...    database is cleaned and service restarted
+
+    ${old_id}=    Get MicroShift Cluster ID From ConfigMap
+    Create New MicroShift Cluster
+    ${new_id}=    Get MicroShift Cluster ID From ConfigMap
+    Should Not Be Equal As Strings    ${old_id}    ${new_id}
+
+
+*** Keywords ***
+Setup
+    [Documentation]    Set up all of the tests in this suite
+    Check Required Env Variables
+    Login MicroShift Host
+    Setup Kubeconfig
+
+Teardown
+    [Documentation]    Test suite teardown
+    Remove Kubeconfig
+    Logout MicroShift Host
+
+Create New MicroShift Cluster
+    [Documentation]    Clean the database and restart MicroShift service.
+    Cleanup MicroShift    --all    --keep-images
+    Enable MicroShift
+    Start MicroShift
+    Setup Kubeconfig
+    Restart Greenboot And Wait For Success
+
+Get MicroShift Cluster ID From File
+    [Documentation]    Read and return the cluster ID from the file.
+    ${stdout}    ${rc}=    Execute Command
+    ...    cat ${CLUSTERID_FILE}
+    ...    sudo=True    return_rc=True    return_stdout=True
+    Should Be Equal As Integers    0    ${rc}
+
+    Should Not Be Empty    ${stdout}
+    RETURN    ${stdout}
+
+Get MicroShift Cluster ID From ConfigMap
+    [Documentation]    Read and return the cluster ID from the configmap.
+    ${yaml_data}=    Oc Get    configmap    ${CLUSTERID_NS}    ${CLUSTERID_RESOURCE}
+    ${clusterid}=    Set Variable    ${yaml_data.data.clusterid}
+
+    Should Not Be Empty    ${clusterid}
+    RETURN    ${clusterid}


### PR DESCRIPTION
**MicroShift database files**
```
# ls -l /var/lib/microshift
total 16
drwxr-xr-x. 14 root root 4096 Dec 26 10:14 certs
-r--------.  1 root root   37 Dec 26 10:16 cluster-id
drwx------.  3 root root   20 Dec 26 10:14 etcd
drwxr-xr-x.  3 root root   20 Dec 26 10:15 kubelet-plugins
drwxr-xr-x. 10 root root 4096 Dec 26 10:14 resources
-rw-------.  1 root root   65 Dec 26 10:14 version

# od -c /var/lib/microshift/cluster-id 
0000000   5   d   0   2   4   a   6   2   -   7   0   e   9   -   4   d
0000020   1   4   -   8   c   9   7   -   2   f   5   e   1   8   3   3
0000040   6   6   d   4
```

**MicroShift microshift-version@kube-public configmap**
```
$ oc get configmap -n kube-public microshift-version -o yaml
apiVersion: v1
data:
  clusterid: 5d024a62-70e9-4d14-8c97-2f5e183366d4
  major: "4"
  minor: "16"
  patch: "0"
  version: 4.16.0_0.nightly_2023_12_15_211129_20231221113415_5f3cc7666_dirty
kind: ConfigMap
metadata:
  creationTimestamp: "2023-12-26T10:15:46Z"
  name: microshift-version
  namespace: kube-public
  resourceVersion: "482"
  uid: 6e1098c4-374a-40e3-9036-800c72f81dad
```