### PR TITLE
USHIFT-4547: Add timeout and retries to ISO downloads when building images

### DIFF
--- a/scripts/image-builder/configure.sh
+++ b/scripts/image-builder/configure.sh
@@ -49,7 +49,7 @@ sudo firewall-cmd --add-service=cockpit --permanent
 
 # The mock utility comes from the EPEL repository
 "${DNF_RETRY}" "install" "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OSVERSION}.noarch.rpm"
-"${DNF_RETRY}" "install" "mock nginx tomcli parallel"
+"${DNF_RETRY}" "install" "mock nginx tomcli parallel aria2"
 sudo usermod -a -G mock "$(whoami)"
 
 # Verify umask and home directory permissions

--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -410,9 +410,9 @@ do_group() {
 
     # Run image-fetcher while osbuilder is running in background
     if [ ${#download_opts[@]} -ne 0 ]; then
-        local -r wget_tmp="wget.part"
-        local -r wget_res="${IMAGEDIR}/image_fetcher_result.json"
-        local -r wget_job="${IMAGEDIR}/image_fetcher_jobs.txt"
+        local -r dload_tmp="download.part"
+        local -r dload_res="${IMAGEDIR}/image_fetcher_result.json"
+        local -r dload_job="${IMAGEDIR}/image_fetcher_jobs.txt"
 
         local fetch_ok=true
         local progress=""
@@ -426,24 +426,25 @@ do_group() {
         if parallel \
             ${progress} \
             --colsep ' ' \
-            --results "${wget_res}" \
-            --joblog "${wget_job}" \
+            --results "${dload_res}" \
+            --joblog "${dload_job}" \
             --jobs ${#download_opts[@]} \
-            wget -c -nv -T 30 -t 3 -O "{1}.${wget_tmp}" "{2}" ::: "${download_opts[@]}" ; then
+            aria2c --max-connection-per-server=4 --split=4 --max-tries=3 --timeout=30 \
+                --continue --dir=/ -o "{1}.${dload_tmp}" "{2}" ::: "${download_opts[@]}" ; then
             # On successful download, rename the files to their original names
-            for fwget in "${VM_DISK_BASEDIR}"/*."${wget_tmp}" ; do
+            for dload_file in "${VM_DISK_BASEDIR}"/*."${dload_tmp}" ; do
                 local forig
-                forig="$(basename -s ".${wget_tmp}" "${fwget}")"
-                mv "${fwget}" "${VM_DISK_BASEDIR}/${forig}"
+                forig="$(basename -s ".${dload_tmp}" "${dload_file}")"
+                mv "${dload_file}" "${VM_DISK_BASEDIR}/${forig}"
             done
         else
             fetch_ok=false
         fi
 
         # Show the summary of the output of the parallel jobs.
-        cat "${wget_job}"
-        if [ -f "${wget_res}" ] ; then
-            jq < "${wget_res}"
+        cat "${dload_job}"
+        if [ -f "${dload_res}" ] ; then
+            jq < "${dload_res}"
         else
             echo "The image-fetcher results file does not exist"
             fetch_ok=false

--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -419,15 +419,17 @@ do_group() {
         if [ -t 0 ]; then
             progress="--progress"
         fi
-        # Download the files under temporary names
+        # Download the files under temporary names with 30s network timeout
+        # and retries. Note that download options are quoted per each job,
+        # resuting in one option per job in the download_opts array.
         echo "Waiting for image-fetcher to complete..."
         if parallel \
             ${progress} \
             --colsep ' ' \
             --results "${wget_res}" \
             --joblog "${wget_job}" \
-            --jobs $(( ${#download_opts[@]} / 2 )) \
-            wget -c -nv -O "{1}.${wget_tmp}" "{2}" ::: "${download_opts[@]}" ; then
+            --jobs ${#download_opts[@]} \
+            wget -c -nv -T 30 -t 3 -O "{1}.${wget_tmp}" "{2}" ::: "${download_opts[@]}" ; then
             # On successful download, rename the files to their original names
             for fwget in "${VM_DISK_BASEDIR}"/*."${wget_tmp}" ; do
                 local forig


### PR DESCRIPTION
Also fixed wrong job count in the parallel command options. Each job parameters are added in quotes, which means 1 parameter per job for count, not 2. Before the fix, the `--jobs 0` argument was used due to `1 / 2 = 0`.

```
    download_opts+=("${expected_iso_file} ${download_url}")
```

Comparing wget and aria2 download speeds on a local workstation.
```
$ time wget -O centos9-wget.iso "https://mi
rrors.centos.org/mirrorlist?path=/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-late
st-x86_64-dvd1.iso&redirect=1&protocol=https"
centos9-wget.iso     100% [==============================>]   10.79G   31.09MB/s
                          [Files: 1  Bytes: 10.79G [31.51M]

real    5m50.796s
user    0m5.486s
sys     0m16.325s

$ time aria2c -x 4 -s 4 -o centos9-aria2.is
o "https://mirrors.centos.org/mirrorlist?path=/9-stream/BaseOS/x86_64/iso/CentOS-
Stream-9-latest-x86_64-dvd1.iso&redirect=1&protocol=https"
...
...

real    2m52.656s
user    0m6.979s
sys     0m13.922s
```