### PR TITLE
USHIFT-2191: force versions in rpm install test

### DIFF
--- a/test/resources/microshift-rpm.resource
+++ b/test/resources/microshift-rpm.resource
@@ -14,8 +14,8 @@ ${REPO_FILE_NAME}       "/etc/yum.repos.d/microshift-local.repo"
 *** Keywords ***
 Install MicroShift RPM Packages From System Repo
     [Documentation]    Installs MicroShift RPM packages from a system repository
-    [Arguments]    ${check_warnings}=True
-    ${stdout}=    Command Should Work    dnf install -y microshift
+    [Arguments]    ${version}    ${check_warnings}=True
+    ${stdout}=    Command Should Work    dnf install -y 'microshift-${version}'
     IF    ${check_warnings}
         # Look for all warnings and errors before testing so that the log
         # shows the output for both.
@@ -27,9 +27,9 @@ Install MicroShift RPM Packages From System Repo
 
 Install MicroShift RPM Packages From Repo
     [Documentation]    Installs MicroShift RPM packages from the specified URL
-    [Arguments]    ${repo_url}
+    [Arguments]    ${repo_url}    ${version}
     Configure MicroShift Repository    ${repo_url}
-    Install MicroShift RPM Packages From System Repo
+    Install MicroShift RPM Packages From System Repo    ${version}
     Unconfigure MicroShift Repository
 
 Configure MicroShift Repository

--- a/test/suites/rpm/install-and-upgrade-successful.robot
+++ b/test/suites/rpm/install-and-upgrade-successful.robot
@@ -44,8 +44,7 @@ ${PREVIOUS_VERSION_REPO_URL}    ${EMPTY}
 Install Source Version
     [Documentation]    Install the version built from source
     Install NetworkManager-ovs
-    Install MicroShift RPM Packages From Repo    ${SOURCE_REPO_URL}
-    Version Should Match    ${TARGET_VERSION}
+    Install MicroShift RPM Packages From Repo    ${SOURCE_REPO_URL}    ${TARGET_VERSION}
     Start MicroShift
     Wait For MicroShift
     [Teardown]    Clean Up Test
@@ -56,19 +55,22 @@ Upgrade From Previous Version
     # need to install from an unofficial repository if the previous
     # release only has EC and RC builds.
     IF    '${PREVIOUS_VERSION_REPO_URL}' != '${EMPTY}'
-        Install MicroShift RPM Packages From Repo    ${PREVIOUS_VERSION_REPO_URL}
+        Install MicroShift RPM Packages From Repo
+        ...    ${PREVIOUS_VERSION_REPO_URL}
+        ...    4.${PREVIOUS_MINOR_VERSION}.*
     ELSE
         # Ignore warnings when installing the previous version because we
         # know some of our older RPMs generate warnings. We care more
         # about warnings on the new RPM.
-        Install MicroShift RPM Packages From System Repo    check_warnings=False
+        Install MicroShift RPM Packages From System Repo
+        ...    4.${PREVIOUS_MINOR_VERSION}.*
+        ...    check_warnings=False
     END
     ${version}=    MicroShift Version
     Should Be Equal As Integers    ${version.minor}    ${PREVIOUS_MINOR_VERSION}
     Start MicroShift
     Wait For MicroShift
-    Install MicroShift RPM Packages From Repo    ${SOURCE_REPO_URL}
-    Version Should Match    ${TARGET_VERSION}
+    Install MicroShift RPM Packages From Repo    ${SOURCE_REPO_URL}    ${TARGET_VERSION}
     # Restart MicroShift
     Reboot MicroShift Host
     # Health of the system is implicitly checked by greenboot successful exit


### PR DESCRIPTION
Instead of relying on the host to only have repos configured for the
version we want, specify the version to use when installing the
RPM. This ensures that after a GA release the source package, with a
x.y.0 nightly version, can override the version from the standard
repos, with a newer version.