### PR TITLE
NO-ISSUE: Relax cri-o versioning requirement before full transition to 1.32

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -64,8 +64,10 @@ BuildRequires: systemd
 BuildRequires: golang
 # DO NOT REMOVE
 
-Requires: cri-o >= 1.31.0, cri-o < 1.32.0
-Requires: cri-tools >= 1.31.0, cri-tools < 1.32.0
+# Temporarily relax cri-o and cri-tools version range between 1.31 and 1.33.
+# This needs to be fixed on 1.32 when both cri-o and cri-tools 1.32 is ready.
+Requires: cri-o >= 1.31.0, cri-o < 1.33.0
+Requires: cri-tools >= 1.31.0, cri-tools < 1.33.0
 Requires: iptables
 Requires: microshift-selinux = %{version}
 Requires: microshift-networking = %{version}


### PR DESCRIPTION
Created a follow-up [USHIFT-5108](https://issues.redhat.com/browse/USHIFT-5108) issue to fix the version requirements in 4.19 branch.