### PR TITLE
Add layer4 blueprints to support building from ART rpms

### DIFF
--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -545,6 +545,10 @@ build_images.sh [-iIsdf] [-l layer-dir | -g group-dir] [-t template]
 
   -d      Dry run by skipping the composer start commands.
 
+  -e      Extract container images.
+
+  -E      Do not extract container images.
+
   -f      Force rebuilding images that already exist.
 
   -g DIR  Build only one group (cannot be used with -l or -t).
@@ -580,12 +584,18 @@ GROUP=""
 TEMPLATE=""
 FORCE_REBUILD=false
 FORCE_SOURCE=false
+EXTRACT_CONTAINER_IMAGES=true
 
 selCount=0
-while getopts "dfg:hiIl:sSt:" opt; do
+while getopts "deEfg:hiIl:sSt:" opt; do
     case "${opt}" in
         d)
             COMPOSER_DRY_RUN=true
+            ;;
+        e)
+            EXTRACT_CONTAINER_IMAGES=true
+            ;;
+        E)  EXTRACT_CONTAINER_IMAGES=false
             ;;
         f)
             FORCE_REBUILD=true
@@ -682,10 +692,13 @@ configure_package_sources
 
 # Prepare container lists for mirroring registries.
 rm -f "${CONTAINER_LIST}"
-extract_container_images "${SOURCE_VERSION}" "${LOCAL_REPO}" "${CONTAINER_LIST}"
-extract_container_images "4.${FAKE_NEXT_MINOR_VERSION}.*" "${NEXT_REPO}" "${CONTAINER_LIST}"
-extract_container_images "4.${FAKE_YPLUS2_MINOR_VERSION}.*" "${YPLUS2_REPO}" "${CONTAINER_LIST}"
-extract_container_images "${PREVIOUS_RELEASE_VERSION}" "${PREVIOUS_RELEASE_REPO}" "${CONTAINER_LIST}"
+if ${EXTRACT_CONTAINER_IMAGES}; then
+    extract_container_images "${SOURCE_VERSION}" "${LOCAL_REPO}" "${CONTAINER_LIST}"
+    # The following images are specific to layers that use fake rpms built from source.
+    extract_container_images "4.${FAKE_NEXT_MINOR_VERSION}.*" "${NEXT_REPO}" "${CONTAINER_LIST}"
+    extract_container_images "4.${FAKE_YPLUS2_MINOR_VERSION}.*" "${YPLUS2_REPO}" "${CONTAINER_LIST}"
+    extract_container_images "${PREVIOUS_RELEASE_VERSION}" "${PREVIOUS_RELEASE_REPO}" "${CONTAINER_LIST}"
+fi
 
 trap 'osbuild_logs' EXIT
 

--- a/test/image-blueprints/layer4-art/group1/rhel.image-installer
+++ b/test/image-blueprints/layer4-art/group1/rhel.image-installer
@@ -1,0 +1,1 @@
+microshift_release

--- a/test/image-blueprints/layer4-art/group1/rhel.toml
+++ b/test/image-blueprints/layer4-art/group1/rhel.toml
@@ -1,0 +1,16 @@
+name = "microshift_release"
+description = "Basic RHEL 9.2 edge image without MicroShift."
+version = "0.0.1"
+distro = "rhel-92"
+modules = []
+groups = []
+
+[[packages]]
+name = "iproute-tc"
+version = "*"
+
+[customizations.firewall]
+ports = ["22:tcp"]
+
+[customizations.firewall.services]
+enabled = ["ssh"]

--- a/test/image-blueprints/layer4-art/group2/rhel-92_microshift-release.image-installer
+++ b/test/image-blueprints/layer4-art/group2/rhel-92_microshift-release.image-installer
@@ -1,0 +1,1 @@
+microshift_release

--- a/test/image-blueprints/layer4-art/group2/rhel-92_microshift-release.toml
+++ b/test/image-blueprints/layer4-art/group2/rhel-92_microshift-release.toml
@@ -1,0 +1,39 @@
+name = "microshift_release"
+description = "A RHEL 9.2 image with the RPMs built from ART."
+version = "0.0.1"
+modules = []
+groups = []
+distro = "rhel-92"
+
+[[packages]]
+name = "microshift"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "microshift-greenboot"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "microshift-networking"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "microshift-selinux"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "systemd-resolved"
+version = "*"
+
+[customizations.services]
+enabled = ["microshift"]
+
+[customizations.firewall]
+ports = ["22:tcp", "80:tcp", "443:tcp", "5353:udp", "6443:tcp", "30000-32767:tcp", "30000-32767:udp"]
+
+[customizations.firewall.services]
+enabled = ["mdns", "ssh", "http", "https"]
+
+[[customizations.firewall.zones]]
+name = "trusted"
+sources = ["10.42.0.0/16", "169.254.169.1"]

--- a/test/image-blueprints/layer4-art/group3/rhel-93_microshift-release.image-installer
+++ b/test/image-blueprints/layer4-art/group3/rhel-93_microshift-release.image-installer
@@ -1,0 +1,1 @@
+microshift_release

--- a/test/image-blueprints/layer4-art/group3/rhel-93_microshift-release.toml
+++ b/test/image-blueprints/layer4-art/group3/rhel-93_microshift-release.toml
@@ -1,0 +1,39 @@
+name = "microshift_release"
+description = "A RHEL 9.3 image with the RPMs built from ART."
+version = "0.0.1"
+modules = []
+groups = []
+distro = "rhel-93"
+
+[[packages]]
+name = "microshift"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "microshift-greenboot"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "microshift-networking"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "microshift-selinux"
+version = "{{ .Env.SOURCE_VERSION }}"
+
+[[packages]]
+name = "systemd-resolved"
+version = "*"
+
+[customizations.services]
+enabled = ["microshift"]
+
+[customizations.firewall]
+ports = ["22:tcp", "80:tcp", "443:tcp", "5353:udp", "6443:tcp", "30000-32767:tcp", "30000-32767:udp"]
+
+[customizations.firewall.services]
+enabled = ["mdns", "ssh", "http", "https"]
+
+[[customizations.firewall.zones]]
+name = "trusted"
+sources = ["10.42.0.0/16", "169.254.169.1"]


### PR DESCRIPTION
This PR addresses [USHIFT-2344](https://issues.redhat.com//browse/USHIFT-2344) and provides a layer of blueprints intended to be used with RPMs build by ART.
