### PR TITLE
USHIFT-2382: Increase timeout for osconfig periodic scenario

### DIFF
--- a/test/scenarios-periodics/el92-src@osconfig.sh
+++ b/test/scenarios-periodics/el92-src@osconfig.sh
@@ -4,7 +4,7 @@
 
 # Override the default test timeout of 30m
 # shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT="1h"
+TEST_EXECUTION_TIMEOUT="1.5h"
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart.ks.template rhel-9.2-microshift-source


### PR DESCRIPTION
The osconfig suite takes a long time because of the restarts tests. Reducing the amount of restarts has been discouraged, so instead we increase the timeout for the whole test, as it was too close to 1h and it flaked sometimes.
A different suite partition for execution should be studied as a long term alternative.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
