### PR TITLE
[release-4.15] USHIFT-2476: change sonobuoy command to match the CNCF readme

### DIFF
--- a/test/scenarios-periodics/el92-src@cncf-conformance.sh
+++ b/test/scenarios-periodics/el92-src@cncf-conformance.sh
@@ -38,11 +38,11 @@ run_sonobuoy() {
     oc adm policy add-scc-to-group anyuid     system:authenticated system:serviceaccounts
 
     go install github.com/vmware-tanzu/sonobuoy@v0.56.16
-    ~/go/bin/sonobuoy gen \
+    ~/go/bin/sonobuoy run \
         --mode=certified-conformance \
         --dns-namespace=openshift-dns \
         --dns-pod-labels=dns.operator.openshift.io/daemonset-dns=default \
-        --e2e-parallel=y | oc apply -f -
+        --e2e-parallel=y
 
     # Wait for up to 5m until tests start
     WAIT_FAILURE=true


### PR DESCRIPTION
change the  sonobuoy invocation command to match the  [readme](https://github.com/cncf/k8s-conformance/blob/master/v1.27/rh-device-edge/README.md#run-conformance-tests)

manual cherry-pick from https://github.com/openshift/microshift/pull/3026