### PR TITLE
[release-4.19] NO-ISSUE: Get router's logs after checking readiness

### DIFF
--- a/test/suites/standard1/router.robot
+++ b/test/suites/standard1/router.robot
@@ -229,8 +229,17 @@ Wait For Router Ready
     [Documentation]    Wait for the default router to be ready.
     # Wait for the namespace to be ready, as sometimes apiserver may signal readiness before all
     # the manifests have been applied.
-    Oc Wait    namespace/openshift-ingress    --for jsonpath='{.status.phase}=Active' --timeout=5m
-    Named Deployment Should Be Available    router-default    openshift-ingress    5m
+
+    ${fail}=    Set Variable    ${FALSE}
+    TRY
+        Oc Wait    namespace/openshift-ingress    --for jsonpath='{.status.phase}=Active' --timeout=5m
+        Named Deployment Should Be Available    router-default    openshift-ingress    5m
+    EXCEPT
+        ${fail}=    Set Variable    ${TRUE}
+    END
+
+    Oc Logs    deployment/router-default    openshift-ingress
+    IF    ${fail}    Fail    router did not become ready
 
 Setup With Custom Config
     [Documentation]    Install a custom config and restart MicroShift.


### PR DESCRIPTION
Router's time-to-ready varies between 40s and 2m. Sometimes increased readiness time stacks and causes standard1 suite to exceed it's 30 minute timeout.
This PR adds `oc logs` for the router to obtain logs that might help investigating the reason for readiness time differences.

Example failing jobs:
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_microshift/5023/pull-ci-openshift-microshift-release-4.19-e2e-aws-tests-bootc-arm/1930927044384788480/artifacts/e2e-aws-tests-bootc-arm/openshift-microshift-e2e-metal-tests/artifacts/scenario-info/el96-src@standard-suite1/log.html
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-microshift-release-4.19-periodics-e2e-aws-tests-bootc-arm-nightly/1928995167189078016/artifacts/e2e-aws-tests-bootc-arm-nightly/openshift-microshift-e2e-metal-tests/artifacts/scenario-info/el96-crel@published-images-standard1/log.html