### PR TITLE
Fix build_rpm.sh call when building bootc images

### DIFF
--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -545,7 +545,7 @@ def main():
             raise Exception(f"The input directory '{dir2process}' does not exist")
         # Make sure the local RPM repository exists
         if not os.path.isdir(LOCAL_REPO):
-            common.run_command(f"{SCRIPTDIR}/build_rpms.sh")
+            common.run_command([f"{SCRIPTDIR}/build_rpms.sh"], args.dry_run)
         # Initialize force rebuild option
         global FORCE_REBUILD
         if args.force_rebuild:


### PR DESCRIPTION
Fixes the following error:
```
$ ./test/bin/build_bootc_images.sh -l ./test/image-blueprints/layer5-bootc/ 
06:26:22.565109968 An error occurred: run_command() missing 1 required positional argument: 'dry_run'
Traceback (most recent call last):
  File "/home/microshift/microshift/test/bin/pyutils/build_bootc_images.py", line 548, in main
    common.run_command(f"{SCRIPTDIR}/build_rpms.sh")
TypeError: run_command() missing 1 required positional argument: 'dry_run'
06:26:22.565556287 Running atexit cleanup
06:26:22.567635774 [SHELL] sudo podman ps --filter ancestor=[registry.redhat.io/rhel9/bootc-image-builder:latest](http://registry.redhat.io/rhel9/bootc-image-builder:latest) --format {{.ID}}
06:26:22.597914457 Build FAILED
```