### PR TITLE
USHIFT-2430: when closing check story points before dry-run flag

### DIFF
--- a/scripts/jira/manage_ticket.py
+++ b/scripts/jira/manage_ticket.py
@@ -291,12 +291,12 @@ def command_close(args):
         else:
             next_state = 'Review'
         print(f'  Transition: {next_state}')
+        if not points:
+            print('  SKIPPING: story points are not set')
+            continue
         if args.dry_run:
             print('  DRY RUN')
         else:
-            if not points:
-                print('  SKIPPING: story points are not set')
-                continue
             server.transition_issue(
                 issue=ticket,
                 transition=next_state,


### PR DESCRIPTION
Swapping the order of the 2 checks means that someone using --dry-run
still sees that the reason a ticket is not being closed is that it has
no story points.

/assign @ggiguash