### PR TITLE
add script to generate a advisory, cves and jira tickets report

### DIFF
--- a/scripts/advisory_publication/advisory_publication_report.py
+++ b/scripts/advisory_publication/advisory_publication_report.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import jira.client
+import requests
+import urllib3
+import json
+import jira
+import yaml
+
+SERVER_URL = 'https://issues.redhat.com/'
+
+
+def get_advisories(ocp_version: str) -> dict[str, int]:
+    """
+    Get a list of advisory ids for a OCP version from github.com/openshift-eng/ocp-build-data repository
+        Parameters:
+            ocp_version (str): OCP version with format: "X.Y.Z"
+        Returns:
+            (dict): advisory dict with type and id
+    """
+    # Suppress only InsecureRequestWarning
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    try:
+        microshift_xy_version = ".".join(ocp_version.split(".")[:2])
+        request = requests.get(f"https://raw.githubusercontent.com/openshift-eng/ocp-build-data/refs/heads/openshift-{microshift_xy_version}/releases.yml", verify=False)
+        request.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        raise SystemExit(err)
+    result = yaml.load(str(request.text), Loader=yaml.SafeLoader)
+    if ocp_version in result['releases']:
+        return result['releases'][ocp_version]['assembly']['group']['advisories']
+    else:
+        raise KeyError(f"{ocp_version} OCP version does NOT exist")
+
+
+def get_advisory_info(advisory_id: int) -> dict[str, str]:
+    """
+    Get a list of strings with the CVEs ids for an advisory
+        Parameters:
+            advisory_id (int): advisory id
+        Returns:
+            (list): list of strings with CVE ids
+    """
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    try:
+        request = requests.get(f"https://errata.devel.redhat.com/cve/show/{advisory_id}.json", verify=False)
+        request.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        raise SystemExit(err)
+
+    advisory_info = json.loads(request.text)
+    if advisory_info is None:
+        raise ValueError
+    if not isinstance(advisory_info, dict):
+        raise TypeError
+    return advisory_info
+
+
+def search_microshift_tickets(affects_version: str, cve_id: str) -> jira.client.ResultList:
+    """
+    Query Jira for MicroShift ticket with CVE id and MicroShift version
+        Parameters:
+            affects_version (str): MicroShift affected version with format: "X.Y"
+            cve_id (str): the CVE id with format: "CVE-YYYY-NNNNN"
+        Returns:
+            (jira.client.ResultList): a list with all the Jira tickets matching the query
+    """
+    server = jira.JIRA(server=SERVER_URL, token_auth=os.environ.get('JIRA_API_TOKEN'))
+    jira_tickets = server.search_issues(f"summary  ~ '{cve_id}' and component = MicroShift and affectedVersion = {affects_version}")
+    if jira_tickets is None:
+        raise ValueError
+    if not isinstance(jira_tickets, jira.client.ResultList):
+        raise TypeError
+    return jira_tickets
+
+
+def usage():
+    print("""\
+        usage: advisory_publication_report.py OCP_VERSION
+
+        arguments:
+            OCP_VERSION: The OCP versions to analyse if MicroShift version should be published. Format: "4.X.Z"\
+    """)
+
+
+def get_report(ocp_version: str) -> dict[str, dict]:
+    """
+    Get a json object with all the advisories, CVEs and jira tickets linked
+        Parameters:
+            ocp_version (str): OCP version with format: "X.Y.Z"
+        Returns:
+            (dict): json object with all the advisories, CVEs and jira tickets linked
+    """
+    result_json = dict()
+    advisories = get_advisories(ocp_version)
+    for advisory_type, advisory_id in advisories.items():
+        advisory_info = get_advisory_info(advisory_id)
+        cve_list = advisory_info['cve']
+        advisory_dict = dict()
+        advisory_dict['type'] = advisory_type
+        advisory_dict['url'] = f"https://errata.devel.redhat.com/advisory/{advisory_id}"
+        advisory_dict['cves'] = dict()
+        for cve in cve_list:
+            jira_tickets = search_microshift_tickets(".".join(ocp_version.split(".")[:2]), cve)
+            advisory_dict['cves'][cve] = dict()
+            for ticket in jira_tickets:
+                jira_ticket_dict = dict()
+                jira_ticket_dict['id'] = ticket.key
+                jira_ticket_dict['summary'] = ticket.fields.summary
+                jira_ticket_dict['status'] = ticket.fields.status.name
+                jira_ticket_dict['resolution'] = ticket.fields.resolution.name
+                advisory_dict['cves'][cve]['jira_ticket'] = jira_ticket_dict
+        result_json[advisory_info['advisory']] = advisory_dict
+    return result_json
+
+
+def main():
+    if len(sys.argv) != 2:
+        usage()
+        raise ValueError("Invalid number of arguments")
+
+    ocp_version = str(sys.argv[1])
+    result_json = get_report(ocp_version)
+    print(f"{json.dumps(result_json, indent=4)}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/advisory_publication/advisory_publication_report.sh
+++ b/scripts/advisory_publication/advisory_publication_report.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTDIR="$(dirname "${BASH_SOURCE[0]}")"
+REPOROOT="$(git rev-parse --show-toplevel)"
+OUTPUT_DIR="${REPOROOT}/_output"
+ENVDIR="${OUTPUT_DIR}/advisory_publication"
+
+if [ ! -d "${ENVDIR}" ]; then
+    echo "Setting up required tools..."
+    mkdir -p "${OUTPUT_DIR}"
+    python3 -m venv "${ENVDIR}"
+    "${ENVDIR}/bin/pip3" install -r "${SCRIPTDIR}/requirements.txt"
+fi
+
+"${ENVDIR}/bin/python3" "${SCRIPTDIR}/advisory_publication_report.py" "$@"

--- a/scripts/advisory_publication/requirements.txt
+++ b/scripts/advisory_publication/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.32.2
+jira>=3.5.0
+PyYAML>=6.0.2


### PR DESCRIPTION
Add script to generate a report for any OCP version with advisory, cves and jira tickets info. The report will be use to decide if new MicroShift advisory publication should be requested.