### PR TITLE
USHIFT-5800: rpm verify command only checks no modification time for no config files

### DIFF
--- a/test/resources/microshift-rpm.resource
+++ b/test/resources/microshift-rpm.resource
@@ -90,7 +90,7 @@ Get Version Of MicroShift RPM
     ${version_string}=    Strip String    ${version_string_raw}
     RETURN    ${version_string}
 
-Verify MicroShift RPM Install
+Verify MicroShift RPM Install    # robocop: disable=too-many-calls-in-keyword
     [Documentation]    Run 'rpm -V' package verification command
     ...    on all the installed MicroShift RPM packages.
     # The ostree-based file system does not preserve modification
@@ -102,8 +102,17 @@ Verify MicroShift RPM Install
         ${nomtime}=    Set Variable    ${EMPTY}
     END
 
+    # Checks all files from RPM packages except config files
     ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
-    ...    rpm -qa microshift\* | xargs -I {} bash -c 'echo {}; sudo rpm -V ${nomtime} {}'
+    ...    rpm -qa microshift\* | xargs -I {} bash -c 'echo {}; sudo rpm -V --noconfig ${nomtime} {}'
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Log    ${stdout}
+    Log    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+
+    # Checks only config files from RPM packages excluding modification time check
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    rpm -qa microshift\* | xargs -I {} bash -c 'echo {}; sudo rpm -V --configfiles --nomtime {}'
     ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
     Log    ${stdout}
     Log    ${stderr}


### PR DESCRIPTION
Split `rpm -V` command check into 2 commands:
- `rpm -V --noconfig` to check all files except config files
- `rpm -V --configfiles --nomtime` to exclude modification time from only config files

This change is needed if, for example, a previous test modify a config file.