### PR TITLE
USHIFT-5763: file naming issue in config-operator scc 

### DIFF
--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -192,7 +192,6 @@ assets:
     src: release-manifests/
     files:
       - file: 0000_03_config-operator_01_securitycontextconstraints.crd.yaml
-        src: 0000_03_config-operator_01_securitycontextconstraints-Default.crd.yaml
       - file: 0000_03_config-operator_02_rangeallocations.crd.yaml
       - file: storage_version_migration.crd.yaml
         src:  0000_50_cluster-kube-storage-version-migrator-operator_01_storage_migration_crd.yaml


### PR DESCRIPTION
fixing in rebase `periodic-ci-openshift-microshift-main-rebase-on-nightlies` jobs
```log
2025-05-16 23:59:41,998     DEBUG      Copying assets/crd/0000_03_config-operator_01_securitycontextconstraints.crd.yaml <- _output/staging/release-manifests/0000_03_config-operator_01_securitycontextconstraints-Default.crd.yaml
Traceback (most recent call last):
  File "/go/src/github.com/openshift/microshift/scripts/auto-rebase/handle_assets.py", line 162, in <module>
    main()
  File "/go/src/github.com/openshift/microshift/scripts/auto-rebase/handle_assets.py", line 155, in main
    handle_dir(asset)
  File "/go/src/github.com/openshift/microshift/scripts/auto-rebase/handle_assets.py", line 129, in handle_dir
    handle_file(file, dst, new_src_prefix)
  File "/go/src/github.com/openshift/microshift/scripts/auto-rebase/handle_assets.py", line 112, in handle_file
    copy(src, dst)
  File "/go/src/github.com/openshift/microshift/scripts/auto-rebase/handle_assets.py", line 71, in copy
    shutil.copyfile(src, dst)
  File "/usr/lib64/python3.9/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '_output/staging/release-manifests/0000_03_config-operator_01_securitycontextconstraints-Default.crd.yaml'
```