### PR TITLE
NO-ISSUE: Enable rhocp repos if mirror is used

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -186,6 +186,10 @@ enabled=1
 gpgcheck=0
 skip_if_unavailable=0
 EOF
+        PREVIOUS_RHOCP=$("${RHOCP_REPO}" $((ver-1)))
+        if [[ "${PREVIOUS_RHOCP}" =~ ^[0-9]{2} ]]; then
+            sudo subscription-manager repos --enable "rhocp-4.${PREVIOUS_RHOCP}-for-rhel-9-$(uname -m)-rpms"
+        fi
     fi
 
     # Enable fast-datapath (ovn) only for non-beta. Beta RHEL will use openvswitch from RHOCP beta mirror.


### PR DESCRIPTION
When $current_minor beta mirror is enabled we may also need the $previous_minor rhocp repo enabled. This is necessary for example for some scenarios.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
