### PR TITLE
[release-4.18] USHIFT-5352: Use EUS bootc base images and prevent unintended OS version upgrade

### DIFF
--- a/docs/config/Containerfile.bootc-rhel9
+++ b/docs/config/Containerfile.bootc-rhel9
@@ -1,10 +1,11 @@
-FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+FROM registry.redhat.io/rhel9-eus/rhel-9.4-bootc:9.4
 
 ARG USHIFT_VER=4.16
 RUN dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
         --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms"
-RUN dnf install -y firewalld microshift && \
+RUN dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release) && \
+    dnf install -y firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all
 

--- a/docs/config/Containerfile.bootc-rhel9
+++ b/docs/config/Containerfile.bootc-rhel9
@@ -1,10 +1,11 @@
 FROM registry.redhat.io/rhel9-eus/rhel-9.4-bootc:9.4
 
-ARG USHIFT_VER=4.16
-RUN dnf config-manager \
+ARG USHIFT_VER=4.17
+# hadolint ignore=SC1091
+RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
+    dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
-        --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms"
-RUN dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)" && \
+        --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms" && \
     dnf install -y firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/docs/config/Containerfile.bootc-rhel9
+++ b/docs/config/Containerfile.bootc-rhel9
@@ -4,7 +4,7 @@ ARG USHIFT_VER=4.16
 RUN dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
         --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms"
-RUN dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release) && \
+RUN dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)" && \
     dnf install -y firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -69,7 +69,7 @@ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
 > may cause unintended operating system version upgrade (e.g. from `9.4` to
 > `9.5`). To prevent this from happening, use the following command instead.
 > ```
-> RUN dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release)
+> RUN dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)"
 > ```
 
 Verify that the local MicroShift 4.16 `bootc` image was created.

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -69,7 +69,7 @@ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
 > may cause unintended operating system version upgrade (e.g. from `9.4` to
 > `9.5`). To prevent this from happening, use the following command instead.
 > ```
-> RUN dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)"
+> RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}"
 > ```
 
 Verify that the local MicroShift 4.16 `bootc` image was created.

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -50,8 +50,8 @@ curl -s -o Containerfile "${URL}"
 Run the following image build command to create a local `bootc` image.
 
 Note how secrets are used during the image build:
-* The podman `--authfile` argument is required to pull the base `rhel-bootc:9.4`
-image from the `registry.redhat.io` registry
+* The podman `--authfile` argument is required to pull the base image from the
+`registry.redhat.io` registry
 * The build `USER_PASSWD` argument is used to set a password for the `redhat` user
 
 ```bash
@@ -63,6 +63,14 @@ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --build-arg USER_PASSWD="${USER_PASSWD}" \
     -f Containerfile
 ```
+
+> **Important:**<br>
+> If `dnf upgrade` command is used in the container image build procedure, it
+> may cause unintended operating system version upgrade (e.g. from `9.4` to
+> `9.5`). To prevent this from happening, use the following command instead.
+> ```
+> RUN dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release)
+> ```
 
 Verify that the local MicroShift 4.16 `bootc` image was created.
 

--- a/packaging/imagemode/Containerfile.repobase
+++ b/packaging/imagemode/Containerfile.repobase
@@ -9,6 +9,8 @@ FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG DNF_OPTIONS
 
+# Do not run 'dnf upgrade' command to avoid overrides of the base
+# images specified by the container image build pipelines.
 RUN dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/packaging/imagemode/Containerfile.repourl
+++ b/packaging/imagemode/Containerfile.repourl
@@ -26,7 +26,8 @@ gpgcheck=0
 enabled=1
 EOF
 
-RUN dnf install -y ${DNF_OPTIONS} firewalld microshift && \
+RUN dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release) && \
+    dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all
 

--- a/packaging/imagemode/Containerfile.repourl
+++ b/packaging/imagemode/Containerfile.repourl
@@ -26,7 +26,7 @@ gpgcheck=0
 enabled=1
 EOF
 
-RUN dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release) && \
+RUN dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)" && \
     dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/packaging/imagemode/Containerfile.repourl
+++ b/packaging/imagemode/Containerfile.repourl
@@ -26,7 +26,8 @@ gpgcheck=0
 enabled=1
 EOF
 
-RUN dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)" && \
+# hadolint ignore=SC1091
+RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
     dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/packaging/imagemode/Containerfile.rhocp
+++ b/packaging/imagemode/Containerfile.rhocp
@@ -8,6 +8,7 @@ ARG USHIFT_VER
 RUN dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
         --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms" && \
+    dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release) && \
     dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/packaging/imagemode/Containerfile.rhocp
+++ b/packaging/imagemode/Containerfile.rhocp
@@ -5,10 +5,11 @@ FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 ARG DNF_OPTIONS
 ARG USHIFT_VER
 
-RUN dnf config-manager \
+# hadolint ignore=SC1091
+RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
+    dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
         --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms" && \
-    dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)" && \
     dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/packaging/imagemode/Containerfile.rhocp
+++ b/packaging/imagemode/Containerfile.rhocp
@@ -8,7 +8,7 @@ ARG USHIFT_VER
 RUN dnf config-manager \
         --set-enabled "rhocp-${USHIFT_VER}-for-rhel-9-$(uname -m)-rpms" \
         --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms" && \
-    dnf upgrade -y --releasever=$(rpm -q --qf "%{VERSION}" redhat-release) && \
+    dnf upgrade -y --releasever="$(rpm -q --qf "%{VERSION}" redhat-release)" && \
     dnf install -y ${DNF_OPTIONS} firewalld microshift && \
     systemctl enable microshift && \
     dnf clean all

--- a/packaging/imagemode/Makefile
+++ b/packaging/imagemode/Makefile
@@ -3,7 +3,7 @@
 # using NAME=value make arguments
 #
 PULL_SECRET ?= $(HOME)/.pull-secret.json
-BASE_IMAGE_URL ?= registry.redhat.io/rhel9/rhel-bootc
+BASE_IMAGE_URL ?= registry.redhat.io/rhel9-eus/rhel-9.4-bootc
 BASE_IMAGE_TAG ?= 9.4
 DNF_OPTIONS ?=
 

--- a/packaging/imagemode/README.md
+++ b/packaging/imagemode/README.md
@@ -156,7 +156,7 @@ default values used in `Containerfile` for `rhocp` and `repourl` targets.
 | Parameter Name | Default Value | Comment |
 |----------------|---------------|---------|
 | PULL_SECRET    | `~/.pull-secret.json` | Used for accessing base `bootc` images |
-| BASE_IMAGE_URL | `registry.redhat.io/rhel9/rhel-bootc` | Base `bootc` image URL |
+| BASE_IMAGE_URL | `registry.redhat.io/rhel9-eus/rhel-9.4-bootc` | Base `bootc` image URL |
 | BASE_IMAGE_TAG | `9.4` | Base `bootc` image tag |
 | DNF_OPTIONS    | none | Additional options to be passed to the `dnf` command |
 

--- a/test/image-blueprints-bootc/layer1-base/group1/rhel94-bootc-base.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group1/rhel94-bootc-base.containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+FROM registry.redhat.io/rhel9-eus/rhel-9.4-bootc:9.4
 
 # Build a container image to be used by Bootc Image Builder in the subsequent
 # stages for producing ISO images.

--- a/test/image-blueprints-bootc/layer1-base/group1/rhel94-test-agent.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group1/rhel94-test-agent.containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+FROM registry.redhat.io/rhel9-eus/rhel-9.4-bootc:9.4
 
 # Build arguments
 ARG USHIFT_RPM_REPO_NAME=microshift-local

--- a/test/scenarios-bootc-containers/presubmits/el94-src@standard-suite1.sh
+++ b/test/scenarios-bootc-containers/presubmits/el94-src@standard-suite1.sh
@@ -12,5 +12,7 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/standard1/
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.5" \
+        suites/standard1/
 }

--- a/test/scenarios-bootc-containers/presubmits/el94-src@standard-suite1.sh
+++ b/test/scenarios-bootc-containers/presubmits/el94-src@standard-suite1.sh
@@ -13,6 +13,6 @@ scenario_remove_vms() {
 
 scenario_run_tests() {
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.5" \
+        --variable "EXPECTED_OS_VERSION:9.4" \
         suites/standard1/
 }

--- a/test/scenarios-bootc/periodics/el94-crel@optional-sigstore.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@optional-sigstore.sh
@@ -35,6 +35,7 @@ scenario_run_tests() {
     # Run a minimal test for this scenario as its main functionality is
     # to verify container image signature check is enabled
 	run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.5" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard1/containers-policy.robot
 }

--- a/test/scenarios-bootc/periodics/el94-crel@optional-sigstore.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@optional-sigstore.sh
@@ -35,7 +35,6 @@ scenario_run_tests() {
     # Run a minimal test for this scenario as its main functionality is
     # to verify container image signature check is enabled
 	run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.5" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard1/containers-policy.robot
 }

--- a/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
@@ -47,6 +47,7 @@ scenario_run_tests() {
         exit 0
     fi
     run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.5" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard1/
     # When SELinux is working on RHEL 9.6 bootc systems add following suite:

--- a/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
@@ -47,7 +47,7 @@ scenario_run_tests() {
         exit 0
     fi
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.5" \
+        --variable "EXPECTED_OS_VERSION:9.4" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard1/
     # When SELinux is working on RHEL 9.6 bootc systems add following suite:

--- a/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
@@ -13,6 +13,6 @@ scenario_remove_vms() {
 
 scenario_run_tests() {
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.0" \
-        suites/selinux/validate-selinux-policy.robot
+        --variable "EXPECTED_OS_VERSION:9" \
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/cos9-src@standard-suite1.sh
@@ -12,7 +12,7 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/standard1/
-    # When SELinux is working on bootc systems add following suite:
-    # suites/selinux/validate-selinux-policy.robot
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.0" \
+        suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/presubmits/el94-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/el94-src@standard-suite1.sh
@@ -12,7 +12,9 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/standard1/
-    # When SELinux is working on bootc systems add following suite:
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.5" \
+        suites/standard1/
+    # When SELinux is working on RHEL 9.6 bootc systems add following suite:
     # suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/presubmits/el94-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/el94-src@standard-suite1.sh
@@ -13,7 +13,7 @@ scenario_remove_vms() {
 
 scenario_run_tests() {
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.5" \
+        --variable "EXPECTED_OS_VERSION:9.4" \
         suites/standard1/
     # When SELinux is working on RHEL 9.6 bootc systems add following suite:
     # suites/selinux/validate-selinux-policy.robot

--- a/test/scenarios/periodics/el94-crel@optional-sigstore.sh
+++ b/test/scenarios/periodics/el94-crel@optional-sigstore.sh
@@ -35,6 +35,7 @@ scenario_run_tests() {
     # Run a minimal test for this scenario as its main functionality is
     # to verify container image signature check is enabled
 	run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.4" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard1/containers-policy.robot
 }

--- a/test/scenarios/periodics/el94-src@rpm-standard1.sh
+++ b/test/scenarios/periodics/el94-src@rpm-standard1.sh
@@ -12,5 +12,7 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/standard1 suites/selinux/validate-selinux-policy.robot
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.4" \
+        suites/standard1 suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios/presubmits/el94-src@standard-suite1.sh
+++ b/test/scenarios/presubmits/el94-src@standard-suite1.sh
@@ -4,7 +4,7 @@
 
 scenario_create_vms() {
     prepare_kickstart host1 kickstart.ks.template rhel-9.4-microshift-source
-    launch_vm 
+    launch_vm
 }
 
 scenario_remove_vms() {
@@ -12,5 +12,7 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-    run_tests host1 suites/standard1/ suites/selinux/validate-selinux-policy.robot
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:9.4" \
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/suites/standard1/version.robot
+++ b/test/suites/standard1/version.robot
@@ -13,8 +13,9 @@ Suite Teardown      Teardown
 
 
 *** Variables ***
-${USHIFT_HOST}      ${EMPTY}
-${USHIFT_USER}      ${EMPTY}
+${USHIFT_HOST}              ${EMPTY}
+${USHIFT_USER}              ${EMPTY}
+${EXPECTED_OS_VERSION}      ${EMPTY}
 
 
 *** Test Cases ***
@@ -60,6 +61,21 @@ Metadata File Contents
 
     Should Match    ${contents}    ${expected}
 
+Expected OS Version
+    [Documentation]    Ensure the OS version is as expected by the test.
+
+    ${os_id}=    Command Should Work    awk -F= '/^ID=/ {print $2}' /etc/os-release | xargs
+    IF    '${os_id}' == 'rhel'
+        ${package_name}=    Set Variable    redhat-release
+    ELSE IF    '${os_id}' == 'centos'
+        ${package_name}=    Set Variable    centos-stream-release
+    ELSE
+        Fail    Expected OS Version only supports RHEL or CentOS operating systems
+    END
+
+    ${os_version}=    Command Should Work    rpm -qi ${package_name} | awk -F: '/^Version/ {print $2}' | xargs
+    Should Be Equal As Strings    ${EXPECTED_OS_VERSION}    ${os_version}
+
 
 *** Keywords ***
 Setup
@@ -67,6 +83,7 @@ Setup
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig
+    Should Not Be Empty    ${EXPECTED_OS_VERSION}    EXPECTED_OS_VERSION variable is required
     Read Expected Versions
     Verify MicroShift RPM Install
 

--- a/test/suites/standard1/version.robot
+++ b/test/suites/standard1/version.robot
@@ -64,16 +64,7 @@ Metadata File Contents
 Expected OS Version
     [Documentation]    Ensure the OS version is as expected by the test.
 
-    ${os_id}=    Command Should Work    awk -F= '/^ID=/ {print $2}' /etc/os-release | xargs
-    IF    '${os_id}' == 'rhel'
-        ${package_name}=    Set Variable    redhat-release
-    ELSE IF    '${os_id}' == 'centos'
-        ${package_name}=    Set Variable    centos-stream-release
-    ELSE
-        Fail    Expected OS Version only supports RHEL or CentOS operating systems
-    END
-
-    ${os_version}=    Command Should Work    rpm -qi ${package_name} | awk -F: '/^Version/ {print $2}' | xargs
+    ${os_version}=    Command Should Work    bash -c '. /etc/os-release && echo "\${VERSION_ID}"'
     Should Be Equal As Strings    ${EXPECTED_OS_VERSION}    ${os_version}
 
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/microshift/pull/4531