### PR TITLE
USHIFT-5213: Fix host name setting to persist when applied in bootc kickstart

### DIFF
--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -60,9 +60,14 @@ USER_PASSWD="<your_redhat_user_password>"
 IMAGE_NAME=microshift-4.17-bootc
 
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
+    --no-hostname \
     --build-arg USER_PASSWD="${USER_PASSWD}" \
     -f Containerfile
 ```
+
+> Note: The `--no-hostname` argument is required to avoid embedding `/etc/hostname`
+> file into the image. This allows for a proper host name setting by the anaconda
+> installer if the image is used for installing a new operating system.
 
 Verify that the local MicroShift 4.17 `bootc` image was created.
 
@@ -468,6 +473,7 @@ IMAGE_PLATFORM="linux/${IMAGE_ARCH}"
 IMAGE_NAME="microshift-4.17-bootc:linux-${IMAGE_ARCH}"
 
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
+    --no-hostname \
     --platform "${IMAGE_PLATFORM}" \
     --build-arg USER_PASSWD="${USER_PASSWD}" \
     -f Containerfile

--- a/okd/src/README.md
+++ b/okd/src/README.md
@@ -6,15 +6,21 @@
   ```
   To use OVN-K as CNI
   ```bash
-  cd ~/microshift && sudo podman build -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
+  cd ~/microshift
+  sudo podman build --no-hostname \
+    -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
   ```
   To use flannel as CNI
   ```bash
-  cd ~/microshift && sudo podman build --env WITH_FLANNEL=1 -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
+  cd ~/microshift
+  sudo podman build --no-hostname --env WITH_FLANNEL=1 \
+    -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
   ```
   To embed all component images
   ```bash
-  cd ~/microshift && sudo podman build --env EMBED_CONTAINER_IMAGES=1 -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
+  cd ~/microshift
+  sudo podman build --no-hostname --env EMBED_CONTAINER_IMAGES=1 \
+    -f okd/src/microshift-okd-multi-build.Containerfile . -t microshift-okd
   ```
   - build runnable container based on current source:
     1. replace microshift assets images to OKD  upstream images
@@ -22,7 +28,7 @@
     1. will build micrsoshift_okd bootc container based on `centos-bootc:stream9`
     1. apply upstream customization  (see below)
 
-- running the container with ovn-kubernetes 
+- running the container with ovn-kubernetes
   - make sure to load the openvswitch kernel module  :
     > `sudo modprobe openvswitch`
 
@@ -35,10 +41,10 @@
 - verify everything is working:
   ```bash
     export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig
-    > oc get nodes  
+    > oc get nodes
     NAME           STATUS   ROLES                         AGE     VERSION
     d2877aa41787   Ready    control-plane,master,worker   7m39s   v1.30.3
-    
+
     > oc get pods
     NAMESPACE                  NAME                                       READY   STATUS    RESTARTS        AGE
     kube-system                csi-snapshot-controller-7d6c78bc58-5p7tb   1/1     Running   0               8m52s
@@ -65,4 +71,4 @@
   make: *** [/src/vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk:16: build] Error 1
   Error: building at STEP "RUN make build": while running runtime: exit status 2
   ```
-  
+

--- a/packaging/imagemode/Makefile
+++ b/packaging/imagemode/Makefile
@@ -45,6 +45,7 @@ endif
 	sudo podman build \
 		--no-cache \
 		--authfile "${PULL_SECRET}" \
+		--no-hostname \
 		--build-arg BASE_IMAGE_URL="${BASE_IMAGE_URL}" \
 		--build-arg BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
 		--build-arg DNF_OPTIONS="${DNF_OPTIONS}" \
@@ -70,6 +71,7 @@ endif
 	sudo podman build \
 		--no-cache \
 		--authfile "${PULL_SECRET}" \
+		--no-hostname \
 		--build-arg BASE_IMAGE_URL="${BASE_IMAGE_URL}" \
 		--build-arg BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
 		--build-arg DNF_OPTIONS="${DNF_OPTIONS}" \
@@ -94,6 +96,7 @@ endif
 	sudo podman build \
 		--no-cache \
 		--authfile "${PULL_SECRET}" \
+		--no-hostname \
 		--build-arg BASE_IMAGE_URL="${BASE_IMAGE_URL}" \
 		--build-arg BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
 		--build-arg DNF_OPTIONS="${DNF_OPTIONS}" \

--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -243,12 +243,16 @@ def process_containerfile(groupdir, containerfile, dry_run):
             # Note:
             # - The pull secret is necessary in some builds for pulling embedded
             #   container images specified by SOURCE_IMAGES environment variable
+            # - The no-hostname option is necessary to avoid embedding /etc/hostname
+            #   file into the image, so that it can be later overridden during the
+            #   installation by anaconda when this image is deployed.
             # - The explicit push-to-mirror sets the 'latest' tag as all the build
             #   layers are in the mirror due to 'cache-to' option
             build_args = [
                 "sudo", "podman", "build",
                 "--authfile", PULL_SECRET,
                 "--secret", f"id=pullsecret,src={PULL_SECRET}",
+                "--no-hostname",
                 "--cache-to", f"{MIRROR_REGISTRY}/{cf_outname}",
                 "--cache-from", f"{MIRROR_REGISTRY}/{cf_outname}",
                 "-t", cf_outname, "-f", cf_outfile,

--- a/test/suites/standard1/hostname.robot
+++ b/test/suites/standard1/hostname.robot
@@ -18,6 +18,18 @@ ${OLD_HOSTNAME}     ${EMPTY}
 
 
 *** Test Cases ***
+Verify proper host name setting
+    [Documentation]    Verify a host name setting was performed successfully
+    ...    by the anaconda installer
+
+    ${name}=    Command Should Work    hostname
+    # The format of the host name includes scenario, suite and hostX parts.
+    # Check the suite and host part of the name to allow the test usage in
+    # multiple scenarios.
+    Should Not Contain    ${name}    localhost
+    Should Contain    ${name}    -standard
+    Should Contain    ${name}    -host
+
 Verify local name resolution
     [Documentation]    Verify correct name resolution through mDNS
     [Setup]    Configure New Hostname


### PR DESCRIPTION
The `--no-hostname` argument is required to avoid embedding `/etc/hostname` file into the image. 
This allows for a proper host name setting by the anaconda installer if the image is used for installing a new operating system.