### PR TITLE
NO-ISSUE: Optimize build-base-branch RPM build target

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -18,13 +18,14 @@ fake-next-minor-rpm:
 # against non-main branches. The base-branch is used for the initial microshift layer deployed in some rpm-ostree scenarios.
 .PHONY: build-base-branch
 build-base-branch: BASE_BRANCH ?=release-$(MAJOR).$(MINOR)
+build-base-branch: RPMBUILD_DIR :=$(REPO)/_output/rpmbuild-base/
 build-base-branch: TMP_REPO !=mktemp -d
 build-base-branch:
-	if ! [ -d "$(REPO)/_output" ]; then mkdir $(REPO)/_output; fi
+	rm -rf $(RPMBUILD_DIR)
 	git clone --single-branch --branch $(BASE_BRANCH) https://github.com/openshift/microshift.git $(TMP_REPO)
 	MICROSHIFT_VERSION="$(MAJOR).$(MINOR).$(PATCH)_base_branch" \
+	RPMBUILD_DIR=$(RPMBUILD_DIR) \
 		$(MAKE) -C $(TMP_REPO) rpm
-	mv $(TMP_REPO)/_output/rpmbuild $(REPO)/_output/rpmbuild-base
 	rm -rf "$(TMP_REPO)"
 
 .PHONY: robotidy


### PR DESCRIPTION
Sync the target code with the pattern used in other similar targets. 

Besides removing unnecessary file system operations, the new code may be more efficient when the repo is mounted over NFS (building in-place and avoiding a costly `mv` operation).

> Note: even after the fix, the times may fluctuate due to network dependency, etc.

**Before the fix**
```
$ for _ in $(seq 3) ; do sudo rm -rf ~/go ~/microshift/_output ; sudo sync; echo 3 | sudo tee /proc/sys/vm/drop_caches ; (time make -C test/ build-base-branch) 2>&1 | tail -3 ; done
3
real    4m9.657s
user    10m6.212s
sys     0m47.177s
3
real    3m59.904s
user    10m56.316s
sys     0m49.832s
3
real    4m14.363s
user    10m30.233s
sys     0m49.803s
```

**After the fix**
```
$ for _ in $(seq 3) ; do sudo rm -rf ~/go ~/microshift/_output ; sudo sync; echo 3 | sudo tee /proc/sys/vm/drop_caches ; (time make -C test/ build-base-branch) 2>&1 | tail -3 ; done
3
real    1m7.871s
user    0m37.844s
sys     0m15.516s
3
real    1m5.006s
user    0m39.223s
sys     0m16.604s
3
real    1m9.395s
user    0m39.089s
sys     0m16.795s
```