### PR TITLE
USHIFT-5202: Use offline images for standard suites to speed up service startup

### DIFF
--- a/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
@@ -3,7 +3,9 @@
 # Sourced from scenario.sh and uses functions defined there.
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source
+    # Use a layer with preloaded container images to speed up MicroShift startup
+    # for this long running suite
+    prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source-isolated
     launch_vm --boot_blueprint centos9-bootc
 }
 

--- a/test/scenarios-bootc/presubmits/cos9-src@standard-suite2.sh
+++ b/test/scenarios-bootc/presubmits/cos9-src@standard-suite2.sh
@@ -3,7 +3,9 @@
 # Sourced from scenario.sh and uses functions defined there.
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source
+    # Use a layer with preloaded container images to speed up MicroShift startup
+    # for this long running suite
+    prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source-isolated
     launch_vm --boot_blueprint centos9-bootc
 }
 

--- a/test/scenarios-bootc/presubmits/el95-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/el95-src@standard-suite1.sh
@@ -3,7 +3,9 @@
 # Sourced from scenario.sh and uses functions defined there.
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel95-bootc-source
+    # Use a layer with preloaded container images to speed up MicroShift startup
+    # for this long running suite
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel95-bootc-source-isolated
     launch_vm --boot_blueprint rhel95-bootc
 }
 

--- a/test/scenarios-bootc/presubmits/el95-src@standard-suite2.sh
+++ b/test/scenarios-bootc/presubmits/el95-src@standard-suite2.sh
@@ -3,7 +3,9 @@
 # Sourced from scenario.sh and uses functions defined there.
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel95-bootc-source
+    # Use a layer with preloaded container images to speed up MicroShift startup
+    # for this long running suite
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel95-bootc-source-isolated
     launch_vm --boot_blueprint rhel95-bootc
 }
 


### PR DESCRIPTION
The standard tests runtime is around 25 and 20 minutes. These are the longest tests for pre-submits. 

* Using preloaded container images for bootc pre-submit tests to speed up their startup
  * Note that this is not possible for ostree tests because we only build offline layer in periodic jobs.