### PR TITLE
USHIFT-3113: Enhancements for build_bootc_image.py script

### DIFF
--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -56,7 +56,7 @@ def should_skip(file):
     if not os.path.exists(file):
         return False
     # Forcing the rebuild if needed
-    if FORCE_REBUILD is True:
+    if FORCE_REBUILD:
         common.print_msg(f"Forcing rebuild of '{file}'")
         return False
 
@@ -348,7 +348,7 @@ def main():
             raise Exception("Run create_local_repo.sh before building images")
         # Initialize force rebuild option
         global FORCE_REBUILD
-        if args.force_rebuild and args.force_rebuild is True:
+        if args.force_rebuild:
             FORCE_REBUILD = True
 
         # Determine versions of RPM packages

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -324,6 +324,7 @@ def main():
     parser = argparse.ArgumentParser(description="Build image layers using Bootc Image Builder and Podman.")
     parser.add_argument("-d", "--dry-run", action="store_true", help="Dry run: skip executing build commands.")
     parser.add_argument("-f", "--force-rebuild", action="store_true", help="Force rebuilding images that already exist.")
+    parser.add_argument("-E", "--no-extract-images", action="store_true", help="Skip container image extraction.")
     parser.add_argument("-b", "--build-type", choices=["image-bootc", "containerfile"], help="Only build images of the specified type.")
     dirgroup = parser.add_mutually_exclusive_group(required=True)
     dirgroup.add_argument("-l", "--layer-dir", type=str, help="Path to the layer directory to process.")
@@ -352,13 +353,16 @@ def main():
 
         # Determine versions of RPM packages
         set_rpm_version_info_vars()
-        # Prepare container lists for mirroring registries
-        common.delete_file(CONTAINER_LIST)
-        extract_container_images(SOURCE_VERSION, LOCAL_REPO, CONTAINER_LIST, args.dry_run)
-        # The following images are specific to layers that use fake rpms built from source
-        extract_container_images(f"4.{FAKE_NEXT_MINOR_VERSION}.*", NEXT_REPO, CONTAINER_LIST, args.dry_run)
-        extract_container_images(PREVIOUS_RELEASE_VERSION, PREVIOUS_RELEASE_REPO, CONTAINER_LIST, args.dry_run)
-        extract_container_images(YMINUS2_RELEASE_VERSION, YMINUS2_RELEASE_REPO, CONTAINER_LIST, args.dry_run)
+        # Prepare container image lists for mirroring registries
+        if args.no_extract_images:
+            common.print_msg("Skipping container image extraction")
+        else:
+            common.delete_file(CONTAINER_LIST)
+            extract_container_images(SOURCE_VERSION, LOCAL_REPO, CONTAINER_LIST, args.dry_run)
+            # The following images are specific to layers that use fake rpms built from source
+            extract_container_images(f"4.{FAKE_NEXT_MINOR_VERSION}.*", NEXT_REPO, CONTAINER_LIST, args.dry_run)
+            extract_container_images(PREVIOUS_RELEASE_VERSION, PREVIOUS_RELEASE_REPO, CONTAINER_LIST, args.dry_run)
+            extract_container_images(YMINUS2_RELEASE_VERSION, YMINUS2_RELEASE_REPO, CONTAINER_LIST, args.dry_run)
 
         # Process individual group directory
         if args.group_dir:

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -305,12 +305,12 @@ def process_group(groupdir, build_type, dry_run=False):
                     if build_type and build_type != "containerfile":
                         common.print_msg(f"Skipping '{file}' due to '{build_type}' filter")
                         continue
-                    futures += [executor.submit(process_containerfile, groupdir, file, dry_run)]
+                    futures.append(executor.submit(process_containerfile, groupdir, file, dry_run))
                 elif file.endswith(".image-bootc"):
                     if build_type and build_type != "image-bootc":
                         common.print_msg(f"Skipping '{file}' due to '{build_type}' filter")
                         continue
-                    futures += [executor.submit(process_image_bootc, groupdir, file, dry_run)]
+                    futures.append(executor.submit(process_image_bootc, groupdir, file, dry_run))
                 else:
                     common.print_msg(f"Skipping unknown file {file}")
 

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -330,7 +330,7 @@ def main():
     dirgroup.add_argument("-g", "--group-dir", type=str, help="Path to the group directory to process.")
 
     args = parser.parse_args()
-
+    success_message = False
     try:
         # Convert input directories to absolute paths
         if args.group_dir:
@@ -370,14 +370,16 @@ def main():
                 # Check if this item is a directory
                 if os.path.isdir(item_path):
                     process_group(item_path, args.build_type, args.dry_run)
-        # Success message
-        common.print_msg("Build complete")
+        # Toggle the success flag
+        success_message = True
     except Exception as e:
         common.print_msg(f"An error occurred: {e}")
         traceback.print_exc()
         sys.exit(1)
     finally:
         cleanup_atexit(args.dry_run)
+        # Exit status message
+        common.print_msg("Build " + ("OK" if success_message else "FAILED"))
 
 
 if __name__ == "__main__":

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -278,15 +278,21 @@ def process_image_bootc(groupdir, bootcfile, dry_run):
         os.rename(f"{bf_outdir}/bootiso/install.iso", bf_targetiso)
 
 
-def process_group(groupdir, dry_run=False):
+def process_group(groupdir, build_type, dry_run=False):
     futures = []
     # Parallel processing loop
     with concurrent.futures.ProcessPoolExecutor() as executor:
         # Scan group directory contents sorted by length and then alphabetically
         for file in sorted(os.listdir(groupdir), key=lambda i: (len(i), i)):
             if file.endswith(".containerfile"):
+                if build_type and build_type != "containerfile":
+                    common.print_msg(f"Skipping '{file}' due to '{build_type}' filter")
+                    continue
                 futures += [executor.submit(process_containerfile, groupdir, file, dry_run)]
             elif file.endswith(".image-bootc"):
+                if build_type and build_type != "image-bootc":
+                    common.print_msg(f"Skipping '{file}' due to '{build_type}' filter")
+                    continue
                 futures += [executor.submit(process_image_bootc, groupdir, file, dry_run)]
             else:
                 common.print_msg(f"Skipping unknown file {file}")
@@ -309,8 +315,9 @@ def process_group(groupdir, dry_run=False):
 
 def main():
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description="Process container files with Podman.")
-    parser.add_argument("-d", "--dry-run", action="store_true", help="Dry run: skip executing Podman commands.")
+    parser = argparse.ArgumentParser(description="Build image layers using Bootc Image Builder and Podman.")
+    parser.add_argument("-d", "--dry-run", action="store_true", help="Dry run: skip executing build commands.")
+    parser.add_argument("-b", "--build-type", choices=["image-bootc", "containerfile"], help="Only build images of the specified type.")
     dirgroup = parser.add_mutually_exclusive_group(required=True)
     dirgroup.add_argument("-l", "--layer-dir", type=str, help="Path to the layer directory to process.")
     dirgroup.add_argument("-g", "--group-dir", type=str, help="Path to the group directory to process.")
@@ -344,14 +351,14 @@ def main():
 
         # Process individual group directory
         if args.group_dir:
-            process_group(args.group_dir, args.dry_run)
+            process_group(args.group_dir, args.build_type, args.dry_run)
         else:
             # Process layer directory contents sorted by length and then alphabetically
             for item in sorted(os.listdir(args.layer_dir), key=lambda i: (len(i), i)):
                 item_path = os.path.join(args.layer_dir, item)
                 # Check if this item is a directory
                 if os.path.isdir(item_path):
-                    process_group(item_path, args.dry_run)
+                    process_group(item_path, args.build_type, args.dry_run)
         # Success message
         common.print_msg("Build complete")
     except Exception as e:

--- a/test/bin/pyutils/common.py
+++ b/test/bin/pyutils/common.py
@@ -202,12 +202,17 @@ def terminate_process(pid, wait=True):
             run_command(["sudo", "kill", "-TERM", f"{pid}"], False)
         else:
             proc.terminate()
+        if not wait:
+            return
+
         # Wait for process to terminate
-        if wait:
-            try:
-                proc.wait(timeout=10)
-            except psutil.TimeoutExpired:
-                print_msg(f"The {pid} PID did not exit after 10s")
-    except Exception:
+        try:
+            proc.wait(timeout=10)
+        except psutil.TimeoutExpired:
+            print_msg(f"The {pid} PID did not exit after 10s")
+    except psutil.NoSuchProcess:
         # Ignore non-existent processes
         pass
+    except Exception:
+        # Propagate the exception to the caller
+        raise

--- a/test/bin/pyutils/common.py
+++ b/test/bin/pyutils/common.py
@@ -189,7 +189,7 @@ def find_subprocesses(ppid=None):
     # Collect the child process IDs
     pids = []
     for child in children:
-        pids += [child.pid]
+        pids.append(child.pid)
     return pids
 
 


### PR DESCRIPTION
These changes should attain a usability feature parity with the build_images.sh script:
* Atexit terminates running subprocesses and bib containers
* The `--build-type` argument allows for filtering build by a specified type
* Force rebuild option 
* The `--no-extract-images` skips container image extraction procedure
* Junit handling for better integration in CI
