### PR TITLE
USHIFT-3734: Avoid using build image dnf wrapper script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,14 +310,19 @@ rpm-podman:
 	podman build \
 		--volume /etc/pki/entitlement/:/etc/pki/entitlement \
 		--build-arg TAG=$(RPM_BUILDER_IMAGE_TAG) \
+		--build-arg DNF=dnf.real \
 		--authfile $(PULLSECRET) \
-		--tag microshift-builder:$(RPM_BUILDER_IMAGE_TAG) - < ./packaging/images/Containerfile.rpm-builder ; \
+		--tag microshift-builder:$(RPM_BUILDER_IMAGE_TAG) \
+		--file ./packaging/images/Containerfile.rpm-builder \
+	&& \
 	podman run \
 		--rm -i \
 		--volume $$(pwd):/opt/microshift:z \
 		--env TARGET_ARCH=$(TARGET_ARCH) \
 		microshift-builder:$(RPM_BUILDER_IMAGE_TAG) \
-		bash -ilc 'cd /opt/microshift && make rpm & pid=$$! ; trap "pkill $${pid}" INT ; wait $${pid}'
+		bash -ilc 'cd /opt/microshift && make rpm & pid=$$! ; \
+				   trap "echo Killing make PID $${pid}; kill $${pid}" INT ; \
+				   wait $${pid}'
 .PHONY: rpm-podman
 
 ###############################

--- a/packaging/images/Containerfile.rpm-builder
+++ b/packaging/images/Containerfile.rpm-builder
@@ -1,12 +1,19 @@
 ARG TAG
 FROM registry.ci.openshift.org/ocp/builder:$TAG
 
-RUN rm -rfv /etc/yum.repos.d/ci-rpm-mirrors.repo /etc/yum.repos.d/localdev* && \
-    dnf install \
+# Allow for optional override of the dnf command. This is necessary when build
+# images are configured to use a dnf shim and dnf.real executable name.
+ARG DNF=dnf
+
+# Delete the builder repos to allow usage of the host repository entitlement.
+# This requires '--volume /etc/pki/entitlement/:/etc/pki/entitlement' option
+# during the build.
+RUN rm -fv /etc/yum.repos.d/ci-rpm-mirrors.repo /etc/yum.repos.d/localdev* && \
+    ${DNF} install \
         --setopt=tsflags=nodocs \
         --setopt=install_weak_deps=False \
         -y \
         selinux-policy-devel rpmdevtools jq gettext \
     && \
-    dnf clean all && \
+    ${DNF} clean all && \
     rm -rf /var/cache/dnf/*


### PR DESCRIPTION
ART changed build images to use `dnf` wrapper script. 
Fix the MicroShift build image configuration to use the `dnf.real` executable directly.

Other minor enhancements include adding comments and build command optimization.