### PR TITLE
USHIFT-5381: Check microshift.service for all healthchecks

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -31,6 +31,13 @@ func MicroShiftHealthcheck(ctx context.Context, timeout time.Duration) error {
 }
 
 func CustomWorkloadHealthcheck(ctx context.Context, timeout time.Duration, definition string) error {
+	if enabled, err := microshiftServiceShouldBeOk(ctx, timeout); err != nil {
+		printPrerunLog()
+		return err
+	} else if !enabled {
+		return nil
+	}
+
 	workloads := map[string]NamespaceWorkloads{}
 
 	err := json.Unmarshal([]byte(definition), &workloads)
@@ -47,6 +54,13 @@ func CustomWorkloadHealthcheck(ctx context.Context, timeout time.Duration, defin
 }
 
 func EasyCustomWorkloadHealthcheck(ctx context.Context, timeout time.Duration, namespace string, deployments, daemonsets, statefulsets []string) error {
+	if enabled, err := microshiftServiceShouldBeOk(ctx, timeout); err != nil {
+		printPrerunLog()
+		return err
+	} else if !enabled {
+		return nil
+	}
+
 	workloads := map[string]NamespaceWorkloads{
 		namespace: {
 			Deployments:  deployments,

--- a/test/suites/optional/healthchecks-disabled-service.robot
+++ b/test/suites/optional/healthchecks-disabled-service.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Documentation       Test if healthcheck exits quickly when MicroShift service is disabled
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/microshift-process.resource
+Library             DateTime
+
+Suite Setup         Setup Suite
+Suite Teardown      Teardown Suite
+
+
+*** Test Cases ***
+Healthchecks Should Exit Fast And Successful When MicroShift Is Disabled
+    [Documentation]    When microshift.service is disabled, the healtchecks should
+    ...    exit quickly and without an error. They should not attempt to query API Server.
+    [Tags]    ushift-5381
+    [Setup]    Disable MicroShift
+
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    find /etc/greenboot/check/required.d/ -iname '*_microshift_running_check_*'
+    ...    sudo=True
+    ...    return_rc=True
+    ...    return_stderr=True
+    ...    return_stdout=True
+    Should Be Equal As Integers    0    ${rc}
+
+    @{checks}=    Split String    ${stdout}
+    FOR    ${check}    IN    @{checks}
+        ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+        ...    ${check}
+        ...    sudo=True
+        ...    return_rc=True
+        ...    return_stderr=True
+        ...    return_stdout=True
+        Should Be Equal As Integers    0    ${rc}
+        Should Contain    ${stderr}    microshift.service is not enabled
+    END
+    [Teardown]    Enable MicroShift


### PR DESCRIPTION
If microshift optional RPMs were installed, but microshift is not enabled, primary healthcheck will exit early without an error.

This doesn't hold for other healthchecks - there's no check if microshift.service is enabled, it just proceeds to querying the API server.

Result is that optional healthchecks fail greenboot even if MicroShift is disabled.