### PR TITLE
OCPBUGS-30807: Add --collect to systemd-run microshift-etcd

### DIFF
--- a/pkg/controllers/etcd.go
+++ b/pkg/controllers/etcd.go
@@ -78,6 +78,7 @@ func (s *EtcdService) Run(ctx context.Context, ready chan<- struct{}, stopped ch
 		args = append(args,
 			"--uid=root",
 			"--scope",
+			"--collect",
 			"--unit", "microshift-etcd",
 			"--property", "Before=microshift.service",
 			"--property", "BindsTo=microshift.service",


### PR DESCRIPTION
`--collect` causes transient unit to be unloaded even if it failed. If the microshift-etcd.scope failed, it would leave an existing transient unit that could prevent restart of the microshift-etcd.
