### PR TITLE
OCPBUGS-43471: Service restart when upgrading MicroShift RPM

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -492,11 +492,11 @@ usermod -a -G hugetlbfs openvswitch
 
 %systemd_post microshift.service
 
-# only for install, not on upgrades
-if [ $1 -eq 1 ]; then
-	# if crio was already started, restart it so it will catch /etc/crio/crio.conf.d/10-microshift.conf
-	systemctl is-active --quiet crio && systemctl restart --quiet crio || true
-fi
+# Restart crio and microshift services if they are active, both on installs and upgrades
+# - Crio should pick up potential configuration updates
+# - MicroShift should refresh running containers, pick up potential manifest updates, etc.
+systemctl is-active --quiet crio       && systemctl restart --quiet crio       || true
+systemctl is-active --quiet microshift && systemctl restart --quiet microshift || true
 
 %pre selinux
 %selinux_relabel_pre -s %{selinuxtype}
@@ -645,6 +645,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Mon Nov 11 2024 Gregory Giguashvili <ggiguash@redhat.com> 4.18.0
+- Restart crio and microshift services on RPM post-install
+
 * Fri Oct 25 2024 Pablo Acevedo Montserrat <pacevedo@redhat.com> 4.18.0
 - USHIFT-4715: Add gateway-api-release-info rpm
 


### PR DESCRIPTION
Added a test verifying the `crio` and `microshift` services actually get restarted on upgrade.