### PR TITLE
NO-ISSUE: Add avahi-tools requirement for router smoke test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -70,6 +70,14 @@ the ssh agent to provide the correct credentials.
 `API_PORT` should be set when connections are performed through a
 forwarded port.
 
+To ensure the router smoke test works properly on a Microshift host,
+you need to install the `avahi-resolve-host-name` command, which is
+essential for hostname resolution. You can install it using the following command:
+
+```
+sudo dnf install -y avahi-tools
+```
+
 ### Running Tests
 
 Use `run.sh` to run the tests. It will create a Python virtual


### PR DESCRIPTION
Without this package the router smoke test fails with following error:
```
Start / End / Elapsed: 	20241007 13:54:13.779 / 20241007 13:54:13.781 / 00:00:00.002
13:54:13.779 	TRACE 	Arguments: [ '${result.stdout}' | '${result.stderr}' ]
13:54:13.780 	INFO
13:54:13.781 	INFO 	/bin/sh: line 1: avahi-resolve-host-name: command not found
13:54:13.781 	TRACE 	Return: None
```
