### PR TITLE
USHIFT-5406: Optimize mirror images operation for repetitive runs

### DIFF
--- a/scripts/mirror-images.sh
+++ b/scripts/mirror-images.sh
@@ -72,14 +72,8 @@ function mirror_registry() {
         skopeo_retry copy ${skopeo_opts} --quiet \
             --preserve-digests \
             --authfile "${img_pull_file}" \
+            --additional-tag  "${dst_img_no_tag}:latest" \
             docker://"${src_img}" docker://"${dst_img}"
-
-        echo "Tagging '${dst_img_no_tag}' as 'latest'"
-        # shellcheck disable=SC2086
-        skopeo_retry copy ${skopeo_opts} --quiet \
-            --preserve-digests \
-            --authfile "${img_pull_file}" \
-            docker://"${dst_img}" docker://"${dst_img_no_tag}:latest"
     }
 
     # Export functions for xargs to use
@@ -153,14 +147,8 @@ function dir_to_registry() {
         skopeo_retry copy ${skopeo_opts} --quiet \
             --preserve-digests \
             --authfile "${img_pull_file}" \
+            --additional-tag  "${dst_img_no_tag}:latest" \
             dir://"${local_dir}/${src_img}" docker://"${dst_img}"
-
-        echo "Tagging '${dst_img}' as '${dst_img_no_tag}:latest'"
-        # shellcheck disable=SC2086
-        skopeo_retry copy ${skopeo_opts} --quiet \
-            --preserve-digests \
-            --authfile "${img_pull_file}" \
-            docker://"${dst_img}" docker://"${dst_img_no_tag}:latest"
     }
 
     # Export functions for xargs to use

--- a/scripts/mirror-images.sh
+++ b/scripts/mirror-images.sh
@@ -72,7 +72,7 @@ function mirror_registry() {
         skopeo_retry copy ${skopeo_opts} --quiet \
             --preserve-digests \
             --authfile "${img_pull_file}" \
-            --additional-tag  "${dst_img_no_tag}:latest" \
+            --additional-tag "${dst_img_no_tag}:latest" \
             docker://"${src_img}" docker://"${dst_img}"
     }
 
@@ -147,7 +147,7 @@ function dir_to_registry() {
         skopeo_retry copy ${skopeo_opts} --quiet \
             --preserve-digests \
             --authfile "${img_pull_file}" \
-            --additional-tag  "${dst_img_no_tag}:latest" \
+            --additional-tag "${dst_img_no_tag}:latest" \
             dir://"${local_dir}/${src_img}" docker://"${dst_img}"
     }
 

--- a/test/bin/mirror_registry.sh
+++ b/test/bin/mirror_registry.sh
@@ -266,8 +266,8 @@ finalize_registry() {
     # Ensure that permissions are open for the current user on the mirror registry
     # directories and files. This is necessary to avoid 'find' command errors.
     sudo chgrp -R "$(id -gn)" "${MIRROR_REGISTRY_DIR}"
-    sudo find "${MIRROR_REGISTRY_DIR}" -type d -exec sudo chmod a+rx '{}' \;
-    sudo find "${MIRROR_REGISTRY_DIR}" -type f -exec sudo chmod a+r  '{}' \;
+    sudo find "${MIRROR_REGISTRY_DIR}" -type d -exec chmod a+rx '{}' +
+    sudo find "${MIRROR_REGISTRY_DIR}" -type f -exec chmod a+r  '{}' +
 }
 
 mirror_images() {


### PR DESCRIPTION
The `mirror_registry.sh` script is run automatically on every `build_bootc_images.sh` invocation and the process takes ~1m after all the images were mirrored. This is annoying in development environment.

With the optimizations in the PR commits, the repetitive run time was brought down to 10-15s. Interestingly, the majority of time was taken by suboptimal `find+chmod` operations.
