### PR TITLE
[release-4.15] USHIFT-2152: look for dependency in rpm repo before trying to use it

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -97,6 +97,13 @@ if ${RHEL_SUBSCRIPTION}; then
         sudo subscription-manager release --show
         "${DNF_RETRY}" "clean" "all"
     fi
+
+    # Enable RHEL CDN repos to avoid problems with incomplete RHUI mirrors
+    OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
+    sudo subscription-manager config --rhsm.manage_repos=1
+    sudo subscription-manager repos \
+        --enable "rhel-${OSVERSION}-for-$(uname -m)-baseos-rpms" \
+        --enable "rhel-${OSVERSION}-for-$(uname -m)-appstream-rpms"
 fi
 
 if ${INSTALL_BUILD_DEPS} || ${BUILD_AND_RUN}; then


### PR DESCRIPTION
This is a manual backport of #2837 