### PR TITLE
USHIFT-3761: Set default networks separately

### DIFF
--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/config.go
@@ -263,15 +263,20 @@ func (c *Config) incorporateUserSettings(u *Config) {
 // inputs to more easily consumable units or fills in any defaults
 // computed based on the values of other settings.
 func (c *Config) updateComputedValues() error {
-	if len(c.Network.ClusterNetwork) == 0 && len(c.Network.ServiceNetwork) == 0 {
+	if len(c.Network.ClusterNetwork) == 0 {
 		defaultClusterNetwork := "10.42.0.0/16"
-		defaultServiceNetwork := "10.43.0.0/16"
 		ip := net.ParseIP(c.Node.NodeIP)
 		if ip.To4() == nil {
 			defaultClusterNetwork = "fd01::/48"
-			defaultServiceNetwork = "fd02::/112"
 		}
 		c.Network.ClusterNetwork = []string{defaultClusterNetwork}
+	}
+	if len(c.Network.ServiceNetwork) == 0 {
+		defaultServiceNetwork := "10.43.0.0/16"
+		ip := net.ParseIP(c.Node.NodeIP)
+		if ip.To4() == nil {
+			defaultServiceNetwork = "fd02::/112"
+		}
 		c.Network.ServiceNetwork = []string{defaultServiceNetwork}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,15 +263,20 @@ func (c *Config) incorporateUserSettings(u *Config) {
 // inputs to more easily consumable units or fills in any defaults
 // computed based on the values of other settings.
 func (c *Config) updateComputedValues() error {
-	if len(c.Network.ClusterNetwork) == 0 && len(c.Network.ServiceNetwork) == 0 {
+	if len(c.Network.ClusterNetwork) == 0 {
 		defaultClusterNetwork := "10.42.0.0/16"
-		defaultServiceNetwork := "10.43.0.0/16"
 		ip := net.ParseIP(c.Node.NodeIP)
 		if ip.To4() == nil {
 			defaultClusterNetwork = "fd01::/48"
-			defaultServiceNetwork = "fd02::/112"
 		}
 		c.Network.ClusterNetwork = []string{defaultClusterNetwork}
+	}
+	if len(c.Network.ServiceNetwork) == 0 {
+		defaultServiceNetwork := "10.43.0.0/16"
+		ip := net.ParseIP(c.Node.NodeIP)
+		if ip.To4() == nil {
+			defaultServiceNetwork = "fd02::/112"
+		}
 		c.Network.ServiceNetwork = []string{defaultServiceNetwork}
 	}
 


### PR DESCRIPTION
Allows configuring only one of them, keeping old behavior for both ipv4 and ipv6.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
