### PR TITLE
USHIFT-2204: add script to tag stable releases

### DIFF
--- a/scripts/release-notes/tag_stable_releases.py
+++ b/scripts/release-notes/tag_stable_releases.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import logging
+import os
+import platform
+import subprocess
+import sys
+
+import dnf
+
+logger = logging.getLogger()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--verbose', '-v', action='store_true', dest='verbose')
+    args = parser.parse_args()
+
+    log_level = logging.WARN
+    if args.verbose:
+        log_level = logging.DEBUG
+
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=log_level,
+    )
+
+    machine_arch = platform.machine()
+
+    logger.debug('reading dnf database')
+    base = dnf.Base()
+    base.read_all_repos()
+    base.fill_sack()
+    logger.debug('finding matching repositories')
+    repos = base.repos.get_matching(f'rhocp-4.*-{machine_arch}-rpms')
+
+    for repo in sorted(repos, key=lambda r: r.name):
+        reponame = repo.id
+        logger.debug('starting %s', reponame)
+
+        q = base.sack.query().available().filter(
+            name='microshift',
+            reponame=reponame,
+        )
+
+        for pkg in q:
+            # a release string looks like:
+            #   202305161335.p0.g17cae44.assembly.4.13.0.el9
+            sha = pkg.release.split('.')[2].lstrip('g')
+            buildtime = datetime.datetime.fromtimestamp(pkg.buildtime)
+            tag = f'v{pkg.version}'
+            logger.debug('package %s sha %s tag %s buildtime %s', pkg, sha, tag, buildtime)
+            if tag_exists(tag):
+                logger.debug('found tag %s', tag)
+            else:
+                tag_release(tag, sha, buildtime)
+
+
+def tag_exists(tag):
+    "Checks if a given tag exists in the local repository."
+    try:
+        subprocess.run(["git", "show", tag],
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL,
+                       check=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def tag_release(tag, sha, buildtime):
+    env = {}
+    # Include our existing environment settings to ensure values like
+    # HOME and other git settings are propagated.
+    env.update(os.environ)
+    timestamp = buildtime.strftime('%Y-%m-%d %H:%M')
+    env['GIT_COMMITTER_DATE'] = timestamp
+    print(f'GIT_COMMITTER_DATE={timestamp} git tag -s {tag} {sha}')
+    subprocess.run(
+        ['git', 'tag', '-s', '-m', tag, tag, sha],
+        env=env,
+        check=True,
+    )
+
+
+# git-tag man page shows how to backdate tags using GIT_COMMITTER_DATE variable
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a script to tag stable releases by looking at the dnf database to
find the packages and comparing them to the existing tags.

Running this script on my system today produced

```
GIT_COMMITTER_DATE=2023-05-16 09:44 git tag -s v4.13.0 17cae44
GIT_COMMITTER_DATE=2023-06-15 07:47 git tag -s v4.13.4 9ceaa92
GIT_COMMITTER_DATE=2023-07-14 14:09 git tag -s v4.13.5 59bf35c
GIT_COMMITTER_DATE=2023-07-20 04:31 git tag -s v4.13.6 694973d
GIT_COMMITTER_DATE=2023-08-03 10:56 git tag -s v4.13.8 717bea4
GIT_COMMITTER_DATE=2023-08-10 08:44 git tag -s v4.13.9 7dc6a00
GIT_COMMITTER_DATE=2023-08-24 07:42 git tag -s v4.13.10 2dd1281
GIT_COMMITTER_DATE=2023-08-31 12:52 git tag -s v4.13.11 30d1fee
GIT_COMMITTER_DATE=2023-09-07 09:07 git tag -s v4.13.12 b1c836a
GIT_COMMITTER_DATE=2023-09-14 05:25 git tag -s v4.13.13 75a516d
GIT_COMMITTER_DATE=2023-09-28 12:26 git tag -s v4.13.14 9f0fc3b
GIT_COMMITTER_DATE=2023-10-05 09:47 git tag -s v4.13.15 9f0fc3b
GIT_COMMITTER_DATE=2023-10-16 09:32 git tag -s v4.13.17 9f0fc3b
GIT_COMMITTER_DATE=2023-10-19 10:37 git tag -s v4.13.18 9f0fc3b
GIT_COMMITTER_DATE=2023-10-26 08:07 git tag -s v4.13.19 2966374
GIT_COMMITTER_DATE=2023-11-06 14:06 git tag -s v4.13.21 d134dd0
GIT_COMMITTER_DATE=2023-10-26 10:47 git tag -s v4.14.0 1586504
GIT_COMMITTER_DATE=2023-10-27 09:59 git tag -s v4.14.1 1586504
GIT_COMMITTER_DATE=2023-11-09 11:16 git tag -s v4.14.2 d80d6de
GIT_COMMITTER_DATE=2023-11-16 09:10 git tag -s v4.14.3 4524a36
GIT_COMMITTER_DATE=2023-11-27 09:43 git tag -s v4.14.4 b36526e
GIT_COMMITTER_DATE=2023-11-30 04:19 git tag -s v4.14.5 55ad66f
GIT_COMMITTER_DATE=2023-12-07 05:19 git tag -s v4.14.6 0b9707e
GIT_COMMITTER_DATE=2023-12-21 09:59 git tag -s v4.14.7 e76e116
GIT_COMMITTER_DATE=2024-01-04 04:58 git tag -s v4.14.8 3cfb480
GIT_COMMITTER_DATE=2024-01-12 14:33 git tag -s v4.14.9 95d8dc1
```

And created the tags listed above with the timestamps of the package builds.