### PR TITLE
NO-ISSUE: Remove microshift-gateway-api from rhel94-crel-with-optionals.toml until the package is published on mirror

### DIFF
--- a/test/image-blueprints/layer3-periodic/group1/rhel94-crel-with-optionals.toml
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-crel-with-optionals.toml
@@ -40,10 +40,6 @@ name = "microshift-multus"
 version = "{{ .Env.CURRENT_RELEASE_VERSION }}"
 
 [[packages]]
-name = "microshift-gateway-api"
-version = "{{ .Env.CURRENT_RELEASE_VERSION }}"
-
-[[packages]]
 name = "microshift-test-agent"
 version = "*"
 


### PR DESCRIPTION
The problem was introduced in [this commit](https://github.com/pacevedom/microshift/commit/8f6c92dc75259e0c6d65e342b486139d67d18794).

Otherwise, the following error is encountered during the rpm-ostree builds.
```
ERROR: BlueprintsError: rhel-9.4-microshift-crel-optionals: DNF error occurred: MarkingErrors: Error occurred when marking packages for installation: Problems in request:
missing packages: microshift-gateway-api-4.18.0~ec.2-202410101849.p0.ge6b2865.assembly.ec.2.el9
blueprint: rhel-9.4-microshift-crel-optionals v0.0.1
```