### PR TITLE
USHIFT-4117: Auto Recovery: Restore

### DIFF
--- a/pkg/admin/autorecovery/restore.go
+++ b/pkg/admin/autorecovery/restore.go
@@ -1,0 +1,180 @@
+package autorecovery
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/microshift/pkg/admin/data"
+	"github.com/openshift/microshift/pkg/config"
+	"github.com/openshift/microshift/pkg/util"
+	"k8s.io/klog/v2"
+)
+
+const (
+	failedSubstorageName   = "failed"
+	restoredSubstorageName = "restored"
+)
+
+type Manager struct {
+	storage    data.StoragePath
+	saveFailed bool
+}
+
+func NewManager(storage data.StoragePath, saveFailed bool) (*Manager, error) {
+	if storage == "" {
+		return nil, fmt.Errorf("`storage` argument is empty")
+	}
+
+	return &Manager{storage: storage, saveFailed: saveFailed}, nil
+}
+
+func (m *Manager) PerformRestore() error {
+	if err := storageShouldExist(m.storage); err != nil {
+		return err
+	}
+
+	existingState, err := GetState(m.storage)
+	if err != nil {
+		return err
+	}
+
+	restoreCandidate, err := getCandidateForRestore(m.storage, existingState)
+	if err != nil {
+		return err
+	}
+
+	/*
+		Preparations - initial file system operations:
+		  COPY    $STORAGE/$CANDIDATE -> /var/lib/microshift.tmp
+		  COPY    /var/lib/microshift -> $STORAGE/failed/$DATE_DEPLOY-ID.tmp
+		  CREATE  $STORAGE/state.json.new
+		  -       $STORAGE/$PREVIOUSLY_RESTORED									Should already exist, nothing to do.
+
+		"Closing the transaction"
+		  RENAME    /var/lib/microshift.tmp -> /var/lib/microshift
+						This operation is first, because it's the most important one - whole point of the restore is to get to running state.
+		  RENAME    $STORAGE/failed/DATE_DEPLOY-ID.tmp -> $STORAGE/failed/DATE_DEPLOY-ID
+		  RENAME    $STORAGE/state.json.new -> $STORAGE/state.json
+		  RENAME    $STORAGE/$PREVIOUSLY_RESTORED -> $STORAGE/restored/$PREVIOUSLY_RESTORED
+	*/
+
+	// Copies/creations into intermediate destinations
+	var oldData *data.AtomicDirCopy
+	if m.saveFailed {
+		oldDataBackupName, err := GetBackupName()
+		if err != nil {
+			return err
+		}
+		failedStorage := m.storage.SubStorage(failedSubstorageName)
+		if err := os.MkdirAll(string(failedStorage), 0600); err != nil {
+			return fmt.Errorf("failed to create %q subdirectory: %w", failedSubstorageName, err)
+		}
+		oldData = &data.AtomicDirCopy{Source: config.DataDir, Destination: failedStorage.GetBackupPath(oldDataBackupName)}
+		if err := oldData.CopyToIntermediate(); err != nil {
+			return fmt.Errorf("old microshift data: %w", err)
+		}
+	}
+
+	newData := data.AtomicDirCopy{Source: m.storage.GetBackupPath(restoreCandidate.Name()), Destination: config.DataDir}
+	if err := newData.CopyToIntermediate(); err != nil {
+		if rollbackErr := oldData.RollbackIntermediate(); rollbackErr != nil {
+			klog.ErrorS(rollbackErr, "Failed to rollback intermediate state for old data")
+		}
+		return fmt.Errorf("new microshift data: %w", err)
+	}
+
+	newState := NewState(m.storage, restoreCandidate.Name())
+	if err := newState.SaveToIntermediate(); err != nil {
+		if rollbackErr := oldData.RollbackIntermediate(); rollbackErr != nil {
+			klog.ErrorS(rollbackErr, "Failed to rollback intermediate state for old data")
+		}
+		if rollbackErr := newData.RollbackIntermediate(); rollbackErr != nil {
+			klog.ErrorS(rollbackErr, "Failed to rollback intermediate state for new data")
+		}
+		return fmt.Errorf("new state file: %w", err)
+	}
+
+	// Renames into final destinations
+	if err := newData.RenameToFinal(); err != nil {
+		return fmt.Errorf("new microshift data: %w", err)
+	}
+	// Update the state file right after /var/lib/microshift is restored from a backup
+	if err := newState.MoveToFinal(); err != nil {
+		return fmt.Errorf("new state file: %w", err)
+	}
+	if err := oldData.RenameToFinal(); err != nil {
+		return fmt.Errorf("old microshift data: %w", err)
+	}
+
+	//nolint:nestif
+	if existingState != nil {
+		previous := m.storage.GetBackupPath(existingState.LastBackup)
+		exists, err := util.PathExists(previous)
+		if err != nil {
+			klog.ErrorS(err, "Failed to check if previously restored backup exists")
+			return err
+		}
+		if exists {
+			restoredStorage := m.storage.SubStorage(restoredSubstorageName)
+			if err := os.MkdirAll(string(restoredStorage), 0600); err != nil {
+				return fmt.Errorf("failed to create `restored` subdirectory: %w", err)
+			}
+
+			previouslyRestored := data.AtomicDirCopy{
+				Source:      m.storage.GetBackupPath(existingState.LastBackup),
+				Destination: restoredStorage.GetBackupPath(existingState.LastBackup),
+			}
+			if err := previouslyRestored.RenameToFinal(); err != nil {
+				return fmt.Errorf("previously restored backup: %w", err)
+			}
+		}
+	}
+
+	klog.InfoS("Auto-recovery restore completed")
+	return nil
+}
+
+func getCandidateForRestore(storagePath data.StoragePath, existingState *state) (Backup, error) {
+	backups, err := GetBackups(storagePath)
+	if err != nil {
+		return Backup{}, err
+	}
+
+	if existingState != nil {
+		backups = backups.RemoveBackup(existingState.LastBackup)
+	}
+
+	if len(backups) == 0 {
+		klog.InfoS("There are no candidate backups for restoring!")
+		return Backup{}, fmt.Errorf("no backups for restoring")
+	}
+
+	ver, err := getVersion()
+	if err != nil {
+		return Backup{}, err
+	}
+
+	backups = backups.FilterByVersion(ver)
+	if len(backups) == 0 {
+		klog.InfoS("There are no candidate backups for restoring after filtering by version!")
+		return Backup{}, fmt.Errorf("no backups for restoring")
+	}
+	klog.InfoS("Potential backups", "bz", backups)
+
+	restoreCandidate := backups.GetMostRecent()
+	klog.InfoS("Candidate backup for restore", "b", restoreCandidate)
+
+	return restoreCandidate, nil
+}
+
+func storageShouldExist(storage data.StoragePath) error {
+	path := string(storage)
+	exists, err := util.PathExists(path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("%q doesn't exist", path)
+	}
+	return nil
+}

--- a/pkg/admin/autorecovery/state.go
+++ b/pkg/admin/autorecovery/state.go
@@ -1,0 +1,109 @@
+package autorecovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/microshift/pkg/admin/data"
+	"github.com/openshift/microshift/pkg/util"
+	"k8s.io/klog/v2"
+)
+
+const (
+	stateFilename = "state.json"
+)
+
+type state struct {
+	LastBackup       data.BackupName `json:"LastBackup"`
+	storageFS        fsConstraint    `json:"-"`
+	storagePath      string          `json:"-"`
+	intermediatePath string          `json:"-"`
+}
+
+func (s *state) Serialize() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *state) SaveToIntermediate() error {
+	contents, err := s.Serialize()
+	if err != nil {
+		return err
+	}
+	path, err := data.GenerateUniqueTempPath(filepath.Join(s.storagePath, stateFilename))
+	if err != nil {
+		return err
+	}
+	s.intermediatePath = path
+	klog.InfoS("Saving intermediate state", "state", contents, "path", path)
+	return os.WriteFile(path, contents, 0600)
+}
+
+func (s *state) MoveToFinal() error {
+	path := filepath.Join(s.storagePath, stateFilename)
+	klog.InfoS("Moving state file to final path", "intermediatePath", s.intermediatePath, "finalPath", path)
+	return os.Rename(s.intermediatePath, path)
+}
+
+func NewState(storagePath data.StoragePath, lastBackup data.BackupName) *state {
+	return &state{
+		LastBackup:  lastBackup,
+		storagePath: string(storagePath),
+	}
+}
+
+type fsConstraint interface {
+	fs.StatFS
+	fs.ReadFileFS
+}
+
+func GetState(storagePath data.StoragePath) (*state, error) {
+	sp := string(storagePath)
+	storageFS, ok := os.DirFS(sp).(fsConstraint)
+	if !ok {
+		// This should never happen.
+		// Concrete type returned from os.DirFS() implements interfaces specified in fsConstaint,
+		// but the function actually returns fs.FS interface which cannot be used
+		// as more specialized interface without casting.
+		err := fmt.Errorf("failed to cast os.DirFS to more specialized type")
+		klog.ErrorS(err, "Something went terribly wrong")
+		return nil, err
+	}
+
+	state, err := getStateFS(storageFS)
+	if err != nil {
+		return nil, err
+	}
+	if state != nil {
+		klog.InfoS("Read state from the disk", "state", state)
+		state.storagePath = sp
+	}
+
+	return state, nil
+}
+
+func getStateFS(fsys fsConstraint) (*state, error) {
+	if exists, err := util.PathExistsFS(fsys, stateFilename); err != nil {
+		return nil, err
+	} else if !exists {
+		klog.InfoS("State file doesn't exists", "storage", fsys)
+		// State is optional (file will not exist on when 1st restore happens).
+		// Using pointer as optional.
+		var state *state
+		return state, nil
+	}
+
+	contents, err := fsys.ReadFile(stateFilename)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &state{storageFS: fsys}
+	if err := json.Unmarshal(contents, s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/pkg/admin/autorecovery/state_test.go
+++ b/pkg/admin/autorecovery/state_test.go
@@ -1,0 +1,47 @@
+package autorecovery
+
+import (
+	"fmt"
+	"testing"
+	"testing/fstest"
+
+	"github.com/openshift/microshift/pkg/admin/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getStateFS(t *testing.T) {
+	lastBackup := "20241001111100_4.18.0"
+	storageFS := fstest.MapFS{
+		stateFilename: &fstest.MapFile{
+			Data: []byte(fmt.Sprintf(`{"LastBackup": "%s"}`, lastBackup))},
+	}
+
+	state, err := getStateFS(storageFS)
+	assert.NoError(t, err)
+	assert.NotNil(t, state)
+	assert.Equal(t, data.BackupName(lastBackup), state.LastBackup)
+}
+
+func Test_getStateFS_NoState(t *testing.T) {
+	storageFS := fstest.MapFS{}
+
+	state, err := getStateFS(storageFS)
+	assert.NoError(t, err)
+	assert.Nil(t, state)
+}
+
+func Test_state_MarshalJSON(t *testing.T) {
+	{
+		s := state{LastBackup: "asd"}
+		data, err := s.Serialize()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"LastBackup":"asd"}`, string(data))
+	}
+
+	{
+		s := &state{LastBackup: "asd"}
+		data, err := s.Serialize()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"LastBackup":"asd"}`, string(data))
+	}
+}

--- a/pkg/admin/autorecovery/storage.go
+++ b/pkg/admin/autorecovery/storage.go
@@ -1,0 +1,103 @@
+package autorecovery
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/openshift/microshift/pkg/admin/data"
+	"k8s.io/klog/v2"
+)
+
+type Backup struct {
+	CreationTime time.Time
+
+	// Version is either Deployment ID (bootc/ostree systems) or version of the MicroShift binary (RPM systems).
+	// Used for selecting version-wise compatible backups for restoring.
+	Version string
+}
+
+func (b Backup) Name() data.BackupName {
+	t := b.CreationTime.Format(backupCreationTimeFormat)
+	return data.BackupName(fmt.Sprintf("%s_%s", t, b.Version))
+}
+
+type Backups []Backup
+
+func (bs Backups) RemoveBackup(bb data.BackupName) Backups {
+	match := false
+	filtered := slices.DeleteFunc(bs, func(b Backup) bool {
+		if b.Name() == bb {
+			match = true
+			return true
+		}
+		return false
+	})
+	if match {
+		klog.InfoS("Filtered list of backups - removed previously restored backup", "removed", bb, "newList", filtered)
+	}
+	return filtered
+}
+
+func (bs Backups) FilterByVersion(ver string) Backups {
+	filtered := slices.DeleteFunc(bs, func(b Backup) bool {
+		return b.Version != ver
+	})
+	klog.InfoS("Filtered list of backups by version", "version", ver, "newList", filtered)
+	return filtered
+}
+
+func (bs Backups) GetMostRecent() Backup {
+	slices.SortFunc(bs, func(a, b Backup) int {
+		return b.CreationTime.Compare(a.CreationTime)
+	})
+	return bs[0]
+}
+
+func GetBackups(storagePath data.StoragePath) (Backups, error) {
+	fsys := os.DirFS(string(storagePath))
+	return getBackups(fsys)
+}
+
+func getBackups(fsys fs.FS) (Backups, error) {
+	dirEntries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := make([]string, 0, len(dirEntries))
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			dirs = append(dirs, dirEntry.Name())
+		}
+	}
+	bs := dirListToBackups(dirs)
+	klog.InfoS("Auto-recovery backup storage read and parsed", "dirs", dirs, "backups", bs)
+
+	return bs, nil
+}
+
+func dirListToBackups(files []string) Backups {
+	backups := make([]Backup, 0, len(files))
+	for _, file := range files {
+		splitName := strings.Split(file, "_")
+		if len(splitName) != 2 {
+			continue
+		}
+		dt := splitName[0]
+		ver := splitName[1]
+		creationTime, err := time.Parse(backupCreationTimeFormat, dt)
+		if err != nil {
+			klog.ErrorS(err, "Failed to parse datetime part of the backup name", "name", file)
+			continue
+		}
+		backups = append(backups, Backup{
+			CreationTime: creationTime,
+			Version:      ver,
+		})
+	}
+	return backups
+}

--- a/pkg/admin/autorecovery/storage_test.go
+++ b/pkg/admin/autorecovery/storage_test.go
@@ -1,0 +1,82 @@
+package autorecovery
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Backups(t *testing.T) {
+	previouslyRestoredBackup := Backup{CreationTime: time.Date(2024, 10, 1, 1, 0, 0, 0, time.UTC), Version: "4.18.1"}
+	oldVersion := Backup{CreationTime: time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC), Version: "4.18.0"}
+	mostRecent := Backup{CreationTime: time.Date(2024, 10, 1, 3, 0, 0, 0, time.UTC), Version: "4.18.1"}
+	initialBackups := Backups{
+		oldVersion,
+		previouslyRestoredBackup,
+		{
+			CreationTime: time.Date(2024, 10, 1, 2, 0, 0, 0, time.UTC),
+			Version:      "4.18.1",
+		},
+		mostRecent,
+	}
+
+	backupsWithoutPrevious := initialBackups.RemoveBackup(previouslyRestoredBackup.Name())
+	assert.Len(t, backupsWithoutPrevious, 3)
+	assert.NotContains(t, backupsWithoutPrevious, previouslyRestoredBackup)
+
+	backupsFilteredByVersion := backupsWithoutPrevious.FilterByVersion("4.18.1")
+	assert.Len(t, backupsFilteredByVersion, 2)
+	assert.NotContains(t, backupsFilteredByVersion, oldVersion)
+
+	candidate := backupsFilteredByVersion.GetMostRecent()
+	assert.Equal(t, mostRecent, candidate)
+}
+
+func Test_dirListToBackups(t *testing.T) {
+	expectedBackups := Backups{
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 11, 00, 0, time.UTC), Version: "4.18.0"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 22, 00, 0, time.UTC), Version: "4.18.0"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 33, 00, 0, time.UTC), Version: "4.18.1"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 44, 00, 0, time.UTC), Version: "default-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 55, 00, 0, time.UTC), Version: "rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0"},
+	}
+
+	files := []string{
+		"20241001111100_4.18.0",
+		"20241001112200_4.18.0",
+		"20241001113300_4.18.1",
+		"202410011139004.18.1", // Missing delimiter `_`` - should be ignored
+		"1239832asd_4.18.1",    // Invalid datetime - should be ignored
+		"20241001114400_default-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0",
+		"20241001115500_rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0",
+	}
+
+	backups := dirListToBackups(files)
+	assert.Len(t, backups, 5)
+	assert.Equal(t, expectedBackups, backups)
+}
+
+func Test_getBackups(t *testing.T) {
+	expectedBackups := Backups{
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 11, 00, 0, time.UTC), Version: "4.18.0"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 22, 00, 0, time.UTC), Version: "4.18.0"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 33, 00, 0, time.UTC), Version: "4.18.1"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 44, 00, 0, time.UTC), Version: "default-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0"},
+		Backup{CreationTime: time.Date(2024, 10, 01, 11, 55, 00, 0, time.UTC), Version: "rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0"},
+	}
+
+	storageFS := fstest.MapFS{
+		"20241001111100_4.18.0": &fstest.MapFile{Mode: fs.ModeDir},
+		"20241001112200_4.18.0": &fstest.MapFile{Mode: fs.ModeDir},
+		"20241001113300_4.18.1": &fstest.MapFile{Mode: fs.ModeDir},
+		"20241001114400_default-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0": &fstest.MapFile{Mode: fs.ModeDir},
+		"20241001115500_rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0":    &fstest.MapFile{Mode: fs.ModeDir},
+	}
+
+	bs, err := getBackups(storageFS)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBackups, bs)
+}

--- a/pkg/admin/data/atomic_dir_copy.go
+++ b/pkg/admin/data/atomic_dir_copy.go
@@ -1,0 +1,149 @@
+package data
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/openshift/microshift/pkg/util"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// cpArgs contains arguments passed to 'cp' command required to copy MicroShift
+	// data dir as a backup with Copy-On-Write feature.
+	cpArgs = []string{
+		"--verbose",
+		"--recursive",    // copy directories recursively
+		"--preserve",     // preserve mode, ownership, timestamps
+		"--reflink=auto", // enable Copy-on-Write copy
+	}
+)
+
+// AtomicDirCopy atomically copies directory.
+// It performs a two operation: copies source path to a destination
+// location with temporary name, then renames it to final name.
+// On Unix systems, the rename operation is atomic. This ensures that the file
+// is either fully renamed or not at all, which helps prevent issues like partial
+// file copies in cases of power failure or unexpected program termination.
+type AtomicDirCopy struct {
+	Source      string
+	Destination string
+
+	intermediatePath string
+}
+
+func (c *AtomicDirCopy) CopyToIntermediate() error {
+	if c == nil {
+		return nil
+	}
+	var err error
+	c.intermediatePath, err = GenerateUniqueTempPath(c.Destination)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("cp", append(cpArgs, c.Source, c.intermediatePath)...) //nolint:gosec
+
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+	err = cmd.Run()
+
+	if err != nil {
+		klog.ErrorS(nil, "Failed to make an intermediate copy", "cmd", cmd,
+			"stdout", strings.ReplaceAll(outb.String(), "\n", `, `),
+			"stderr", errb.String())
+		copyErr := fmt.Errorf("failed to copy %q to %q: %w", c.Source, c.intermediatePath, err)
+		if err := c.RollbackIntermediate(); err != nil {
+			return errors.Join(copyErr, err)
+		}
+		return copyErr
+	}
+	klog.InfoS("Made an intermediate copy", "cmd", cmd)
+
+	return nil
+}
+
+func (c *AtomicDirCopy) RollbackIntermediate() error {
+	if c == nil {
+		return nil
+	}
+	if c.intermediatePath == "" {
+		return nil
+	}
+	if err := os.RemoveAll(c.intermediatePath); err != nil {
+		return fmt.Errorf("failed to remove intermediate path %q: %w", c.intermediatePath, err)
+	}
+	return nil
+}
+
+func (c *AtomicDirCopy) RenameToFinal() error {
+	if c == nil {
+		return nil
+	}
+	var src, dest string
+	if c.intermediatePath == "" {
+		// Empty value means there was no intermediate copy.
+		src = c.Source
+		dest = c.Destination
+	} else {
+		// Path was copied to a temporary location with .tmp suffix.
+		// Now it needs to be renamed into final destination.
+		// This two-step operation should provide a high guarantee that
+		// copying is complete and not partial thanks to rename being OS/filesystem atomic.
+		src = c.intermediatePath
+		dest = c.Destination
+	}
+
+	// Delete the destination if it's a non-empty directory.
+	// This is a limitation of the POSIX's rename.
+	if err := removeDirIfExists(dest); err != nil {
+		return err
+	}
+
+	if err := os.Rename(src, dest); err != nil {
+		klog.ErrorS(err, "Failed to rename the path - removing", "path", src)
+		if removeErr := os.RemoveAll(src); removeErr != nil {
+			return errors.Join(err, fmt.Errorf("failed to remove %q: %w", src, removeErr))
+		}
+		return err
+	}
+	klog.InfoS("Renamed to final destination", "src", src, "dest", dest)
+	return nil
+}
+
+func removeDirIfExists(path string) error {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat %q: %w", path, err)
+	}
+
+	if fileInfo.IsDir() {
+		return os.RemoveAll(path)
+	}
+
+	return nil
+}
+
+// GenerateUniqueTempPath returns a filepath from given path with extra suffix
+// which doesn't exist.
+func GenerateUniqueTempPath(path string) (string, error) {
+	// 1000 tries
+	for i := 0; i < 1000; i++ {
+		rnd := rand.IntN(100000)
+		newPath := fmt.Sprintf("%s.tmp.%d", path, rnd)
+		if exists, err := util.PathExists(newPath); err != nil {
+			return "", err
+		} else if !exists {
+			return newPath, nil
+		}
+	}
+	return "", fmt.Errorf("attempted to generate unique temporary path (%q) for 1000 tries - giving up", path)
+}

--- a/pkg/admin/data/data_manager.go
+++ b/pkg/admin/data/data_manager.go
@@ -1,11 +1,8 @@
 package data
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -16,13 +13,6 @@ import (
 )
 
 var (
-	cpArgs = []string{
-		"--verbose",
-		"--recursive",
-		"--preserve",
-		"--reflink=auto",
-	}
-
 	expectedBackupContent = sets.New[string](
 		// .nodename omitted
 		"certs",
@@ -224,48 +214,13 @@ func checkDirectoryContents(existing sets.Set[string]) error {
 }
 
 func copyPath(src, dest string) error {
-	tmpDest := fmt.Sprintf("%s.tmp", dest)
-	if exists, err := pathExists(tmpDest); err != nil {
+	copier := AtomicDirCopy{Source: src, Destination: dest}
+	if err := copier.CopyToIntermediate(); err != nil {
 		return err
-	} else if exists {
-		if err := os.RemoveAll(tmpDest); err != nil {
-			return fmt.Errorf("failed to remove %q: %w", tmpDest, err)
-		}
 	}
-	cmd := exec.Command("cp", append(cpArgs, src, tmpDest)...) //nolint:gosec
-	klog.InfoS("Starting copy to intermediate location", "cmd", cmd)
-
-	var outb, errb bytes.Buffer
-	cmd.Stdout = &outb
-	cmd.Stderr = &errb
-	err := cmd.Run()
-
-	if err != nil {
-		klog.InfoS("Failed to copy to intermediate location", "cmd", cmd,
-			"stdout", strings.ReplaceAll(outb.String(), "\n", `, `),
-			"stderr", errb.String())
-		copyErr := fmt.Errorf("failed to copy %q to %q: %w", src, dest, err)
-		if err := os.RemoveAll(tmpDest); err != nil {
-			return errors.Join(copyErr, fmt.Errorf("failed to remove intermediate path %q: %w", tmpDest, err))
-		}
-		return copyErr
+	if err := copier.RenameToFinal(); err != nil {
+		return err
 	}
-
-	// Path was copied to a temporary location with .tmp suffix.
-	// Now it needs to be renamed into final destination.
-	// This two-step operation should provide a high guarantee that
-	// copying is complete and not partial thanks to rename being OS/filesystem atomic.
-	klog.InfoS("Renaming intermediate path to final destination", "src", tmpDest, "dest", dest)
-	if err := os.Rename(tmpDest, dest); err != nil {
-		klog.InfoS("Failed to rename - removing intermediate path", "path", tmpDest)
-		renameErr := fmt.Errorf("failed to rename %q to %q: %w", tmpDest, dest, err)
-		if err := os.RemoveAll(tmpDest); err != nil {
-			return errors.Join(renameErr, fmt.Errorf("failed to remove %q: %w", tmpDest, err))
-		}
-		return renameErr
-	}
-	klog.InfoS("Renamed intermediate path to final destination", "src", tmpDest, "dest", dest)
-	klog.InfoS("Path copied", "src", src, "dest", dest)
 
 	return nil
 }

--- a/pkg/admin/data/types.go
+++ b/pkg/admin/data/types.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"path/filepath"
 )
 
 type EmptyArgErr struct {
@@ -12,8 +13,16 @@ func (e *EmptyArgErr) Error() string {
 	return fmt.Sprintf("empty argument: %s", e.argName)
 }
 
-type StoragePath string
 type BackupName string
+type StoragePath string
+
+func (sp StoragePath) GetBackupPath(backupName BackupName) string {
+	return filepath.Join(string(sp), string(backupName))
+}
+
+func (sp StoragePath) SubStorage(subdir string) StoragePath {
+	return StoragePath(filepath.Join(string(sp), subdir))
+}
 
 type Manager interface {
 	Backup(BackupName) (string, error)

--- a/pkg/admin/prerun/system.go
+++ b/pkg/admin/prerun/system.go
@@ -41,7 +41,7 @@ func getDeploymentsFromOSTree() ([]deployment, error) {
 	outputToLog := stdout.String()
 	outputToLog = strings.ReplaceAll(outputToLog, "\n", "")
 	outputToLog = strings.ReplaceAll(outputToLog, " ", "")
-	klog.InfoS("rpm-ostree status", "output", outputToLog)
+	klog.V(2).InfoS("rpm-ostree status", "output", outputToLog)
 
 	status := struct {
 		Deployments []deployment `json:"deployments"`

--- a/pkg/cmd/admin.go
+++ b/pkg/cmd/admin.go
@@ -201,7 +201,7 @@ created using the naming scheme compatible with "restore --auto-recovery"`)
 
 func NewRestoreCommand() *cobra.Command {
 	autorec := false
-	saveFailed := false
+	dontSaveFailed := false
 
 	cmd := &cobra.Command{
 		Use:               "restore PATH",
@@ -211,7 +211,7 @@ func NewRestoreCommand() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if autorec {
-				acManager, err := autorecovery.NewManager(data.StoragePath(args[0]), saveFailed)
+				acManager, err := autorecovery.NewManager(data.StoragePath(args[0]), !dontSaveFailed)
 				if err != nil {
 					return err
 				}
@@ -234,9 +234,9 @@ func NewRestoreCommand() *cobra.Command {
 The PATH argument will be treated as a directory where backups are
 created with "backup --auto-recovery" command.`)
 
-	cmd.Flags().BoolVar(&saveFailed, "save-failed", false,
+	cmd.Flags().BoolVar(&dontSaveFailed, "dont-save-failed", false,
 		`Only applicable if --auto-recovery is also specified.
-It set, a copy of MicroShift data directory will be made inside
+Don't make a copy of MicroShift data directory inside
 "failed" subdirectory for later analysis.`)
 
 	return cmd

--- a/pkg/cmd/admin.go
+++ b/pkg/cmd/admin.go
@@ -200,6 +200,9 @@ created using the naming scheme compatible with "restore --auto-recovery"`)
 }
 
 func NewRestoreCommand() *cobra.Command {
+	autorec := false
+	saveFailed := false
+
 	cmd := &cobra.Command{
 		Use:               "restore PATH",
 		Short:             "Restore MicroShift data from a backup",
@@ -207,6 +210,14 @@ func NewRestoreCommand() *cobra.Command {
 		PersistentPreRunE: backupRestorePreRun(false),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if autorec {
+				acManager, err := autorecovery.NewManager(data.StoragePath(args[0]), saveFailed)
+				if err != nil {
+					return err
+				}
+				return acManager.PerformRestore()
+			}
+
 			// err is checked in PersistentPreRunE
 			storage, name, _ := backupPathToStorageAndName(args[0])
 			dataManager, err := data.NewManager(storage)
@@ -217,6 +228,16 @@ func NewRestoreCommand() *cobra.Command {
 			return dataManager.Restore(name)
 		},
 	}
+
+	cmd.Flags().BoolVar(&autorec, "auto-recovery", false,
+		`Changes the behavior of the restore command.
+The PATH argument will be treated as a directory where backups are
+created with "backup --auto-recovery" command.`)
+
+	cmd.Flags().BoolVar(&saveFailed, "save-failed", false,
+		`Only applicable if --auto-recovery is also specified.
+It set, a copy of MicroShift data directory will be made inside
+"failed" subdirectory for later analysis.`)
 
 	return cmd
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,6 +25,16 @@ func Default(s string, defaultS string) string {
 		return defaultS
 	}
 	return s
+}
+
+func PathExistsFS(fsys fs.StatFS, path string) (bool, error) {
+	if _, err := fsys.Stat(path); err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("checking if path %q exists in the fsys %q failed: %w", path, fsys, err)
+	}
 }
 
 func PathExists(path string) (bool, error) {

--- a/test/suites/backup/auto-recovery.robot
+++ b/test/suites/backup/auto-recovery.robot
@@ -43,7 +43,7 @@ Restore Fails When There Are No Suitable Backups
         Command Should Work    sudo mv ${backup_path} ${new_path}
         Sleep    2s
     END
-    Command Should Fail    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Fail    microshift restore --dont-save-failed --auto-recovery ${WORKDIR}
 
     [Teardown]    Command Should Work    rm -rf ${WORKDIR}
 
@@ -59,10 +59,10 @@ Restore Selects Right Backup
     ${new_path}=    Set Variable    ${{ "${last_backup}[:-1]" + str(int("${last_backup}[-1]")+1) }}
     Command Should Work    sudo mv ${last_backup} ${new_path}
 
-    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Work    microshift restore --dont-save-failed --auto-recovery ${WORKDIR}
     ${backup_marker}=    Command Should Work    cat /var/lib/microshift/marker
     Should Be Equal As Numbers    ${backup_marker}    2
-    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Work    microshift restore --dont-save-failed --auto-recovery ${WORKDIR}
 
     [Teardown]    Run Keywords
     ...    Command Should Work    rm -rf ${WORKDIR}
@@ -77,19 +77,19 @@ Previously Restored Backup Is Moved To Special Subdirectory
     ${expected_path}=    Set Variable
     ...    ${{ "/".join( "${last_backup}".split("/")[:-1] + ["restored"] + [ "${last_backup}".split("/")[-1] ] ) }}
     Log    ${expected_path}
-    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Work    microshift restore --dont-save-failed --auto-recovery ${WORKDIR}
     # On second restore, previously restored backup ^ is moved into restored/ subdir.
-    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Work    microshift restore --dont-save-failed --auto-recovery ${WORKDIR}
     Command Should Work    ls ${expected_path}
 
     [Teardown]    Command Should Work    rm -rf ${WORKDIR}
 
 MicroShift Data Is Backed Up For Later Analysis
-    [Documentation]    When --save-failed option is given, MicroShift data
-    ...    should be copied to a "failed" subdirectory for later analysis.
+    [Documentation]    By default, MicroShift data should be copied
+    ...    to a "failed" subdirectory for later analysis.
 
     ${last_backup}=    Create Backups    1
-    Command Should Work    microshift restore --save-failed --auto-recovery ${WORKDIR}
+    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
     ${data_backup}=    Command Should Work    ls ${WORKDIR}/failed
     Verify Backup Name    ${data_backup}
 
@@ -101,7 +101,7 @@ State File Is Created
     ${last_backup}=    Create Backups    1
     ${backup_name}=    Remove String    ${last_backup}    ${WORKDIR}
 
-    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Work    microshift restore --dont-save-failed --auto-recovery ${WORKDIR}
     ${state_json}=    Command Should Work    cat ${WORKDIR}/state.json
     ${state}=    Json Parse    ${state_json}
     Should Be Equal As Strings    ${backup_name}    ${state}[LastBackup]

--- a/test/suites/backup/auto-recovery.robot
+++ b/test/suites/backup/auto-recovery.robot
@@ -11,29 +11,114 @@ Suite Setup         Setup
 Suite Teardown      Teardown
 
 
+*** Variables ***
+${WORKDIR}      /var/lib/microshift-auto-recovery/
+
+
 *** Test Cases ***
 Backups Are Created Successfully With Expected Schema
     [Documentation]    Verify that backups intended for auto-recovery are created successfully
     ...    and they are named with expected schema of DATETIME_DEPLOY-ID for ostree/bootc and DATETIME_MICROSHIFT-VERSION.
-    [Setup]    Stop MicroShift
 
-    Command Should Work    microshift backup --auto-recovery /var/lib/microshift-auto-recovery
-    ${backup_name}=    Command Should Work    ls /var/lib/microshift-auto-recovery
+    ${backup_path}=    Command Should Work    microshift backup --auto-recovery ${WORKDIR}
+    ${backup_name}=    Remove String    ${backup_path}    ${WORKDIR}
     Verify Backup Name    ${backup_name}
 
+    [Teardown]    Command Should Work    rm -rf ${WORKDIR}
+
+Restore Fails When There Are No Backups
+    [Documentation]    Restoring fail if the storage contains no backups at all.
+
+    Command Should Fail    microshift restore --auto-recovery ${WORKDIR}
+
+Restore Fails When There Are No Suitable Backups
+    [Documentation]    Create 3 backups, but change their versions to other
+    ...    MicroShift version/Deployment ID, so even there are backups present,
+    ...    none is suitable for restoring.
+
+    FOR    ${counter}    IN RANGE    1    4
+        ${backup_path}=    Command Should Work    microshift backup --auto-recovery ${WORKDIR}
+        Command Should Work    bash -c "echo ${counter} > ${backup_path}/marker"
+        ${new_path}=    Set Variable    ${{ "${backup_path}[:-1]" + str(int("${backup_path}[-1]")+1) }}
+        Command Should Work    sudo mv ${backup_path} ${new_path}
+        Sleep    2s
+    END
+    Command Should Fail    microshift restore --auto-recovery ${WORKDIR}
+
+    [Teardown]    Command Should Work    rm -rf ${WORKDIR}
+
+Restore Selects Right Backup
+    [Documentation]    Test creates 3 backups and changes the last one's version.
+    ...    Restore command should use the second created backup as it's the most recent
+    ...    among backups that match the version.
+
+    ${last_backup}=    Create Backups    3    ${TRUE}
+
+    # Rename the last backup to different deployment ID. When restoring it should be skipped.
+    # Incrementing the last character is enough and works for both ostree/bootc and rpm systems.
+    ${new_path}=    Set Variable    ${{ "${last_backup}[:-1]" + str(int("${last_backup}[-1]")+1) }}
+    Command Should Work    sudo mv ${last_backup} ${new_path}
+
+    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    ${backup_marker}=    Command Should Work    cat /var/lib/microshift/marker
+    Should Be Equal As Numbers    ${backup_marker}    2
+    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+
     [Teardown]    Run Keywords
-    ...    Start MicroShift
+    ...    Command Should Work    rm -rf ${WORKDIR}
     ...    AND
-    ...    Command Should Work    rm -rf /var/lib/microshift-auto-recovery
+    ...    Command Should Work    rm -f /var/lib/microshift/marker
+
+Previously Restored Backup Is Moved To Special Subdirectory
+    [Documentation]    Executing Restore command results in
+    ...    moving previously restored backup to a "restored" subdir.
+
+    ${last_backup}=    Create Backups    3
+    ${expected_path}=    Set Variable
+    ...    ${{ "/".join( "${last_backup}".split("/")[:-1] + ["restored"] + [ "${last_backup}".split("/")[-1] ] ) }}
+    Log    ${expected_path}
+    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    # On second restore, previously restored backup ^ is moved into restored/ subdir.
+    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    Command Should Work    ls ${expected_path}
+
+    [Teardown]    Command Should Work    rm -rf ${WORKDIR}
+
+MicroShift Data Is Backed Up For Later Analysis
+    [Documentation]    When --save-failed option is given, MicroShift data
+    ...    should be copied to a "failed" subdirectory for later analysis.
+
+    ${last_backup}=    Create Backups    1
+    Command Should Work    microshift restore --save-failed --auto-recovery ${WORKDIR}
+    ${data_backup}=    Command Should Work    ls ${WORKDIR}/failed
+    Verify Backup Name    ${data_backup}
+
+    [Teardown]    Command Should Work    rm -rf ${WORKDIR}
+
+State File Is Created
+    [Documentation]    Restoring causes a state file creation.
+
+    ${last_backup}=    Create Backups    1
+    ${backup_name}=    Remove String    ${last_backup}    ${WORKDIR}
+
+    Command Should Work    microshift restore --auto-recovery ${WORKDIR}
+    ${state_json}=    Command Should Work    cat ${WORKDIR}/state.json
+    ${state}=    Json Parse    ${state_json}
+    Should Be Equal As Strings    ${backup_name}    ${state}[LastBackup]
+
+    [Teardown]    Command Should Work    rm -rf ${WORKDIR}
 
 
 *** Keywords ***
 Setup
     [Documentation]    Test suite setup
     Login MicroShift Host
+    # Scenario needs to start with MicroShift running, so there's something to back up.
+    Stop MicroShift
 
 Teardown
     [Documentation]    Test suite teardown
+    Start MicroShift
     Logout MicroShift Host
 
 Verify Backup Name
@@ -67,3 +152,15 @@ Verify Backup Version Against The System
         ${microshift_ver}=    MicroShift Version
         Should Be Equal As Strings    ${microshift_ver.major}.${microshift_ver.minor}.${microshift_ver.patch}    ${ver}
     END
+
+Create Backups
+    [Documentation]    Create specified amount of backups and return path to the last one.
+    [Arguments]    ${amount}    ${markers}=${FALSE}
+    FOR    ${counter}    IN RANGE    1    ${{ ${amount}+1 }}
+        ${backup_path}=    Command Should Work    microshift backup --auto-recovery ${WORKDIR}
+        IF    ${markers}
+            Command Should Work    bash -c "echo ${counter} > ${backup_path}/marker"
+        END
+        Sleep    2s
+    END
+    RETURN    ${backup_path}


### PR DESCRIPTION
Adds two new options to `microshift restore` command:
- `--auto-recovery` to run the procedure of restoring the most recent backup from provided directory
- `--save-failed` to opt-out from making a copy of current MicroShift data to "failed" subdirectory