### PR TITLE
USHIFT-2968: Simplify router tests

### DIFF
--- a/test/suites/standard1/router.robot
+++ b/test/suites/standard1/router.robot
@@ -92,15 +92,10 @@ Router Exposure Configuration
     ...    Configure Router Exposure
     ...    Add Fake IP To NIC
 
-    Wait Until Keyword Succeeds    60x    1s
-    ...    Port Should Be Closed    ${HTTP_PORT}
-    Wait Until Keyword Succeeds    60x    1s
-    ...    Port Should Be Closed    ${HTTPS_PORT}
     Wait Until Keyword Succeeds    60x    2s
     ...    Internal Router Port Should Be Open    10.44.0.0    ${ALTERNATIVE_HTTP_PORT}    http
     Wait Until Keyword Succeeds    60x    2s
     ...    Internal Router Port Should Be Open    10.44.0.0    ${ALTERNATIVE_HTTPS_PORT}    https
-
     # The link in which this IP was added was configured in MicroShift. Note the IP was
     # added after MicroShift started, therefore it must pick it up dynamically.
     Wait Until Keyword Succeeds    60x    2s


### PR DESCRIPTION
Sometimes the operations are not deterministic or take too long. Remove whatever is not mandatory for the test, as listening in the new ports also means not listening in the old ones, so the test may be simplified and the flakes should disappear.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
