### PR TITLE
USHIFT-5712: Snyk fixes

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -611,7 +611,7 @@ func cleanupStaleKubeconfigs(cfg *config.Config, path string) error {
 		}
 	}
 	for _, deletePath := range deleteDirs {
-		if err := os.RemoveAll(deletePath); err != nil {
+		if err := os.RemoveAll(filepath.Clean(deletePath)); err != nil {
 			klog.Warningf("Unable to remove %s: %v", deletePath, err)
 		}
 		klog.Infof("Removed stale kubeconfig %s", deletePath)

--- a/pkg/controllers/kube-controller-manager_test.go
+++ b/pkg/controllers/kube-controller-manager_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	embedded "github.com/openshift/microshift/assets"
 	"github.com/openshift/microshift/pkg/config"
+	"github.com/openshift/microshift/pkg/util/cryptomaterial"
 )
 
 func TestKCMDefaultConfigAsset(t *testing.T) {
@@ -72,8 +73,10 @@ func TestConfigure(t *testing.T) {
 		"--secure-port=10257",
 		fmt.Sprintf("--service-account-private-key-file=%s", kcmServiceAccountPrivateKeyFile()),
 		fmt.Sprintf("--service-cluster-ip-range=%s", cfg.Network.ServiceNetwork[0]),
+		fmt.Sprintf("--tls-cert-file=%s", cryptomaterial.ServingCertPath(cryptomaterial.KubeAPIServerLocalhostServingCertDir(cryptomaterial.CertsDirectory(config.DataDir)))),
 		fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(crypto.OpenSSLToIANACipherSuites(fixedTLSProfile.Ciphers), ",")),
 		fmt.Sprintf("--tls-min-version=%s", string(fixedTLSProfile.MinTLSVersion)),
+		fmt.Sprintf("--tls-private-key-file=%s", cryptomaterial.ServingKeyPath(cryptomaterial.KubeAPIServerLocalhostServingCertDir(cryptomaterial.CertsDirectory(config.DataDir)))),
 		"--use-service-account-credentials=true",
 		"-v=2",
 	}

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -110,7 +110,8 @@ func RetryGet(ctx context.Context, url, additionalCAPath string) int {
 		c := http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					RootCAs: rootCAs,
+					RootCAs:    rootCAs,
+					MinVersion: tls.VersionTLS12,
 				},
 			},
 		}


### PR DESCRIPTION
Manual cherry-picking from https://github.com/openshift/microshift/pull/4868

Addressing snyk errors:
```bash
 ✗ [Medium] Path Traversal
ID: 7154f7f8-a0c9-42ec-b8b7-dc8727837ddf Path: pkg/cmd/init.go, line 614   
Info: Unsanitized input from file name flows into os.RemoveAll, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to delete arbitrary files

✗ [Medium] Improper Certificate Validation   
ID: cd1300f4-2c30-4395-b9cd-31e44905379f   
Path: pkg/util/net.go, line 91   
Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
```

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
