### PR TITLE
[release-4.15] OCPBUGS-54714: Upgrade openvswitch package version to 3.3

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -112,7 +112,8 @@ The microshift-selinux package provides the SELinux policy modules required by M
 %package networking
 Summary: Networking components for MicroShift
 Requires: microshift = %{version}
-Requires: (openvswitch3.1 or openvswitch >= 3.1)
+Obsoletes: openvswitch3.1 < 3.3
+Requires: (openvswitch3.3 or openvswitch >= 3.3)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -425,6 +426,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Tue Mar 18 2025 Ilya Maximets <i.maximets@ovn.org> 4.15.0
+- Upgrade openvswitch package version to 3.3
+
 * Tue Jul 02 2024 Patryk Matuszak <pmatusza@redhat.com> 4.15.21
 - Set CRI-O version to match Kubernetes' version
 


### PR DESCRIPTION
Open vSwitch 3.1 is EoL upstream and so the support of this version in FDP is limited.  To ensure timely bug fix delivery for 4.14+ we need to upgrade to the current LTS stream, which is Open vSwitch 3.3. It will be fully supported for much longer.

This change follows a corresponding move of RHCOS at https://github.com/openshift/os/pull/1774 and OVN-Kubernetes at https://github.com/openshift/ovn-kubernetes/pull/2492 to the same OVS 3.3.  MicroShift should stay in sync.

The plan is to get this change to 4.15 once corresponding os and ovn-kubernetes PRs are in, and then backport to 4.14 when corresponding os and ovn-kubernetes PRs are backported.