### PR TITLE
USHIFT-2963: Start using RHEL-9.4 ISO for booting RHEL-based tests

### DIFF
--- a/test/image-blueprints/layer5-bootc/group0/rhel94-bootc-base.containerfile
+++ b/test/image-blueprints/layer5-bootc/group0/rhel94-bootc-base.containerfile
@@ -1,0 +1,6 @@
+FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+
+# Build a container image to be used by Bootc Image Builder in the subsequent
+# stages for producing ISO images.
+#
+# This is a workaround until https://issues.redhat.com/browse/RHEL-34807 is fixed.

--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9-beta/rhel-bootc:9.4
+FROM registry.redhat.io/rhel9/rhel-bootc:9.4
 
 # Build arguments
 ARG PREVIOUS_MINOR_VERSION=15

--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc.image-bootc
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc.image-bootc
@@ -1,1 +1,1 @@
-registry.redhat.io/rhel9/rhel-bootc:9.4
+localhost/rhel94-bootc-base:latest

--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc.image-bootc
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc.image-bootc
@@ -1,0 +1,1 @@
+registry.redhat.io/rhel9/rhel-bootc:9.4

--- a/test/scenarios-bootc/el94-src@backup-and-restore-on-reboot.sh
+++ b/test/scenarios-bootc/el94-src@backup-and-restore-on-reboot.sh
@@ -4,9 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@backups.sh
+++ b/test/scenarios-bootc/el94-src@backups.sh
@@ -4,9 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@greenboot.sh
+++ b/test/scenarios-bootc/el94-src@greenboot.sh
@@ -4,9 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@log-scan.sh
+++ b/test/scenarios-bootc/el94-src@log-scan.sh
@@ -10,9 +10,7 @@ export TEST_RANDOMIZATION=none
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@multi-nic.sh
+++ b/test/scenarios-bootc/el94-src@multi-nic.sh
@@ -4,9 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" 2 "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" 2 "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@optional.sh
+++ b/test/scenarios-bootc/el94-src@optional.sh
@@ -9,10 +9,8 @@ WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source-optionals
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
     # Two nics - one for macvlan, another for ipvlan (they cannot enslave the same interface)
-    launch_vm host1 centos9 "${VM_MULTUS_NETWORK}" "" "" "" "2" "" "1"
+    launch_vm host1 rhel94-bootc "${VM_MULTUS_NETWORK}" "" "" "" "2" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@osconfig.sh
+++ b/test/scenarios-bootc/el94-src@osconfig.sh
@@ -8,9 +8,7 @@ TEST_EXECUTION_TIMEOUT="1.5h"
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@standard-suite2.sh
+++ b/test/scenarios-bootc/el94-src@standard-suite2.sh
@@ -4,9 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el94-src@storage.sh
+++ b/test/scenarios-bootc/el94-src@storage.sh
@@ -4,9 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source
-    # Using centos9 is necessary for getting the latest anaconda.
-    # It is a temporary workaround until rhel-9.4.iso build is available.
-    launch_vm host1 centos9 "" "" "" "" "" "" "1"
+    launch_vm host1 rhel94-bootc "" "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
Also fixes [USHIFT-2926](https://issues.redhat.com//browse/USHIFT-2926)