### PR TITLE
[release-4.19] USHIFT-5778: Stop excluding router security tests

### DIFF
--- a/test/suites/standard1/router.robot
+++ b/test/suites/standard1/router.robot
@@ -170,7 +170,6 @@ Router Verify Tuning Configuration
 
 Router Verify Security Configuration
     [Documentation]    Test ingress security configuration.
-    [Tags]    robot:exclude
     [Setup]    Run Keywords
     ...    Setup With Custom Config    ${ROUTER_SECURITY_CONFIG}
     ...    AND


### PR DESCRIPTION
Manual cherry-pick from https://github.com/openshift/microshift/pull/4958
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
