### PR TITLE
NO-ISSUE: microshift-test-agent improvements

### DIFF
--- a/test/agent/microshift-test-agent.service
+++ b/test/agent/microshift-test-agent.service
@@ -3,7 +3,7 @@ Description=MicroShift Test Agent
 Before=microshift.service sshd.service
 
 [Service]
-ExecStart=/bin/bash /usr/bin/microshift-test-agent.sh
+ExecStart=/usr/bin/microshift-test-agent.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/test/agent/microshift-test-agent.service
+++ b/test/agent/microshift-test-agent.service
@@ -4,6 +4,8 @@ Before=microshift.service sshd.service
 
 [Service]
 ExecStart=/usr/bin/microshift-test-agent.sh
+# Allow agent to finish cleanup instead of (sometimes) getting two consecutive SIGTERMs.
+TimeoutStopSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/test/agent/microshift-test-agent.sh
+++ b/test/agent/microshift-test-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 set -xeuo pipefail
 
@@ -95,7 +95,7 @@ prevent_backup() {
 fail_greenboot() {
     local -r path="/etc/greenboot/check/required.d/99_microshift_test_failure.sh"
     cat >"${path}" <<EOF
-#!/bin/bash
+#!/usr/bin/bash
 echo 'Forced greenboot failure by MicroShift Failure Agent'
 sleep 5
 exit 1


### PR DESCRIPTION
- Remove `/bin/bash` from the `ExecStart` so `microshift-test-agent.sh` is used in journal leading to easier debbuging.
- Add 5s stop timeout, to (hopefully) not receive two SIGTERMs in a row which can lead to _cleanup function to running completely and breaking the test.
- Don't fail if no file matches `/etc/ssh/ssh_host*key` wildcard