### PR TITLE
NO-ISSUE: Upstream router crd path changed, breaking 4.16 rebase pipeline

### DIFF
--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -196,7 +196,7 @@ assets:
       - file: storage_version_migration.crd.yaml
         src:  0000_50_cluster-kube-storage-version-migrator-operator_01_storage_migration_crd.yaml
       - file: route.crd.yaml
-        src:  /kubernetes/vendor/github.com/openshift/api/route/v1/
+        src:  /kubernetes/vendor/github.com/openshift/api/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml
 
   - dir: release/
     ignore: "it contains files generated during rebase procedure"


### PR DESCRIPTION
The upstream version of the file is now stored at https://github.com/openshift/api/blob/master/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml
