### PR TITLE
NO-ISSUE: Allow using custom pool for the dev vm disk

### DIFF
--- a/scripts/devenv-builder/create-vm.sh
+++ b/scripts/devenv-builder/create-vm.sh
@@ -40,6 +40,9 @@ SYSROOTSIZE=$(( SYSROOTSIZE * 1024 ))
 SWAPSIZE=$(( SWAPSIZE * 1024 ))
 # Network name
 NETWORK=${NETWORK:-default}
+# Pool name - determin the pool for vm disk the volume
+MICROSHIFT_VOL_POOL="${MICROSHIFT_VOL_POOL:-default}"
+
 
 KICKSTART_FILE=$(mktemp "/tmp/kickstart-${VMNAME}-XXXXX.ks")
 cat < "${ROOTDIR}/config/kickstart.ks.template" | \
@@ -57,7 +60,7 @@ virt-install \
     --name ${VMNAME} \
     --vcpus ${NCPUS} \
     --memory ${RAMSIZE} \
-    --disk path=./${VMNAME}.qcow2,size=${DISKSIZE} \
+    --disk pool=${MICROSHIFT_VOL_POOL},path=./${VMNAME}.qcow2,size=${DISKSIZE} \
     --network network=${NETWORK},model=virtio \
     --events on_reboot=restart \
     --location ${ISOFILE} \

--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -90,6 +90,7 @@ function action_create {
     export DISKSIZE="${DISKSIZE:-100}"
     export SWAPSIZE="${SWAPSIZE:-8}"
     export DATAVOLSIZE="${DATAVOLSIZE:-2}"
+    export MICROSHIFT_VOL_POOL="${MICROSHIFT_VOL_POOL}"
     if [ -z "${ISOFILE}" ]; then
         ISOFILE="${VMDISKDIR}/$(get_base_isofile "${MICROSHIFT_RHEL_VERSION}")"
     fi


### PR DESCRIPTION
This is usefull for cases where the default storage pool doesn't have sufficient capacity e.g.
```
WARNING  The requested volume capacity will exceed the available pool space when the volume is fully allocated. (102400 M requested capacity > 87253 M available)
```
Usage:
```
export MICROSHIFT_VOL_POOL=<your custom volume pool>
./scripts/devenv-builder/manage-vm.sh create -n ${VMNAME}
Creating VM microshift-dev from /var/lib/libvirt/images//rhel-9.4-x86_64-dvd.iso ...
...
Allocating 'microshift-dev.qcow2 | 100 GB  00:00:00     
...
VM online
.
.
.

 virsh vol-list --pool my_pool | grep microshift
 microshift-dev.qcow2        /root/dell/disks/dev-scripts/pool/microshift-dev.qcow2
```
Note this doesn't affect the iso location, you can still use `/var/lib/libvirt/images/` for the iso 