### PR TITLE
NO-ISSUE: okd: Add step to embed all component images to final image

### DIFF
--- a/okd/src/README.md
+++ b/okd/src/README.md
@@ -12,6 +12,10 @@
   ```bash
   cd ~/microshift && sudo podman build --env WITH_FLANNEL=1 -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
   ```
+  To embed all component images
+  ```bash
+  cd ~/microshift && sudo podman build --env EMBED_CONTAINER_IMAGES=1 -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
+  ```
   - build runnable container based on current source:
     1. replace microshift assets images to OKD  upstream images
     1. will build microshift RPMs and repo based on current sources.

--- a/okd/src/microshift-okd-multi-build.Containerfile
+++ b/okd/src/microshift-okd-multi-build.Containerfile
@@ -48,7 +48,7 @@ RUN dnf install -y centos-release-nfv-openvswitch && \
 # once microshift is installed so better to disable it because it cause issue when required
 # module is not enabled.
 RUN ${REPO_CONFIG_SCRIPT} ${USHIFT_RPM_REPO_PATH} && \
-    dnf install -y microshift && \
+    dnf install -y microshift microshift-release-info && \
     if [ "$WITH_FLANNEL" -eq 1 ]; then \
       dnf install -y microshift-flannel; \
       systemctl disable openvswitch; \
@@ -59,6 +59,20 @@ RUN ${REPO_CONFIG_SCRIPT} ${USHIFT_RPM_REPO_PATH} && \
     dnf clean all
     
 RUN ${OKD_CONFIG_SCRIPT} && rm -rf ${OKD_CONFIG_SCRIPT}
+
+# If the EMBED_CONTAINER_IMAGES environment variable is set to 1:
+# 1. Temporarily configure user namespace UID and GID mappings by writing to /etc/subuid and /etc/subgid and clean it later
+#    - This allows the skopeo command to operate properly which requires user namespace support.
+#    - Without it following error occur during image build
+#       - FATA[0129] copying system image from manifest list:[...]unpacking failed (error: exit status 1; output: potentially insufficient UIDs or GIDs available[...]
+# 2. Extract the list of image URLs from a JSON file (`release-$(uname -m).json`) while excluding the "lvms_operator" image.
+#    - `lvms_operator` image is excluded because it is not available upstream
+RUN if [ "$EMBED_CONTAINER_IMAGES" -eq 1 ]; then \
+      echo "root:100000:65536" > /etc/subuid; \
+      echo "root:100000:65536" > /etc/subgid; \
+      jq -r '.images | to_entries | map(select(.key != "lvms_operator")) | .[].value' /usr/share/microshift/release/release-$(uname -m).json |  xargs -n 1 -I {} skopeo copy docker://{} containers-storage:{}; \
+      rm -f /etc/subuid /etc/subgid; \
+   fi
 
 # Create a systemd unit to recursively make the root filesystem subtree
 # shared as required by OVN images


### PR DESCRIPTION
This will helpful for offline run of the container image. It is also helpful for podman desktop scenario where only have to pull image once and run it fast even on slow network connnectivity.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
