### PR TITLE
NO-ISSUE: okd: Add read permission to /etc/shadow

### DIFF
--- a/okd/src/microshift-okd-multi-build.Containerfile
+++ b/okd/src/microshift-okd-multi-build.Containerfile
@@ -11,7 +11,8 @@ ENV GOMODCACHE=/microshift/.cache
 
 # Adding non-root user for building microshift
 RUN useradd -m -s /bin/bash microshift -d /microshift && \
-    echo 'microshift  ALL=(ALL)  NOPASSWD: ALL' >/etc/sudoers.d/microshift 
+    echo 'microshift  ALL=(ALL)  NOPASSWD: ALL' >/etc/sudoers.d/microshift && \
+    chmod 0640 /etc/shadow
 COPY . /src 
 RUN chown -R microshift:microshift /microshift /src
 


### PR DESCRIPTION
During the github runner on arm64, found out that running configure-vm script fails with following error. After debugging it in the runner looks like in the container after creating the `microshift` user the `/etc/shadow` file permission is not updated. This is only happening with github ubuntu-arm runner. This PR fixes it.
```
 STEP 15/16: RUN echo '{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}' > /tmp/.pull-secret &&    /src/scripts/devenv-builder/configure-vm.sh --no-build --no-set-release-version --skip-dnf-update /tmp/.pull-secret &&    /src/okd/sr
c/use_okd_assets.sh --replace ${OKD_REPO} ${OKD_VERSION_TAG}
sudo: PAM account management error: Authentication service cannot retrieve authentication info
```

- https://github.com/praveenkumar/minp/actions/runs/13047611605/job/36400806209