### PR TITLE
NO-ISSUE: Use /run/cni/bin location for flannel cni

### DIFF
--- a/assets/optional/flannel/05-daemonset.yaml
+++ b/assets/optional/flannel/05-daemonset.yaml
@@ -70,14 +70,14 @@ spec:
         - args:
             - -f
             - /flannel
-            - /usr/libexec/cni
+            - /run/cni/bin
           command:
             - cp
           image: flannel-plugin
           imagePullPolicy: IfNotPresent
           name: install-cni-plugin
           volumeMounts:
-            - mountPath: /usr/libexec/cni
+            - mountPath: /run/cni/bin
               name: cni-plugin
         - args:
             - -f
@@ -103,7 +103,8 @@ spec:
             path: /run/flannel
           name: run
         - hostPath:
-            path: /usr/libexec/cni
+            path: /run/cni/bin
+            type: DirectoryOrCreate
           name: cni-plugin
         - hostPath:
             path: /etc/cni/net.d


### PR DESCRIPTION
Recently one of user experienced that putting the cni plugin binary to `/usr/libexec/cni` location causing failure because of read only file system like below. Hopefully this will fix it.

```
$ oc logs kube-flannel-ds-rlksq -n kube-flannel -c install-cni-plugin
cp: can't create '/usr/libexec/cni/flannel': Read-only file system
9:08
```

