### PR TITLE
OCPBUGS-51186: skip installing ai-model and low-latency  optional RPMs 

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -258,7 +258,9 @@ if ${BUILD_AND_RUN}; then
         # Skip gateway api rpms because:
         # - Feature is still dev preview and no tests/docs are guaranteed.
         # - There is one issue with conformance (see USHIFT-4757) that needs to be addressed in the operator.
-        "${DNF_RETRY}" "localinstall" "$(find ~/microshift/_output/rpmbuild/RPMS -type f -name "*.rpm" -not -name "*gateway-api*")"
+        SKIPPED_RPMS="gateway-api ai-model-serving low-latency"
+        # shellcheck disable=SC2046,SC2086
+        "${DNF_RETRY}" "localinstall" "$(find ~/microshift/_output/rpmbuild/RPMS -type f -name "*.rpm" $(printf ' -not -name *%s* ' ${SKIPPED_RPMS}))" 
     else
         createrepo "${HOME}/microshift/_output/rpmbuild"
         "${DNF_RETRY}" "install" \


### PR DESCRIPTION
when all the RPMs  installed together  it introduces instability in conformance-optional-components tests

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
