### PR TITLE
ART-10563: Remove dnf upgrade from image mode container builds

### DIFF
--- a/packaging/imagemode/Containerfile.repobase
+++ b/packaging/imagemode/Containerfile.repobase
@@ -9,8 +9,7 @@ FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG DNF_OPTIONS
 
-RUN dnf upgrade -y ${DNF_OPTIONS} && \
-    dnf install -y ${DNF_OPTIONS} firewalld microshift && \
+RUN dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all
 

--- a/packaging/imagemode/Containerfile.repourl
+++ b/packaging/imagemode/Containerfile.repourl
@@ -26,8 +26,7 @@ gpgcheck=0
 enabled=1
 EOF
 
-RUN dnf upgrade -y ${DNF_OPTIONS} && \
-    dnf install -y ${DNF_OPTIONS} firewalld microshift && \
+RUN dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all
 

--- a/packaging/imagemode/Containerfile.rhocp
+++ b/packaging/imagemode/Containerfile.rhocp
@@ -8,7 +8,6 @@ ARG USHIFT_VER
 RUN dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
         --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms" && \
-    dnf upgrade -y ${DNF_OPTIONS} && \
     dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all


### PR DESCRIPTION
The upgrades occasionally cause problems, like the following one:
```
Running transaction
[build]   Preparing        :                                                        1/1 
[build]   Upgrading        : microcode_ctl-4:20230808-2.20240910.1.el9_4.noarch     1/2 
[build]   Running scriptlet: microcode_ctl-4:20230808-2.20240910.1.el9_4.noarch     1/2 
[build] /var/tmp/rpm-tmp.rIQFD8: line 18: /dev/kmsg: Read-only file system
[build] 
[build]   Running scriptlet: microcode_ctl-4:20230808-2.20240531.1.el9_4.noarch     2/2 
[build] /var/tmp/rpm-tmp.LaGb5F: line 11: /var/lib/rpm-state/microcode_ctl_un_intel-ucode: No such file or directory
[build] /var/tmp/rpm-tmp.LaGb5F: line 13: /var/lib/rpm-state/microcode_ctl_un_ucode_caveats: No such file or directory
[build] /var/tmp/rpm-tmp.LaGb5F: line 15: /var/lib/rpm-state/microcode_ctl_un_file_list: No such file or directory
[build] error: %preun(microcode_ctl-4:20230808-2.20240531.1.el9_4.noarch) scriptlet failed, exit status 1
[build] 
[build] Error in PREUN scriptlet in rpm package microcode_ctl
[build]   Running scriptlet: microcode_ctl-4:20230808-2.20240910.1.el9_4.noarch     2/2 
[build] error: microcode_ctl-4:20230808-2.20240531.1.el9_4.noarch: erase failed
```

See [this Slack discussion](https://redhat-internal.slack.com/archives/C02CU30L7GF/p1730995333037979)