### PR TITLE
USHIFT-2549: simplify repoquery command used to look up microshift RPM version

### DIFF
--- a/test/bin/get_rel_version_repo.sh
+++ b/test/bin/get_rel_version_repo.sh
@@ -53,7 +53,12 @@ get_current_release_from_sub_repos() {
 	local -r rhsm_repo="$(get_ocp_repo_name_for_version "${minor}")"
 
 	local newest
-	newest=$(sudo dnf repoquery microshift --quiet --queryformat '%{version}-%{release}' --repo "${rhsm_repo}" | sort --version-sort | tail -n1)
+	newest=$(sudo dnf repoquery microshift \
+                  --quiet \
+                  --queryformat '%{version}-%{release}' \
+                  --repo "${rhsm_repo}" \
+                  --latest-limit 1 \
+          )
 	if [ -n "${newest}" ]; then
 		echo "${newest}"
 		return


### PR DESCRIPTION
dnf supports limiting results so we don't have to sort and filter them
ourselves.

/assign @pmtk