### PR TITLE
NO-ISSUE: Fix common versions script not to produce errors for non-existent repos

### DIFF
--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -9,7 +9,7 @@ get_vrel_from_beta() {
             --queryformat '%{version}-%{release}' \
             --disablerepo '*' \
             --repofrompath "this,${beta_repo}" \
-            --latest-limit 1 \
+            --latest-limit 1 2>/dev/null \
         )
     if [ -n "${beta_vrel}" ]; then
         echo "${beta_vrel}"
@@ -25,7 +25,7 @@ get_vrel_from_rhsm() {
             --quiet \
             --queryformat '%{version}-%{release}' \
             --repo "${rhsm_repo}" \
-            --latest-limit 1 \
+            --latest-limit 1 2>/dev/null \
         )
     if [ -n "${rhsm_vrel}" ]; then
         echo "${rhsm_vrel}"


### PR DESCRIPTION
Example of error messages when run on a Fedora OS
```
$ cat /etc/redhat-release 
Fedora release 39 (Thirty Nine)
$ source ./test/bin/common_versions.sh 
Error: Unknown repo: 'rhocp-4.16-for-rhel-9-x86_64-rpms'
Error: Unknown repo: 'rhocp-4.15-for-rhel-9-x86_64-rpms'
```
