### PR TITLE
USHIFT-3127: Update docs and scripts for support RHEL 9.4 devenv

### DIFF
--- a/docs/contributor/devenv_setup.md
+++ b/docs/contributor/devenv_setup.md
@@ -3,18 +3,18 @@ This document describes how to setup the MicroShift development environment runn
 in a virtual machine.
 
 ## Create Development Virtual Machine
-Start by downloading one of the boot DVD images for the `x86_64` or `aarch64` architecture:
-* RHEL 9.3 from https://developers.redhat.com/products/rhel/download
+Start by downloading one of the DVD ISO images for the `x86_64` or `aarch64` architecture:
+* RHEL 9.4 from https://developers.redhat.com/products/rhel/download
 * CentOS 9 Stream from https://www.centos.org/download
 
 ### Creating VM
 Log into the hypervisor host and run the following commands to create a RHEL virtual
-machine with 4 cores, 8GB of RAM and 70GB of storage.
+machine with 4 cores, 8GB of RAM and 100GB of storage.
 
 > See [Increase Virtual Machine Disk Size](#increase-virtual-machine-disk-size) section
 > for increasing the storage size if necessary.
 
-Move the boot DVD image to `/var/lib/libvirt/images` directory and run the following
+Move the DVD ISO image to `/var/lib/libvirt/images` directory and run the following
 commands to install the `libvirt` packages and create a virtual machine.
 ```
 VMNAME="microshift-dev"

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -86,7 +86,7 @@ if [ ! -x "${RHOCP_REPO}" ] ; then
     chmod 755 "${RHOCP_REPO}"
 fi
 if [ ! -f "${MAKE_VERSION}" ] ; then
-    MAKE_VERSION=$(mktemp /tmp/Makefile.version.XXXXXXXX.var)
+    MAKE_VERSION=$(mktemp "/tmp/Makefile.version.$(uname -m).XXXXXXXX.var")
     curl -s "https://raw.githubusercontent.com/openshift/microshift/main/Makefile.version.$(uname -m).var" -o "${MAKE_VERSION}"
     chmod 644 "${MAKE_VERSION}"
 fi

--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -43,19 +43,19 @@ function get_base_isofile {
 
     case ${rhel_version} in
         8)
-            echo "rhel-8.7-$(uname -m)-dvd.iso"
+            echo "rhel-8.10-$(uname -m)-dvd.iso"
             ;;
         8.*)
             echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         9)
-            echo "rhel-9.2-$(uname -m)-dvd.iso"
+            echo "rhel-9.4-$(uname -m)-dvd.iso"
             ;;
         9.*)
             echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         *)
-            echo "unknown RHEL version ${rhel_version}" 1>&2
+            echo "Unknown RHEL version ${rhel_version}" 1>&2
             exit 1
     esac
 }
@@ -80,7 +80,7 @@ function action_create {
     export VMDISKDIR="${MICROSHIFT_VMDISKDIR}"
     export NCPUS="${NCPUS:-4}"
     export RAMSIZE="${RAMSIZE:-8}"
-    export DISKSIZE="${DISKSIZE:-70}"
+    export DISKSIZE="${DISKSIZE:-100}"
     export SWAPSIZE="${SWAPSIZE:-8}"
     export DATAVOLSIZE="${DATAVOLSIZE:-2}"
     if [ -z "${ISOFILE}" ]; then

--- a/scripts/get-latest-rhocp-repo.sh
+++ b/scripts/get-latest-rhocp-repo.sh
@@ -22,7 +22,17 @@ fi
 
 # Get minor version of currently checked out branch.
 # It's based on values stored in Makefile.version.$ARCH.var.
-current_minor=$(cut -d'.' -f2 "${REPOROOT}/Makefile.version.$(uname -m).var")
+make_version="${REPOROOT}/Makefile.version.$(uname -m).var"
+if [ ! -f "${make_version}" ] ; then
+    # Attempt to locate the Makefile version file next to the current script.
+    # This is necessary when bootstrapping the development environment for the first time.
+    make_version=$(find "${SCRIPTDIR}" -maxdepth 1 -name "Makefile.version.$(uname -m).*.var" | tail -1)
+    if [ ! -f "${make_version}" ] ; then
+        >&2 echo "Cannot find the Makefile.version.$(uname -m).var file"
+        exit 1
+    fi
+fi
+current_minor=$(cut -d'.' -f2 "${make_version}")
 stop=$(( current_minor - 3 ))
 
 # Go through minor versions, starting from current_mirror counting down


### PR DESCRIPTION
The following minor fixes were implemented:
* In devenv docs, change the OS version to 9.4 and increase the disk size requirements to 100GB
* In manage-vm.sh script, change the default OS version and increase the default VM disk size to 100GB
* In configure-vm.sh script, fix a crash during the initial bootstrap by adding a more flexible search for Makefile version file.