### PR TITLE
USHIFT-2210: Run FIPS tests on RPM and ostree-based RHEL 9.4 systems

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -206,16 +206,11 @@ prepare_kickstart() {
     local -r vm_hostname="${full_vmname/./-}"
     local -r hostname=$(hostname)
 
-    local fips_command=""
-
     echo "Preparing kickstart file ${template} at ${output_dir}"
     if [ ! -f "${KICKSTART_TEMPLATE_DIR}/${template}" ]; then
         error "No ${template} in ${KICKSTART_TEMPLATE_DIR}"
         record_junit "${vmname}" "prepare_kickstart" "no-template"
         exit 1
-    fi
-    if "${fips_enabled}"; then
-        fips_command="fips-mode-setup --enable"
     fi
 
     mkdir -p "${output_dir}"
@@ -237,7 +232,7 @@ prepare_kickstart() {
             -e "s|REPLACE_HOST_NAME|${vm_hostname}|g" \
             -e "s|REPLACE_REDHAT_AUTHORIZED_KEYS|${REDHAT_AUTHORIZED_KEYS}|g" \
             -e "s|REPLACE_PUBLIC_IP|${PUBLIC_IP}|g" \
-            -e "s|REPLACE_FIPS_COMMAND|${fips_command}|g" \
+            -e "s|REPLACE_FIPS_ENABLED|${fips_enabled}|g" \
             -e "s|REPLACE_ENABLE_MIRROR|${ENABLE_REGISTRY_MIRROR}|g" \
             -e "s|REPLACE_MIRROR_HOSTNAME|${hostname}|g" \
             "${ifile}" > "${output_file}"

--- a/test/image-blueprints/layer3-periodic/group1/rhel92-source-isolated.image-installer
+++ b/test/image-blueprints/layer3-periodic/group1/rhel92-source-isolated.image-installer
@@ -1,1 +1,0 @@
-rhel-9.2-microshift-source-isolated

--- a/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.image-installer
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.image-installer
@@ -1,0 +1,1 @@
+rhel-9.4-microshift-source-isolated

--- a/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.toml
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.toml
@@ -1,9 +1,9 @@
-name = "rhel-9.2-microshift-source-isolated"
-description = "A RHEL 9.2 image with the RPMs built from source with embedded container images."
+name = "rhel-9.4-microshift-source-isolated"
+description = "A RHEL 9.4 image with the RPMs built from source with embedded container images."
 version = "0.0.1"
 modules = []
 groups = []
-distro = "rhel-92"
+distro = "rhel-94"
 
 [[packages]]
 name = "microshift"

--- a/test/kickstart-templates/includes/post-fips.cfg
+++ b/test/kickstart-templates/includes/post-fips.cfg
@@ -1,0 +1,6 @@
+# The --no-bootcfg option disables boot loader reconfiguration, which does not work on ostree-based systems.
+# However, this is not necessary because 'fips=1' option is already present in the kernel command line when
+# the virtual machine is created.
+if REPLACE_FIPS_ENABLED ; then
+    fips-mode-setup --enable --no-bootcfg
+fi

--- a/test/kickstart-templates/kickstart-liveimg.ks.template
+++ b/test/kickstart-templates/kickstart-liveimg.ks.template
@@ -8,8 +8,6 @@
 %include /post-containers.cfg
 %include /post-system.cfg
 %include /post-network.cfg
-
-# Configure FIPS
-REPLACE_FIPS_COMMAND
+%include /post-fips.cfg
 
 %end

--- a/test/kickstart-templates/kickstart.ks.template
+++ b/test/kickstart-templates/kickstart.ks.template
@@ -8,5 +8,6 @@
 %include /post-containers.cfg
 %include /post-system.cfg
 %include /post-network.cfg
+%include /post-fips.cfg
 
 %end

--- a/test/scenarios-periodics/el94-src@fips-rpm.sh
+++ b/test/scenarios-periodics/el94-src@fips-rpm.sh
@@ -5,8 +5,8 @@
 scenario_create_vms() {
     [[ "${UNAME_M}" =~ aarch64 ]] && { record_junit "setup" "scenario_create_vms" "SKIPPED"; exit 0; }
 
-    prepare_kickstart host1 kickstart-liveimg.ks.template rhel-9.2-microshift-source-isolated true
-    launch_vm host1 "rhel-9.2-microshift-source-isolated" "" "" "" "" "" "1"
+    prepare_kickstart host1 kickstart-liveimg.ks.template "" true
+    launch_vm host1 rhel-9.4-microshift-source-isolated "" "" "" "" "" "1"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-periodics/el94-src@fips.sh
+++ b/test/scenarios-periodics/el94-src@fips.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there. 
+
+scenario_create_vms() {
+    [[ "${UNAME_M}" =~ aarch64 ]] && { record_junit "setup" "scenario_create_vms" "SKIPPED"; exit 0; }
+
+    prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source-isolated true
+    launch_vm host1 rhel-9.4-microshift-source-isolated "" "" "" "" "" "1"
+}
+
+scenario_remove_vms() {
+    [[ "${UNAME_M}" =~ aarch64 ]] && { echo "Only x86_64 architecture is supported with FIPS";  exit 0; }
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    [[ "${UNAME_M}" =~ aarch64 ]] && { echo "Only x86_64 architecture is supported with FIPS"; exit 0; }
+
+    run_tests host1 suites/fips/
+}

--- a/test/scenarios-periodics/el94-src@isolated-net.sh
+++ b/test/scenarios-periodics/el94-src@isolated-net.sh
@@ -8,7 +8,7 @@ VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
 WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart.ks.template rhel-9.2-microshift-source-isolated
+    prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source-isolated
     # Use the isolated network when creating a VM
     launch_vm host1 "" "${VM_ISOLATED_NETWORK}"
 }

--- a/test/scenarios-periodics/el94-src@offline.sh
+++ b/test/scenarios-periodics/el94-src@offline.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Sourced from scenario.sh and uses functions defined there.
+
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-offline.ks.template ""
-    launch_vm host1  rhel-9.2-microshift-source-isolated ""           ""       ""        ""          0
+    launch_vm host1  rhel-9.4-microshift-source-isolated "" "" "" "" 0
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-periodics/el94-src@rpm-standard1.sh
+++ b/test/scenarios-periodics/el94-src@rpm-standard1.sh
@@ -4,7 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-liveimg.ks.template ""
-    launch_vm host1 "rhel-9.2-microshift-source-isolated"
+    launch_vm host1 "rhel-9.4-microshift-source-isolated"
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-periodics/el94-src@rpm-standard2.sh
+++ b/test/scenarios-periodics/el94-src@rpm-standard2.sh
@@ -4,7 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-liveimg.ks.template ""
-    launch_vm host1 "rhel-9.2-microshift-source-isolated"
+    launch_vm host1 "rhel-9.4-microshift-source-isolated"
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
The [FIPS blueprint customization](https://osbuild.org/docs/user-guide/blueprint-reference/#fips) is not supported for edge-commits, so it cannot be used in `image-installer` due to the current MicroShift bluepring organization. Instead, we explicitly pass `fips=1` when booting the VM and call `fips-mode-setup` in kickstart.

The following message is produced by `fips-mode-setup` command when run in kickstart.
```
Setting system policy to FIPS
Note: System-wide crypto policies are applied on application start-up.
It is recommended to restart the system for the change of policies to fully take place.
FIPS mode will be enabled.
Now you need to configure the bootloader to add kernel options "fips=1 boot=UUID=<your-boot-device-uuid>" and reboot the system for the setting to take effect.
```

Since we are using `microshift-source-isolated` images for FIPS tests, I had to upgrade those to run RHEL 9.4 OS and fix the dependent scenarios to use these upgraded images. This is anyway part of the work we are doing on RHEL 9.4 transition (CC: @copejon)

