### PR TITLE
USHIFT-2927: Remove fstab workaround in kickstart

### DIFF
--- a/test/kickstart-templates/includes/post-bootc-wa.cfg
+++ b/test/kickstart-templates/includes/post-bootc-wa.cfg
@@ -1,3 +1,0 @@
-# Workarounds necessary to start MicroShift
-# See https://github.com/CentOS/centos-bootc/issues/442 and https://github.com/ostreedev/ostree/issues/3193
-sed -i 's;^/dev/mapper/rhel-root;#/dev/mapper/rhel-root;g' /etc/fstab

--- a/test/kickstart-templates/kickstart-bootc.ks.template
+++ b/test/kickstart-templates/kickstart-bootc.ks.template
@@ -8,7 +8,6 @@
 %include /post-containers.cfg
 %include /post-system.cfg
 %include /post-network.cfg
-%include /post-bootc-wa.cfg
 
 %end
 


### PR DESCRIPTION
https://github.com/containers/bootc/pull/417 has landed to support a workaround directly on the bootc side.