### PR TITLE
USHIFT-4336: Implement embedded container build support in bootc tests

### DIFF
--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -135,10 +135,18 @@ def set_rpm_version_info_vars():
     SOURCE_VERSION = common.run_command_in_shell(f"rpm -q --queryformat '%{{version}}-%{{release}}' {release_info_rpm}")
     SOURCE_VERSION_BASE = common.run_command_in_shell(f"rpm -q --queryformat '%{{version}}-%{{release}}' {release_info_rpm_base}")
 
+    # The source images are used in selected container image builds
+    global SOURCE_IMAGES
+
+    src_img_cmd = f"rpm2cpio {release_info_rpm}"
+    src_img_cmd += f' | cpio -i --to-stdout "*release-{UNAME_M}.json" 2>/dev/null'
+    src_img_cmd += ' | jq -r \'[ .images[] ] | join(",")\''
+    SOURCE_IMAGES = common.run_command_in_shell(src_img_cmd)
+
     # Update the source version environment variables based on the global variables.
     # These are used for templating container files and images.
     rpmver_globals_vars = [
-        'SOURCE_VERSION', 'SOURCE_VERSION_BASE'
+        'SOURCE_VERSION', 'SOURCE_VERSION_BASE', 'SOURCE_IMAGES'
     ]
     for var in rpmver_globals_vars:
         value = globals().get(var)
@@ -230,10 +238,13 @@ def process_containerfile(groupdir, containerfile, dry_run):
     try:
         # Redirect the output to the log file
         with open(cf_logfile, 'w') as logfile:
-            # Run the container build command
+            # Run the container build command.
+            # Note: The pull secret is necessary in some builds for pulling embedded
+            # container images specified by SOURCE_IMAGES environment variable.
             build_args = [
                 "sudo", "podman", "build",
                 "--authfile", PULL_SECRET,
+                "--secret", f"id=pullsecret,src={PULL_SECRET}",
                 "-t", cf_outname, "-f", cf_outfile,
                 IMAGEDIR
             ]

--- a/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
@@ -1,0 +1,35 @@
+FROM localhost/cos9-bootc-source:latest
+
+# SOURCE_IMAGES contains a comma-separated list of container image references.
+# Split the variable and pull each image in a separate layer.
+#
+# Note: Gomplate blocks are commented out to avoid hadolint warnings.
+# {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
+RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
+    skopeo copy \
+    --authfile /run/secrets/pull-secret.json \
+    "docker://{{ . }}" \
+    dir:/var/lib/containers/storage-preloaded
+# {{ end }}
+
+# Edit the container storage configuration file to include the new path
+RUN sed -i '/^additionalimagestores.*/a\   "/var/lib/containers/storage-preloaded",' /etc/containers/storage.conf
+
+# Apply a workaround to set the SELinux context on the new storage directory and
+# also restore 'NET_BIND_SERVICE' capability that is currently lost when including
+# images in the container.
+#
+# Note: This requires setting the additional image stores path to a read-write
+# location on the file system. The images will still be treated as read-only by
+# the container subsystem.
+# See https://github.com/ostreedev/ostree-rs-ext/issues/654
+COPY --chmod=755 ./bootc-images/microshift-imagestore-config.sh /usr/bin/microshift-imagestore-config
+RUN printf '[Unit]\n\
+Description=Configure the image store directory for MicroShift\n\
+Before=microshift.service\n\
+[Service]\n\
+Type=oneshot\n\
+ExecStart=/usr/bin/microshift-imagestore-config /var/lib/containers/storage /var/lib/containers/storage-preloaded\n\
+[Install]\n\
+WantedBy=multi-user.target\n' > /etc/systemd/system/microshift-imagestore-config.service && \
+    systemctl enable microshift-imagestore-config.service

--- a/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
@@ -7,9 +7,10 @@ FROM localhost/cos9-bootc-source:latest
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
     skopeo copy \
-    --authfile /run/secrets/pull-secret.json \
-    "docker://{{ . }}" \
-    dir:/var/lib/containers/storage-preloaded
+        --retry-times 3 \
+        --authfile /run/secrets/pull-secret.json \
+        "docker://{{ . }}" \
+        dir:/var/lib/containers/storage-preloaded
 # {{ end }}
 
 # Edit the container storage configuration file to include the new path

--- a/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
@@ -6,7 +6,7 @@ FROM localhost/cos9-bootc-source:latest
 # Note: Gomplate blocks are commented out to avoid hadolint warnings.
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
-    skopeo copy \
+    GOMAXPROCS=8 skopeo copy \
         --retry-times 3 \
         --authfile /run/secrets/pull-secret.json \
         "docker://{{ . }}" \

--- a/test/image-blueprints/layer5-bootc/group2/microshift-imagestore-config.sh.template
+++ b/test/image-blueprints/layer5-bootc/group2/microshift-imagestore-config.sh.template
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -ne 2 ] ; then
+    echo "Usage: $(basename "$0") </default/image/store/path> </new/image/store/path>"
+    exit 1
+fi
+
+if [ "$(id -u)" != 0 ] ; then
+    echo "This script should be executed with root permissions"
+    exit 1
+fi
+
+DEF_IMGPATH="$1"
+NEW_IMGPATH="$2"
+
+semanage fcontext -a -e "${DEF_IMGPATH}" "${NEW_IMGPATH}"
+restorecon -R "${NEW_IMGPATH}"
+
+find "${NEW_IMGPATH}" -type f -path "*/usr/sbin/haproxy" -exec setcap "cap_net_bind_service=+ep" {} \;

--- a/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
@@ -1,0 +1,35 @@
+FROM localhost/rhel94-bootc-source:latest
+
+# SOURCE_IMAGES contains a comma-separated list of container image references.
+# Split the variable and pull each image in a separate layer.
+#
+# Note: Gomplate blocks are commented out to avoid hadolint warnings.
+# {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
+RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
+    skopeo copy \
+    --authfile /run/secrets/pull-secret.json \
+    "docker://{{ . }}" \
+    dir:/var/lib/containers/storage-preloaded
+# {{ end }}
+
+# Edit the container storage configuration file to include the new path
+RUN sed -i '/^additionalimagestores.*/a\   "/var/lib/containers/storage-preloaded",' /etc/containers/storage.conf
+
+# Apply a workaround to set the SELinux context on the new storage directory and
+# also restore 'NET_BIND_SERVICE' capability that is currently lost when including
+# images in the container.
+#
+# Note: This requires setting the additional image stores path to a read-write
+# location on the file system. The images will still be treated as read-only by
+# the container subsystem.
+# See https://github.com/ostreedev/ostree-rs-ext/issues/654
+COPY --chmod=755 ./bootc-images/microshift-imagestore-config.sh /usr/bin/microshift-imagestore-config
+RUN printf '[Unit]\n\
+Description=Configure the image store directory for MicroShift\n\
+Before=microshift.service\n\
+[Service]\n\
+Type=oneshot\n\
+ExecStart=/usr/bin/microshift-imagestore-config /var/lib/containers/storage /var/lib/containers/storage-preloaded\n\
+[Install]\n\
+WantedBy=multi-user.target\n' > /etc/systemd/system/microshift-imagestore-config.service && \
+    systemctl enable microshift-imagestore-config.service

--- a/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
@@ -7,9 +7,10 @@ FROM localhost/rhel94-bootc-source:latest
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
     skopeo copy \
-    --authfile /run/secrets/pull-secret.json \
-    "docker://{{ . }}" \
-    dir:/var/lib/containers/storage-preloaded
+        --retry-times 3 \
+        --authfile /run/secrets/pull-secret.json \
+        "docker://{{ . }}" \
+        dir:/var/lib/containers/storage-preloaded
 # {{ end }}
 
 # Edit the container storage configuration file to include the new path

--- a/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
@@ -6,7 +6,7 @@ FROM localhost/rhel94-bootc-source:latest
 # Note: Gomplate blocks are commented out to avoid hadolint warnings.
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
-    skopeo copy \
+    GOMAXPROCS=8 skopeo copy \
         --retry-times 3 \
         --authfile /run/secrets/pull-secret.json \
         "docker://{{ . }}" \

--- a/test/scenarios-bootc/periodics/cos9-src@isolated-net.sh
+++ b/test/scenarios-bootc/periodics/cos9-src@isolated-net.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# Redefine network-related settings to use the isolated network bridge
+VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
+# shellcheck disable=SC2034  # used elsewhere
+BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source-isolated
+    # Use the isolated network when creating a VM
+    launch_vm --boot_blueprint centos9-bootc --network_name "${VM_ISOLATED_NETWORK}" --bootc
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_tests host1 suites/network/isolated-network.robot
+}

--- a/test/scenarios-bootc/periodics/el94-src@isolated-net.sh
+++ b/test/scenarios-bootc/periodics/el94-src@isolated-net.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# Redefine network-related settings to use the isolated network bridge
+VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
+# shellcheck disable=SC2034  # used elsewhere
+BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source-isolated
+    # Use the isolated network when creating a VM
+    launch_vm --boot_blueprint rhel94-bootc --network_name "${VM_ISOLATED_NETWORK}" --bootc
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_tests host1 suites/network/isolated-network.robot
+}


### PR DESCRIPTION
When rehearsing the current change, detected a few unrelated problems and opened follow-up issues:
* [The onerror handler in CI kickstart reboots the VM without returning failure](https://issues.redhat.com//browse/USHIFT-4520)
* [The ostree2bootc upgrade test may fail when switching the layer](https://issues.redhat.com/browse/USHIFT-4518)
* [The osconfig-lifecycle test may fail in CI](https://issues.redhat.com/browse/USHIFT-4519)
