### PR TITLE
OCPBUGS-30833: Added a check for loadBalancerClass for built-in load balancing service.

### DIFF
--- a/pkg/loadbalancerservice/controller.go
+++ b/pkg/loadbalancerservice/controller.go
@@ -154,7 +154,7 @@ func (c *LoadbalancerServiceController) updateServiceStatus(key string) error {
 		klog.Infof("Service %s does not exist anymore", key)
 	} else {
 		svc := obj.(*corev1.Service)
-		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer || (svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != "microshift-internal") {
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer || svc.Spec.LoadBalancerClass != nil {
 			return nil
 		}
 		klog.Infof("Process service %s/%s", svc.Namespace, svc.Name)

--- a/pkg/loadbalancerservice/controller.go
+++ b/pkg/loadbalancerservice/controller.go
@@ -154,7 +154,7 @@ func (c *LoadbalancerServiceController) updateServiceStatus(key string) error {
 		klog.Infof("Service %s does not exist anymore", key)
 	} else {
 		svc := obj.(*corev1.Service)
-		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer || (svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != "microshift-internal") {
 			return nil
 		}
 		klog.Infof("Process service %s/%s", svc.Namespace, svc.Name)


### PR DESCRIPTION
Fixes #3136

**Which issue(s) this PR addresses**: #3136 

Closes #3136

This is my idea for an option to implement the checking of loadBalancerClass in the internal load balancing service. It would avoid conflicts with metallb or other load balancers being used. 

I specified "microshift-internal" as the name of the internal balancer service, but that could be anything really, was just the first thing that I thought of. 

Let me know what you think 😄 