### PR TITLE
NO-ISSUE: Update asset.yaml source for the route crd

### DIFF
--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -200,7 +200,8 @@ assets:
       - file: storage_version_migration.crd.yaml
         src:  0000_50_cluster-kube-storage-version-migrator-operator_01_storage_migration_crd.yaml
       - file: route.crd.yaml
-        src:  /route-controller-manager/vendor/github.com/openshift/api/route/v1/route.crd.yaml
+        src: /api/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml
+
 
   - dir: release/
     ignore: "it contains files generated during rebase procedure"

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -33,7 +33,7 @@ STAGING_DIR="$REPOROOT/_output/staging"
 PULL_SECRET_FILE="${HOME}/.pull-secret.json"
 GO_MOD_DIRS=("$REPOROOT/" "$REPOROOT/etcd")
 
-EMBEDDED_COMPONENTS="route-controller-manager cluster-policy-controller hyperkube etcd kube-storage-version-migrator"
+EMBEDDED_COMPONENTS="route-controller-manager cluster-policy-controller hyperkube etcd kube-storage-version-migrator cluster-config-api"
 EMBEDDED_COMPONENT_OPERATORS="cluster-kube-apiserver-operator cluster-kube-controller-manager-operator cluster-openshift-controller-manager-operator cluster-kube-scheduler-operator machine-config-operator operator-lifecycle-manager"
 LOADED_COMPONENTS="cluster-dns-operator cluster-ingress-operator service-ca-operator cluster-network-operator cluster-csi-snapshot-controller-operator"
 declare -a ARCHS=("amd64" "arm64")


### PR DESCRIPTION
The route API CRD was previously source from the route-controller-manager. This has proven to be problematic since the source file path has change in the last release.  MicroShift should source the CRD from the router repository instead, which should be safer in the future.

The source path used here is `amd64`.  It doesn't matter which arch is manifest is pulled from since the CRD is not arch-dependent.