### PR TITLE
OCPBUGS-31739: Use host directory /run/cni/bin for CNI binaries

### DIFF
--- a/assets/components/ovn/multi-node/node/daemonset.yaml
+++ b/assets/components/ovn/multi-node/node/daemonset.yaml
@@ -259,7 +259,7 @@ spec:
           path: "/etc/cni/net.d"
       - name: host-cni-bin
         hostPath:
-          path: "/opt/cni/bin"
+          path: "/run/cni/bin"
       - name: host-var-lib-cni-networks-ovn-kubernetes
         hostPath:
           path: /var/lib/cni/networks/ovn-k8s-cni-overlay

--- a/assets/components/ovn/single-node/master/daemonset.yaml
+++ b/assets/components/ovn/single-node/master/daemonset.yaml
@@ -470,7 +470,7 @@ spec:
           path: "/etc/cni/net.d"
       - name: host-cni-bin
         hostPath:
-          path: "/opt/cni/bin"
+          path: "/run/cni/bin"
 
       - name: kubeconfig
         hostPath:

--- a/assets/optional/multus/05-configmap.yaml
+++ b/assets/optional/multus/05-configmap.yaml
@@ -14,7 +14,7 @@ data:
     {
         echo "$(date --iso-8601=seconds) [cnibincopy] ${1}"
     }
-    DESTINATION_DIRECTORY=/host/opt/cni/bin/
+    DESTINATION_DIRECTORY=/host/run/cni/bin/
     # Perform validation of usage
     if [ -z "$DEFAULT_SOURCE_DIRECTORY" ]; then
       log "FATAL ERROR: You must set env variables: DEFAULT_SOURCE_DIRECTORY"

--- a/assets/optional/multus/06-daemonset.yaml
+++ b/assets/optional/multus/06-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             /entrypoint/cnibincopy.sh;
         volumeMounts:
         - name: cnibin
-          mountPath: /host/opt/cni/bin
+          mountPath: /host/run/cni/bin
         - mountPath: /entrypoint
           name: cni-binary-copy
         env:
@@ -70,6 +70,7 @@ spec:
             echo "$(date --iso-8601=seconds) /etc/cni/net.d/10-ovn-kubernetes.conf exists - proceeding";
             exec /usr/src/multus-cni/bin/thin_entrypoint
             --multus-conf-file=auto
+            --cni-bin-dir=/host/run/cni/bin
             --multus-autoconfig-dir=/host/etc/cni/net.d
             --readiness-indicator-file=/etc/cni/net.d/10-ovn-kubernetes.conf
             --cleanup-config-on-exit=true
@@ -93,16 +94,14 @@ spec:
               - "-c"
               - >
                 rm -vf /host/etc/cni/net.d/00-multus.conf* > /proc/1/fd/1 2>&1;
-                rm -vf /host/opt/cni/bin/multus > /proc/1/fd/1 2>&1;
                 rm -vfr /host/etc/cni/net.d/multus.d > /proc/1/fd/1 2>&1;
-                rm -vf /host/opt/cni/bin/{bridge,ipvlan,macvlan,static,dhcp,host-local} > /proc/1/fd/1 2>&1;
         volumeMounts:
         - mountPath: /entrypoint
           name: cni-binary-copy
         - name: system-cni-dir
           mountPath: /host/etc/cni/net.d
         - name: cnibin
-          mountPath: /host/opt/cni/bin
+          mountPath: /host/run/cni/bin
         env:
         - name: DEFAULT_SOURCE_DIRECTORY
           # TODO: Change when microshift-specific multus image is ready
@@ -117,7 +116,12 @@ spec:
             type: Directory
         - name: cnibin
           hostPath:
-            path: "/opt/cni/bin"
+            path: "/run/cni/bin"
+            type: DirectoryOrCreate
+            defaultMode: 0766
+        - name: run
+          hostPath:
+            path: "/run"
             type: Directory
         - name: cni-binary-copy
           configMap:

--- a/packaging/crio.conf.d/10-microshift_amd64.conf
+++ b/packaging/crio.conf.d/10-microshift_amd64.conf
@@ -18,7 +18,7 @@ absent_mount_sources_to_reject = [
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
         "/usr/libexec/cni",
-        "/opt/cni/bin"
+        "/run/cni/bin"
 ]
 
 # the pull secret is mandatory for MicroShift builds on top of OpenShift

--- a/packaging/crio.conf.d/10-microshift_arm64.conf
+++ b/packaging/crio.conf.d/10-microshift_arm64.conf
@@ -18,7 +18,7 @@ absent_mount_sources_to_reject = [
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
         "/usr/libexec/cni",
-        "/opt/cni/bin"
+        "/run/cni/bin"
 ]
 
 # the pull secret is mandatory for MicroShift builds on top of OpenShift

--- a/packaging/crio.conf.d/12-microshift-multus.conf
+++ b/packaging/crio.conf.d/12-microshift-multus.conf
@@ -2,9 +2,9 @@
 # Override default network so CRI-O waits for and calls Multus CNI instead of ovn-kubernetes.
 cni_default_network = "multus-cni-network"
 
-# Change the order, so the CNIs from the container-networking-plugins (copied to host's /opt/cni/bin)
+# Change the order, so the CNIs from the container-networking-plugins (copied to host's /run/cni/bin)
 # are picked over CNIs from containernetworking-plugins RPM (which a dependency of CRI-O).
 plugin_dirs = [
-        "/opt/cni/bin",
+        "/run/cni/bin",
         "/usr/libexec/cni"
 ]

--- a/scripts/microshift-cleanup-data.sh
+++ b/scripts/microshift-cleanup-data.sh
@@ -124,7 +124,7 @@ function clean_data() {
         rm -rf /var/run/ovn
         rm -rf /var/run/ovn-kubernetes
         rm -f /etc/cni/net.d/10-ovn-kubernetes.conf
-        rm -f /opt/cni/bin/ovn-k8s-cni-overlay
+        rm -f /run/cni/bin/ovn-k8s-cni-overlay
     fi
 }
 

--- a/test/image-blueprints/layer5-bootc/group1/cos9-bootc-source.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/cos9-bootc-source.containerfile
@@ -28,15 +28,11 @@ gpgcheck=0\n\
 skip_if_unavailable=0\n" > "/etc/yum.repos.d/openshift-mirror-beta.repo"
 
 # Implement workarounds necessary for the successful MicroShift operation
-# - OVN-k copies an executable to /opt/cni/bin directory on the host, which is
-#   read-only on bootc images. Create the /opt/cni/bin -> /var/opt/cni/bin
-#   symbolic link as a workaround.
 # - The /var/run directory must be a symbolic link to /run, which is not
 #   the case in bootc images. This cases problems with services like DBus
 #   and NetworkManager. DBus creates its socket in /run/dbus directory, which
 #   is accessed by NetworkManager at /var/run/dbus.
-RUN mkdir -p /opt/cni && mkdir -p /var/opt/cni/bin && ln -s /var/opt/cni/bin /opt/cni/ ; \
-    [ ! -L /var/run ] && rm -rf /var/run && ln -s /run /var/
+RUN [ ! -L /var/run ] && rm -rf /var/run && ln -s /run /var/
 
 # Install MicroShift, few helper utilities and cleanup
 RUN dnf install -y vi firewalld microshift && \

--- a/test/suites/osconfig/cleanup-data.robot
+++ b/test/suites/osconfig/cleanup-data.robot
@@ -235,7 +235,7 @@ OVN Data Should Not Exist
     Verify Remote Directory Does Not Exist With Sudo    /var/run/ovn
     Verify Remote Directory Does Not Exist With Sudo    /var/run/ovn-kubernetes
     Verify Remote File Does Not Exist With Sudo    /etc/cni/net.d/10-ovn-kubernetes.conf
-    Verify Remote File Does Not Exist With Sudo    /opt/cni/bin/ovn-k8s-cni-overlay
+    Verify Remote File Does Not Exist With Sudo    /run/cni/bin/ovn-k8s-cni-overlay
 
 OVN Data Should Exist
     [Documentation]    Make sure that OVN data files and directories exist
@@ -244,7 +244,7 @@ OVN Data Should Exist
     Verify Remote Directory Exists With Sudo    /var/run/ovn
     Verify Remote Directory Exists With Sudo    /var/run/ovn-kubernetes
     Verify Remote File Exists With Sudo    /etc/cni/net.d/10-ovn-kubernetes.conf
-    Verify Remote File Exists With Sudo    /opt/cni/bin/ovn-k8s-cni-overlay
+    Verify Remote File Exists With Sudo    /run/cni/bin/ovn-k8s-cni-overlay
 
 OVN Internal Bridge Should Not Exist
     [Documentation]    Make sure that OVN internal bridge devices do not exist


### PR DESCRIPTION
The /opt/cni/bin host directory will become immutable in some configurations. We need a writable directory for CNI binaries.
