### PR TITLE
USHIFT-5580: Use CentOS base image for RHEL 9.6 ISO creation until GA

### DIFF
--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -32,7 +32,7 @@ HOME_DIR = common.get_env_var("HOME")
 PULL_SECRET = common.get_env_var('PULL_SECRET', f"{HOME_DIR}/.pull-secret.json")
 # Switch to quay.io/centos-bootc/bootc-image-builder:latest if any new upstream
 # features are required
-BIB_IMAGE = "registry.redhat.io/rhel9/bootc-image-builder:latest"
+BIB_IMAGE = "registry.stage.redhat.io/rhel9-eus/rhel-9.6-bootc-image-builder:9.6"
 GOMPLATE = common.get_env_var('GOMPLATE')
 MIRROR_REGISTRY = common.get_env_var('MIRROR_REGISTRY_URL')
 FORCE_REBUILD = False
@@ -362,7 +362,7 @@ def process_image_bootc(groupdir, bootcfile, dry_run):
             common.record_junit(bf_path, "pull-bootc-bib", "OK", start)
 
             # Read the image reference
-            bf_imgref = common.read_file(bf_outfile).strip()
+            bf_imgref = common.read_file_valid_lines(bf_outfile).strip()
 
             # If not already local, download the image to be used by bootc image builder
             if not bf_imgref.startswith('localhost/'):
@@ -388,7 +388,6 @@ def process_image_bootc(groupdir, bootcfile, dry_run):
             build_args += [
                 BIB_IMAGE,
                 "--type", "anaconda-iso",
-                "--local",
                 bf_imgref
             ]
             start = time.time()

--- a/test/bin/pyutils/common.py
+++ b/test/bin/pyutils/common.py
@@ -183,6 +183,17 @@ def read_file(file_path: str):
     return content
 
 
+def read_file_valid_lines(file_path: str):
+    """Read the file contents skipping empty and commented lines and return them to the caller"""
+    content = []
+    with open(file_path, 'r') as file:
+        for line in file:
+            sline = line.strip()
+            if sline and not sline.startswith('#'):
+                content.append(line)
+    return ''.join(content)
+
+
 def append_file(file_path: str, content: str):
     """Append the specified content to a file"""
     with open(file_path, 'a') as file:

--- a/test/image-blueprints-bootc/layer1-base/group1/rhel96-test-agent.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group1/rhel96-test-agent.containerfile
@@ -1,4 +1,9 @@
-FROM registry.stage.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6
+# Note:
+# This is a workaround for the problem described in https://issues.redhat.com/browse/USHIFT-5584.
+# Revert to the rhel-9.6 base image when it is in GA.
+#
+# FROM registry.stage.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6
+FROM quay.io/centos-bootc/centos-bootc:stream9
 
 # Build arguments
 ARG USHIFT_RPM_REPO_NAME=microshift-local

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel96-bootc.image-bootc
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel96-bootc.image-bootc
@@ -1,1 +1,6 @@
-registry.stage.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6
+# Note:
+# This is a workaround for the problem described in https://issues.redhat.com/browse/USHIFT-5584.
+# Revert to the rhel-9.6 base image when it is in GA.
+#
+# registry.stage.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6
+quay.io/centos-bootc/centos-bootc:stream9

--- a/test/scenarios-bootc/periodics/el96-crel@brew-standard1.sh
+++ b/test/scenarios-bootc/periodics/el96-crel@brew-standard1.sh
@@ -11,8 +11,13 @@ scenario_remove_vms() {
     remove_vm host1
 }
 
+# Note:
+# This is a workaround for the problem described in https://issues.redhat.com/browse/USHIFT-5584.
+# Revert to the rhel-9.6 base image when it is in GA.
+#
+#       --variable "EXPECTED_OS_VERSION:9.6" \
 scenario_run_tests() {
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.6" \
+        --variable "EXPECTED_OS_VERSION:9" \
         suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }

--- a/test/scenarios-bootc/presubmits/el96-src@standard-suite1.sh
+++ b/test/scenarios-bootc/presubmits/el96-src@standard-suite1.sh
@@ -11,8 +11,13 @@ scenario_remove_vms() {
     remove_vm host1
 }
 
+# Note:
+# This is a workaround for the problem described in https://issues.redhat.com/browse/USHIFT-5584.
+# Revert to the rhel-9.6 base image when it is in GA.
+#
+#       --variable "EXPECTED_OS_VERSION:9.6" \
 scenario_run_tests() {
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.6" \
+        --variable "EXPECTED_OS_VERSION:9" \
         suites/standard1/ suites/selinux/validate-selinux-policy.robot
 }


### PR DESCRIPTION
Note that [USHIFT-5584](https://issues.redhat.com/browse/USHIFT-5584) issue was opened to revert the current workaround when RHEL 9.6 is in GA.