### PR TITLE
NO-ISSUE: Add 4.15 rhocp repo to configure-vm.sh

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -178,11 +178,14 @@ fi
 OCPVERSION="4.${LATEST_RHOCP_MINOR}"
 
 if ${RHEL_SUBSCRIPTION}; then
+    OCPPREVVERSION="4.$((LATEST_RHOCP_MINOR-1))"
     OSVERSION=$(awk -F: '{print $5}' /etc/system-release-cpe)
     sudo subscription-manager config --rhsm.manage_repos=1
 
     sudo subscription-manager repos \
         --enable "rhocp-${OCPVERSION}-for-rhel-${OSVERSION}-$(uname -m)-rpms"
+    sudo subscription-manager repos \
+        --enable "rhocp-${OCPPREVVERSION}-for-rhel-${OSVERSION}-$(uname -m)-rpms"
 
     if ! ${RHEL_BETA_VERSION} ; then
         sudo subscription-manager repos \

--- a/test/scenarios/el94-src@rpm-install.sh
+++ b/test/scenarios/el94-src@rpm-install.sh
@@ -49,6 +49,9 @@ scenario_run_tests() {
     # name, so should include the major and minor version number.
     local -r dependency_version="4.$("${ROOTDIR}/scripts/get-latest-rhocp-repo.sh")"
 
+    # Force enable the previous minor version repo to pull microshift-*-4.15
+    run_command_on_vm host1 "sudo subscription-manager repos --enable rhocp-4.${previous_minor_version}-for-rhel-9-\$(uname -m)-rpms"
+
     run_tests host1 \
         --exitonfailure \
         --variable "SOURCE_REPO_URL:${source_repo_url}" \

--- a/test/suites/rpm/install-and-upgrade-successful.robot
+++ b/test/suites/rpm/install-and-upgrade-successful.robot
@@ -38,6 +38,14 @@ ${TARGET_VERSION}               ${EMPTY}
 ${DEPENDENCY_VERSION}           ${EMPTY}
 # Optional URL for repo for previous minor version
 ${PREVIOUS_VERSION_REPO_URL}    ${EMPTY}
+# Crun configuration
+${CRIO_CONFIG}                  SEPARATOR=\n
+...                             [crio.runtime.runtimes.crun]
+...                             runtime_path = ""
+...                             runtime_type = "oci"
+...                             runtime_root = "/run/crun"
+...                             runtime_config_path = ""
+...                             monitor_path = ""
 
 
 *** Test Cases ***
@@ -68,6 +76,13 @@ Upgrade From Previous Version
     END
     ${version}=    MicroShift Version
     Should Be Equal As Integers    ${version.minor}    ${PREVIOUS_MINOR_VERSION}
+    # Since 4.15 RPMs do not restrict the crio max version, and crio 1.29 (which is the
+    # version in 4.16 repo) includes a breaking change in the default config(that was fixed
+    # in 4.16 for microshift), we need to manually configure it here. A proper fix would be
+    # to have microshift 4.15 install crio<=1.28, but here we can work around it by copying
+    # the file.
+    # This is a temporary fix until 4.15 RPMs set their dependencies with min and max versions.
+    Upload String To File    ${CRIO_CONFIG}    /etc/crio/crio.conf.d/00-crio-crun.conf
     Start MicroShift
     Wait For MicroShift
     Install MicroShift RPM Packages From Repo    ${SOURCE_REPO_URL}    ${TARGET_VERSION}


### PR DESCRIPTION
Manually add this repo to the configure-vm.sh script. The get_latest_rhocp_repo has been returning 4.15 and inadvertently enabling that repo until 4.16 went GA and the repo was publicly available. Now that this is the case, the scenario preparation for upgrade tests fails, as there is no repo configured to pull those packages.
This PR fixes that by adding not just 4.16 repo, but also 4.15. This is a manual cherry-pick of https://github.com/openshift/microshift/pull/3556

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
