### PR TITLE
USHIFT-3155: Fix greenboot configuration update

### DIFF
--- a/test/kickstart-templates/includes/post-system.cfg
+++ b/test/kickstart-templates/includes/post-system.cfg
@@ -28,4 +28,4 @@ echo "fs.inotify.max_user_instances = 8192" >> /etc/sysctl.conf
 sysctl --system
 
 # Extend Greenboot wait timeout to 10m for MicroShift to be ready
-echo "MICROSHIFT_WAIT_TIMEOUT_SEC=600" >> /etc/greenboot/greenboot.conf
+printf "\nMICROSHIFT_WAIT_TIMEOUT_SEC=600\n" >> /etc/greenboot/greenboot.conf


### PR DESCRIPTION
Follow-up fix on #3352 
The /etc/greenboot/greenboot.conf file does not have the trailing EOL.
