### PR TITLE
USHIFT-3780: Fix cleanup-all option in manage_hypervisor_config.sh

### DIFF
--- a/test/bin/manage_hypervisor_config.sh
+++ b/test/bin/manage_hypervisor_config.sh
@@ -163,7 +163,7 @@ action_cleanup() {
 
 action_cleanup-all() {
     # Clean up all of the VMs
-    for scenario in "${TESTDIR}"/scenarios*/*.sh; do
+    for scenario in "${TESTDIR}"/scenarios*/*/*.sh; do
         echo "Deleting $(basename "${scenario}")"
         "${TESTDIR}/bin/scenario.sh" cleanup "${scenario}" &>/dev/null || true
     done


### PR DESCRIPTION
The bug introduced by https://github.com/openshift/microshift/pull/3716