### PR TITLE
NO-ISSUE: Install nfv-openvswitch package to get openvswitch-selinux-extra-policy package

### DIFF
--- a/okd/src/microshift-okd-multi-build.Containerfile
+++ b/okd/src/microshift-okd-multi-build.Containerfile
@@ -39,6 +39,9 @@ COPY --chmod=755 ./okd/src/create_repos.sh ${REPO_CONFIG_SCRIPT}
 COPY --chmod=755 ./okd/src/configure.sh ${OKD_CONFIG_SCRIPT}
 COPY --from=builder /src/_output/rpmbuild/RPMS ${USHIFT_RPM_REPO_PATH}
 
+# Install nfv-openvswitch repo which provides openvswitch extra policy package
+RUN dnf install -y centos-release-nfv-openvswitch
+
 # Installing MicroShift and cleanup
 # In case of flannel we don't need openvswitch service which is by default enabled as part
 # once microshift is installed so better to disable it because it cause issue when required


### PR DESCRIPTION
openvswitch-selinux-extra-policy package is part of nfv-openvswitch repo for centos stream and without it building image for microshift-okd fails with following error:

```
Error:
 Problem: package microshift-4.18.0_0.nightly_2024_11_15_113437_20241120110835_10cf3b14d_dirty-1.el9.x86_64 from microshift-local requires microshift-networking = 4.18.0_0.nightly_2024_11_15_113437_20241120110835_10cf3b14d_dirty, but none of the providers can be installed
  - package microshift-networking-4.18.0_0.nightly_2024_11_15_113437_20241120110835_10cf3b14d_dirty-1.el9.x86_64 from microshift-local requires (openvswitch3.4 or openvswitch >= 3.4), but none of the providers can be installed
  - conflicting requests
  - nothing provides openvswitch-selinux-extra-policy needed by openvswitch3.4-3.4.0-1.el9fdp.x86_64 from openshift-mirror-beta
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
Error: building at STEP "RUN ${REPO_CONFIG_SCRIPT} ${USHIFT_RPM_REPO_PATH} &&     dnf install -y microshift &&     if [ "$WITH_FLANNEL" -eq 1 ]; then       dnf install -y microshift-flannel;       systemctl disable openvswitch;     fi &&     ${REPO_CONFIG_SCRIPT} -delete &&     rm -f ${REPO_CONFIG_SCRIPT} &&     rm -rf $USHIFT_RPM_REPO_PATH &&     dnf clean all": while running runtime: exit status 1
```
