### PR TITLE
USHIFT-3494: Add explicit command line mode to virtual machine creation

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -44,24 +44,24 @@ validate_vm_hostname() {
     local vm_name="$1"
 
     if [ -z "${vm_name}" ]; then
-        error "VM hostname cannot be empty string" 
+        error "VM hostname cannot be empty string"
         record_junit "${vm_name}" "vm_hostname_validation" "FAILED"
         exit 1
     fi
 
     if [ ${#vm_name} -gt 64 ]; then
-        error "VM hostname is too long" 
+        error "VM hostname is too long"
         record_junit "${vm_name}" "vm_hostname_validation" "FAILED"
         exit 1
     fi
-    
+
     if ! echo "${vm_name}" | grep -E '^([a-zA-Z0-9]+-*[a-zA-Z0-9]+)+$|^[a-zA-Z0-9]+$' > /dev/null; then
         error "VM hostname is invalid"
         record_junit "${vm_name}" "vm_hostname_validation" "FAILED"
         exit 1
     fi
 
-    record_junit "${vm_name}" "vm_hostname_validation" "OK"   
+    record_junit "${vm_name}" "vm_hostname_validation" "OK"
 }
 
 vm_property_filename() {
@@ -514,6 +514,17 @@ launch_vm() {
         ;;
     esac
 
+    # Attach the graphical console if specified in the scenario settings
+    local graphics_args
+    graphics_args="none"
+    if "${VNC_CONSOLE}"; then
+        graphics_args="vnc,listen=0.0.0.0"
+    else
+        # The inst.cmdline mode does not allow any interaction and it ensures
+        # that %onerror kickstart handlers are executed on failure
+        vm_extra_args+=" inst.cmdline"
+    fi
+
     for _ in $(seq "${vm_nics}") ; do
         vm_network_args+="--network network=${network_name},model=virtio "
     done
@@ -544,12 +555,6 @@ launch_vm() {
     local attempt=1
     local max_attempts=2
     while true ; do
-        local graphics_args
-        graphics_args="none"
-        if "${VNC_CONSOLE}"; then
-            graphics_args="vnc,listen=0.0.0.0"
-        fi
-
         # Make sure the virt-install command times out after a predefined period.
         # The 'timeout' command sends the HUP signal and, if the process does not
         # exit after 1m, it sends the KILL signal to terminate the process.


### PR DESCRIPTION
I verified that any failure to the installation now invokes the kickstart [%onerror handler](https://github.com/openshift/microshift/blob/main/test/kickstart-templates/includes/onerror-logs.cfg).

The terminal output looks like this:
```
[   33.517655] anaconda[2628]: Installing.
[   34.520412] anaconda[2628]: The installation was stopped due to an error which occurred while running in non-interactive cmdline mode. Since there cannot be any questions in cmdline mode, edit your kickstart file and retry installation.
[   34.520498] anaconda[2628]: The exact error message is:
[   34.520680] anaconda[2628]: Non interactive installation failed: The command 'ostree container image deploy --sysroot=/mnt/sysimage --image=192.168.100.1:5000/rhel94-bootc-source --transport=registry' exited with the code 1..
[   34.520788] anaconda[2628]: The installer will now terminate.
Displaying log files on installation failure
---- /tmp/anaconda.log ----
05:35:38,756 INF core.configuration.product: Loading information about products from /etc/anaconda/product.d.
...
...
INFO:anaconda.threading:Thread Done: AnaTaskThread-MountFilesystemsTask-1 (139805871302208)
----      ----
Finished diplaying log files on installation failure
```
Note that the installation process actually stops after a short while and we fall back to the `scenario.sh` checking if the machine is up and running.
```
dracut Warning: Killing all remaining processes
[  224.656120] dracut Warning: Killing all remaining processes
dracut Warning: Unmounted /oldroot.
[  224.690980] dracut Warning: Unmounted /oldroot.
Rebooting.
[  224.758325] reboot: Restarting system

Domain has shutdown. Continuing.
Domain creation completed.
You can restart your domain by running:
  virsh --connect qemu:///system start el94-src-log-scan-host1
Domain 'el94-src-log-scan-host1' started

Waiting for VM el94-src-log-scan-host1 to have an IP
VM el94-src-log-scan-host1 has IP 192.168.100.246
```

The wait process finishes with a timeout and `scenario.sh` reports a VM creation failure as expected.