### PR TITLE
USHIFT-2247: Remove /usr/libexec/cni from CRI-O conf

### DIFF
--- a/packaging/crio.conf.d/microshift_amd64.conf
+++ b/packaging/crio.conf.d/microshift_amd64.conf
@@ -17,7 +17,6 @@ absent_mount_sources_to_reject = [
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
-        "/usr/libexec/cni",
         "/opt/cni/bin"
 ]
 

--- a/packaging/crio.conf.d/microshift_arm64.conf
+++ b/packaging/crio.conf.d/microshift_arm64.conf
@@ -17,7 +17,6 @@ absent_mount_sources_to_reject = [
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
-        "/usr/libexec/cni",
         "/opt/cni/bin"
 ]
 


### PR DESCRIPTION
containernetworking-plugins RPM which is a dependency of CRI-O installs
CNIs to /usr/libexec/cni but we don't want to use them because as part
of Multus integration we will get CNIs from container image shipped
with OpenShift.