### PR TITLE
USHIFT-2367: Minor enhancements of docs-preview scripts

### DIFF
--- a/scripts/docs-preview/Containerfile
+++ b/scripts/docs-preview/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM registry.fedoraproject.org/fedora:37
 
 # glibc-all-langpacks is needed to make asciibinder read UTF-8 properly
 RUN dnf -y install ruby-devel gcc-c++ redhat-rpm-config make git glibc-all-langpacks && dnf clean all
@@ -6,12 +6,10 @@ RUN dnf -y install ruby-devel gcc-c++ redhat-rpm-config make git glibc-all-langp
 # install the tools for building documentation
 RUN gem install ascii_binder:1.2 asciidoctor-diagram:2.3.0
 
-COPY build-in-container.sh /
-
 ENV LANG="en_US.UTF-8"
 
 # When run via podman, the openshift-docs source directory should be
 # mounted as /docs
 WORKDIR /docs
 
-ENTRYPOINT ["/bin/bash", "/build-in-container.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "asciibinder build --distro microshift"]

--- a/scripts/docs-preview/README.md
+++ b/scripts/docs-preview/README.md
@@ -3,14 +3,16 @@
 This directory contains the scripts and tools for running the
 documentation preview server.
 
-1. Check out `openshift/microshift` repository.
-2. Set the `BRANCH` variable in
-   `scripts/docs-preview/common.sh`. Typically in `main` this is set
-   to the _previous_ release branch. Note that the branches in the
-   docs repo use `enterprise` as a prefix instead of `release`.
-3. Run `scripts/docs-preview/build.sh` to ensure the build works
-   properly on your host.
-4. Run `scripts/docs-preview/serve.sh` to set up the server. This
-   requires port 8081 be open in the firewall, if you are serving to
-   anyone else.
-5. Set up a cron job to run `build.sh` regularly.
+1. Set the `DOCS_BRANCH` environment variable. Typically in `main` this
+   is set to the _previous_ release branch. Note that the branches in the
+   docs repository use `enterprise` as a prefix instead of `release`.
+1. Run `scripts/docs-preview/build.sh` to build the documentation.
+1. Run `scripts/docs-preview/serve.sh` to set up the server. 
+1. Open the http://0.0.0.0:8081/microshift_welcome/ URL.
+
+> Notes:
+> - To view up-to-date documentation, set up a cron job to run the
+> `scripts/docs-preview/build.sh` script regularly.
+> - Open port 8081 in the firewall if you are serving to anyone else.
+> - Run `scripts/docs-preview/clean.sh` to delete all the documentation
+> podman images, containers and artifacts.

--- a/scripts/docs-preview/build-in-container.sh
+++ b/scripts/docs-preview/build-in-container.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -x
-
-asciibinder build --distro microshift

--- a/scripts/docs-preview/build.sh
+++ b/scripts/docs-preview/build.sh
@@ -7,16 +7,20 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=scripts/docs-preview/common.sh
 source "${SCRIPTDIR}/common.sh"
 
-podman build -f "${SCRIPTDIR}/Containerfile" --tag asciibinder
+# Build the documentation builder image
+podman build -f "${SCRIPTDIR}/Containerfile" \
+    --tag "${PODMAN_IMAGE_TAG}"
 
 if [ ! -d "${PREVIEWDIR}" ]; then
     cd "${OUTPUTDIR}"
     git clone https://github.com/openshift/openshift-docs.git \
-        --branch "${BRANCH}" \
+        --branch "${DOCS_BRANCH}" \
         openshift-docs-preview
 fi
 cd "${PREVIEWDIR}"
 
+git checkout "${DOCS_BRANCH}"
 git pull
 
-podman run -it --rm -v "$(pwd):/docs:Z" asciibinder
+# Run the documentation build
+podman run -it --rm -v "$(pwd):/docs:Z" "${PODMAN_IMAGE_TAG}"

--- a/scripts/docs-preview/clean.sh
+++ b/scripts/docs-preview/clean.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=scripts/docs-preview/common.sh
+source "${SCRIPTDIR}/common.sh"
+
+# Delete sequence:
+# - Running docs container
+# - Build image
+# - All unused images, i.e. Fedora, httpd, etc.
+# - Documentation sources
+podman rm  -f "${PODMAN_CONTAINER_NAME}"
+podman rmi -f "${PODMAN_IMAGE_TAG}" 
+podman rmi -a || true
+rm -rf "${PREVIEWDIR}"

--- a/scripts/docs-preview/common.sh
+++ b/scripts/docs-preview/common.sh
@@ -10,4 +10,10 @@ OUTPUTDIR="${ROOTDIR}/_output"
 PREVIEWDIR="${OUTPUTDIR}/openshift-docs-preview"
 
 # shellcheck disable=SC2034  # used elsewhere
-BRANCH=enterprise-4.15
+PODMAN_IMAGE_TAG="ushift-docs-asciibinder"
+
+# shellcheck disable=SC2034  # used elsewhere
+PODMAN_CONTAINER_NAME="ushift-docs-httpd"
+
+# shellcheck disable=SC2034  # used elsewhere
+DOCS_BRANCH=${DOCS_BRANCH:-enterprise-4.15}

--- a/scripts/docs-preview/serve.sh
+++ b/scripts/docs-preview/serve.sh
@@ -7,9 +7,12 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=scripts/docs-preview/common.sh
 source "${SCRIPTDIR}/common.sh"
 
+podman rm  -f "${PODMAN_CONTAINER_NAME}"
 podman run --rm \
        --detach \
-       --name openshift-docs-preview-httpd \
+       --name "${PODMAN_CONTAINER_NAME}" \
        -p 8081:80 \
-       -v "${PREVIEWDIR}/_preview/microshift/${BRANCH}:/usr/local/apache2/htdocs:Z" \
+       -v "${PREVIEWDIR}/_preview/microshift/${DOCS_BRANCH}:/usr/local/apache2/htdocs:Z" \
        docker.io/library/httpd
+
+echo "Open the http://0.0.0.0:8081/microshift_welcome/ URL"


### PR DESCRIPTION
- Rename `BRANCH` to `DOCS_BRANCH` and allow environment override
- Remove `build-in-container.sh` script and embed the command in `Containerfile`
- Use named images and containers when building docs and running server
- Add a message with the URL of the docs when running `serve.sh`
- Add `clean.sh` script to clean-up images, containers, docs (e.g. to allow other doc branch builds)
- Updated `README.md` with all the changes
