### PR TITLE
USHIFT-3177: Use only ipv4 addresses for default router

### DIFF
--- a/pkg/loadbalancerservice/router.go
+++ b/pkg/loadbalancerservice/router.go
@@ -123,7 +123,7 @@ func ipAddressesFromNIC(name string) ([]string, error) {
 		return nil, err
 	}
 
-	addrList, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	addrList, err := netlink.AddrList(link, netlink.FAMILY_V4)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There was a mismatch between what the config package IP addresses from the host and the router controller. The config package only gets ipv4 addresses while the router controller takes ipv6 too. This caused a mismatch between allowed/configured IP addresses that triggered fake warning logs about ipv6 entries not allowed in the service (even if they were not configured).

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
