### PR TITLE
USHIFT-5281: Implement MicroShift CI image build rules and docs

### DIFF
--- a/packaging/images/Containerfile.ci-brew
+++ b/packaging/images/Containerfile.ci-brew
@@ -5,13 +5,8 @@ FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 # Allow dnf command override to operate in minimal images, etc.
 ARG DNF=dnf
 
-# Install brew
+# Install brew and other dependencies
 RUN ${DNF} install -y epel-release && \
-    ${DNF} install -y koji && \
-    ${DNF} clean all
-
-# Configure brew and microshift user
-RUN ln -sv /usr/bin/koji /usr/bin/brew && \
-    useradd microshift
-
-USER microshift
+    ${DNF} install -y koji git golang && \
+    ${DNF} clean all && \
+    ln -sv /usr/bin/koji /usr/bin/brew

--- a/packaging/images/Containerfile.ci-brew
+++ b/packaging/images/Containerfile.ci-brew
@@ -8,5 +8,8 @@ ARG DNF=dnf
 # Install brew and other dependencies
 RUN ${DNF} install -y epel-release && \
     ${DNF} install -y koji git golang && \
-    ${DNF} clean all && \
-    ln -sv /usr/bin/koji /usr/bin/brew
+    ${DNF} clean all
+
+# Configure brew and create top-level source directory
+RUN ln -sv /usr/bin/koji /usr/bin/brew && \
+    mkdir --mode=0775 /go

--- a/packaging/images/Containerfile.ci-brew
+++ b/packaging/images/Containerfile.ci-brew
@@ -6,7 +6,8 @@ FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 ARG DNF=dnf
 
 # Install brew and other dependencies
-RUN ${DNF} install -y epel-release && \
+RUN ${DNF} upgrade -y && \
+    ${DNF} install -y epel-release && \
     ${DNF} install -y koji git golang && \
     ${DNF} clean all
 

--- a/packaging/images/Containerfile.ci-brew
+++ b/packaging/images/Containerfile.ci-brew
@@ -1,0 +1,17 @@
+ARG BASE_IMAGE_URL
+ARG BASE_IMAGE_TAG
+FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
+
+# Allow dnf command override to operate in minimal images, etc.
+ARG DNF=dnf
+
+# Install brew
+RUN ${DNF} install -y epel-release && \
+    ${DNF} install -y koji && \
+    ${DNF} clean all
+
+# Configure brew and microshift user
+RUN ln -sv /usr/bin/koji /usr/bin/brew && \
+    useradd microshift
+
+USER microshift

--- a/packaging/images/Makefile
+++ b/packaging/images/Makefile
@@ -1,7 +1,7 @@
-UNAME ?= $$(uname -m)
+ARCH ?= $$(uname -m)
 BASE_IMAGE_URL ?= quay.io/centos/centos
 BASE_IMAGE_TAG ?= stream9
-QUAY_IMAGE_URL ?= quay.io/microshift/microshift-ci
+DEST_IMAGE_REPO ?= quay.io/microshift/microshift-ci
 
 .PHONY: all build publish
 all:
@@ -15,8 +15,7 @@ build:
 		podman build \
 			--build-arg BASE_IMAGE_URL="${BASE_IMAGE_URL}" \
 			--build-arg BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
-			--build-arg DNF=dnf \
-			--tag "${QUAY_IMAGE_URL}":"$${tag}"-"${UNAME}" \
+			--tag "${DEST_IMAGE_REPO}":"$${tag}"-"${ARCH}" \
 			--file "$${file}"|| exit 1; \
 	done
 
@@ -24,5 +23,5 @@ publish:
 	for file in Containerfile.ci* ; do \
 		tag="$$(awk -F. '{print $$NF}' <<< "$${file}")" ; \
 		podman push \
-			"${QUAY_IMAGE_URL}":"$${tag}"-"${UNAME}" || exit 1; \
+			"${DEST_IMAGE_REPO}":"$${tag}"-"${ARCH}" || exit 1; \
 	done

--- a/packaging/images/Makefile
+++ b/packaging/images/Makefile
@@ -1,0 +1,28 @@
+UNAME ?= $$(uname -m)
+BASE_IMAGE_URL ?= quay.io/centos/centos
+BASE_IMAGE_TAG ?= stream9
+QUAY_IMAGE_URL ?= quay.io/microshift/microshift-ci
+
+.PHONY: all build publish
+all:
+	@echo "Usage: make <build | publish>"
+	@echo "  build:     Build images locally"
+	@echo "  publish:   Publish images at quay.io/microshift"
+
+build:
+	for file in Containerfile.ci* ; do \
+		tag="$$(awk -F. '{print $$NF}' <<< "$${file}")" ; \
+		podman build \
+			--build-arg BASE_IMAGE_URL="${BASE_IMAGE_URL}" \
+			--build-arg BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
+			--build-arg DNF=dnf \
+			--tag "${QUAY_IMAGE_URL}":"$${tag}"-"${UNAME}" \
+			--file "$${file}"|| exit 1; \
+	done
+
+publish:
+	for file in Containerfile.ci* ; do \
+		tag="$$(awk -F. '{print $$NF}' <<< "$${file}")" ; \
+		podman push \
+			"${QUAY_IMAGE_URL}":"$${tag}"-"${UNAME}" || exit 1; \
+	done

--- a/packaging/images/README.md
+++ b/packaging/images/README.md
@@ -1,0 +1,42 @@
+# MicroShift CI Custom Images
+
+MicroShift CI uses custom images that are based on standard CentOS 9 Stream image
+contents and a few additional tools. The image build and publishing process is
+implemented as `make` rules.
+
+Run the following command to see the available options.
+
+```bash
+$ cd packages/images
+$ make
+Usage: make <build | publish>
+  build:     Build images locally
+  publish:   Publish images at quay.io/microshift
+```
+
+## Build and Publish
+
+Run the following command to build the container images for all the supported configurations.
+
+```bash
+$ make build
+```
+
+Run the following commands to publish the container images to `quay.io/microshift`
+repository.
+
+```bash
+$ podman login quay.io/microshift
+$ make publish
+```
+
+> Important: Make sure that `quay.io/microshift/microshift-ci` repository has
+> read-only public access.
+
+## Use in CI
+
+MicroShift CI needs to be configured to mirror the custom images from the `quay.io`
+repository to the CI registry. See the [Using External Images in CI](https://docs.ci.openshift.org/docs/how-tos/external-images/)
+document for more information.
+
+The image mirroring rules are defined in [this project](https://github.com/openshift/release/tree/master/core-services/image-mirroring/microshift).


### PR DESCRIPTION
See https://docs.ci.openshift.org/docs/how-tos/external-images/ for more information.
The CI changes are in https://github.com/openshift/release/pull/61099 