### PR TITLE
NO-ISSUE: Add teardown for "Router Disabled" test

### DIFF
--- a/test/suites/router/router.robot
+++ b/test/suites/router/router.robot
@@ -161,6 +161,11 @@ Router Disabled
 
     Oc Wait    namespace/openshift-ingress    --for=delete --timeout=300s
 
+    [Teardown]    Run Keywords
+    ...    Remove Custom Config
+    ...    Restart MicroShift
+    ...    Wait For Router Ready
+
 Router Exposure Configuration
     [Documentation]    Test custom ports and custom listening addresses.
     [Setup]    Run Keywords


### PR DESCRIPTION
PR aims to fix recent issues where `Router Verify Security Configuration` test would fail because the namespace does not exist.