### PR TITLE
OCPBUGS-21901: increase core dns pod buffersize

### DIFF
--- a/assets/components/openshift-dns/dns/configmap.yaml
+++ b/assets/components/openshift-dns/dns/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   Corefile: |
     .:5353 {
-        bufsize 512
+        bufsize 1232
         errors
         log . {
             class error


### PR DESCRIPTION
increase the buffer-size to be in-sync with the upsteam fixed configuration [value](https://github.com/openshift/cluster-dns-operator/pull/266) .