### PR TITLE
Revert "USHIFT-2247: Remove /usr/libexec/cni from CRI-O conf"

### DIFF
--- a/packaging/crio.conf.d/10-microshift_amd64.conf
+++ b/packaging/crio.conf.d/10-microshift_amd64.conf
@@ -17,6 +17,7 @@ absent_mount_sources_to_reject = [
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
+        "/usr/libexec/cni",
         "/opt/cni/bin"
 ]
 

--- a/packaging/crio.conf.d/10-microshift_arm64.conf
+++ b/packaging/crio.conf.d/10-microshift_arm64.conf
@@ -17,6 +17,7 @@ absent_mount_sources_to_reject = [
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
+        "/usr/libexec/cni",
         "/opt/cni/bin"
 ]
 


### PR DESCRIPTION
Reverts openshift/microshift#2955

Reason is CRI-O will constantly log following and impact of this was not fully assessed.
When Multus will be added to MicroShift, it will overwrite the `plugin_dirs` to make sure that CNIs from containernetwork-plugins have priority.
```
Feb 06 13:07:21 i-0bd8f58175b615d74.us-west-2.compute.internal crio[46248]: time="2024-02-06 13:07:21.268158558Z" level=warning msg="Error validating CNI config file /etc/cni/net.d/100-crio-bridge.conflist: [failed to find plugin \"bridge\" in path [/opt/cni/bin]]"
Feb 06 13:07:21 i-0bd8f58175b615d74.us-west-2.compute.internal crio[46248]: time="2024-02-06 13:07:21.268289685Z" level=warning msg="Error validating CNI config file /etc/cni/net.d/200-loopback.conflist: [failed to find plugin \"loopback\" in path [/opt/cni/bin]]"
```