### PR TITLE
NO-ISSUE: Missing persistent journal on 1st boot when installing using rhel94 iso

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -16,7 +16,7 @@ source "${SCRIPTDIR}/common.sh"
 # shellcheck source=test/bin/common_versions.sh
 source "${SCRIPTDIR}/common_versions.sh"
 
-DEFAULT_BOOT_BLUEPRINT="rhel-9.2"
+DEFAULT_BOOT_BLUEPRINT="rhel-9.4"
 LVM_SYSROOT_SIZE="10240"
 WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
 BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"

--- a/test/kickstart-templates/includes/post-system.cfg
+++ b/test/kickstart-templates/includes/post-system.cfg
@@ -13,6 +13,7 @@ Storage=persistent
 SystemMaxUse=1G
 RuntimeMaxUse=1G
 EOF
+sudo mkdir -p /var/log/journal
 
 # Disable a timer that sets boot_success to 1 after two minutes from a user login.
 # It impacts greenboot checks because grub script decrementing boot_counter works

--- a/test/scenarios/el92-yminus2@el94-src@upgrade-ok.sh
+++ b/test/scenarios/el92-yminus2@el94-src@upgrade-ok.sh
@@ -4,7 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart.ks.template "rhel-9.2-microshift-4.${YMINUS2_MINOR_VERSION}"
-    launch_vm host1
+    launch_vm host1 rhel-9.2
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
For some reason, when using only `Storage=persistent`, the journal on first boot is not persistent. This causes some upgrade tests fail when they depend on counting amount of boots.