### PR TITLE
USHIFT-2116: CI implementation - Introduce cluster id

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -75,7 +75,7 @@ cd "${SCRIPTDIR}" || (echo "Did not find ${SCRIPTDIR}" 1>&2; exit 1)
 TESTS="$*"
 # if TESTS is not set - run the standard suite.
 if [ -z "${TESTS}" ]; then
-    TESTS=(./suites/standard1 ./suites/standard2)
+    TESTS=(./suites/standard1 ./suites/standard2 ./suites/osconfig/clusterid.robot)
 fi
 
 # enable stress condition


### PR DESCRIPTION
Add `Cluster ID` tests to default set of tests triggered from `test/run.sh` script. This list of tests is triggered on QE Regression and Upgrade tests.

Closes Jira ticket: [USHIFT-2116](https://issues.redhat.com/browse/USHIFT-2116)
