### PR TITLE
USHIFT-5772:  explicitly specify kernel path when running virt-install

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -573,6 +573,7 @@ launch_vm() {
     local vm_vcpus=2
     local vm_disksize=20
     local fips_mode=0
+    local kernel_location="images/pxeboot"
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -647,7 +648,7 @@ launch_vm() {
     local vm_network_args
     local vm_extra_args
     local vm_initrd_inject
-    vm_loc_args="--location ${VM_DISK_BASEDIR}/${boot_blueprint}.iso"
+    vm_loc_args="--location ${VM_DISK_BASEDIR}/${boot_blueprint}.iso,initrd=${kernel_location}/initrd.img,kernel=${kernel_location}/vmlinuz"
     vm_network_args=""
     vm_extra_args="fips=${fips_mode}"
     vm_initrd_inject=""


### PR DESCRIPTION
virt-insall is using .treeinfo  to [find](https://github.com/virt-manager/virt-manager/blob/f901c3277768a30c92daccc066b01784dccc1a05/virtinst/install/urldetect.py#L55) the correct kernel location , and if its missing incorrect default assumed.



microshift is running `virt-install` for starting  VMs  using `--location` (its appending kernel cmdline),
 similiar issue also described in  https://github.com/osbuild/bootc-image-builder/issues/265#issuecomment-2446241061

 kernel location is set by osbuild [here](https://github.com/osbuild/images/blob/a1bfcfe91c97e6ec9d17176d66b908de31661711/internal/manifest/iso_tree.go#L101-L112)