### PR TITLE
NO-ISSUE: build_bootc_image.py-Add dry_run arg for rpm build

### DIFF
--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -545,7 +545,7 @@ def main():
             raise Exception(f"The input directory '{dir2process}' does not exist")
         # Make sure the local RPM repository exists
         if not os.path.isdir(LOCAL_REPO):
-            common.run_command(f"{SCRIPTDIR}/build_rpms.sh")
+            common.run_command(f"{SCRIPTDIR}/build_rpms.sh", args.dry_run)
         # Initialize force rebuild option
         global FORCE_REBUILD
         if args.force_rebuild:


### PR DESCRIPTION
It will fix following error
```
12:36:33.617973327 An error occurred: run_command() missing 1 required positional argument: 'dry_run'
Traceback (most recent call last):
  File "/home/prkumar/work/github/microshift/test/bin/pyutils/build_bootc_images.py", line 548, in main
    common.run_command(f"{SCRIPTDIR}/build_rpms.sh")
TypeError: run_command() missing 1 required positional argument: 'dry_run'
12:36:33.619852304 Running atexit cleanup
```

