### PR TITLE
USHIFT-2105: cert rotation test wait for greenboot

### DIFF
--- a/test/suites/standard1/validate-certificate-rotation.robot
+++ b/test/suites/standard1/validate-certificate-rotation.robot
@@ -4,6 +4,7 @@ Documentation       Tests related to MicroShift automated certificate rotation.
 Resource            ../../resources/common.resource
 Resource            ../../resources/microshift-process.resource
 Resource            ../../resources/microshift-host.resource
+Resource            ../../resources/ostree-health.resource
 Library             DateTime
 Library             Collections
 
@@ -39,6 +40,7 @@ Setup
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig    # for readiness checks
+    Restart Greenboot And Wait For Success
 
 Teardown
     [Documentation]    Test suite teardown


### PR DESCRIPTION
This test changes the time immediately after starting. If the test is executed when the system is running greenboot (from a reboot, for example), the time warp makes it fail with fake timeouts, as time jumped to the future. Depending on the test execution order this might happen randomly.
Force waiting for greenboot before starting to avoid glitches.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
