### PR TITLE
USHIFT-5228: Use microshift healthcheck for verifying cncf multinode health

### DIFF
--- a/packaging/greenboot/functions.sh
+++ b/packaging/greenboot/functions.sh
@@ -16,7 +16,7 @@ echo "DEPRECATION NOTICE:"
 echo "/usr/share/microshift/functions/greenboot.sh is now deprecated and will be removed in future release."
 echo "Planned removal: MicroShift 4.21"
 echo ""
-echo "As a replacement consider using 'microshift healthcheck --namespaces' command"
+echo "As a replacement consider using 'microshift healthcheck' command"
 echo "--------------------"
 echo ""
 

--- a/scripts/multinode/configure-pri.sh
+++ b/scripts/multinode/configure-pri.sh
@@ -23,6 +23,11 @@ function configure_system() {
     sudo systemctl stop firewalld
     sudo systemctl disable firewalld
 
+    # Greenboot checks are tuned for a single node
+    sudo systemctl stop greenboot-healthcheck
+    sudo systemctl reset-failed greenboot-healthcheck
+    sudo systemctl disable greenboot-healthcheck
+
     # Configure the MicroShift host name
     sudo hostnamectl hostname "${PRI_NODE_HOST}"
 

--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -16,9 +16,10 @@ prepare_scenario_sources() {
     rm -rf "${SCENARIOS_TO_RUN}"
     mkdir -p "${SCENARIOS_TO_RUN}"
     cp "${SCENARIO_SOURCES}"/*.sh "${SCENARIOS_TO_RUN}"/
-    if ${EXCLUDE_CNCF_CONFORMANCE}; then
-        find "${SCENARIOS_TO_RUN}" -name "*cncf-conformance.sh" -delete
-    fi
+    # TODO: Undo this change
+    # if ${EXCLUDE_CNCF_CONFORMANCE}; then
+    #     find "${SCENARIOS_TO_RUN}" -name "*cncf-conformance.sh" -delete
+    # fi
 }
 
 # Log output automatically

--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -16,10 +16,9 @@ prepare_scenario_sources() {
     rm -rf "${SCENARIOS_TO_RUN}"
     mkdir -p "${SCENARIOS_TO_RUN}"
     cp "${SCENARIO_SOURCES}"/*.sh "${SCENARIOS_TO_RUN}"/
-    # TODO: Undo this change
-    # if ${EXCLUDE_CNCF_CONFORMANCE}; then
-    #     find "${SCENARIOS_TO_RUN}" -name "*cncf-conformance.sh" -delete
-    # fi
+    if ${EXCLUDE_CNCF_CONFORMANCE}; then
+        find "${SCENARIOS_TO_RUN}" -name "*cncf-conformance.sh" -delete
+    fi
 }
 
 # Log output automatically


### PR DESCRIPTION
To test a CNCF fix in pre-submits, the c3710444498c9d3142ddfbebd2f0c01557c4807b was implemented to temporarily disable CNCF test exclusion. It must be reverted before merging the PR.