### PR TITLE
USHIFT-2468: update default version for docs preview builds

### DIFF
--- a/scripts/docs-preview/common.sh
+++ b/scripts/docs-preview/common.sh
@@ -16,4 +16,4 @@ PODMAN_IMAGE_TAG="ushift-docs-asciibinder"
 PODMAN_CONTAINER_NAME="ushift-docs-httpd"
 
 # shellcheck disable=SC2034  # used elsewhere
-DOCS_BRANCH=${DOCS_BRANCH:-enterprise-4.15}
+DOCS_BRANCH=${DOCS_BRANCH:-enterprise-4.16}


### PR DESCRIPTION
Now that 4.15 is released, we can update the default version for doc builds to 4.16.
