### PR TITLE
NO-ISSUE: Fix hadolint errors in OKD container file

### DIFF
--- a/okd/src/microshift-okd-multi-build.Containerfile
+++ b/okd/src/microshift-okd-multi-build.Containerfile
@@ -15,7 +15,7 @@ RUN useradd -m -s /bin/bash microshift -d /microshift && \
 COPY . /src 
 RUN chown -R microshift:microshift /microshift /src
 
-USER 1000:1000
+USER microshift:microshift
 WORKDIR /src
 # Preparing for the build
 RUN echo '{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}' > /tmp/.pull-secret && \
@@ -49,9 +49,9 @@ RUN dnf install -y centos-release-nfv-openvswitch && \
 # module is not enabled.
 RUN ${REPO_CONFIG_SCRIPT} ${USHIFT_RPM_REPO_PATH} && \
     dnf install -y microshift microshift-release-info && \
-    if [ "$WITH_FLANNEL" -eq 1 ]; then \
-      dnf install -y microshift-flannel; \
-      systemctl disable openvswitch; \
+    if [ -n "$WITH_FLANNEL" ] ; then \
+        dnf install -y microshift-flannel ; \
+        systemctl disable openvswitch ; \
     fi && \
     ${REPO_CONFIG_SCRIPT} -delete && \
     rm -f ${REPO_CONFIG_SCRIPT} && \
@@ -67,12 +67,14 @@ RUN ${OKD_CONFIG_SCRIPT} && rm -rf ${OKD_CONFIG_SCRIPT}
 #       - FATA[0129] copying system image from manifest list:[...]unpacking failed (error: exit status 1; output: potentially insufficient UIDs or GIDs available[...]
 # 2. Extract the list of image URLs from a JSON file (`release-$(uname -m).json`) while excluding the "lvms_operator" image.
 #    - `lvms_operator` image is excluded because it is not available upstream
-RUN if [ "$EMBED_CONTAINER_IMAGES" -eq 1 ]; then \
-      echo "root:100000:65536" > /etc/subuid; \
-      echo "root:100000:65536" > /etc/subgid; \
-      jq -r '.images | to_entries | map(select(.key != "lvms_operator")) | .[].value' /usr/share/microshift/release/release-$(uname -m).json |  xargs -n 1 -I {} skopeo copy docker://{} containers-storage:{}; \
-      rm -f /etc/subuid /etc/subgid; \
-   fi
+RUN if [ -n "$EMBED_CONTAINER_IMAGES" ] ; then \
+        echo "root:100000:65536" > /etc/subuid ; \
+        echo "root:100000:65536" > /etc/subgid ; \
+        for i in $(jq -r '.images | to_entries | map(select(.key != "lvms_operator")) | .[].value' "/usr/share/microshift/release/release-$(uname -m).json") ; do \
+            skopeo copy --retry-times 3 --preserve-digests "docker://${i}" "containers-storage:${i}" ; \
+        done ; \
+        rm -f /etc/subuid /etc/subgid ; \
+    fi
 
 # Create a systemd unit to recursively make the root filesystem subtree
 # shared as required by OVN images


### PR DESCRIPTION
The verify job does not run container file check because it's using a hadolint container, so this error was missed in https://github.com/openshift/microshift/pull/4388.

```
./okd/src/microshift-okd-multi-build.Containerfile:70 DL4006 [1m[93mwarning[0m: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
./okd/src/microshift-okd-multi-build.Containerfile:70 SC2046 [1m[93mwarning[0m: Quote this to prevent word splitting.
make: *** [Makefile:180: verify-containers] Error 1
```
