### PR TITLE
NO-ISSUE:  add RestartSec=10s for systemd service

### DIFF
--- a/packaging/flannel/microshift-flannel.service
+++ b/packaging/flannel/microshift-flannel.service
@@ -14,6 +14,7 @@ Before=kubepods.slice
 WorkingDirectory=/usr/bin/
 ExecStart=microshift run
 Restart=always
+RestartSec=10s
 User=root
 Type=notify
 Delegate=yes

--- a/packaging/observability/microshift-observability.service
+++ b/packaging/observability/microshift-observability.service
@@ -10,6 +10,7 @@ Environment=K8S_NODE_NAME="%l"
 ExecStartPre=/usr/bin/mkdir -p /var/lib/microshift-observability
 ExecStart=/usr/bin/opentelemetry-collector --config=/etc/microshift/observability/opentelemetry-collector.yaml
 Restart=always
+RestartSec=10s
 User=root
 
 [Install]

--- a/packaging/systemd/microshift.service
+++ b/packaging/systemd/microshift.service
@@ -14,6 +14,7 @@ Before=kubepods.slice
 WorkingDirectory=/usr/bin/
 ExecStart=microshift run
 Restart=always
+RestartSec=10s
 User=root
 Type=notify
 Delegate=yes

--- a/test/assets/auto-recovery/10-auto-recovery.conf
+++ b/test/assets/auto-recovery/10-auto-recovery.conf
@@ -9,4 +9,6 @@ OnFailure=microshift-auto-recovery.service
 # StartLimitBurst (5) wasn't reached within 10 seconds. That resulted in systemd
 # never marking microshift.service as failed (it kept restarting several hundred times)
 # and the OnFailure= service not getting triggered.
-StartLimitIntervalSec=25s
+# Add RestartSec=10s for microshift, every time the microshift need more than 10s to Restart.
+# So the 25s is not enough anymore, expand this to 75s(10s * 5 times + 25s).
+StartLimitIntervalSec=75s


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

As the default RestartSec is 100ms，The microshift may not startup in default StartLimitBurst(5 times) ; we should expand the systemd RestartSec to 10s，just like the etcd serivce does as follows:
https://github.com/openshift/microshift/blob/032d259f3c000e68758e7f2e207ddfce2397a19e/ansible/roles/install-microshift/files/etcd.service#L20