### PR TITLE
USHFT-2969: Release notes job: use token for `git` commands

### DIFF
--- a/scripts/release-notes/gen_ec_release_notes.py
+++ b/scripts/release-notes/gen_ec_release_notes.py
@@ -58,6 +58,7 @@ import pathlib
 import re
 import subprocess
 import textwrap
+import urllib
 from urllib import request
 
 import github
@@ -514,6 +515,10 @@ def publish_release(new_release, take_action):
     # Create draft release with message that includes download URLs and history
     try:
         github_release_create(release_name, notes)
+    except urllib.error.URLError as e:
+        print(f"Failed to create the release {release_name}: {e}")
+        print(f"Response: {str(e.fp.readlines())}")
+        raise
     except Exception as err:
         print(f"Failed to create the release {release_name}: {err}")
         raise

--- a/scripts/release-notes/gen_ec_release_notes.py
+++ b/scripts/release-notes/gen_ec_release_notes.py
@@ -521,7 +521,7 @@ def publish_release(new_release, take_action):
 
 def github_release_create(tag, notes_header):
     results = github_api(
-        '/repos/openshift/microshift/releases',
+        f'/repos/{GITHUB_ORG}/{GITHUB_REPO}/releases',
         tag_name=tag,
         name=tag,
         body=notes_header,
@@ -538,7 +538,7 @@ def github_release_create(tag, notes_header):
 
 def github_release_exists(tag):
     try:
-        github_api(f'/repos/openshift/microshift/releases/tags/{tag}')
+        github_api(f'/repos/{GITHUB_ORG}/{GITHUB_REPO}releases/tags/{tag}')
         return True
     except Exception:
         return False


### PR DESCRIPTION
When ci-operator clones the repository it does not include any credentials to talk back to the repository.
To be able to execute `git push` we need to add a special remote that will use token that is either supplied (personal) or generated (Installation Access Token, IAT).
