### PR TITLE
USHIFT-4684: Optimize microshift-test-agent code to avoid race conditions

### DIFF
--- a/test/agent/microshift-test-agent.service
+++ b/test/agent/microshift-test-agent.service
@@ -1,12 +1,17 @@
 [Unit]
 Description=MicroShift Test Agent
-Before=microshift.service sshd.service
+Before=microshift.service greenboot-healthcheck.service sshd.service
 
 [Service]
+# Script must call 'systemd-notify --ready' to signal its readiness.
+# The notification access is limited to the main script process.
+Type=notify
+NotifyAccess=main
+
 ExecStart=/usr/bin/microshift-test-agent.sh
 # Default value of KillMode is control-group which results in
 # sending SIGTERM to the process and its child processes.
-# By changing to `mixed`, only the main process will get the
+# By changing to 'mixed', only the main process will get the
 # SIGTERM and cleanup activities won't be interrupted.
 KillMode=mixed
 


### PR DESCRIPTION
* Started to use systemd notify mechanism to signal service readiness
* Run cleanup actions on exit, rather than watching selected signals
* Minor bash syntax optimizations
* Optimized the wait loop in the script to avoid unwanted interruptions of the sleep command
