### PR TITLE
OCPBUGS-32946: Default to watch all interfaces and IPs for router lis…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/openshift/microshift/pkg/config/apiserver"
 	"math"
 	"net"
 	"net/url"
@@ -15,6 +14,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/openshift/microshift/pkg/config/apiserver"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -279,21 +280,6 @@ func (c *Config) updateComputedValues() error {
 		// First and last are the same because of the /32 netmask.
 		firstValidIP, _ := cidr.AddressRange(nextSubnet)
 		c.ApiServer.AdvertiseAddress = firstValidIP.String()
-	}
-
-	if len(c.Ingress.ListenAddress) == 0 {
-		// If the listenAddress is not configured we need to include all of the host addresses
-		// to preserve previous behavior. However, if the apiserver advertise address has
-		// not been configured, it will do so in a later stage and we also need to
-		// include it here.
-		addresses, err := AllowedListeningIPAddresses()
-		if err != nil {
-			return fmt.Errorf("unable to compute default listening addresses: %v", err)
-		}
-		if !c.ApiServer.SkipInterface {
-			addresses = append(addresses, c.ApiServer.AdvertiseAddress)
-		}
-		c.Ingress.ListenAddress = addresses
 	}
 
 	c.computeLoggingSetting()

--- a/pkg/loadbalancerservice/router.go
+++ b/pkg/loadbalancerservice/router.go
@@ -78,6 +78,11 @@ func defaultRouterListenAddresses(ipAddresses, nicNames []string) ([]string, err
 		return nil, err
 	}
 
+	if len(ipAddresses) == 0 && len(nicNames) == 0 {
+		ipAddresses = allowedAddresses
+		nicNames = allowedNicNames
+	}
+
 	ipList := make([]string, 0, len(ipAddresses)+len(nicNames)*2)
 
 	for _, ip := range ipAddresses {


### PR DESCRIPTION
…tenAddress

During first boot MicroShift will start scanning all IP addresses in the host to setup the router load balancer service. When this happens, not all interfaces may have an IP yet, leaving them out until the next microshift restart.

By leaving the defaults empty we allow the IP address subscription handler to add anything that is not forbidden automatically. If this list is fixed with the IPs and interfaces that were present only when MicroShift started, we might miss out on some of hte listening IPs unless the user restarts.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
