### PR TITLE
NO-ISSUE: Revert "Update flannel to v0.26.5 and plugin to v1.6.2-flannel1"

### DIFF
--- a/assets/optional/flannel/kustomization.aarch64.yaml
+++ b/assets/optional/flannel/kustomization.aarch64.yaml
@@ -2,7 +2,7 @@
 images:
   - name: flannel
     newName: docker.io/flannel/flannel
-    digest: sha256:2a120e84be40412d2ce27c483165e2e8ccb4941fb33568aa8c68beb9140968f9
+    digest: sha256:16fc8a9bc02163d9c02056ec6ac649d47f6f9a5e3adb5c1f2e93b547dba1315f
   - name: flannel-plugin
     newName: docker.io/flannel/flannel-cni-plugin
-    digest: sha256:72d30ed052c1ef18cb3de6357009ffb7e5f8eb99599b3e216a4ff692d47c5796
+    digest: sha256:2a6ed38c6f14402aec3433ca0613a3a0e54993d3fa59124687dd94cb39fb59cb

--- a/assets/optional/flannel/kustomization.x86_64.yaml
+++ b/assets/optional/flannel/kustomization.x86_64.yaml
@@ -2,7 +2,7 @@
 images:
   - name: flannel
     newName: docker.io/flannel/flannel
-    digest: sha256:ffbc360bd071f093138a026d23e35b8b759e153badaae351a931a238d3c80987
+    digest: sha256:9e0e9170ed1f82029ccc4cf20fb20f6325456ab7a00f0544dc23275f11f8bb1c
   - name: flannel-plugin
     newName: docker.io/flannel/flannel-cni-plugin
-    digest: sha256:8d1323e984e2ba05394f38b4cbed18eb591037987e1b52bae852df77d4dac2d0
+    digest: sha256:6e700d30d2c9316b4f54f9d0b1423a2d15290bf082f5d1fbd87f9f25173a374c

--- a/assets/optional/flannel/release-flannel-aarch64.json
+++ b/assets/optional/flannel/release-flannel-aarch64.json
@@ -3,7 +3,7 @@
     "base": "4.18.0-0.nightly-arm64-2024-08-29-120159"
   },
   "images": {
-    "flannel": "docker.io/flannel/flannel@sha256:2a120e84be40412d2ce27c483165e2e8ccb4941fb33568aa8c68beb9140968f9",
-    "flannel-plugin": "docker.io/flannel/flannel-cni-plugin@sha256:72d30ed052c1ef18cb3de6357009ffb7e5f8eb99599b3e216a4ff692d47c5796"
+    "flannel": "docker.io/flannel/flannel@sha256:16fc8a9bc02163d9c02056ec6ac649d47f6f9a5e3adb5c1f2e93b547dba1315f",
+    "flannel-plugin": "docker.io/flannel/flannel-cni-plugin@sha256:2a6ed38c6f14402aec3433ca0613a3a0e54993d3fa59124687dd94cb39fb59cb"
   }
 }

--- a/assets/optional/flannel/release-flannel-x86_64.json
+++ b/assets/optional/flannel/release-flannel-x86_64.json
@@ -3,7 +3,7 @@
     "base": "4.18.0-0.nightly-2024-08-29-020346"
   },
   "images": {
-    "flannel": "docker.io/flannel/flannel@sha256:ffbc360bd071f093138a026d23e35b8b759e153badaae351a931a238d3c80987",
-    "flannel-plugin": "docker.io/flannel/flannel-cni-plugin@sha256:8d1323e984e2ba05394f38b4cbed18eb591037987e1b52bae852df77d4dac2d0"
+    "flannel": "docker.io/flannel/flannel@sha256:9e0e9170ed1f82029ccc4cf20fb20f6325456ab7a00f0544dc23275f11f8bb1c",
+    "flannel-plugin": "docker.io/flannel/flannel-cni-plugin@sha256:6e700d30d2c9316b4f54f9d0b1423a2d15290bf082f5d1fbd87f9f25173a374c"
   }
 }


### PR DESCRIPTION
This reverts commit 177391dda436e7cc82adfc146afcc4d37e7a95de.

So looks like flannel now require br_netfilter module to start as per https://github.com/flannel-io/flannel?tab=readme-ov-file#deploying-flannel-with-helm because https://github.com/kubernetes/kubernetes/pull/123464, which means it would problem to run microshift in container. I might going to check much simpler CNI like what kind use https://github.com/kubernetes-sigs/kind/tree/main/images/kindnetd

I am reverting this to make sure main branch have working flannel plugin.

