### PR TITLE
USHIFT-5528: Add new option to scenario.sh to target any given VM

### DIFF
--- a/test/scenario_settings.sh.example
+++ b/test/scenario_settings.sh.example
@@ -23,3 +23,7 @@ SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY:-${HOME}/.ssh/id_rsa.pub}
 # `subscription_manager_register`. See
 # `load_subscription_manager_plugin` in scenario.sh for details.
 # SUBSCRIPTION_MANAGER_PLUGIN="${SCRIPTDIR}/subscription_manager_register.sh"
+
+# USHIFT_USER should be set to microshift when running tests on vms created by
+# QE pipelines. Make sure to uncomment this line while doing so.
+#USHIFT_USER=${USHIFT_USER:-microshift}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:

This PR address to add a new option to scenario.sh to target any given VM.

For example: ./test/bin/scenario.sh run ./test/scenarios/periodics/el94-src@rpm-standard1.sh <vm_ip>

Closes https://issues.redhat.com/browse/USHIFT-5528
