### PR TITLE
USHIFT-5367: Increase the max_connections setting of Postgres to improve mirror registry stability

### DIFF
--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -142,6 +142,12 @@ setup_registry() {
         new_db=true
     fi
 
+    # The number of maximum connections to the database is increased from the
+    # default of 100 to avoid 'FATAL: sorry, too many clients already' errors.
+    #
+    # Note that the container log still shows the default setting of 100. Run
+    # the 'echo SHOW max_connections | psql -d quay -U quayuser' query to
+    # determine the current setting.
     echo "Running Postgres container"
     sudo podman run -d --rm --name microshift-postgres \
         -e POSTGRES_USER=quayuser \
@@ -150,7 +156,7 @@ setup_registry() {
         -e POSTGRESQL_ADMIN_PASSWORD=adminpass \
         -p 5432:5432 \
         -v "${MIRROR_REGISTRY_DIR}/postgres:/var/lib/postgresql/data:Z" \
-        "${POSTGRES_IMAGE}" >/dev/null
+        "${POSTGRES_IMAGE}" -c max_connections=1024 >/dev/null
     postgres_ip=$(sudo podman inspect -f "{{.NetworkSettings.IPAddress}}" microshift-postgres)
 
     # Retry the query until the database is available


### PR DESCRIPTION
Should help mitigating the following errors in CI.
```
2025-02-09T16:04:16.683889000Z gunicorn-registry stdout | 2025-02-09 16:04:16,679 [330] [ERROR] [gunicorn.error] Error handling request /v2/auth?account=microshift&scope=repository%3Amicroshift%2Frhel94-bootc-yminus2%3Apull%2Cpush&scope=repository%3Amicroshift%2Frhel94-bootc-prel%3Apull&service=i-020da06ecb9dac2ef.us-west-2.compute.internal%3A5000
2025-02-09T16:04:16.683942000Z gunicorn-registry stdout | Traceback (most recent call last):
2025-02-09T16:04:16.683970000Z gunicorn-registry stdout |   File "/app/lib/python3.9/site-packages/peewee.py", line 2993, in connect
2025-02-09T16:04:16.684005000Z gunicorn-registry stdout |     self._state.set_connection(self._connect())
2025-02-09T16:04:16.684032000Z gunicorn-registry stdout |   File "/app/lib/python3.9/site-packages/playhouse/pool.py", line 156, in _connect
2025-02-09T16:04:16.684058000Z gunicorn-registry stdout |     conn = super(PooledDatabase, self)._connect()
2025-02-09T16:04:16.684084000Z gunicorn-registry stdout |   File "/app/lib/python3.9/site-packages/peewee.py", line 3688, in _connect
2025-02-09T16:04:16.684109000Z gunicorn-registry stdout |     conn = psycopg2.connect(database=self.database, **self.connect_params)
2025-02-09T16:04:16.684135000Z gunicorn-registry stdout |   File "/app/lib/python3.9/site-packages/psycopg2/__init__.py", line 122, in connect
2025-02-09T16:04:16.684161000Z gunicorn-registry stdout |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
2025-02-09T16:04:16.684188000Z gunicorn-registry stdout | psycopg2.OperationalError: FATAL:  sorry, too many clients already 
```