### PR TITLE
USHIFT-3749: Add subscription-manager to the base ostree image to enable DNF install in containers

### DIFF
--- a/test/image-blueprints/layer1-base/group2/rhel94-microshift-previous-minor.toml
+++ b/test/image-blueprints/layer1-base/group2/rhel94-microshift-previous-minor.toml
@@ -25,10 +25,18 @@ version = "{{ .Env.PREVIOUS_RELEASE_VERSION }}*"
 name = "microshift-test-agent"
 version = "*"
 
-# The bootc package is required for testing upgrades
-# from ostree to bootc images
+# The bootc, dnf and subscription-manager packages are required for
+# testing upgrades from ostree to bootc images
 [[packages]]
 name = "bootc"
+version = "*"
+
+[[packages]]
+name = "dnf"
+version = "*"
+
+[[packages]]
+name = "subscription-manager"
 version = "*"
 
 [customizations.services]


### PR DESCRIPTION
Need to include dnf and subscription-manager packages in the base ostree image to enable RPM package installation when building containers.
If those packages are not included in the ostree commit, the container image produced by `rpm-ostree` does not have these utilities, so any `dnf install` command present in the derived container builds fails.

A follow-up on https://github.com/openshift/microshift/pull/3625.
