### PR TITLE
USHIFT-2992: Always allow RHSM to manage repos

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -112,6 +112,7 @@ if ${RHEL_SUBSCRIPTION}; then
     if ! sudo subscription-manager status >&/dev/null; then
         sudo subscription-manager register --auto-attach
     fi
+    sudo subscription-manager config --rhsm.manage_repos=1
 
     if ${SET_RHEL_RELEASE} && ! ${RHEL_BETA_VERSION} ; then
         # https://access.redhat.com/solutions/238533
@@ -124,7 +125,6 @@ if ${RHEL_SUBSCRIPTION}; then
     # Enable RHEL CDN repos to avoid problems with incomplete RHUI mirrors
     if ! ${RHEL_BETA_VERSION} ; then
         OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
-        sudo subscription-manager config --rhsm.manage_repos=1
         sudo subscription-manager repos \
             --enable "rhel-${OSVERSION}-for-$(uname -m)-baseos-rpms" \
             --enable "rhel-${OSVERSION}-for-$(uname -m)-appstream-rpms"


### PR DESCRIPTION
If RHSM cannot manage repositories, then `dnf` is not aware of `rhocp` repositories and `scripts/get-latest-rhocp-repo.sh` fails.
