### PR TITLE
THEEDGE-4109: Explictly disable IPv4 in anaconda for IPv6 single stack scenarios

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -240,16 +240,23 @@ EOF
 #                     first on the host. This usually matches an image
 #                     blueprint name.
 #  fips_enabled -- Enable FIPS mode (true or false).
+#  ipv6_only -- Only use IPv6 single stack configuration by explicitly
+#               disabling IPv4 (true or false)
 prepare_kickstart() {
     local vmname="$1"
     local template="$2"
     local boot_commit_ref="$3"
     local fips_enabled=${4:-false}
+    local ipv6_only=${5:-false}
 
     local -r full_vmname="$(full_vm_name "${vmname}")"
     local -r output_dir="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/${vmname}"
     local -r vm_hostname="${full_vmname/./-}"
     local -r hostname=$(hostname)
+    local ipv6_opt=""
+    if ${ipv6_only} ; then
+        ipv6_opt="--noipv4 --ipv6 auto"
+    fi
 
     validate_vm_hostname "${vm_hostname}"
 
@@ -287,6 +294,7 @@ prepare_kickstart() {
             -e "s|REPLACE_BOOT_COMMIT_REF|${boot_commit_ref}|g" \
             -e "s|REPLACE_PULL_SECRET|${PULL_SECRET_CONTENT}|g" \
             -e "s|REPLACE_HOST_NAME|${vm_hostname}|g" \
+            -e "s|REPLACE_IPV6_ONLY|${ipv6_opt}|g" \
             -e "s|REPLACE_REDHAT_AUTHORIZED_KEYS|${REDHAT_AUTHORIZED_KEYS}|g" \
             -e "s|REPLACE_FIPS_ENABLED|${fips_enabled}|g" \
             -e "s|REPLACE_MIRROR_HOSTNAME|${hostname}|g" \

--- a/test/kickstart-templates/includes/main-network.cfg
+++ b/test/kickstart-templates/includes/main-network.cfg
@@ -1,2 +1,2 @@
 # Configure network to use DHCP and activate on boot
-network --bootproto=dhcp --device=link --activate --onboot=on --hostname=REPLACE_HOST_NAME
+network --bootproto=dhcp --device=link --activate --onboot=on --hostname=REPLACE_HOST_NAME REPLACE_IPV6_ONLY

--- a/test/scenarios-bootc/presubmits/el95-src@ipv6.sh
+++ b/test/scenarios-bootc/presubmits/el95-src@ipv6.sh
@@ -15,7 +15,8 @@ WEB_SERVER_URL="http://[${VM_BRIDGE_IP}]:${WEB_SERVER_PORT}"
 MIRROR_REGISTRY_URL="$(hostname):${MIRROR_REGISTRY_PORT}"
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel95-bootc-source
+    # Enable IPv6 single stack in kickstart
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel95-bootc-source false true
     launch_vm --boot_blueprint rhel95-bootc --network "${VM_IPV6_NETWORK}"
 }
 

--- a/test/scenarios/presubmits/el94-src@ipv6.sh
+++ b/test/scenarios/presubmits/el94-src@ipv6.sh
@@ -11,7 +11,8 @@ WEB_SERVER_URL="http://[${VM_BRIDGE_IP}]:${WEB_SERVER_PORT}"
 MIRROR_REGISTRY_URL="${VM_BRIDGE_IP}:${MIRROR_REGISTRY_PORT}"
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source
+    # Enable IPv6 single stack in kickstart
+    prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source false true
     launch_vm  --network "${VM_IPV6_NETWORK}"
 }
 


### PR DESCRIPTION
Besides the importance of "clean" testing environment, this is necessary to avoid ~2m delays when booting IPv6 VMs. See the [THEEDGE-4109](https://issues.redhat.com//browse/THEEDGE-4109) for details.
