### PR TITLE
NO-ISSUE: Add runtime crun to crio for y-2 blueprint

### DIFF
--- a/test/image-blueprints/layer1-base/group2/rhel92-microshift-yminus2.toml
+++ b/test/image-blueprints/layer1-base/group2/rhel92-microshift-yminus2.toml
@@ -37,3 +37,14 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+[[customizations.files]]
+path = "/etc/crio/crio.conf.d/00-crio-crun.yaml"
+data = """
+[crio.runtime.runtimes.crun]
+runtime_path = ""
+runtime_type = "oci"
+runtime_root = "/run/crun"
+runtime_config_path = ""
+monitor_path = ""
+"""


### PR DESCRIPTION
microshift 4.15 RPM still specifies `crio >= 1.25` and doesn't ship its own `crun` runtime definition for crio. When it gets newest crio (>= 1.29), the test fails because crio exits shortly after startup.
This PR introduces a workaround: explicitly adds missing file to the blueprint.
When 4.15 RPM has its crio version fixed, we can remove the workaround.
