### PR TITLE
NOISSUE: Unconditionally clean all scenarios and container images

### DIFF
--- a/scripts/image-builder/cleanup.sh
+++ b/scripts/image-builder/cleanup.sh
@@ -14,13 +14,21 @@ clean_podman_images() {
         return
     fi
 
-    title "Cleaning up container images"
-    for id in $(sudo podman ps -a | grep microshift | awk '{print $1}') ; do
+    title "Cleaning up running containers"
+    for id in $(sudo podman ps -a | awk '{print $1}') ; do
         sudo podman rm -f "${id}"
+    done
+    for id in $(podman ps -a | awk '{print $1}') ; do
+        podman rm -f "${id}"
     done
 
     if [ "${FULL_CLEAN}" = 1 ] ; then
+        title "Cleaning up container images"
+
         sudo podman rmi -af
+        podman rmi -af
+        # Ensure the user-specific container storage is deleted
+        sudo rm -rf ~/.local/share/containers/
     fi
 }
 

--- a/test/bin/cleanup_hypervisor.sh
+++ b/test/bin/cleanup_hypervisor.sh
@@ -10,7 +10,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPTDIR}/common.sh"
 
 # Clean up all of the VMs
-for scenario in "${SCENARIO_SOURCES}"/*.sh; do
+for scenario in "${TESTDIR}"/scenarios*/*.sh; do
     echo "Deleting $(basename "${scenario}")"
     "${TESTDIR}/bin/scenario.sh" cleanup "${scenario}" &>/dev/null || true
 done


### PR DESCRIPTION
A small usability fix to always end up with no old VMs when running the `cleanup_hypervisor.sh` script