### PR TITLE
NO-ISSUE: Fix ami list filtering in manage_aws_stack.sh script

### DIFF
--- a/scripts/aws/manage_aws_stack.sh
+++ b/scripts/aws/manage_aws_stack.sh
@@ -128,7 +128,7 @@ get_amis() {
     local -r region="${3}"
     local ami_table
     ami_table=$(aws ec2 describe-images --region "${region}" \
-        --filters "Name=name,Values=$(tr '[:lower:]' '[:upper:]' <<< "${os}")*HVM-*Hourly2-GP3" "Name=architecture,Values=${arch}*" \
+        --filters "Name=name,Values=$(tr '[:lower:]' '[:upper:]' <<< "${os}")*HVM*Hourly2-GP3" "Name=architecture,Values=${arch}*" \
         --query 'Images[*].[Name,ImageId,Architecture]' --output text)
   
     echo "${ami_table}" | sort -t'-' -k3,3r


### PR DESCRIPTION
Relax the filtering to accomodate for RHEL 9.6 image names.