### PR TITLE
USHIFT-2257: detect the released RPMs using the current system architecture

### DIFF
--- a/test/bin/get_rel_version_repo.sh
+++ b/test/bin/get_rel_version_repo.sh
@@ -50,7 +50,7 @@ dnf_repo_is_enabled() {
 
 get_current_release_from_sub_repos() {
 	local -r minor="${1}"
-	local -r rhsm_repo="rhocp-4.${minor}-for-rhel-9-x86_64-rpms"
+	local -r rhsm_repo="rhocp-4.${minor}-for-rhel-9-${UNAME_M}-rpms"
 
 	# getting version of RPM within a rhocp repo depends on the repo being enabled,
 	# which is done in configure_vm.sh


### PR DESCRIPTION
Failing to look at the system arch leads to choosing the wrong version
of 4.14 on ARM, which blocks the new Y-2 upgrade job being created in #2952.

/assign @pmtk