### PR TITLE
USHIFT-4704: Port bootc build procedure to directly use mirror registry instead of local storage

### DIFF
--- a/scripts/image-builder/mirror-images.sh
+++ b/scripts/image-builder/mirror-images.sh
@@ -25,6 +25,7 @@ function skopeo_retry() {
         else
             return 0
         fi
+        sleep $(( "${attempt}" * 10 ))
     done
 
     echo "ERROR: Failed to run skopeo, quitting after 3 tries"

--- a/test/README.md
+++ b/test/README.md
@@ -342,11 +342,8 @@ scp -r microshift@${MICROSHIFT_HOST}:microshift/_output/test-images/ _output/
 ```
 #### Mirroring the container registry
 In order to avoid possible disruptions from external sources such as container
-registries, there is an option to mirror the registry locally for all the
-images MicroShift requires.
-
-`ENABLE_REGISTRY_MIRROR` -- Boolean value controlling whether there will be a
-local mirror for all MicroShift container images configured in the hypervisor.
+registries, container registry is mirrored locally for all the images MicroShift
+requires.
 
 The registry will contain all images extracted from previously built MicroShift
 RPMs in the `build` phase (taken from `microshift-release-info`).

--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -21,9 +21,6 @@ prepare_scenario_sources() {
     fi
 }
 
-ENABLE_REGISTRY_MIRROR=${ENABLE_REGISTRY_MIRROR:-true}
-export ENABLE_REGISTRY_MIRROR
-
 # Log output automatically
 LOGDIR="${ROOTDIR}/_output/ci-logs"
 LOGFILE="${LOGDIR}/$(basename "$0" .sh).log"
@@ -49,9 +46,7 @@ cd "${ROOTDIR}/test"
 bash -x ./bin/manage_hypervisor_config.sh create
 
 # Setup a container registry and mirror images.
-if ${ENABLE_REGISTRY_MIRROR}; then
-    bash -x ./bin/mirror_registry.sh
-fi
+bash -x ./bin/mirror_registry.sh
 
 # Prepare all the scenarios that need to run into a special directory
 prepare_scenario_sources

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -119,9 +119,6 @@ RF_VENV=${RF_VENV:-${OUTPUTDIR}/robotenv}
 # shellcheck disable=SC2034  # used elsewhere
 export GOMPLATE=${OUTPUTDIR}/bin/gomplate
 
-# Which port the web server should run on.
-WEB_SERVER_PORT=${WEB_SERVER_PORT:-8080}
-
 title() {
     # Only use color when reporting to a terminal
     if [ -t 1 ]; then
@@ -193,6 +190,22 @@ get_vm_bridge_ip() {
 # default network for libvirt VMs.
 # shellcheck disable=SC2034  # used elsewhere
 VM_BRIDGE_IP="$(get_vm_bridge_ip "default")"
+
+# Web server port number
+WEB_SERVER_PORT=${WEB_SERVER_PORT:-8080}
+
+# Web server URL using VM bridge IP with fallback to host name
+# shellcheck disable=SC2034  # used elsewhere
+WEB_SERVER_URL="http://${VM_BRIDGE_IP:-$(hostname)}:${WEB_SERVER_PORT}"
+
+# Mirror registry port number
+# shellcheck disable=SC2034  # used elsewhere
+export MIRROR_REGISTRY_PORT=5000
+
+# Mirror registry URL using VM bridge IP with fallback to host name
+# shellcheck disable=SC2034  # used elsewhere
+MIRROR_REGISTRY_URL="${VM_BRIDGE_IP:-$(hostname)}:${MIRROR_REGISTRY_PORT}"
+export MIRROR_REGISTRY_URL
 
 get_build_branch() {
     local -r ocp_ver="$(grep ^OCP_VERSION "${ROOTDIR}/Makefile.version.$(uname -m).var"  | awk '{print $NF}' | awk -F. '{print $1"."$2}')"

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -72,6 +72,10 @@ export BASE_REPO="${IMAGEDIR}/rpm-repos/microshift-base"
 # shellcheck disable=SC2034  # used elsewhere
 export CONTAINER_LIST="${IMAGEDIR}/container-images-list"
 
+# Location of the local mirror registry data
+# shellcheck disable=SC2034  # used elsewhere
+export MIRROR_REGISTRY_DIR="${IMAGEDIR}/mirror-registry"
+
 # Location of container images in oci-dir format for all the bootc images
 # shellcheck disable=SC2034  # used elsewhere
 export BOOTC_IMAGE_DIR="${IMAGEDIR}/bootc-images"

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -192,7 +192,7 @@ get_vm_bridge_ip() {
 VM_BRIDGE_IP="$(get_vm_bridge_ip "default")"
 
 # Web server port number
-WEB_SERVER_PORT=${WEB_SERVER_PORT:-8080}
+WEB_SERVER_PORT=8080
 
 # Web server URL using VM bridge IP with fallback to host name
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -7,7 +7,7 @@ source "${SCRIPTDIR}/common.sh"
 
 DISTRIBUTION_VERSION=2.8.3
 REGISTRY_IMAGE="quay.io/microshift/distribution:${DISTRIBUTION_VERSION}"
-REGISTRY_HOST=${REGISTRY_HOST:-$(hostname):5000}
+REGISTRY_HOST=${REGISTRY_HOST:-${MIRROR_REGISTRY_URL}}
 PULL_SECRET=${PULL_SECRET:-${HOME}/.pull-secret.json}
 LOCAL_REGISTRY_NAME="microshift-local-registry"
 
@@ -41,7 +41,7 @@ setup_registry() {
     # and it defaults to https. Since this is not supported we need to configure registries.conf so that skopeo tries http instead.
     sudo bash -c 'cat > /etc/containers/registries.conf.d/900-microshift-mirror.conf' << EOF
 [[registry]]
-location = "$(hostname)"
+location = "${REGISTRY_HOST}"
 insecure = true
 EOF
     sudo systemctl restart podman

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -56,18 +56,11 @@ mirror_images() {
     rm -f "${ofile}"
 }
 
-mirror_bootc_images() {
-    local -r idir=$1
-    "${ROOTDIR}/scripts/image-builder/mirror-images.sh" --dir-to-reg "${PULL_SECRET}" "${idir}" "${REGISTRY_HOST}"
-}
-
 usage() {
     echo ""
     echo "Usage: ${0} [-cf FILE] [-bd DIR]"
     echo "   -cf FILE    File containing the container image references to mirror."
     echo "               Defaults to '${CONTAINER_LIST}', skipped if does not exist."
-    echo "   -bd DIR     Directory containing the bootc containers data to mirror."
-    echo "               Defaults to '${BOOTC_IMAGE_DIR}', skipped if does not exist."
     echo ""
     echo "The registry data is stored at '${MIRROR_REGISTRY_DIR}' on the host."
     exit 1
@@ -77,7 +70,6 @@ usage() {
 # Main
 #
 image_list_file="${CONTAINER_LIST}"
-bootc_image_dir="${BOOTC_IMAGE_DIR}"
 
 while [ $# -gt 0 ]; do
     case $1 in
@@ -85,11 +77,6 @@ while [ $# -gt 0 ]; do
         shift
         [ -z "$1" ] && usage
         image_list_file=$1
-        ;;
-    -bd)
-        shift
-        [ -z "$1" ] && usage
-        bootc_image_dir=$1
         ;;
     *)
         usage
@@ -105,10 +92,4 @@ if [ -f "${image_list_file}" ]; then
     mirror_images "${image_list_file}"
 else
     echo "WARNING: File '${image_list_file}' does not exist, skipping"
-fi
-
-if [ -d "${bootc_image_dir}" ] ; then
-    mirror_bootc_images "${bootc_image_dir}"
-else
-    echo "WARNING: Directory '${bootc_image_dir}' does not exist, skipping"
 fi

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -7,7 +7,6 @@ import glob
 import os
 import platform
 import re
-import shutil
 import sys
 import traceback
 
@@ -380,7 +379,7 @@ def process_container_encapsulate(groupdir, containerfile, dry_run):
             if src_ref == dst_ref:
                 common.print_msg(f"The '{ce_targetimg}' already exists, skipping")
                 return True
-        except:
+        except Exception:
             None
         return False
 
@@ -539,8 +538,8 @@ def main():
             extract_container_images(f"4.{FAKE_NEXT_MINOR_VERSION}.*", NEXT_REPO, CONTAINER_LIST, args.dry_run)
             extract_container_images(PREVIOUS_RELEASE_VERSION, PREVIOUS_RELEASE_REPO, CONTAINER_LIST, args.dry_run)
             extract_container_images(YMINUS2_RELEASE_VERSION, YMINUS2_RELEASE_REPO, CONTAINER_LIST, args.dry_run)
-            # Run the mirror registry
-            common.run_command([f"{SCRIPTDIR}/mirror_registry.sh"], args.dry_run)
+        # Run the mirror registry
+        common.run_command([f"{SCRIPTDIR}/mirror_registry.sh"], args.dry_run)
         # Process package source templates
         ipkgdir = f"{SCRIPTDIR}/../package-sources-bootc"
         for ifile in os.listdir(ipkgdir):

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -18,8 +18,6 @@ source "${SCRIPTDIR}/common_versions.sh"
 
 DEFAULT_BOOT_BLUEPRINT="rhel-9.4"
 LVM_SYSROOT_SIZE="10240"
-WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
-BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
 PULL_SECRET="${PULL_SECRET:-${HOME}/.pull-secret.json}"
 PULL_SECRET_CONTENT="$(jq -c . "${PULL_SECRET}")"
 VM_BOOT_TIMEOUT=1200 # Overall total boot times are around 15m
@@ -273,7 +271,7 @@ prepare_kickstart() {
 
         sed -e "s|REPLACE_LVM_SYSROOT_SIZE|${LVM_SYSROOT_SIZE}|g" \
             -e "s|REPLACE_OSTREE_SERVER_URL|${WEB_SERVER_URL}/repo|g" \
-            -e "s|REPLACE_BOOTC_REGISTRY_URL|${BOOTC_REGISTRY_URL}|g" \
+            -e "s|REPLACE_BOOTC_REGISTRY_URL|${MIRROR_REGISTRY_URL}|g" \
             -e "s|REPLACE_RPM_SERVER_URL|${WEB_SERVER_URL}/rpm-repos|g" \
             -e "s|REPLACE_MINOR_VERSION|${MINOR_VERSION}|g" \
             -e "s|REPLACE_BOOT_COMMIT_REF|${boot_commit_ref}|g" \

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -22,7 +22,6 @@ PULL_SECRET="${PULL_SECRET:-${HOME}/.pull-secret.json}"
 PULL_SECRET_CONTENT="$(jq -c . "${PULL_SECRET}")"
 VM_BOOT_TIMEOUT=1200 # Overall total boot times are around 15m
 VM_GREENBOOT_TIMEOUT=1800 # Greenboot readiness may take up to 15-30m depending on the load
-ENABLE_REGISTRY_MIRROR=${ENABLE_REGISTRY_MIRROR:-false}
 SKIP_SOS=${SKIP_SOS:-false}  # may be overridden in global settings file
 SKIP_GREENBOOT=${SKIP_GREENBOOT:-false}  # may be overridden in scenario file
 VNC_CONSOLE=${VNC_CONSOLE:-false}  # may be overridden in global settings file
@@ -279,7 +278,6 @@ prepare_kickstart() {
             -e "s|REPLACE_HOST_NAME|${vm_hostname}|g" \
             -e "s|REPLACE_REDHAT_AUTHORIZED_KEYS|${REDHAT_AUTHORIZED_KEYS}|g" \
             -e "s|REPLACE_FIPS_ENABLED|${fips_enabled}|g" \
-            -e "s|REPLACE_ENABLE_MIRROR|${ENABLE_REGISTRY_MIRROR}|g" \
             -e "s|REPLACE_MIRROR_HOSTNAME|${hostname}|g" \
             -e "s|REPLACE_VM_BRIDGE_IP|${VM_BRIDGE_IP}|g" \
             "${ifile}" > "${output_file}"

--- a/test/kickstart-templates/includes/post-containers.cfg
+++ b/test/kickstart-templates/includes/post-containers.cfg
@@ -6,18 +6,15 @@ REPLACE_PULL_SECRET
 EOF
 chmod 600 /etc/crio/openshift-pull-secret
 
-if REPLACE_ENABLE_MIRROR; then
-    # Setup mirror registries configuration here, as the hostname is dynamic and the file is verbose.
-    # Use hostnames as IP addresses are not allowed. Since ec2 hostnames do not resolve to IPv6 addresses
-    # the /etc/hosts file will contain the hostname with the bridge IP from the host.
-    mkdir -p /etc/containers/registries.conf.d
-    cat > /etc/containers/registries.conf.d/999-microshift-mirror.conf <<EOF
+# Setup mirror registries configuration here, as the hostname is dynamic and the file is verbose.
+# Use hostnames as IP addresses are not allowed.
+mkdir -p /etc/containers/registries.conf.d
+cat > /etc/containers/registries.conf.d/999-microshift-mirror.conf <<EOF
 [[registry]]
     prefix = ""
     location = "REPLACE_MIRROR_HOSTNAME:5000"
     mirror-by-digest-only = true
     insecure = true
-
 [[registry]]
     prefix = ""
     location = "quay.io"
@@ -25,7 +22,6 @@ if REPLACE_ENABLE_MIRROR; then
 [[registry.mirror]]
     location = "REPLACE_MIRROR_HOSTNAME:5000"
     insecure = true
-
 [[registry]]
     prefix = ""
     location = "registry.redhat.io"
@@ -35,9 +31,9 @@ if REPLACE_ENABLE_MIRROR; then
     insecure = true
 EOF
 
-    # Skip signature verifying for red hat registries, since the signatures are bound the original
-    # registry name and mirroring images changes that.
-    cat > /etc/containers/policy.json <<EOF
+# Skip signature verifying for red hat registries, since the signatures are bound the original
+# registry name and mirroring images changes that.
+cat > /etc/containers/policy.json <<EOF
 {
     "default": [
         {
@@ -57,4 +53,3 @@ EOF
 cat >> /etc/hosts <<EOF
 REPLACE_VM_BRIDGE_IP REPLACE_MIRROR_HOSTNAME
 EOF
-fi

--- a/test/scenarios-bootc/periodics/cos9-src@isolated-net.sh
+++ b/test/scenarios-bootc/periodics/cos9-src@isolated-net.sh
@@ -5,7 +5,7 @@
 # Redefine network-related settings to use the isolated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere
-BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
+MIRROR_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source-isolated

--- a/test/scenarios-bootc/periodics/el94-prel@el94-src@upgrade-ostree2bootc-ok.sh
+++ b/test/scenarios-bootc/periodics/el94-prel@el94-src@upgrade-ostree2bootc-ok.sh
@@ -16,6 +16,6 @@ scenario_remove_vms() {
 scenario_run_tests() {
     run_tests host1 \
         --variable "TARGET_REF:rhel94-bootc-source-ostree-parent" \
-        --variable "BOOTC_REGISTRY:${BOOTC_REGISTRY_URL}" \
+        --variable "BOOTC_REGISTRY:${MIRROR_REGISTRY_URL}" \
         suites/upgrade/upgrade-successful-bootc.robot
 }

--- a/test/scenarios-bootc/periodics/el94-src@isolated-net.sh
+++ b/test/scenarios-bootc/periodics/el94-src@isolated-net.sh
@@ -5,7 +5,7 @@
 # Redefine network-related settings to use the isolated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere
-BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
+MIRROR_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source-isolated

--- a/test/scenarios-bootc/presubmits/el94-src@downgrade-block.sh
+++ b/test/scenarios-bootc/presubmits/el94-src@downgrade-block.sh
@@ -14,6 +14,6 @@ scenario_remove_vms() {
 scenario_run_tests() {
     run_tests host1 \
         --variable "OLDER_MICROSHIFT_REF:rhel94-bootc-source" \
-        --variable "BOOTC_REGISTRY:${BOOTC_REGISTRY_URL}" \
+        --variable "BOOTC_REGISTRY:${MIRROR_REGISTRY_URL}" \
         suites/upgrade/downgrade-block.robot
 }

--- a/test/scenarios/presubmits/el94-src@ipv6.sh
+++ b/test/scenarios/presubmits/el94-src@ipv6.sh
@@ -2,17 +2,13 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Redefine network-related settings to use the dedicated network bridge
+# Redefine network-related settings to use the dedicated IPv6 network bridge
 # shellcheck disable=SC2034  # used elsewhere
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_IPV6_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere
 WEB_SERVER_URL="http://[${VM_BRIDGE_IP}]:${WEB_SERVER_PORT}"
 # shellcheck disable=SC2034  # used elsewhere
-BOOTC_REGISTRY_URL="${VM_BRIDGE_IP}:5000"
-# Redefine registry mirror. The redhat.registry.io does not resolve to
-# ipv6 and the mirror is mandatory.
-# shellcheck disable=SC2034  # used elsewhere
-ENABLE_REGISTRY_MIRROR=true
+MIRROR_REGISTRY_URL="${VM_BRIDGE_IP}:${MIRROR_REGISTRY_PORT}"
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source


### PR DESCRIPTION
The functional changes include:
* Consolidation of Web and Registry URL definition using VM bridge interface, or host name if libvirt is not configured
* Mirror registry script uses an external storage and configuration file
* Bootc containerfile and container encapsulate builds save artifacts to the mirror registry directly bypassing file system export.
* Mirror registry startup is implicit when running bootc builds
* Mirror registry is no longer optional

These changes should result in reduced resource consumption and reduced runtime of the builds.

**Test prerequisites**
* Delete `_output`
* `sudo podman rmi -af && podman rmi -af && podman volume rm -af`
* Run `./test/bin/build_rpms.sh` and download cache.
* Compare bootc build times and disk space

**Test results on AWS `c5n.metal` host**
* Registry creation of 1m is included in the build time and 34G of disk saved.
* Registry recreation is fast due to external persistent storage

|What                       | Before|After|
|--------------------------|-----------|-------|
|Bootc build time   | 10m    | 10m|
|Create mirror reg | 1.5m   | 20s  |
|sudo podman df  | 11G     |  11G |
| podman df           | 16G     | 0G  |
|_output du            | 53G     | 35G |



