### PR TITLE
USHIFT-4881: Optimize bootc image builds by extending local mirror usage

### DIFF
--- a/test/bin/build_images.sh
+++ b/test/bin/build_images.sh
@@ -54,9 +54,9 @@ extract_container_images() {
         dnf_options="--repo ${repo_spec}"
     fi
     # shellcheck disable=SC2086  # double quotes
-    sudo dnf download ${dnf_options} microshift-release-info-"${version}"
+    dnf download ${dnf_options} microshift-release-info-"${version}"
     get_container_images "${version}" "${IMAGEDIR}/release-info-rpms" | sed 's/,/\n/g' >> "${outfile}"
-    sudo rm -f microshift-release-info-*.rpm
+    rm -f microshift-release-info-*.rpm
     popd
 }
 

--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -9,7 +9,7 @@ fi
 get_vrel_from_beta() {
     local -r beta_repo="$1"
     local -r beta_vrel=$(\
-        sudo dnf repoquery microshift \
+        dnf repoquery microshift \
             --quiet \
             --queryformat '%{version}-%{release}' \
             --disablerepo '*' \
@@ -26,7 +26,7 @@ get_vrel_from_beta() {
 get_vrel_from_rhsm() {
     local -r rhsm_repo="$1"
     local -r rhsm_vrel=$(\
-        sudo dnf repoquery microshift \
+        dnf repoquery microshift \
             --quiet \
             --queryformat '%{version}-%{release}' \
             --repo "${rhsm_repo}" \

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -73,7 +73,7 @@ def is_rhocp_available(ver):
 
     try:
         # Run the dnf command to check for cri-o in the specified repository
-        repo_info = common.run_command_in_shell(f"sudo dnf repository-packages --showduplicates {repository} info cri-o")
+        repo_info = common.run_command_in_shell(f"dnf repository-packages --showduplicates {repository} info cri-o")
         common.print_msg(repo_info)
         return True
     except Exception:
@@ -86,10 +86,10 @@ def get_rhocp_beta_url_if_available(ver):
 
     try:
         # Run the dnf command to check for cri-o in the specified repository
-        repo_info = common.run_command_in_shell(f"sudo dnf repository-packages --showduplicates --disablerepo '*' --repofrompath 'this,{url_amd}' this info cri-o")
+        repo_info = common.run_command_in_shell(f"dnf repository-packages --showduplicates --disablerepo '*' --repofrompath 'this,{url_amd}' this info cri-o")
         common.print_msg(repo_info)
 
-        repo_info = common.run_command_in_shell(f"sudo dnf repository-packages --showduplicates --disablerepo '*' --repofrompath 'this,{url_arm}' this info cri-o")
+        repo_info = common.run_command_in_shell(f"dnf repository-packages --showduplicates --disablerepo '*' --repofrompath 'this,{url_arm}' this info cri-o")
         common.print_msg(repo_info)
 
         # Use specific minor version RHOCP mirror only if both arches are available.
@@ -186,7 +186,7 @@ def extract_container_images(version, repo_spec, outfile, dry_run=False):
         dnf_options.extend(["--repo", repo_spec])
 
     # Construct and execute the dnf download command
-    dnf_command = ["sudo", "dnf", "download"] + dnf_options + [f"microshift-release-info-{version}"]
+    dnf_command = ["dnf", "download"] + dnf_options + [f"microshift-release-info-{version}"]
     if common.run_command(dnf_command, dry_run) is not None:
         images_output = get_container_images(str(image_path), version)
         with open(outfile, "a") as f:
@@ -195,7 +195,7 @@ def extract_container_images(version, repo_spec, outfile, dry_run=False):
 
         # Cleanup RPM files
         rpm_list = list(map(str, image_path.glob("microshift-release-info-*.rpm")))
-        common.run_command(["sudo", "rm", "-f"] + rpm_list, dry_run)
+        common.run_command(["rm", "-f"] + rpm_list, dry_run)
     # Restore the current directory
     common.popd()
 

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -231,28 +231,24 @@ def process_containerfile(groupdir, containerfile, dry_run):
     try:
         # Redirect the output to the log file
         with open(cf_logfile, 'w') as logfile:
-            # Run the container build command.
-            # Note: The pull secret is necessary in some builds for pulling embedded
-            # container images specified by SOURCE_IMAGES environment variable.
+            # Run the container build command
+            # Note:
+            # - The pull secret is necessary in some builds for pulling embedded
+            #   container images specified by SOURCE_IMAGES environment variable
+            # - The --cache-to option updates the build layers in the mirror
+            #   registry so no explicit push-to-mirror is necessary
             build_args = [
                 "sudo", "podman", "build",
                 "--authfile", PULL_SECRET,
                 "--secret", f"id=pullsecret,src={PULL_SECRET}",
+                "--cache-to", f"{MIRROR_REGISTRY}/{cf_outname}",
+                "--cache-from", f"{MIRROR_REGISTRY}/{cf_outname}",
                 "-t", cf_outname, "-f", cf_outfile,
                 IMAGEDIR
             ]
             start = time.time()
             common.retry_on_exception(3, common.run_command_in_shell, build_args, dry_run, logfile, logfile)
             common.record_junit(cf_path, "build-container", "OK", start)
-
-            push_args = [
-                "sudo", "podman", "push",
-                cf_outname,
-                f"{MIRROR_REGISTRY}/{cf_outname}"
-            ]
-            start = time.time()
-            common.run_command_in_shell(push_args, dry_run, logfile, logfile)
-            common.record_junit(cf_path, "push-container", "OK", start)
     except Exception:
         common.record_junit(cf_path, "process-container", "FAILED", start_process_container, log_filepath=cf_logfile)
         # Propagate the exception to the caller


### PR DESCRIPTION
The following enhancements were implemented to speed up mirroring and builds in general:
* Add `cache-to` and `cache-from` options to bootc image builds for storing layers in the local registry rather than local storage
* Remove elevation from dnf query and download commands to avoid **potentially slow** subscription updates (for common environment initialization and also in ostree builds)
* The mirror registry script now explicitly adds non-localhost `FROM` container images to the list
* The mirror registry script now checks the local mirror before attempting to download the images