### PR TITLE
AUTH-482: Add required-scc annotation to router

### DIFF
--- a/assets/components/openshift-router/deployment.yaml
+++ b/assets/components/openshift-router/deployment.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted
       labels:
         ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
     spec:


### PR DESCRIPTION
Adds the `required-scc` annotation to the default router (set to `restricted`) so that it can't be preempted by any other custom SCCs that might exist with a higher priority.

Test (flaking) showing that `restricted` is the correct SCC for the router: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-microshift-release-4.19-periodics-e2e-aws-ovn-ocp-conformance-optional-components-arm/1899015011318108160

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**: AUTH-482
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #none
