### PR TITLE
USHIFT-4724: Isolated tests must not have access to mirror registry

### DIFF
--- a/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.toml
+++ b/test/image-blueprints/layer3-periodic/group1/rhel94-source-isolated.toml
@@ -37,6 +37,10 @@ version = "*"
 name = "podman"
 version = "*"
 
+[[packages]]
+name = "skopeo"
+version = "*"
+
 [customizations.services]
 enabled = ["microshift", "microshift-test-agent", "qemu-guest-agent"]
 

--- a/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
@@ -3,14 +3,20 @@ FROM localhost/cos9-bootc-source:latest
 # SOURCE_IMAGES contains a comma-separated list of container image references.
 # Split the variable and pull each image in a separate layer.
 #
-# Note: Gomplate blocks are commented out to avoid hadolint warnings.
+# Note:
+# - Gomplate blocks are commented out to avoid hadolint warnings.
+# - Retries work around sporadic "cannot set user namespace" podman error.
+#
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
-    GOMAXPROCS=8 skopeo copy \
-        --retry-times 3 \
-        --authfile /run/secrets/pull-secret.json \
-        "docker://{{ . }}" \
-        dir:/var/lib/containers/storage-preloaded
+    for i in {1..3}; do \
+        GOMAXPROCS=8 podman pull \
+            --authfile /run/secrets/pull-secret.json \
+            --root /var/lib/containers/storage-preloaded \
+            "docker://{{ . }}" && break; \
+        echo "Attempt $i failed. Retrying in 5 seconds..."; \
+        sleep 5; \
+    done
 # {{ end }}
 
 # Edit the container storage configuration file to include the new path

--- a/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/cos9-bootc-source-isolated.containerfile
@@ -9,7 +9,7 @@ FROM localhost/cos9-bootc-source:latest
 #
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
-    for i in {1..3}; do \
+    for i in 1 2 3; do \
         GOMAXPROCS=8 podman pull \
             --authfile /run/secrets/pull-secret.json \
             --root /var/lib/containers/storage-preloaded \

--- a/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
@@ -3,14 +3,20 @@ FROM localhost/rhel94-bootc-source:latest
 # SOURCE_IMAGES contains a comma-separated list of container image references.
 # Split the variable and pull each image in a separate layer.
 #
-# Note: Gomplate blocks are commented out to avoid hadolint warnings.
+# Note:
+# - Gomplate blocks are commented out to avoid hadolint warnings.
+# - Retries work around sporadic "cannot set user namespace" podman error.
+#
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
-    GOMAXPROCS=8 skopeo copy \
-        --retry-times 3 \
-        --authfile /run/secrets/pull-secret.json \
-        "docker://{{ . }}" \
-        dir:/var/lib/containers/storage-preloaded
+    for i in {1..3}; do \
+        GOMAXPROCS=8 podman pull \
+            --authfile /run/secrets/pull-secret.json \
+            --root /var/lib/containers/storage-preloaded \
+            "docker://{{ . }}" && break; \
+        echo "Attempt $i failed. Retrying in 5 seconds..."; \
+        sleep 5; \
+    done
 # {{ end }}
 
 # Edit the container storage configuration file to include the new path

--- a/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
+++ b/test/image-blueprints/layer5-bootc/group2/rhel94-bootc-source-isolated.containerfile
@@ -9,7 +9,7 @@ FROM localhost/rhel94-bootc-source:latest
 #
 # {{ range (.Env.SOURCE_IMAGES | strings.Split ",") }}
 RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
-    for i in {1..3}; do \
+    for i in 1 2 3; do \
         GOMAXPROCS=8 podman pull \
             --authfile /run/secrets/pull-secret.json \
             --root /var/lib/containers/storage-preloaded \

--- a/test/kickstart-templates/kickstart-bootc-isolated.ks.template
+++ b/test/kickstart-templates/kickstart-bootc-isolated.ks.template
@@ -1,0 +1,15 @@
+%include /main-prologue.cfg
+%include /main-network.cfg
+%include /main-ostreecontainer.cfg
+
+%post --log=/dev/console --erroronfail
+
+# Isolated environments must not perform container registry configuration
+# because it may give the VM access to mirror registry images.
+%include /post-microshift.cfg
+%include /post-system.cfg
+%include /post-network.cfg
+
+%end
+
+%include /onerror-logs.cfg

--- a/test/kickstart-templates/kickstart-isolated.ks.template
+++ b/test/kickstart-templates/kickstart-isolated.ks.template
@@ -1,0 +1,16 @@
+%include /main-prologue.cfg
+%include /main-network.cfg
+%include /main-ostree.cfg
+
+%post --log=/dev/console --erroronfail
+
+# Isolated environments must not perform container registry configuration
+# because it may give the VM access to mirror registry images.
+%include /post-microshift.cfg
+%include /post-system.cfg
+%include /post-network.cfg
+%include /post-fips.cfg
+
+%end
+
+%include /onerror-logs.cfg

--- a/test/scenarios-bootc/periodics/cos9-src@isolated-net.sh
+++ b/test/scenarios-bootc/periodics/cos9-src@isolated-net.sh
@@ -8,7 +8,7 @@ VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
 MIRROR_REGISTRY_URL="${VM_BRIDGE_IP}:${MIRROR_REGISTRY_PORT}"
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source-isolated
+    prepare_kickstart host1 kickstart-bootc-isolated.ks.template cos9-bootc-source-isolated
     # Use the isolated network when creating a VM
     launch_vm --boot_blueprint centos9-bootc --network_name "${VM_ISOLATED_NETWORK}" --bootc
 }

--- a/test/scenarios-bootc/periodics/el94-src@isolated-net.sh
+++ b/test/scenarios-bootc/periodics/el94-src@isolated-net.sh
@@ -8,7 +8,7 @@ VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
 MIRROR_REGISTRY_URL="${VM_BRIDGE_IP}:${MIRROR_REGISTRY_PORT}"
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-source-isolated
+    prepare_kickstart host1 kickstart-bootc-isolated.ks.template rhel94-bootc-source-isolated
     # Use the isolated network when creating a VM
     launch_vm --boot_blueprint rhel94-bootc --network_name "${VM_ISOLATED_NETWORK}" --bootc
 }

--- a/test/scenarios/periodics/el94-src@isolated-net.sh
+++ b/test/scenarios/periodics/el94-src@isolated-net.sh
@@ -8,7 +8,7 @@ VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_ISOLATED_NETWORK}")"
 WEB_SERVER_URL="http://${VM_BRIDGE_IP}:${WEB_SERVER_PORT}"
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source-isolated
+    prepare_kickstart host1 kickstart-isolated.ks.template rhel-9.4-microshift-source-isolated
     # Use the isolated network when creating a VM
     launch_vm  --network_name "${VM_ISOLATED_NETWORK}"
 }


### PR DESCRIPTION
A problem was discovered with how container images were preloaded for isolated tests in bootc configurations. This led to a question on why the [isolated-network.robot](https://github.com/openshift/microshift/blob/main/test/suites/network/isolated-network.robot) tests were passing. Apparently, it was due to the [post-containers.cfg](https://github.com/openshift/microshift/blob/main/test/kickstart-templates/includes/post-containers.cfg) configuration in kickstart that opened up access to the mirror registry from the isolated VMs. The network routing to the mirror registry on the hypervisor works via the libvirt bridge IP.

This PR addresses fixes the container image embedding in the bootc configurations, adds a test for verifying no container image access from VMs and introduces a dedicated kickstart (without container configuration) for isolated tests.