### PR TITLE
OCPBUGS-34491: fix: adjust topolvm controller probes

### DIFF
--- a/assets/components/lvms/topolvm-controller_deployment.yaml
+++ b/assets/components/lvms/topolvm-controller_deployment.yaml
@@ -27,27 +27,35 @@ spec:
         startupProbe:
           failureThreshold: 60
           periodSeconds: 2
+          timeoutSeconds: 3
           httpGet:
             port: healthz
             path: /healthz
         livenessProbe:
-          failureThreshold: 3
           httpGet:
-            path: /healthz
             port: healthz
-          initialDelaySeconds: 10
-          periodSeconds: 60
+            path: /healthz
           timeoutSeconds: 3
+          failureThreshold: 3
+          periodSeconds: 60
+        readinessProbe:
+          httpGet:
+            port: readyz
+            path: /readyz
+          timeoutSeconds: 3
+          failureThreshold: 3
+          periodSeconds: 60
         name: topolvm-controller
         ports:
         - containerPort: 9808
           name: healthz
           protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 8080
-            scheme: HTTP
+        - containerPort: 8081
+          name: readyz
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 2m

--- a/assets/components/lvms/topolvm-node_daemonset.yaml
+++ b/assets/components/lvms/topolvm-node_daemonset.yaml
@@ -39,17 +39,16 @@ spec:
               fieldPath: spec.nodeName
         image: '{{ .ReleaseImage.topolvm_csi }}'
         livenessProbe:
-          failureThreshold: 3
           httpGet:
-            path: /healthz
             port: healthz
-          initialDelaySeconds: 10
-          periodSeconds: 60
+            path: /healthz
           timeoutSeconds: 3
+          failureThreshold: 3
+          periodSeconds: 60
         startupProbe:
           failureThreshold: 60
-          successThreshold: 1
           periodSeconds: 2
+          timeoutSeconds: 3
           httpGet:
             port: healthz
             path: /healthz


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:

Changes the readinessProbe of topolvm-controller to use /readyz instead of /metrics.
Removes the initial delay of 10s because we also have a 2s startup probe that ensures that the probes should exist

Closes #<Issue Number>
