### PR TITLE
USHIFT-2253: Improve microshift start time by reducing readiness checks intervals

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -309,7 +309,7 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 
 	// run readiness check
 	go func() {
-		err := wait.PollUntilContextTimeout(ctx, time.Second, kubeAPIStartupTimeout*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, kubeAPIStartupTimeout*time.Second, true, func(ctx context.Context) (bool, error) {
 			restConfig, err := clientcmd.BuildConfigFromFlags(s.masterURL, "")
 			if err != nil {
 				return false, err

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -75,7 +75,7 @@ found:
 
 func RetryInsecureGet(ctx context.Context, url string) int {
 	status := 0
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 120*time.Second, false, func(ctx context.Context) (bool, error) {
 		c := http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
@@ -101,7 +101,7 @@ func RetryInsecureGet(ctx context.Context, url string) int {
 
 func RetryTCPConnection(ctx context.Context, host string, port string) bool {
 	status := false
-	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 120*time.Second, false, func(ctx context.Context) (bool, error) {
 		timeout := 30 * time.Second
 		_, err := tcpnet.DialTimeout("tcp", tcpnet.JoinHostPort(host, port), timeout)
 


### PR DESCRIPTION
Improves cold and warm boot by making readiness checks more often. With 5s interval and `immediate=false`, some components always take 5s.
Below data between microshift starts in standard-suite-1 for this PR and PR without these optimizations. Sample size = 1 for both tables.

## Cold boot
```
| svc                                | pre-opt         | post-opt       |
|------------------------------------+-----------------+----------------|
| kube-scheduler                     | 5.041438552 s   | 882.369692 ms  |
| kube-controller-manager            | 5.021197046 s   | 900.299865 ms  |
| route-controller-manager           | 11.005827344 s  | 6.182889485 s  |
| kubelet                            | 5.019218917 s   | 124.979189 ms  |
| storage-version-migration-migrator | 5.002376112 s   | 112.298763 ms  |
| MICROSHIFT READY                   | 1m7.613588332 s | 50.823424038 s |
```

## Warm boot
```
| svc                                | pre-opt        | post-opt      |
|------------------------------------+----------------+---------------|
| kube-controller-manager            | 5.00666403 s   | 304.010134 ms |
| kube-scheduler                     | 5.018641145 s  | 839.530615 ms |
| route-controller-manager           | 5.262960054 s  | 290.032943 ms |
| kubelet                            | 5.023991456 s  | 115.393733 ms |
| storage-version-migration-migrator | 5.001826304 s  | 130.896275 ms |
| MICROSHIFT READY                   | 23.068677505 s | 11.37766411 s |
```