### PR TITLE
OCPBUGS-31661: Add MicroShift RPM verification tests

### DIFF
--- a/test/resources/microshift-rpm.resource
+++ b/test/resources/microshift-rpm.resource
@@ -84,3 +84,13 @@ Get Version Of MicroShift RPM
     # 4.15.0_0.nightly_2023_11_01_080931_20231103152813_3f5593fca_dirty-1.el9.x86_64
     ${version_string}=    Strip String    ${version_string_raw}
     RETURN    ${version_string}
+
+Verify MicroShift RPM Install
+    [Documentation]    Run 'rpm -V' package verification command
+    ...    on all the installed MicroShift RPM packages.
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    rpm -qa microshift\* | xargs -I {} bash -c 'echo {}; sudo rpm -V {}'
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Log    ${stdout}
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}

--- a/test/resources/microshift-rpm.resource
+++ b/test/resources/microshift-rpm.resource
@@ -88,8 +88,17 @@ Get Version Of MicroShift RPM
 Verify MicroShift RPM Install
     [Documentation]    Run 'rpm -V' package verification command
     ...    on all the installed MicroShift RPM packages.
+    # The ostree-based file system does not preserve modification
+    # times of the installed files
+    ${is_ostree}=    Is System OSTree
+    IF    ${is_ostree}
+        ${nomtime}=    Set Variable    --nomtime
+    ELSE
+        ${nomtime}=    Set Variable    ${EMPTY}
+    END
+
     ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
-    ...    rpm -qa microshift\* | xargs -I {} bash -c 'echo {}; sudo rpm -V {}'
+    ...    rpm -qa microshift\* | xargs -I {} bash -c 'echo {}; sudo rpm -V ${nomtime} {}'
     ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
     Log    ${stdout}
     Log    ${stderr}

--- a/test/suites/optional/multus.robot
+++ b/test/suites/optional/multus.robot
@@ -4,6 +4,7 @@ Documentation       Tests for Multus and Bridge plugin on MicroShift
 Resource            ../../resources/common.resource
 Resource            ../../resources/multus.resource
 Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/microshift-rpm.resource
 
 Suite Setup         Setup
 Suite Teardown      Teardown Suite With Namespace
@@ -116,6 +117,7 @@ Setup
     Should Be True    ${len}>=2
     Set Suite Variable    ${MACVLAN_MASTER}    ${enps[0]}
     Set Suite Variable    ${IPVLAN_MASTER}    ${enps[1]}
+    Verify MicroShift RPM Install
 
 Template And Create NAD And Pod
     [Documentation]    Template NAD and create it along with Pod

--- a/test/suites/optional/olm.robot
+++ b/test/suites/optional/olm.robot
@@ -3,6 +3,7 @@ Documentation       Operator Lifecycle Manager on MicroShift
 
 Resource            ../../resources/common.resource
 Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/microshift-rpm.resource
 
 Suite Setup         Setup
 Suite Teardown      Teardown
@@ -44,6 +45,7 @@ Setup
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig
+    Verify MicroShift RPM Install
 
 Teardown
     [Documentation]    Test suite teardown

--- a/test/suites/standard1/version.robot
+++ b/test/suites/standard1/version.robot
@@ -68,6 +68,7 @@ Setup
     Login MicroShift Host
     Setup Kubeconfig
     Read Expected Versions
+    Verify MicroShift RPM Install
 
 Teardown
     [Documentation]    Test suite teardown


### PR DESCRIPTION
Follow-up on the https://github.com/openshift/microshift/pull/3296 fix.

Added the `rpm -V` tests on all installed MicroShift RPM packages:
* In the standard1 suite, which is run on both rpm and ostree configurations
* In the optional suite for olm / multus tests to cover the extra package checks
