### PR TITLE
USHIFT-5568: Split AI Model Serving manifest

### DIFF
--- a/assets/optional/ai-model-serving/kserve/kustomization.yaml
+++ b/assets/optional/ai-model-serving/kserve/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: redhat-ods-applications
+
 resources:
 - namespace.yaml
 - overlays/odh/

--- a/assets/optional/ai-model-serving/kustomization.yaml
+++ b/assets/optional/ai-model-serving/kustomization.yaml
@@ -1,8 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-namespace: redhat-ods-applications
-
-resources:
-- kserve/
-- runtimes/

--- a/assets/optional/ai-model-serving/runtimes/kustomization.yaml
+++ b/assets/optional/ai-model-serving/runtimes/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: redhat-ods-applications
+
 resources:
 - caikit-standalone.yaml
 - caikit-tgis.yaml

--- a/docs/user/ai_model_serving.md
+++ b/docs/user/ai_model_serving.md
@@ -198,7 +198,7 @@ to re-create OVMS `ServingRuntime` in the workload's namespace:
 OVMS_IMAGE="$(jq -r '.images | with_entries(select(.key == "ovms-image")) | .[]' /usr/share/microshift/release/release-ai-model-serving-"$(uname -i)".json)"
 
 # Duplicate the original ServingRuntime yaml
-cp /usr/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes/ovms-kserve.yaml ./ovms-kserve.yaml
+cp /usr/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/ovms-kserve.yaml ./ovms-kserve.yaml
 
 # Update the image reference
 sed -i "s,image: ovms-image,image: ${OVMS_IMAGE}," ./ovms-kserve.yaml
@@ -454,10 +454,10 @@ To learn more about kserve endpoints see upstream documentation:
 If you wish to override kserve settings, you need to make a copy of existing ConfigMap, tweak the desired settings, and overwrite the existing ConfigMap.
 
 Settings are stored in a ConfigMap named `inferenceservice-config` in the `redhat-ods-applications` namespace.
-Alternatively, you can copy the ConfigMap from `/usr/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/inferenceservice-config-microshift-patch.yaml`.
+Alternatively, you can copy the ConfigMap from `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/inferenceservice-config-microshift-patch.yaml`.
 
 After tweaking it, you must apply the ConfigMap and restart kserve (e.g. by deleting Pod or scaling the Deployment down to 0 and back to 1).
-For RHEL For Edge and RHEL Image Mode systems, create a new manifest making sure it's applied after `/usr/lib/microshift/manifests.d/001-microshift-ai-model-serving`.
+For RHEL For Edge and RHEL Image Mode systems, create a new manifest making sure it's applied after `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve`.
 
 ### Limitations
 - AI Model Serving on MicroShift is only available on the x86_64 platform.

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -774,14 +774,14 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
-* Wed Apr 04 2025 Patryk Matuszak <pmatusza@redhat.com> 4.19.0
+* Fri Apr 04 2025 Patryk Matuszak <pmatusza@redhat.com> 4.19.0
 - Replace Multus manifests with drop-in configuration
-
-* Mon Mar 31 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.19.0
-- Default crio runtime is crun
 
 * Tue Apr 01 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.19.0
 - Add hostname package dependency to microshift RPM
+
+* Mon Mar 31 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.19.0
+- Default crio runtime is crun
 
 * Mon Mar 31 2025 Patryk Matuszak <pmatusza@redhat.com> 4.19.0
 - Remove unnecessary /var/lib subdir creation

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -521,49 +521,46 @@ install -p -m644 assets/optional/gateway-api/release-gateway-api-{x86_64,aarch64
 # ai-model-serving
 # Currently only x86_64 is supported. Following `ifarch` prevents building aarch64 RPM by not specifying the files for the aarch64 architecture.
 %ifarch x86_64
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving
-install -p -m644  ./assets/optional/ai-model-serving/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve
+install -p -m644  ./assets/optional/ai-model-serving/kserve/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve
-install -p -m644  ./assets/optional/ai-model-serving/kserve/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/configmap/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/configmap/* %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/configmap/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/configmap/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/configmap/* %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/configmap/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/crd/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/crd/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/crd/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/crd/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/crd/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/crd/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/crd/full/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/crd/full/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/crd/full/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/crd/full/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/crd/full/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/crd/full/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/crd/patches/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/crd/patches/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/crd/patches/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/crd/patches/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/crd/patches/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/crd/patches/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/default/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/default/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/default/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/default/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/default/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/default/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/manager/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/manager/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/manager/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/manager/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/manager/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/manager/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/overlays/odh/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/overlays/odh/* %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/overlays/odh/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/overlays/odh/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/overlays/odh/* %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/overlays/odh/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/rbac/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/rbac/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/rbac/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/rbac/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/rbac/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/rbac/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/rbac/localmodel/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/rbac/localmodel/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/rbac/localmodel/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/rbac/localmodel/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/rbac/localmodel/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/rbac/localmodel/
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/webhook/
+install -p -m644  ./assets/optional/ai-model-serving/kserve/webhook/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/webhook/
 
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/webhook/
-install -p -m644  ./assets/optional/ai-model-serving/kserve/webhook/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/kserve/webhook/
-
-install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes
-install -p -m644 assets/optional/ai-model-serving/runtimes/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes
-rm -v %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes/kustomization.x86_64.yaml
+install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes
+install -p -m644 assets/optional/ai-model-serving/runtimes/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes
+rm -v %{buildroot}/%{_prefix}/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/kustomization.x86_64.yaml
 
 install -p -m755 packaging/greenboot/microshift-running-check-ai-model-serving.sh %{buildroot}%{_sysconfdir}/greenboot/check/required.d/41_microshift_running_check_ai_model_serving.sh
 
-cat assets/optional/ai-model-serving/runtimes/kustomization.x86_64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes/kustomization.yaml
+cat assets/optional/ai-model-serving/runtimes/kustomization.x86_64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/kustomization.yaml
 %endif
 
 # ai-model-serving-release-info
@@ -755,8 +752,10 @@ fi
 # Currently only x86_64 is supported. Following `ifarch` prevents building aarch64 RPM by not specifying the files for the aarch64 architecture.
 %ifarch x86_64
 %files ai-model-serving
-%dir %{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving
-%{_prefix}/lib/microshift/manifests.d/001-microshift-ai-model-serving/*
+%dir %{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve
+%dir %{_prefix}/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes
+%{_prefix}/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/*
+%{_prefix}/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/*
 %{_sysconfdir}/greenboot/check/required.d/41_microshift_running_check_ai_model_serving.sh
 %endif
 
@@ -774,6 +773,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Wed Apr 09 2025 Patryk Matuszak <pmatusza@redhat.com> 4.19.0
+- Split AIMS manifest into two: kserve and manifests
+
 * Fri Apr 04 2025 Patryk Matuszak <pmatusza@redhat.com> 4.19.0
 - Replace Multus manifests with drop-in configuration
 

--- a/scripts/auto-rebase/assets_ai_model_serving.yaml
+++ b/scripts/auto-rebase/assets_ai_model_serving.yaml
@@ -2,8 +2,6 @@ assets:
   - dir: optional/ai-model-serving/
     no_clean: True
     files:
-      - file: kustomization.yaml
-        ignore: "MicroShift specific overrides"
       - file: release-ai-model-serving-x86_64.json
         ignore: "Release info file"
 

--- a/scripts/ci-ai-model-serving/tests/06-test-vllm.sh
+++ b/scripts/ci-ai-model-serving/tests/06-test-vllm.sh
@@ -28,7 +28,7 @@ pull_image "${VLLM_IMAGE}"
 pull_image quay.io/microshift/ai-testing-model:vllm-granite-3b-code-base-2k
 
 # Create ServingRuntime
-cp /usr/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes/vllm.yaml /tmp/vllm.yaml
+cp /usr/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/vllm.yaml /tmp/vllm.yaml
 sed -i "s,image: vllm-image,image: ${VLLM_IMAGE}," /tmp/vllm.yaml
 oc apply -n test-vllm -f /tmp/vllm.yaml
 

--- a/test/image-blueprints-bootc/layer3-periodic/group1/ai-model-serving-test-data.sh.template
+++ b/test/image-blueprints-bootc/layer3-periodic/group1/ai-model-serving-test-data.sh.template
@@ -26,7 +26,7 @@ EOF
 
 # Copy 'OpenVino Media Server' ServingRuntime CR and update image with a value taken from the ai-model-serving's release info.
 # Replacing the image is needed because it holds a placeholder substituted by the kustomizer at runtime.
-cp /usr/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes/ovms-kserve.yaml "${DEST}/ovms-kserve.yaml"
+cp /usr/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/ovms-kserve.yaml "${DEST}/ovms-kserve.yaml"
 sed -i "s,image: ovms-image,image: ${OVMS_IMAGE}," "${DEST}/ovms-kserve.yaml"
 
 cat <<EOF > "${DEST}/resources.yaml"

--- a/test/image-blueprints-bootc/layer3-periodic/group1/ai-model-serving-test-data.sh.template
+++ b/test/image-blueprints-bootc/layer3-periodic/group1/ai-model-serving-test-data.sh.template
@@ -93,3 +93,21 @@ cat "${PAYLOAD}" >> "${OUTPUT}"
 EOF
 
 chmod +x "${DEST}/prepare-query.sh"
+
+# Test kserve's ConfigMap override
+OVERRIDE_TEST_DIR="/usr/lib/microshift/manifests.d/011-override-kserve-config/"
+mkdir -p "${OVERRIDE_TEST_DIR}"
+
+cat <<EOF > "${OVERRIDE_TEST_DIR}/kustomization.yaml"
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: redhat-ods-applications
+resources:
+- configmap.yaml
+EOF
+
+# Copy the configmap and and change:
+# - .ingress.disableIngressCreation from true to false
+# - .ingress.ingressDomain from example.com to bad.com (just in case to not make conflicts with default router domain used in tests which is example.com).
+cp /usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/inferenceservice-config-microshift-patch.yaml "${OVERRIDE_TEST_DIR}/configmap.yaml"
+sed -i -e 's,example.com,bad.com,g' -e 's,disableIngressCreation": true,disableIngressCreation": false,g' "${OVERRIDE_TEST_DIR}/configmap.yaml"

--- a/test/suites/ai-model-serving/ai-model-serving-offline.robot
+++ b/test/suites/ai-model-serving/ai-model-serving-offline.robot
@@ -29,6 +29,10 @@ Sanity Test
     Prepare Request Data
     Query Model Server
 
+    # Check if ingress exists.
+    # Enabled only for testing purposes to test Kserve's settings override.
+    offline.Run With Kubeconfig    oc    get    ingress    -n    test-ai    openvino-resnet
+
 
 *** Keywords ***
 Wait For A Deployment

--- a/test/suites/ai-model-serving/ai-model-serving-online.robot
+++ b/test/suites/ai-model-serving/ai-model-serving-online.robot
@@ -45,7 +45,7 @@ Deploy OpenVINO Serving Runtime
     ${ovms_image}=    Command Should Work
     ...    jq -r '.images | with_entries(select(.key == "ovms-image")) | .[]' /usr/share/microshift/release/release-ai-model-serving-"$(uname -i)".json
     SSHLibrary.Get File
-    ...    /usr/lib/microshift/manifests.d/001-microshift-ai-model-serving/runtimes/ovms-kserve.yaml
+    ...    /usr/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/ovms-kserve.yaml
     ...    ${OVMS_KSERVE_MANIFEST}
     Local Command Should Work    sed -i "s,image: ovms-image,image: ${ovms_image}," "${OVMS_KSERVE_MANIFEST}"
     Oc Apply    -n ${NAMESPACE} -f ${OVMS_KSERVE_MANIFEST}


### PR DESCRIPTION
Split AIMS manifest into two parts to enable user to add a manifest in between that overrides the kserve settings.