### PR TITLE
USHIFT-3125: Switch to using non-beta RHEL 9.4 container images for bootc

### DIFF
--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9-beta/rhel-bootc:9.4
+FROM registry.redhat.io/rhel9/rhel-bootc:9.4
 
 # Build arguments
 ARG PREVIOUS_MINOR_VERSION=15


### PR DESCRIPTION
Also fixes [USHIFT-3131](https://issues.redhat.com//browse/USHIFT-3131)