### PR TITLE
USHIFT-2463: Add PreRunModifier flag to skip RF

### DIFF
--- a/test/resources/SkipTests.py
+++ b/test/resources/SkipTests.py
@@ -1,0 +1,25 @@
+"""Pre-run modifier that skips tests by their name.
+
+Tests to skip are specified by Test Name
+"""
+
+from robot.api import SuiteVisitor
+
+
+class SkipTests(SuiteVisitor):
+
+    def __init__(self, list_skip_test):
+        self.list_skip_test = list_skip_test
+
+        if self.list_skip_test:
+            print("List of tests to be skipped:")
+            print(f" - {self.list_skip_test.replace(',', '\n - ')}")
+        else:
+            print("No tests to be skipped")
+
+    def visit_test(self, test):
+        """Set tag to skip tests"""
+
+        # set `robot:skip` tag
+        if test.name in self.list_skip_test.split(","):
+            test.tags.add("robot:skip")

--- a/test/resources/SkipTests.py
+++ b/test/resources/SkipTests.py
@@ -3,6 +3,7 @@
 Tests to skip are specified by Test Name
 """
 
+import os
 from robot.api import SuiteVisitor
 
 
@@ -13,7 +14,7 @@ class SkipTests(SuiteVisitor):
 
         if self.list_skip_test:
             print("List of tests to be skipped:")
-            print(f" - {self.list_skip_test.replace(',', '\n - ')}")
+            print(f" - {self.list_skip_test.replace(',', f'{os.linesep} - ')}")
         else:
             print("No tests to be skipped")
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -14,7 +14,7 @@ OUTDIR="${ROOTDIR}/_output/e2e-$(date +%Y%m%d-%H%M%S)"
 function usage {
     local -r script_name=$(basename "$0")
     cat - <<EOF
-${script_name} [-h] [-n] [-o output_dir] [-v venv_dir] [-i var_file] [-s name=value] [test suite files]
+${script_name} [-h] [-n] [-o output_dir] [-v venv_dir] [-i var_file] [-s name=value] [-k test_names] [test suite files]
 
 Options:
 
@@ -24,10 +24,11 @@ Options:
   -v DIR             The venv directory. (${RF_VENV})
   -i PATH            The variables file. (${RF_VARIABLES})
   -s NAME=VALUE      To enable an stress condition.
+  -k SKIP_TESTS      List of Tests to skip.
 EOF
 }
 
-while getopts "hno:v:i:s:" opt; do
+while getopts "hno:v:i:s:k:" opt; do
     case ${opt} in
         h)
             usage
@@ -47,6 +48,9 @@ while getopts "hno:v:i:s:" opt; do
             ;;
         s)
             STRESS_TESTING=${OPTARG}
+            ;;
+        k)
+            SKIP_TESTS=${OPTARG}
             ;;
         *)
             usage
@@ -101,6 +105,7 @@ else
     # shellcheck disable=SC2086
     "${RF_BINARY}" \
         --randomize all \
+        --prerunmodifier resources/SkipTests.py:${SKIP_TESTS:-} \
         --loglevel TRACE \
         -V "${RF_VARIABLES}" \
         -x junit.xml \

--- a/test/run.sh
+++ b/test/run.sh
@@ -23,8 +23,8 @@ Options:
   -o DIR             The output directory. (${OUTDIR})
   -v DIR             The venv directory. (${RF_VENV})
   -i PATH            The variables file. (${RF_VARIABLES})
-  -s NAME=VALUE      To enable an stress condition.
-  -k SKIP_TESTS      List of Tests to skip.
+  -s NAME=VALUE      To enable a stress condition.
+  -k SKIP_TESTS      Comma separated list of tests to skip.
 EOF
 }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -105,7 +105,7 @@ else
     # shellcheck disable=SC2086
     "${RF_BINARY}" \
         --randomize all \
-        --prerunmodifier resources/SkipTests.py:${SKIP_TESTS:-} \
+        --prerunmodifier "${SCRIPTDIR}/resources/SkipTests.py:${SKIP_TESTS:-}" \
         --loglevel TRACE \
         -V "${RF_VARIABLES}" \
         -x junit.xml \


### PR DESCRIPTION
Closes Jira [USHIFT-2463](https://issues.redhat.com/browse/USHIFT-2463)

Add `--prerunmodifier` [flag](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#programmatic-modification-of-test-data) to RF execution in `run.sh` to skip tests by name.

Example:
`./test/run.sh -o /Users/agullon/workspace/microshift/_output/_output -i /Users/agullon/workspace/microshift/_output/rf_variables.yaml -k 'CLI Output,ConfigMap Matches CLI' -v /Users/agullon/workspace/microshift/_output/venv suites/standard1/version.robot`
```
+ /Users/agullon/workspace/microshift/_output/venv/bin/robot --randomize all --prerunmodifier 'resources/SkipTests.py:CLI Output,ConfigMap Matches CLI' --loglevel TRACE -V /Users/agullon/workspace/microshift/_output/rf_variables.yaml -x junit.xml --outputdir /Users/agullon/workspace/microshift/_output/_output suites/standard1/version.robot
List of tests to be skipped:
 - CLI Output
 - ConfigMap Matches CLI
==============================================================================
Version :: Tests related to the version of MicroShift
==============================================================================
ConfigMap Contents :: Check the version of the server                 | PASS |
------------------------------------------------------------------------------
CLI Output :: Check the version reported by the process               | SKIP |
Test skipped using 'robot:skip' tag.
------------------------------------------------------------------------------
Metadata File Contents :: Ensure the metadata file contents match ... | PASS |
------------------------------------------------------------------------------
ConfigMap Matches CLI :: Ensure the ConfigMap is being updated bas... | SKIP |
Test skipped using 'robot:skip' tag.
------------------------------------------------------------------------------
Version :: Tests related to the version of MicroShift                 | PASS |
4 tests, 2 passed, 0 failed, 2 skipped
==============================================================================
Output:  /Users/agullon/workspace/microshift/_output/_output/output.xml
XUnit:   /Users/agullon/workspace/microshift/_output/_output/junit.xml
Log:     /Users/agullon/workspace/microshift/_output/_output/log.html
Report:  /Users/agullon/workspace/microshift/_output/_output/report.html
+ '[' '' ']'
```