### PR TITLE
USHIFT-4385: Add devenv instructions on mounting shared directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,19 @@ verify-py:
 verify-rf:
 	./scripts/verify/verify-rf.sh
 
+# When run inside a container, the file contents are redirected via stdin and
+# the output of errors does not contain the file path. Work around this issue
+# by replacing the '^-:' token in the output by the actual file name.
 .PHONY: verify-containers
 verify-containers:
-	./scripts/fetch_tools.sh hadolint && \
-	./_output/bin/hadolint $$(find . -iname '*containerfile*' -o -iname '*dockerfile*'| grep -v "vendor\|_output\|origin\|.git")
+	./scripts/fetch_tools.sh hadolint ; \
+	FILES=$$(find . -iname '*containerfile*' -o -iname '*dockerfile*' | grep -v "vendor\|_output\|origin\|.git") ; \
+	for f in $${FILES} ; do \
+		echo "$${f}" ; \
+		podman run --rm -i \
+			-v "$$(pwd)/.hadolint.yaml:/.hadolint.yaml:ro" \
+			ghcr.io/hadolint/hadolint:2.12.0 < "$${f}" | sed "s|^-:|$${f}:|" ; \
+	done
 
 # Vulnerability check is not run in any default verify target
 # It should be run explicitly before the release to track and fix known vulnerabilities

--- a/docs/contributor/devenv_setup.md
+++ b/docs/contributor/devenv_setup.md
@@ -414,30 +414,15 @@ Reboot the development virtual machine to finalize the configuration.
 
 #### Using Shared Directory
 
-One way of using the shared directory would be to keep the whole source tree in
-it for easy access from the host.
+Run the following commands to move the original source tree to a shared location
+and link it from the `microshift` user home directory. Note that this allows to
+keep all the user configuration files locally while sharing the source tree.
 
 ```
 MOUNT_DIR=/home/microshift-shared
 
-sudo mkdir -p -m 0755 "${MOUNT_DIR}/microshift"
-sudo chown $(whoami). "${MOUNT_DIR}/microshift"
+sudo mv ~/microshift "${MOUNT_DIR}/"
 
 # Do not attempt to create the link if the target already exists
 [ ! -e ~/microshift ] && ln -s "${MOUNT_DIR}/microshift" ~/microshift
-```
-
-Another way of using the shared directory would be to keep the whole `microshift`
-user home directory on the host and mount it from the virtual machine.
-
-```
-MOUNT_DIR=/home/microshift-shared
-
-sudo mkdir -p -m 0755 "${MOUNT_DIR}/microshift"
-sudo chown $(whoami). "${MOUNT_DIR}/microshift"
-
-# Move the existing home directory
-[ -d /home/microshift ] && sudo mv /home/microshift /home/microshift.local
-# Do not attempt to create the link if the target already exists
-[ ! -L /home/microshift ] && sudo ln -s "${MOUNT_DIR}" /home/microshift
 ```

--- a/docs/contributor/devenv_setup.md
+++ b/docs/contributor/devenv_setup.md
@@ -307,3 +307,137 @@ sudo lvextend -l +95%FREE /dev/mapper/rhel-root
 # Resize the file system
 sudo xfs_growfs /dev/mapper/rhel-root
 ```
+
+### Sharing Directory with Development Virtual Machine
+
+When the MicroShift development environment is running inside a virtual machine,
+it is sometimes convenient to share the MicroShift repository directory between
+the host and the virtual machine (e.g. to build artifacts on the development
+machine and run on the host, etc.).
+
+One way of sharing the directory is to use NFS mounts. Follow the instructions
+in the remainder of this section to implement the directory mount.
+
+#### Host Configuration
+
+Run the following commands to create and export the directory over an NFS mount.
+
+```
+EXPORT_DIR=/home/microshift-shared
+
+sudo dnf install -y nfs-utils
+
+sudo mkdir -p "${EXPORT_DIR}"
+sudo chown nobody:nobody "${EXPORT_DIR}"
+sudo chmod 755 "${EXPORT_DIR}"
+
+echo "${EXPORT_DIR} *(rw,async,no_root_squash,no_subtree_check)" | sudo tee -a /etc/exports
+sudo exportfs -arv
+```
+
+Run the following commands to configure the NFS service and firewall rules.
+
+```
+sudo systemctl restart nfs-server
+sudo systemctl enable nfs-server
+
+sudo firewall-cmd --permanent --zone=libvirt --add-service=nfs
+sudo firewall-cmd --permanent --zone=libvirt --add-service=mountd
+sudo firewall-cmd --permanent --zone=libvirt --add-service=rpc-bind
+sudo firewall-cmd --reload
+```
+
+Run the following commands to note down the IP address to be used when mounting
+the directory from the virtual machine.
+
+```
+BRIDGE_DEV=$(sudo virsh net-info default | grep '^Bridge:' | awk '{print $2}')
+BRIDGE_IP=$(ip -f inet addr show "${BRIDGE_DEV}" | grep inet)
+
+echo "${BRIDGE_IP}" | awk '{print $2}' | cut -d/ -f1
+```
+
+#### Virtual Machine Configuration
+
+```
+MOUNT_DIR=/home/microshift-shared
+BRIDGE_IP=192.168.100.1
+
+sudo dnf install -y nfs-utils
+
+sudo mkdir -p "${MOUNT_DIR}"
+sudo mount -t nfs4 -o context="system_u:object_r:container_file_t:s0" "${BRIDGE_IP}:${MOUNT_DIR}" "${MOUNT_DIR}"
+```
+
+If the mount works properly, make it permanent by running the following command.
+
+```
+echo "${BRIDGE_IP}:${MOUNT_DIR} ${MOUNT_DIR} nfs4 rw,hard,intr,noatime,context=\"system_u:object_r:container_file_t:s0\" 0 0" | sudo tee -a /etc/fstab
+```
+
+#### Synchronize User and Group Identifiers
+
+For read-write to work properly both on the hypervisor host and on the virtual
+machine, it is recommended to edit the `microshift` user and group
+identifiers on the virtual machine to have the value as on the hypervisor.
+
+Edit the `/etc/passwd` and `/etc/group` files on the virtual machine to replace
+the `microshift` user and group identifiers. The goal is for the `id -u; id -g`
+command to return the same identifiers when run on the host and on the virtual
+machine.
+
+Here is an example of setting the user and group identifiers to `12345` value on
+the virtual machine.
+
+```
+$ grep ^microshift /etc/passwd
+microshift:x:12345:12345::/home/microshift:/bin/bash
+
+$ grep ^microshift /etc/group
+microshift:x:12345:
+```
+
+Run the following commands to fix the ownership of the user home directory and
+the shared directory.
+
+```
+MOUNT_DIR=/home/microshift-shared
+
+sudo chown -R $(whoami). ~
+sudo chown -R $(whoami). "${MOUNT_DIR}"
+
+# Delete user-specific container cache
+sudo rm -rf ~/.local/share/containers/
+```
+
+Reboot the development virtual machine to finalize the configuration.
+
+#### Using Shared Directory
+
+One way of using the shared directory would be to keep the whole source tree in
+it for easy access from the host.
+
+```
+MOUNT_DIR=/home/microshift-shared
+
+sudo mkdir -p -m 0755 "${MOUNT_DIR}/microshift"
+sudo chown $(whoami). "${MOUNT_DIR}/microshift"
+
+# Do not attempt to create the link if the target already exists
+[ ! -e ~/microshift ] && ln -s "${MOUNT_DIR}/microshift" ~/microshift
+```
+
+Another way of using the shared directory would be to keep the whole `microshift`
+user home directory on the host and mount it from the virtual machine.
+
+```
+MOUNT_DIR=/home/microshift-shared
+
+sudo mkdir -p -m 0755 "${MOUNT_DIR}/microshift"
+sudo chown $(whoami). "${MOUNT_DIR}/microshift"
+
+# Move the existing home directory
+[ -d /home/microshift ] && sudo mv /home/microshift /home/microshift.local
+# Do not attempt to create the link if the target already exists
+[ ! -L /home/microshift ] && sudo ln -s "${MOUNT_DIR}" /home/microshift
+```

--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -145,8 +145,8 @@ gettool_hadolint() {
     # If you want to allow all unconfined executables to use libraries requiring text relocation
     # that are not labeled textrel_shlib_t, then you must tell SELinux about this by enabling the
     # 'selinuxuser_execmod' boolean.
-    if which selinuxenabled >/dev/null 2>&1; then
-        if selinuxenabled ; then
+    if which selinuxenabled >/dev/null 2>&1 && selinuxenabled ; then
+        if ! stat -c "%C" "${DEST_DIR}/${filename}" | grep -qE 'textrel_shlib_t|container_file_t' ; then
             chcon -t textrel_shlib_t "${DEST_DIR}/${filename}"
         fi
     fi

--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -123,32 +123,11 @@ gettool_yq() {
 }
 
 gettool_hadolint() {
-    local ver="2.12.0"
-    declare -A checksums=(
-        ["x86_64"]="56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010"
-        ["aarch64"]="5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6")
+    local -r ver="2.12.0"
+    local -r img="ghcr.io/hadolint/hadolint"
 
-    declare -A arch_map=(
-        ["x86_64"]="x86_64"
-        ["aarch64"]="arm64")
-
-    local arch="${arch_map[${ARCH}]}"
-    local checksum="${checksums[${ARCH}]}"
-    local filename="hadolint"
-    local url="https://github.com/hadolint/hadolint/releases/download/v${ver}/hadolint-Linux-${arch}"
-
-    _install "${url}" "${checksum}" "${filename}" "hadolint-Linux-${arch}"
-
-    # SELinux context change is required on some systems to prevent the following error
-    #
-    # SELinux is preventing <exename> from execmod access on the file.
-    # If you want to allow all unconfined executables to use libraries requiring text relocation
-    # that are not labeled textrel_shlib_t, then you must tell SELinux about this by enabling the
-    # 'selinuxuser_execmod' boolean.
-    if which selinuxenabled >/dev/null 2>&1 && selinuxenabled ; then
-        if ! stat -c "%C" "${DEST_DIR}/${filename}" | grep -qE 'textrel_shlib_t|container_file_t' ; then
-            chcon -t textrel_shlib_t "${DEST_DIR}/${filename}"
-        fi
+    if [ "$(podman images -q "${img}:${ver}" | wc -w)" -eq 0 ] ; then
+        podman pull "${img}:${ver}"
     fi
 }
 


### PR DESCRIPTION
This change also contains an optimization for how hadolint is used. This is necessary to avoid SELinux context setting on an NFS-mounted partition. 

Note that `container_file_t` SELinux context is still required for running container images off the mounted directory. But, unlike the context for hadolint that was always set on verify, the `container_file_t` is only set in case of NFS mount.