### PR TITLE
OCPBUGS-33588: Upgrade openvswitch package for 4.16

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -108,7 +108,7 @@ The microshift-selinux package provides the SELinux policy modules required by M
 %package networking
 Summary: Networking components for MicroShift
 Requires: microshift = %{version}
-Requires: (openvswitch3.1 or openvswitch >= 3.1)
+Requires: (openvswitch3.3 or openvswitch >= 3.3)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -470,6 +470,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Mon May 13 2024 Ilya Maximets <i.maximets@redhat.com> 4.16.0
+- Upgrade openvswitch package version to 3.3
+
 * Mon Apr 29 2024 Gregory Giguashvili <ggiguash@redhat.com> 4.16.0
 - Remove references to redundant files in selinux packaging
 

--- a/test/bootc-sources/microshift_repo_config.sh.template
+++ b/test/bootc-sources/microshift_repo_config.sh.template
@@ -5,6 +5,7 @@ USHIFT_LOCAL_REPO_FILE=/etc/yum.repos.d/microshift-local.repo
 OCP_MIRROR_REPO_FILE=/etc/yum.repos.d/openshift-mirror-beta.repo
 OCP_DTPATH_REPO_FILE=/etc/yum.repos.d/openshift-fast-datapath.repo
 OCP_RHOCP_REPO_FILE=/etc/yum.repos.d/openshift-rhocp.repo
+CENTOS_NFV_SIG_REPO_FILE=/etc/yum.repos.d/microshift-sig-nfv.repo
 
 usage() {
     echo "Usage: $(basename $0) <-create microshift_local_repo_path | -delete>"
@@ -36,6 +37,15 @@ config_centos9_repos() {
 [openshift-mirror-beta]
 name=OpenShift Mirror Beta Repository
 baseurl=https://mirror.openshift.com/pub/openshift-v4/{{ .Env.UNAME_M }}/dependencies/rpms/4.{{ .Env.PREVIOUS_MINOR_VERSION }}-el9-beta/
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0
+EOF
+
+    cat > "${CENTOS_NFV_SIG_REPO_FILE}" <<EOF
+[nfv-sig]
+name=CentOS Stream 9 - SIG NFV
+baseurl=http://mirror.stream.centos.org/SIGs/9-stream/nfv/{{ .Env.UNAME_M }}/openvswitch-2/
 enabled=1
 gpgcheck=0
 skip_if_unavailable=0

--- a/test/kickstart-templates/includes/post-cos9rpm.cfg
+++ b/test/kickstart-templates/includes/post-cos9rpm.cfg
@@ -8,7 +8,7 @@ gpgcheck=0
 skip_if_unavailable=0
 EOF
 
-# The openvswitch3.1 dependency
+# The openvswitch3.3 dependency
 cat > "/etc/yum.repos.d/openvswitch2-rpms.repo" <<EOF
 [sig-nfv]
 name=CentOS Stream 9 - SIG NFV

--- a/test/resources/microshift-rpm.resource
+++ b/test/resources/microshift-rpm.resource
@@ -15,7 +15,10 @@ ${REPO_FILE_NAME}       "/etc/yum.repos.d/microshift-local.repo"
 Install MicroShift RPM Packages From System Repo
     [Documentation]    Installs MicroShift RPM packages from a system repository
     [Arguments]    ${version}    ${check_warnings}=True
-    ${stdout}=    Command Should Work    dnf install -y 'microshift-${version}'
+    # Allow erasing because update may require a new version of openvswitch
+    # and major versions of openvswitch are separate packages that obsolete
+    # each other.
+    ${stdout}=    Command Should Work    dnf install -y --allowerasing 'microshift-${version}'
     IF    ${check_warnings}
         # Look for all warnings and errors before testing so that the log
         # shows the output for both.


### PR DESCRIPTION
4.16 ovn-kubernetes and RHCOS are both moved to OVS 3.3:
  - https://github.com/openshift/ovn-kubernetes/pull/2142
  - https://github.com/openshift/os/pull/1495

MicroShift should be kept in sync.