### PR TITLE
NO-ISSUE: update TraceAll loglevel to 10

### DIFF
--- a/pkg/config/debugging.go
+++ b/pkg/config/debugging.go
@@ -20,7 +20,7 @@ var logLevelNames = map[string]int{
 	"normal":   2,
 	"debug":    4,
 	"trace":    6,
-	"traceall": 8,
+	"traceall": 10,
 }
 
 // computeLoggingSetting validates the logging setting and saves a

--- a/pkg/config/debugging_test.go
+++ b/pkg/config/debugging_test.go
@@ -44,12 +44,12 @@ func TestGetVerbosity(t *testing.T) {
 		},
 		{
 			setting:  "TraceAll",
-			level:    8,
+			level:    10,
 			warnings: 0,
 		},
 		{
 			setting:  "traceall",
-			level:    8,
+			level:    10,
 			warnings: 0,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
To Address https://github.com/openshift/microshift/issues/4399


- and the kube-scheduler-operator has already set the TraceAll to 10, as seen in https://github.com/openshift/cluster-kube-scheduler-operator/blame/b1cc4471e2f6c5dc81b2b9471f4634f1ecdb88b4/pkg/operator/targetconfigcontroller/targetconfigcontroller.go#L267
