### PR TITLE
USHIFT-3005: Remove ovsdb-server/memory-trim-on-compaction setting from OVN configuration

### DIFF
--- a/assets/components/ovn/multi-node/master/daemonset.yaml
+++ b/assets/components/ovn/multi-node/master/daemonset.yaml
@@ -218,16 +218,6 @@ spec:
                 /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
                 echo "$(date -Iseconds) - nbdb stopped"
                 rm -f /var/run/ovn/ovnnb_db.pid
-        readinessProbe:
-          timeoutSeconds: 5
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              set -xeo pipefail
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
-
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -339,15 +329,6 @@ spec:
                 /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
                 echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
-        readinessProbe:
-          timeoutSeconds: 5
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              set -xeo pipefail
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
         env:
         - name: OVN_LOG_LEVEL
           value: info

--- a/assets/components/ovn/single-node/master/daemonset.yaml
+++ b/assets/components/ovn/single-node/master/daemonset.yaml
@@ -193,16 +193,6 @@ spec:
                 /usr/share/ovn/scripts/ovn-ctl stop_nb_ovsdb
                 echo "$(date -Iseconds) - nbdb stopped"
                 rm -f /var/run/ovn/ovnnb_db.pid
-        readinessProbe:
-          timeoutSeconds: 5
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              set -xeo pipefail
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
-
         env:
         - name: OVN_LOG_LEVEL
           value: info
@@ -288,15 +278,6 @@ spec:
                 /usr/share/ovn/scripts/ovn-ctl stop_sb_ovsdb
                 echo "$(date -Iseconds) - sbdb stopped"
                 rm -f /var/run/ovn/ovnsb_db.pid
-        readinessProbe:
-          timeoutSeconds: 5
-          exec:
-            command:
-            - /bin/bash
-            - -c
-            - |
-              set -xeo pipefail
-              /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl --timeout=5 ovsdb-server/memory-trim-on-compaction on 2>/dev/null
         env:
         - name: OVN_LOG_LEVEL
           value: info


### PR DESCRIPTION
OVN assets are edited manually due to [this comment](https://github.com/openshift/microshift/blob/main/scripts/auto-rebase/rebase.sh#L747) in the rebase.sh file.
