### PR TITLE
OCPBUGS-38974: Update openvswitch to 3.4

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -109,7 +109,7 @@ The microshift-selinux package provides the SELinux policy modules required by M
 Summary: Networking components for MicroShift
 Requires: microshift = %{version}
 Obsoletes: openvswitch3.1 < 3.3
-Requires: (openvswitch3.3 or openvswitch >= 3.3)
+Requires: (openvswitch3.4 or openvswitch >= 3.4)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -519,6 +519,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Mon Aug 26 2024 Nadia Pinaeva <n.m.pinaeva@gmail.com> 4.17.0
+- Update openvswitch to 3.4
+
 * Mon Jul 29 2024 Patryk Matuszak <pmatusza@redhat.com> 4.17.0
 - Add microshift-tuned daemon for unattended TuneD profile activation
 

--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source-ostree-parent.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source-ostree-parent.containerfile
@@ -22,9 +22,12 @@ COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
 # - MicroShift local RPM repository
 # - OpenShift previous minor version RHEL repositories for MicroShift dependencies
 # Install MicroShift, test agent, a few helper utilities and cleanup
+#
+# Allow erasing because update may require a new version of openvswitch and
+# major versions of openvswitch are separate packages that obsolete each other.
 RUN ${REPO_CONFIG_SCRIPT} -create ${USHIFT_RPM_REPO_PATH} && \
     awk 'FNR==1 {print "=== " FILENAME " ==="} {print}' /etc/yum.repos.d/*.repo && \
-    dnf install -y vi firewalld microshift microshift-test-agent && \
+    dnf install -y --allowerasing vi firewalld microshift microshift-test-agent && \
     systemctl enable microshift microshift-test-agent && \
     ${REPO_CONFIG_SCRIPT} -delete && \
     rm -f ${REPO_CONFIG_SCRIPT} && \

--- a/test/kickstart-templates/includes/post-cos9rpm.cfg
+++ b/test/kickstart-templates/includes/post-cos9rpm.cfg
@@ -8,7 +8,7 @@ gpgcheck=0
 skip_if_unavailable=0
 EOF
 
-# The openvswitch3.3 dependency
+# The openvswitch package dependency
 cat > "/etc/yum.repos.d/openvswitch2-rpms.repo" <<EOF
 [sig-nfv]
 name=CentOS Stream 9 - SIG NFV


### PR DESCRIPTION
Following ovn-k and RHCOS updates:
https://github.com/openshift/ovn-kubernetes/pull/2273
https://github.com/openshift/os/pull/1596
Depends on: https://issues.redhat.com/browse/ART-10428
previous bump: https://github.com/openshift/microshift/pull/3350
