### PR TITLE
Configure internal RHEL 9.6 repos for osbuild.

### DIFF
--- a/scripts/devenv-builder/configure-composer.sh
+++ b/scripts/devenv-builder/configure-composer.sh
@@ -99,31 +99,31 @@ enable_beta_or_eus_repositories() {
         sudo sed -i "s,dist/rhel${version_id_major}/${version_id}/$(uname -m)/baseos/,${version_id_eus}/rhel${version_id_major}/${version_id}/$(uname -m)/baseos/,g" "${composer_config}"
         sudo sed -i "s,dist/rhel${version_id_major}/${version_id}/$(uname -m)/appstream/,${version_id_eus}/rhel${version_id_major}/${version_id}/$(uname -m)/appstream/,g" "${composer_config}"
     fi
-    # If the host OS is configured to use the internal repo, overwrite the composer_config to match
+    # If the host OS is configured to use the internal repo, overwrite the composer configuration to match
     if dnf repolist | grep -q download.eng.brq.redhat.com; then
         # The gpgkey from /usr/share/osbuild-composer/repositories is valid and common for all repos
-        local -r GPGKEY=$(ARCH=$(uname -m) jq '.[env.ARCH][] | select(.name=="baseos") | .gpgkey' /usr/share/osbuild-composer/repositories/rhel-9.6.json)
+        local -r gpgkey=$(ARCH=$(uname -m) jq '.[env.ARCH][] | select(.name=="baseos") | .gpgkey' /usr/share/osbuild-composer/repositories/rhel-"${version_id}".json)
         sudo tee "${composer_config}" &>/dev/null <<EOF
 {
   "$(uname -m)": [
     {
       "name": "baseos",
       "baseurl": "http://download.eng.brq.redhat.com/rhel-${version_id_major}/nightly/RHEL-${version_id_major}/latest-RHEL-${version_id}/compose/BaseOS/$(uname -m)/os",
-      "gpgkey": ${GPGKEY},
+      "gpgkey": ${gpgkey},
       "rhsm": false,
       "check_gpg": true
     },
     {
       "name": "appstream",
       "baseurl": "http://download.eng.brq.redhat.com/rhel-${version_id_major}/nightly/RHEL-${version_id_major}/latest-RHEL-${version_id}/compose/AppStream/$(uname -m)/os",
-      "gpgkey": ${GPGKEY},
+      "gpgkey": ${gpgkey},
       "rhsm": false,
       "check_gpg": true
     },
     {
       "name": "rt",
       "baseurl": "http://download.eng.brq.redhat.com/rhel-${version_id_major}/nightly/RHEL-${version_id_major}/latest-RHEL-${version_id}/compose/RT/$(uname -m)/os",
-      "gpgkey": ${GPGKEY},
+      "gpgkey": ${gpgkey},
       "rhsm": false,
       "check_gpg": true
     }

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -110,6 +110,10 @@ fi
 if grep -qE 'Red Hat Enterprise Linux.*Beta' /etc/redhat-release; then
     RHEL_BETA_VERSION=true
 fi
+# If internal repos are in use set RHEL_BETA_VERSION
+if dnf repolist | grep -q download.eng.brq.redhat.com; then
+    RHEL_BETA_VERSION=true
+fi
 
 OCP_PULL_SECRET=$1
 [ ! -e "${OCP_PULL_SECRET}" ] && usage "OpenShift pull secret file '${OCP_PULL_SECRET}' does not exist"


### PR DESCRIPTION
**Which issue(s) this PR addresses**: [USHIFT-5575](https://issues.redhat.com//browse/USHIFT-5575)

This PR checks to see if an internal rpm repo is configured for the host and if so configures osbuild repos as well.
