### PR TITLE
USHIFT-4059: Add crio metrics config to ansible scripts

### DIFF
--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # install-microshift default vars
 
+crio_metrics_conf: 01-crio-metrics.conf
+crio_metrics_path: "/etc/crio/crio.conf.d/{{ crio_metrics_conf }}"
 etcd_dir: "{{ ansible_env.HOME }}/etcd"
 etcd_repo: https://github.com/openshift/etcd.git
 

--- a/ansible/roles/install-microshift/files/01-crio-metrics.conf
+++ b/ansible/roles/install-microshift/files/01-crio-metrics.conf
@@ -1,0 +1,3 @@
+[crio.metrics]
+enable_metrics = true
+metrics_port = 9537

--- a/ansible/roles/install-microshift/tasks/main.yml
+++ b/ansible/roles/install-microshift/tasks/main.yml
@@ -17,12 +17,6 @@
           - cri-tools
         state: present
 
-    - name: start crio service
-      become: yes
-      ansible.builtin.systemd:
-        name: crio
-        state: started
-
     - name: check if microshift dir exists
       ansible.builtin.stat:
         path: "{{ microshift_dir }}"
@@ -133,3 +127,17 @@
     mode: '0600'
   when: not pull_secret.stat.exists
 
+- name: check if crio metrics config is present
+  ansible.builtin.stat:
+    path: "{{ crio_metrics_path }}"
+  register: crio_metrics
+
+- name: enable crio metrics
+  become: yes
+  ansible.builtin.copy:
+    src: "{{ crio_metrics_conf }}"
+    dest: "{{ crio_metrics_path }}"
+    owner: root
+    group: root
+    mode: '0644'
+  when: not crio_metrics.stat.exists


### PR DESCRIPTION
- Add cri-o config to re-enable metrics as it was in MicroShift 4.15
- Disable prestart of cri-o service