### PR TITLE
[release-4.19] Ignore snyk errors

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,6 @@ exclude:
     - etcd/vendor/**
     - test/**
     - scripts/**
+    - pkg/cmd/init.go
+    - pkg/util/net.go
 version: v1.25.1


### PR DESCRIPTION
Ignore snyk errors in the `.snyk` file. Ignoring the specific errors:
```bash
✗ [Medium] Path Traversal
   ID: 7154f7f8-a0c9-42ec-b8b7-dc8727837ddf 
   Path: pkg/cmd/init.go, line 614 
   Info: Unsanitized input from file name flows into os.RemoveAll, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to delete arbitrary files.
 ✗ [Medium] Improper Certificate Validation
   ID: cd1300f4-2c30-[43](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_microshift/4866/pull-ci-openshift-microshift-release-4.19-security/1919637442869071872#1:build-log.txt%3A43)95-b9cd-31e44905379f 
   Path: pkg/util/net.go, line 91 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
```
Does not seem to work and they do not get ignored. The alternative is to ignore them via UI, but that is not persistent across branches and we cant see it. In fact, this started happening since 4.19 branched out, it didnt before. Most likely because it is ignored for main branch.

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
