### PR TITLE
OCPBUGS-38468: use default route mtu

### DIFF
--- a/pkg/components/networking.go
+++ b/pkg/components/networking.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/microshift/pkg/assets"
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/config/ovn"
+	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
 
@@ -52,7 +53,16 @@ func startCNIPlugin(ctx context.Context, cfg *config.Config, kubeconfigPath stri
 		}
 	}
 
-	ovnConfig, err := ovn.NewOVNKubernetesConfigFromFileOrDefault(filepath.Dir(config.ConfigFile), cfg.MultiNode.Enabled)
+	ipFamily := netlink.FAMILY_ALL
+	if cfg.IsIPv4() && !cfg.IsIPv6() {
+		ipFamily = netlink.FAMILY_V4
+	}
+
+	if cfg.IsIPv6() && !cfg.IsIPv4() {
+		ipFamily = netlink.FAMILY_V6
+	}
+
+	ovnConfig, err := ovn.NewOVNKubernetesConfigFromFileOrDefault(filepath.Dir(config.ConfigFile), cfg.MultiNode.Enabled, ipFamily)
 	if err != nil {
 		return fmt.Errorf("failed to create OVN-K configuration from %q: %w", config.ConfigFile, err)
 	}

--- a/pkg/config/ovn/ovn_test.go
+++ b/pkg/config/ovn/ovn_test.go
@@ -2,6 +2,8 @@ package ovn
 
 import (
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 // tests to make sure that the config file is parsed correctly
@@ -15,7 +17,7 @@ func TestNewOVNKubernetesConfigFromFileOrDefault(t *testing.T) {
 	}
 
 	for _, tt := range ttests {
-		_, err := NewOVNKubernetesConfigFromFileOrDefault(tt.configFile, false)
+		_, err := NewOVNKubernetesConfigFromFileOrDefault(tt.configFile, false, netlink.FAMILY_V4)
 		if (err != nil) != (tt.err != nil) {
 			t.Errorf("NewOVNKubernetesConfigFromFileOrDefault() error = %v, wantErr %v", err, tt.err)
 		}


### PR DESCRIPTION
determine if the host has a default gateway  based on IPv4 or IPv6 routes, then use its MTU,
the original solution was based on net.GetHostIP which didn't cover cases when we  dont have any network connection (hardcoded nodeIP with loopback) .
