### PR TITLE
[release-4.17] USHIFT-4706: Add greenboot healthcheck after reboot on ostree system

### DIFF
--- a/test/suites/standard1/kustomize.robot
+++ b/test/suites/standard1/kustomize.robot
@@ -5,6 +5,7 @@ Resource            ../../resources/common.resource
 Resource            ../../resources/systemd.resource
 Resource            ../../resources/microshift-config.resource
 Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/ostree-health.resource
 
 Suite Setup         Setup Suite
 Suite Teardown      Teardown Suite
@@ -241,7 +242,7 @@ Restore Default Config
     ${is_ostree}=    Is System OSTree
     IF    ${is_ostree}
         Reboot MicroShift Host
-        Wait For MicroShift
+        Wait Until Greenboot Health Check Exited
     ELSE
         Restart MicroShift
         Sleep    10 seconds    # Wait for systemd to catch up


### PR DESCRIPTION
Manual cherry-pick from https://github.com/openshift/microshift/pull/4060