### PR TITLE
USHIFT-3018: Increase CI resource wait default timeout to 60s

### DIFF
--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -8,6 +8,10 @@ Resource            common.resource
 Library             DataFormats.py
 
 
+*** Variables ***
+${DEFAULT_WAIT_TIMEOUT}     60s
+
+
 *** Keywords ***
 Oc Get
     [Documentation]    Run 'oc get' for a specific instance of a type in a namespace.
@@ -54,8 +58,8 @@ Named Pod Should Be Ready
     [Documentation]    Wait for pod with name \${name} to become "Ready"
     ...    ${name}    Name of pod to wait for
     ...    ${ns}    Namespace of named pod. Defaults to NAMESPACE suite variable
-    ...    ${timeout}    Period of time to wait for pod to reach ready status.    Default 30s.
-    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for pod to reach ready status. Default 60s.
+    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
 
     Run With Kubeconfig    oc wait -n ${ns} pod/${name} --for="condition=Ready" --timeout=${timeout}
 
@@ -63,24 +67,24 @@ Named Pod Should Be Deleted
     [Documentation]    Wait for pod with ${name} to be deleted
     ...    ${name}    Name of pod to wait for
     ...    ${ns}    Namespace of named pod. Defaults to NAMESPACE suite variable
-    ...    ${timeout}    Period of time to wait for pod to reach ready status.    Default 30s.
-    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for pod to reach ready status. Default 60s.
+    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     Run With Kubeconfig    oc wait -n ${ns} pod/${name} --for=delete --timeout=${timeout}
 
 Labeled Pod Should Be Ready
     [Documentation]    Wait for pod(s) ready by ${label} to become "Ready"
     ...    ${label}    A label selector value to match by (e.g. "app\=my_app"). Note that '=' must be escaped with '\'.
     ...    ${ns}    Namespace of named pod. Defaults to NAMESPACE suite variable
-    ...    ${timeout}    Period of time to wait for pod to reach ready status.    Default 30s.
-    [Arguments]    ${label}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for pod to reach ready status. Default 60s.
+    [Arguments]    ${label}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     Run With Kubeconfig    oc wait -n ${ns} pod --selector="${label}" --for=condition=Ready --timeout=${timeout}
 
 Named Deployment Should Be Available
     [Documentation]    Wait for a given deployment's Available condition to be true
     ...    ${name}    Name of deployment to wait for
     ...    ${ns}    Namespace of named deployment. Defaults to NAMESPACE suite variable
-    ...    ${timeout}    Period of time to wait for deployment to reach ready status.    Default 30s.
-    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for deployment to reach ready status. Default 60s.
+    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     Run With Kubeconfig    oc wait -n ${ns} deploy ${name} --for=condition=Available --timeout=${timeout}
 
 Named PVC Should Be Resized
@@ -88,8 +92,8 @@ Named PVC Should Be Resized
     ...    ${name}    Name of pvc to wait for
     ...    ${ns}    Namespace of named pvc. Defaults to NAMESPACE suite variable
     ...    ${to_size}    Size pvc is expected to be updated to
-    ...    ${timeout}    Period of time to wait for pvc to resize to new size.    Default 30s.
-    [Arguments]    ${name}    ${to_size}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for pvc to resize to new size. Default 60s.
+    [Arguments]    ${name}    ${to_size}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     ${cmd}=    Catenate
     ...    oc wait -n ${ns} pvc/${name} --for=jsonpath="{.spec.resources.requests.storage}"=${to_size}
     ...    --timeout=${timeout}
@@ -99,8 +103,8 @@ Named PVC Should Be Deleted
     [Documentation]    Wait for pvc with ${name} to be deleted
     ...    ${name}    Name of pvc to wait for
     ...    ${ns}    Namespace of named pvc. Defaults to NAMESPACE suite variable
-    ...    ${timeout}    Period of time to wait for pvc to be deleted. Default 30s.
-    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for pvc to be deleted. Default 60s.
+    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     ${timeout_opt}=    Set Variable    --timeout\=${timeout}
     ${output}=    Run With Kubeconfig    oc wait -n ${ns} pvc/${name} --for=Delete ${timeout_opt}
     RETURN    ${output}
@@ -108,16 +112,16 @@ Named PVC Should Be Deleted
 Named VolumeSnapshot Should Be Ready
     [Documentation]    Wait for a volumesnap ${name} to become "readyToUse"
     ...    ${name}    Name of volumesnapshot to wait for
-    ...    ${timeout}    Period of time to wait for volumeSnapshot ready "readyToUse" state.    Default 30s.
-    [Arguments]    ${name}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for volumeSnapshot ready "readyToUse" state. Default 60s.
+    [Arguments]    ${name}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     Run With Kubeconfig    oc wait volumesnapshot/${name} -n ${NAMESPACE} --for=jsonpath='{.status.readyToUse}=true'
 
 Named VolumeSnapshot Should Be Deleted
     [Documentation]    Wait for volumesnapshot with ${name} to be deleted
     ...    ${name}    Name of volumesnapshot to wait for
     ...    ${ns}    Namespace of named pod. Defaults to NAMESPACE suite variable, specified by
-    ...    ${timeout}    Period of time to wait for volumesnapshot to reach ready status.    Default 30s.
-    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=30s
+    ...    ${timeout}    Period of time to wait for volumesnapshot to reach ready status. Default 60s.
+    [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     Run With Kubeconfig    oc wait -n ${ns} volumesnapshot/${name} --for=Delete --timeout=${timeout}
 
 Oc Create


### PR DESCRIPTION
Tests may fail with timeouts when waiting for resources. See [this example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_microshift/3257/pull-ci-openshift-microshift-main-metal-bootc-test-arm/1781984173133664256/artifacts/metal-bootc-test-arm/openshift-microshift-e2e-metal-tests/artifacts/scenario-info/cos9-src@storage/log.html).

Raising the timeout to 60s should improve test stability in CI running 15-20 VMs at the same time. In addition, it should not hurt the overall functionalily of the tests.