### PR TITLE
USHIFT-2911: Enable SELinux tests on bootc CentOS 9 Stream

### DIFF
--- a/test/scenarios-bootc/periodics/el95-crel@published-images-standard1.sh
+++ b/test/scenarios-bootc/periodics/el95-crel@published-images-standard1.sh
@@ -51,6 +51,6 @@ scenario_run_tests() {
         exit 0
     fi
     run_tests host1 suites/standard1/
-    # When SELinux is working on bootc systems add following suite:
+    # When SELinux is working on RHEL 9.6 bootc systems add following suite:
     # suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
@@ -12,7 +12,5 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/standard1/
-    # When SELinux is working on bootc systems add following suite:
-    # suites/selinux/validate-selinux-policy.robot
+    run_tests host1 suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/presubmits/el95-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/el95-src@standard-suite1.sh
@@ -13,6 +13,6 @@ scenario_remove_vms() {
 
 scenario_run_tests() {
     run_tests host1 suites/standard1/
-    # When SELinux is working on bootc systems add following suite:
+    # When SELinux is working on RHEL 9.6 bootc systems add following suite:
     # suites/selinux/validate-selinux-policy.robot
 }


### PR DESCRIPTION
RHEL tests can only be enabled after switching to RHEL 9.6.
