### PR TITLE
USHIFT-2555: detect existing VM in scenario.sh create

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -406,6 +406,13 @@ launch_vm() {
     local -r vm_pool_name="${VM_POOL_BASENAME}-${SCENARIO}"
     local -r vm_pool_dir="${VM_DISK_BASEDIR}/${vm_pool_name}"
 
+    # See if the VM already exists
+    if sudo virsh dominfo "${full_vmname}" 2>/dev/null; then
+        echo "${full_vmname} already exists"
+        record_junit "${vmname}" "install_vm" "SKIP"
+        return 0
+    fi
+
     echo "Creating ${full_vmname}"
 
     # Create the pool if it does not exist


### PR DESCRIPTION
virt-install reports errors, but with the retry loop it can take a
while before the script exits when the VM already exists. Add a check
for that case and return early. Treat it as not an error, since the
instruction is to ensure the VM exists and it does.

/assign @ggiguash