### PR TITLE
USHIFT-3503: Properly apply greenboot timeout increase in blueprints and container files

### DIFF
--- a/test/image-blueprints/layer1-base/group2/rhel92-microshift-yminus2.toml
+++ b/test/image-blueprints/layer1-base/group2/rhel92-microshift-yminus2.toml
@@ -48,3 +48,13 @@ runtime_root = "/run/crun"
 runtime_config_path = ""
 monitor_path = ""
 """
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer1-base/group2/rhel93-microshift-yminus2.toml
+++ b/test/image-blueprints/layer1-base/group2/rhel93-microshift-yminus2.toml
@@ -37,3 +37,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer1-base/group2/rhel94-microshift-previous-minor.toml
+++ b/test/image-blueprints/layer1-base/group2/rhel94-microshift-previous-minor.toml
@@ -37,3 +37,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer2-presubmit/group1/rhel94-crel.toml
+++ b/test/image-blueprints/layer2-presubmit/group1/rhel94-crel.toml
@@ -55,4 +55,14 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""
 {{- end -}}

--- a/test/image-blueprints/layer2-presubmit/group1/rhel94-source-base.toml
+++ b/test/image-blueprints/layer2-presubmit/group1/rhel94-source-base.toml
@@ -37,3 +37,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer2-presubmit/group1/rhel94-source-fake-next-minor.toml
+++ b/test/image-blueprints/layer2-presubmit/group1/rhel94-source-fake-next-minor.toml
@@ -37,3 +37,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer2-presubmit/group1/rhel94-source-with-optionals.toml
+++ b/test/image-blueprints/layer2-presubmit/group1/rhel94-source-with-optionals.toml
@@ -49,3 +49,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer2-presubmit/group1/rhel94-source.toml
+++ b/test/image-blueprints/layer2-presubmit/group1/rhel94-source.toml
@@ -41,3 +41,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer3-periodic/group1/rhel94-crel-with-optionals.toml
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-crel-with-optionals.toml
@@ -63,4 +63,14 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""
 {{- end -}}

--- a/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.toml
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.toml
@@ -50,19 +50,29 @@ enabled = ["mdns", "ssh", "http", "https"]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
 
-[[customizations.files]]
 # Override the default qemu-ga service configuration on the guest to allow all RPCs.
 # BLOCK_RPCS is a deny-list of qemu-guest-agent RPCs to block, such as file read/write, process execution, etc. By
 # default, all RPCs are blocked.
 # FREEZE_HOOK_PATHNAME is the dir-path containing hook scripts.  This override does not change the default value.
-# These scripts are executed before or after guest image snapshotting ops ("freezing" and "thawing" in libvirt speak).
+# These scripts are executed before or after guest image snapshot ops ("freezing" and "thawing" in libvirt speak).
 # No hooks are installed by default.
+[[customizations.files]]
 path = "/etc/sysconfig/qemu-ga"
 data = """
 # This is a systemd environment file, not a shell script.
 # It provides settings for "/lib/systemd/system/qemu-guest-agent.service".
 BLOCK_RPCS=
 FSFREEZE_HOOK_PATHNAME=/etc/qemu-ga/fsfreeze-hook"""
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""
 
 [[containers]]
 source = "quay.io/microshift/busybox:1.36"

--- a/test/image-blueprints/layer3-periodic/group1/rhel94-source-with-optionals.toml
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-source-with-optionals.toml
@@ -49,3 +49,13 @@ enabled = ["mdns", "ssh", "http", "https"]
 [[customizations.firewall.zones]]
 name = "trusted"
 sources = ["10.42.0.0/16", "169.254.169.1"]
+
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+[[customizations.files]]
+path = "/etc/greenboot/greenboot.conf"
+data = """
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+"""

--- a/test/image-blueprints/layer5-bootc/group1/cos9-bootc-source.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/cos9-bootc-source.containerfile
@@ -30,6 +30,11 @@ RUN ${REPO_CONFIG_SCRIPT} -create ${USHIFT_RPM_REPO_PATH} && \
     rm -rf $USHIFT_RPM_REPO_PATH && \
     dnf clean all
 
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+RUN printf "\nMICROSHIFT_WAIT_TIMEOUT_SEC=600\n" >> /etc/greenboot/greenboot.conf
+
 # Configure firewall
 RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
     firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \

--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
@@ -31,6 +31,11 @@ RUN ${REPO_CONFIG_SCRIPT} -create ${USHIFT_RPM_REPO_PATH} && \
     rm -rf $USHIFT_RPM_REPO_PATH && \
     dnf clean all
 
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready.
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update.
+RUN printf "\nMICROSHIFT_WAIT_TIMEOUT_SEC=600\n" >> /etc/greenboot/greenboot.conf
+
 # Configure firewall
 RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
     firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \

--- a/test/kickstart-templates/includes/post-greenboot.cfg
+++ b/test/kickstart-templates/includes/post-greenboot.cfg
@@ -1,0 +1,6 @@
+# Extend Greenboot wait timeout to 10m for MicroShift to be ready
+if [ ! -f "/etc/greenboot/greenboot.conf" ] ; then
+    echo "ERROR: The /etc/greenboot/greenboot.conf file does not exist"
+    exit 1
+fi
+printf "\nMICROSHIFT_WAIT_TIMEOUT_SEC=600\n" >> /etc/greenboot/greenboot.conf

--- a/test/kickstart-templates/includes/post-system.cfg
+++ b/test/kickstart-templates/includes/post-system.cfg
@@ -26,6 +26,3 @@ ln -sf /dev/null /etc/systemd/user/grub-boot-success.timer
 echo "fs.inotify.max_user_watches = 65536" >> /etc/sysctl.conf
 echo "fs.inotify.max_user_instances = 8192" >> /etc/sysctl.conf
 sysctl --system
-
-# Extend Greenboot wait timeout to 10m for MicroShift to be ready
-printf "\nMICROSHIFT_WAIT_TIMEOUT_SEC=600\n" >> /etc/greenboot/greenboot.conf

--- a/test/kickstart-templates/kickstart-centos.ks.template
+++ b/test/kickstart-templates/kickstart-centos.ks.template
@@ -10,6 +10,9 @@
 %include /post-network.cfg
 
 %include /post-cos9rpm.cfg
+# Greenboot configuration must come after RPM install to avoid
+# /etc/greenboot/greenboot.conf overwrite by the package update
+%include /post-greenboot.cfg
 
 %end
 

--- a/test/resources/libostree.py
+++ b/test/resources/libostree.py
@@ -178,7 +178,7 @@ def write_greenboot_microshift_wait_timeout(seconds: int) -> None:
 
 
 def remove_greenboot_microshift_wait_timeout() -> None:
-    remote_sudo("rm /etc/greenboot/greenboot.conf")
+    remote_sudo("sudo sed -i '/^MICROSHIFT_WAIT_TIMEOUT_SEC=/d' /etc/greenboot/greenboot.conf")
 
 
 def no_transaction_in_progress() -> None:


### PR DESCRIPTION
The greenboot RPM released in RHEL 9.x OS overwrites the `/etc/greenboot/greenboot.conf` customizations (see https://github.com/fedora-iot/greenboot/issues/142).

Work around this issue by:
* ostree: include the customization in blueprints
* bootc: include the customization in containerfiles
* rpm: apply the customization after installing MicroShift (and greenboot) RPMs
