### PR TITLE
USHIFT-2463: Add keyword to skip RF test if bug is open

### DIFF
--- a/scripts/jira/manage_ticket.py
+++ b/scripts/jira/manage_ticket.py
@@ -309,6 +309,16 @@ def command_close(args):
             )
 
 
+def command_get_status(args):
+    """Implement 'get_status' command."""
+    server = jira.JIRA(
+        server=SERVER_URL,
+        token_auth=os.environ.get("JIRA_API_TOKEN"),
+    )
+    ticket = server.issue(args.ticket_id)
+    print(f"{ticket.fields.status}")
+
+
 def main():
     """The main program."""
     parser = argparse.ArgumentParser(
@@ -378,12 +388,22 @@ def main():
         help='report but make no changes',
     )
 
+    get_status_parser = subparsers.add_parser(
+        "get_status",
+        help="Find tickets status from ticket id",
+    )
+    get_status_parser.add_argument(
+        "--ticket-id", dest="ticket_id", default=None, help="the ticket id", type=str
+    )
+
     args = parser.parse_args()
 
     if args.command == 'start':
         command_start(args)
     elif args.command == 'close':
         command_close(args)
+    elif args.command == "get_status":
+        command_get_status(args)
     else:
         parser.print_help()
 

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -119,7 +119,7 @@ Create Random Temp Directory
     Create Directory    ${path}
     RETURN    ${path}
 
-QE Team Skip Test If Bug Is Open
+Skip Test If Bug Is Open
     [Documentation]    Skip jira bug is not in Closed or Done state
     [Arguments]    ${ticket_id}
 

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -128,6 +128,5 @@ Skip Test If Bug Is Open
     ELSE
         ${result}=    Run Process    ../scripts/jira/manage_ticket.sh get_status --ticket-id ${ticket_id} | tail -n1
         ...    shell=True    env:JIRA_API_TOKEN=${JIRA_API_TOKEN}
-        Should Be Equal As Integers    0    ${result.rc}
-        Skip If    '${result.stdout}' != 'Closed'
+        Skip If    '${result.stdout}' == 'To Do' or '${result.stdout}' == 'In Progress' or '${result.stdout}' == 'Code Review' or '${result.stdout}' == 'Review'
     END

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -129,5 +129,5 @@ Skip Test If Bug Is Open
         ${result}=    Run Process    ../scripts/jira/manage_ticket.sh get_status --ticket-id ${ticket_id} | tail -n1
         ...    shell=True    env:JIRA_API_TOKEN=${JIRA_API_TOKEN}
         Should Be Equal As Integers    0    ${result.rc}
-        Skip If    "${result.stdout} != Closed and ${result.stdout} != Done"
+        Skip If    '${result.stdout}' != 'Closed'
     END

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -3,8 +3,13 @@ Documentation       Keywords common to many test suites
 
 Library             OperatingSystem
 Library             String
+Library             Process
 Library             SSHLibrary
 Resource            ../resources/kubeconfig.resource
+
+
+*** Variables ***
+${JIRA_API_TOKEN}       ${EMPTY}
 
 
 *** Keywords ***
@@ -113,3 +118,16 @@ Create Random Temp Directory
     ${path}=    Join Path    ${root_path}    ${rand}
     Create Directory    ${path}
     RETURN    ${path}
+
+QE Team Skip Test If Bug Is Open
+    [Documentation]    Skip jira bug is not in Closed or Done state
+    [Arguments]    ${ticket_id}
+
+    IF    '${JIRA_API_TOKEN}' == '${EMPTY}'
+        Log    Variable 'JIRA_API_TOKEN' does not exist. Test is NOT skipped
+    ELSE
+        ${result}=    Run Process    ./scripts/jira/manage_ticket.sh get_status --ticket-id ${ticket_id} | tail -n1
+        ...    shell=True    env:JIRA_API_TOKEN=${JIRA_API_TOKEN}    cwd=/Users/agullon/workspace/microshift/
+        Should Be Equal As Integers    0    ${result.rc}
+        Skip If    "${result.stdout} != Closed and ${result.stdout} != Done"
+    END

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -126,8 +126,8 @@ QE Team Skip Test If Bug Is Open
     IF    '${JIRA_API_TOKEN}' == '${EMPTY}'
         Log    Variable 'JIRA_API_TOKEN' does not exist. Test is NOT skipped
     ELSE
-        ${result}=    Run Process    ./scripts/jira/manage_ticket.sh get_status --ticket-id ${ticket_id} | tail -n1
-        ...    shell=True    env:JIRA_API_TOKEN=${JIRA_API_TOKEN}    cwd=/Users/agullon/workspace/microshift/
+        ${result}=    Run Process    ../scripts/jira/manage_ticket.sh get_status --ticket-id ${ticket_id} | tail -n1
+        ...    shell=True    env:JIRA_API_TOKEN=${JIRA_API_TOKEN}
         Should Be Equal As Integers    0    ${result.rc}
         Skip If    "${result.stdout} != Closed and ${result.stdout} != Done"
     END

--- a/test/suites/standard1/networking-smoke.robot
+++ b/test/suites/standard1/networking-smoke.robot
@@ -25,7 +25,7 @@ Router Smoke Test
     ...    Expose Hello MicroShift Service Via Route
     ...    Restart Router
 
-    QE Team Skip Test If Bug Is Open    USHIFT-2349
+    Skip Test If Bug Is Open    USHIFT-2349
 
     Wait Until Keyword Succeeds    10x    6s
     ...    Access Hello Microshift Success    ${HTTP_PORT}

--- a/test/suites/standard1/networking-smoke.robot
+++ b/test/suites/standard1/networking-smoke.robot
@@ -25,6 +25,8 @@ Router Smoke Test
     ...    Expose Hello MicroShift Service Via Route
     ...    Restart Router
 
+    QE Team Skip Test If Bug Is Open    USHIFT-2349
+
     Wait Until Keyword Succeeds    10x    6s
     ...    Access Hello Microshift Success    ${HTTP_PORT}
 


### PR DESCRIPTION
Closes Jira [USHIFT-2463](https://issues.redhat.com/browse/USHIFT-2463)

This change leverages the `manage_ticket.py` script to create a Keyword that will skip a RF test if an error encountered while exercising the RF test is not resolved.

How to use this functionality:
 - Set `Team Skip Test If Bug Is Open    ${TICKET_ID}` in a RF test, [example](https://github.com/openshift/microshift/blob/7bf0fadcf35e7e0276b446bf98ffeb3b82b3173d/test/suites/standard1/networking-smoke.robot#L28)
 - Export `JIRA_API_TOKEN` as env variable with the Jira token. You can generate a new one from [here](https://issues.redhat.com/secure/ViewProfile.jspa).
 
 If `JIRA_API_TOKEN` env variable does not exist, RF test won't be skipped.