### PR TITLE
USHIFT-4757: Skip installing gateway-api as optional rpm

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -229,7 +229,10 @@ fi
 
 if ${BUILD_AND_RUN}; then
     if ${OPTIONAL_RPMS}; then
-        "${DNF_RETRY}" "localinstall" "$(ls -1 ~/microshift/_output/rpmbuild/RPMS/*/*.rpm)"
+        # Skip gateway api rpms because:
+        # - Feature is still dev preview and no tests/docs are guaranteed.
+        # - There is one issue with conformance (see USHIFT-4757) that needs to be addressed in the operator.
+        "${DNF_RETRY}" "localinstall" "$(find ~/microshift/_output/rpmbuild/RPMS -type f -name "*.rpm" -not -name "*gateway-api*")"
     else
         createrepo "${HOME}/microshift/_output/rpmbuild"
         "${DNF_RETRY}" "install" \


### PR DESCRIPTION
Gateway API is a dev preview future, meaning there are no guarantees on testing/docs.
When running conformance there is one issue with terminationMessagePolicy values in istio pods that can not be overridden by the operator with current options/configuration.
The RPM is installed using the common script configure-vm.sh which takes all optional packages and installs them. Since this feature is not ready yet for conformance, and the proper fix depends on another team we are disabling the install temporarily.
Other e2e tests will keep testing the feature, as it is included in some of the scenarios.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
