### PR TITLE
[release-4.18] USHIFT-5223: Fix greenboot test to properly handle stdout

### DIFF
--- a/test/suites/greenboot/greenboot.robot
+++ b/test/suites/greenboot/greenboot.robot
@@ -105,7 +105,7 @@ Disrupt Service
 
     ${rc}=    Execute Command
     ...    chmod 000 ${HOSTNAME_BIN_PATH}
-    ...    sudo=True    return_rc=True
+    ...    sudo=True    return_rc=True    return_stdout=False
     Should Be Equal As Integers    0    ${rc}
 
 Restore Service


### PR DESCRIPTION
Backport of db26897ecadadd5cf88290dc89bb814cd8d4d709