### PR TITLE
USHIFT-2911: Enable SELinux tests in standard suite for bootc images

### DIFF
--- a/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@published-images-standard1.sh
@@ -58,7 +58,5 @@ scenario_run_tests() {
     run_tests host1 \
         --variable "EXPECTED_OS_VERSION:9.4" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
-        suites/standard1/
-    # When SELinux is working on RHEL 9.6 bootc systems add following suite:
-    # suites/selinux/validate-selinux-policy.robot
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/periodics/el96-crel@brew-standard1.sh
+++ b/test/scenarios-bootc/periodics/el96-crel@brew-standard1.sh
@@ -14,7 +14,5 @@ scenario_remove_vms() {
 scenario_run_tests() {
     run_tests host1 \
         --variable "EXPECTED_OS_VERSION:9.6" \
-        suites/standard1/
-    # When SELinux is working on RHEL 9.6 bootc systems add following suite:
-    # suites/selinux/validate-selinux-policy.robot
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/periodics/el96-crel@published-images-standard1.sh
+++ b/test/scenarios-bootc/periodics/el96-crel@published-images-standard1.sh
@@ -33,7 +33,7 @@ scenario_create_vms() {
     fi
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${bootc_spec}"
-    launch_vm --boot_blueprint rhel94-bootc
+    launch_vm --boot_blueprint rhel96-bootc
 
     # Open the firewall ports. Other scenarios get this behavior by embedding
     # settings in the blueprint, but we cannot open firewall ports in published

--- a/test/scenarios-bootc/periodics/el96-crel@published-images-standard2.sh
+++ b/test/scenarios-bootc/periodics/el96-crel@published-images-standard2.sh
@@ -32,7 +32,7 @@ scenario_create_vms() {
     fi
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${bootc_spec}"
-    launch_vm --boot_blueprint rhel94-bootc
+    launch_vm --boot_blueprint rhel96-bootc
 
     # Open the firewall ports. Other scenarios get this behavior by embedding
     # settings in the blueprint, but we cannot open firewall ports in published

--- a/test/scenarios-bootc/presubmits/el96-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/el96-src@standard-suite1.sh
@@ -14,7 +14,5 @@ scenario_remove_vms() {
 scenario_run_tests() {
     run_tests host1 \
         --variable "EXPECTED_OS_VERSION:9.6" \
-        suites/standard1/
-    # When SELinux is working on RHEL 9.6 bootc systems add following suite:
-    # suites/selinux/validate-selinux-policy.robot
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios/periodics/el94-src@rpm-standard1.sh
+++ b/test/scenarios/periodics/el94-src@rpm-standard1.sh
@@ -14,5 +14,5 @@ scenario_remove_vms() {
 scenario_run_tests() {
     run_tests host1 \
         --variable "EXPECTED_OS_VERSION:9.4" \
-        suites/standard1 suites/selinux/validate-selinux-policy.robot
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }


### PR DESCRIPTION
After switching to RHEL 9.6 bootc base images, the SELinux functionality should be fully functional.