### PR TITLE
NO-ISSUE: Add --showduplicates to `dnf repository-packages`

### DIFF
--- a/scripts/get-latest-rhocp-repo.sh
+++ b/scripts/get-latest-rhocp-repo.sh
@@ -52,13 +52,13 @@ fi
 # and then rhocp-4.14 (which will be returned from the script because it's usable).
 for ver in $(seq "${current_minor}" -1 "${stop}"); do
     repository="rhocp-4.${ver}-for-rhel-9-$(uname -m)-rpms"
-    if sudo dnf repository-packages "${repository}" info cri-o 1>&2; then
+    if sudo dnf repository-packages --showduplicates "${repository}" info cri-o 1>&2; then
         echo "${ver}"
         exit 0
     fi
 
     rhocp_beta_url="https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/dependencies/rpms/4.${ver}-el9-beta/"
-    if sudo dnf repository-packages --disablerepo '*' --repofrompath "this,${rhocp_beta_url}" this info cri-o 1>&2; then
+    if sudo dnf repository-packages --showduplicates --disablerepo '*' --repofrompath "this,${rhocp_beta_url}" this info cri-o 1>&2; then
         echo "${rhocp_beta_url},${ver}"
         exit 0
     fi


### PR DESCRIPTION
If newer CRI-O is installed than CRI-O present in the inspected repository then DNF will not consider it, meaning it will pretend like there is no CRI-O in the inspected repository.

By adding --showduplicates DNF will show information about the CRI-O in the repository regardless if newer is installed on the system or not.