### PR TITLE
USHIFT-5816: SubMgr: register force & get 'status' output

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -124,8 +124,8 @@ echo -e "${USER}\tALL=(ALL)\tNOPASSWD: ALL" | sudo tee "/etc/sudoers.d/${USER}"
 
 # Check the subscription status and register if necessary
 if ${RHEL_SUBSCRIPTION}; then
-    if ! sudo subscription-manager status >&/dev/null; then
-        sudo subscription-manager register --auto-attach
+    if ! sudo subscription-manager status; then
+        sudo subscription-manager register --auto-attach --force
     fi
     sudo subscription-manager config --rhsm.manage_repos=1
 


### PR DESCRIPTION
In response to recent submgr problems:

```
+ 13:01:45.476308967 ./scripts/devenv-builder/configure-vm.sh:127 	sudo subscription-manager status
+ 13:01:55.896149642 ./scripts/devenv-builder/configure-vm.sh:128 	sudo subscription-manager register --auto-attach
This system is already registered. Use --force to override
+ 13:01:56.178021077 /bin/bash:1 	finalize
```