### PR TITLE
USHIFT-5405: Fix published image spec prefix check

### DIFF
--- a/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
@@ -18,7 +18,7 @@ scenario_create_vms() {
         local -r mirror_url="$(dirname "${CURRENT_RELEASE_REPO}")/bootc-pullspec.txt"
         local -r bootc_spec="$(curl -s "${mirror_url}")"
 
-        if [ -z "${bootc_spec}" ] || [[ "${bootc_spec}" != quay.io/openshift* ]] ; then
+        if [ -z "${bootc_spec}" ] || [[ "${bootc_spec}" != quay.io/* ]] ; then
             echo "ERROR: Failed to retrieve a bootc pull spec from '${mirror_url}'"
             exit 1
         fi

--- a/test/scenarios-bootc/periodics/el94-crel@published-images-standard2.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@published-images-standard2.sh
@@ -17,7 +17,7 @@ scenario_create_vms() {
         local -r mirror_url="$(dirname "${CURRENT_RELEASE_REPO}")/bootc-pullspec.txt"
         local -r bootc_spec="$(curl -s "${mirror_url}")"
 
-        if [ -z "${bootc_spec}" ] || [[ "${bootc_spec}" != quay.io/openshift* ]] ; then
+        if [ -z "${bootc_spec}" ] || [[ "${bootc_spec}" != quay.io/* ]] ; then
             echo "ERROR: Failed to retrieve a bootc pull spec from '${mirror_url}'"
             exit 1
         fi


### PR DESCRIPTION
The new bootc artifacts are now located at `quay.io/redhat-user-workloads/ocp-art-tenant` organization.