### PR TITLE
OCPBUGS-30039: Switch to registry.redhat.io images for OpenSSL dependency in TopoLVM

### DIFF
--- a/assets/release/release-aarch64.json
+++ b/assets/release/release-aarch64.json
@@ -7,7 +7,7 @@
     "coredns": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:67fb2efb64a7fcaed1bb9626189119a695d8c74e2a5fa9f1f455ff18e06f4443",
     "haproxy-router": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ec1badf0dbc6c6470ed5c5c28b7132f4e266f96d5bbff3dce9ac626cf376a5b8",
     "kube-rbac-proxy": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3efa9cffb515812d7a79284e64d9f2cb203589ace5d7a3a720c4f9b897d4b8d8",
-    "openssl": "registry.access.redhat.com/ubi8/openssl@sha256:9e743d947be073808f7f1750a791a3dbd81e694e37161e8c6c6057c2c342d671",
+    "openssl": "registry.redhat.io/ubi9@sha256:ed84f34cd929ea6b0c247b6daef54dd79602804a32480a052951021caf429494",
     "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:171fcea4e66c5dc23cef4d7ca198959cc6d95766ac9faf5fe00baa288573be59",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9cce317c7fb456c067bdcb7f7afd3e951a6e23fa97a68b472727ca54db2a275d",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4829d6cdcc28287d128b305db86eaca078cc5c7e92612ea0473e71836f18ff35",

--- a/assets/release/release-x86_64.json
+++ b/assets/release/release-x86_64.json
@@ -7,7 +7,7 @@
     "coredns": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79401dadbf5b9a1c4269c7945d0cd48147250c054269846b4ee99a51a307acd7",
     "haproxy-router": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6e7497ab6cedbad0187406ca2a91194ec54d5a1641f1922f1f1d03cf7542ba9b",
     "kube-rbac-proxy": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:44001e0c59ad0d95aeef617a5baffe62a5f3f412dbbd1e96646c01a616393324",
-    "openssl": "registry.access.redhat.com/ubi8/openssl@sha256:9e743d947be073808f7f1750a791a3dbd81e694e37161e8c6c6057c2c342d671",
+    "openssl": "registry.redhat.io/ubi9@sha256:ed84f34cd929ea6b0c247b6daef54dd79602804a32480a052951021caf429494",
     "ovn-kubernetes-microshift": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0f3b360e19b6b48321b62d005f92eb64ae11cde90e0aa6e725182bd90643bb38",
     "pod": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6c3e54d3c1d926854636694a4975a07b70c5a200359d62b79eca5971a1a495a5",
     "service-ca-operator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:200e3fd42d027a70bc98f5d5b99430b4c5227a70a9c7fd613d940ed6d97e9bf0",

--- a/packaging/images/openshift-ci/Dockerfile.test-runtime
+++ b/packaging/images/openshift-ci/Dockerfile.test-runtime
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:9.2
+FROM registry.access.redhat.com/ubi9:latest
 USER root
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN printf '%s\n' \

--- a/scripts/image-builder/config/registries.conf.template
+++ b/scripts/image-builder/config/registries.conf.template
@@ -19,11 +19,3 @@
 [[registry.mirror]]
     location = "REPLACE_MIRROR_REGISTRY_HOST"
     insecure = REPLACE_MIRROR_REGISTRY_INSECURE
-
-[[registry]]
-    prefix = ""
-    location = "registry.access.redhat.com"
-    mirror-by-digest-only = true
-[[registry.mirror]]
-    location = "REPLACE_MIRROR_REGISTRY_HOST"
-    insecure = REPLACE_MIRROR_REGISTRY_INSECURE

--- a/scripts/verify/verify-images.sh
+++ b/scripts/verify/verify-images.sh
@@ -29,11 +29,9 @@ while read -r source_file image; do
             debug "${image} OK";;
         registry.redhat.io/openshift4/*)
             debug "${image} OK";;
-        registry.access.redhat.com/*)
-            debug "${image} OK";;
-        registry.redhat.io/odf4/*)
-            debug "${image} OK";;
         registry.redhat.io/lvms4/*)
+            debug "${image} OK";;
+        registry.redhat.io/ubi9*)
             debug "${image} OK";;
         *)
             echo "${image} used in ${source_file} is not from an approved location" 1>&2

--- a/test/kickstart-templates/includes/post-containers.cfg
+++ b/test/kickstart-templates/includes/post-containers.cfg
@@ -31,14 +31,6 @@ if REPLACE_ENABLE_MIRROR; then
 [[registry.mirror]]
     location = "REPLACE_MIRROR_HOSTNAME:5000"
     insecure = true
-
-[[registry]]
-    prefix = ""
-    location = "registry.access.redhat.com"
-    mirror-by-digest-only = true
-[[registry.mirror]]
-    location = "REPLACE_MIRROR_HOSTNAME:5000"
-    insecure = true
 EOF
 
     # Skip signature verifying for red hat registries, since the signatures are bound the original

--- a/test/suites/network/isolated-network.robot
+++ b/test/suites/network/isolated-network.robot
@@ -61,7 +61,7 @@ Teardown
 Verify No Internet Access
     [Documentation]    Verifies that Internet is not accessible
     ${rc}=    Execute Command
-    ...    curl -I redhat.com quay.io registry.access.redhat.com
+    ...    curl -I redhat.com quay.io registry.redhat.io
     ...    return_stdout=False    return_stderr=False    return_rc=True
     Should Not Be Equal As Integers    ${rc}    0
 


### PR DESCRIPTION
Also switched to the latest ubi9 image. 
> Note that neither ubi9-minimal nor ubi9-micro contain the `openssl` executable we need.
