### PR TITLE
[release-4.14] Upgrade openvswitch package version to 3.3

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -108,7 +108,8 @@ The microshift-selinux package provides the SELinux policy modules required by M
 %package networking
 Summary: Networking components for MicroShift
 Requires: microshift = %{version}
-Requires: openvswitch3.1
+Obsoletes: openvswitch3.1 < 3.3
+Requires: (openvswitch3.3 or openvswitch >= 3.3)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -348,6 +349,9 @@ systemctl enable --now --quiet openvswitch || true
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Thu Apr 24 2025 Ilya Maximets <i.maximets@ovn.org> 4.14.0
+- Upgrade openvswitch package version to 3.3
+
 * Wed Jul 03 2024 Patryk Matuszak <pmatusza@redhat.com> 4.14.32
 - Set CRI-O version to match Kubernetes' version
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/microshift/pull/4700 due to some merge conflicts.

Open vSwitch 3.1 is EoL upstream and so the support of this version in FDP is limited. To ensure timely bug fix delivery for 4.14+ we need to upgrade to the current LTS stream, which is Open vSwitch 3.3. It will be fully supported for much longer.

This change follows a corresponding move of RHCOS at https://github.com/openshift/os/pull/1794 and OVN-Kubernetes at https://github.com/openshift/ovn-kubernetes/pull/2511 to the same OVS 3.3. MicroShift should stay in sync.

Corresponding os and ovn-kubernetes PRs above are already merged.