### PR TITLE
USHIFT-5563: introduce cert-manager operator  manifests

### DIFF
--- a/assets/optional/cert-manager/crd/bases/certificaterequests.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/certificaterequests.cert-manager.io-crd.yaml
@@ -1,0 +1,314 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    helm.sh/resource-policy: keep
+  labels:
+    app: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v1.16.4
+  name: certificaterequests.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    categories:
+      - cert-manager
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+      - cr
+      - crs
+    singular: certificaterequest
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Approved")].status
+          name: Approved
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Denied")].status
+          name: Denied
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          type: string
+        - jsonPath: .spec.username
+          name: Requester
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A CertificateRequest is used to request a signed certificate from one of the
+            configured issuers.
+
+            All fields within the CertificateRequest's `spec` are immutable after creation.
+            A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+            condition and its `status.failureTime` field.
+
+            A CertificateRequest is a one-shot resource, meaning it represents a single
+            point in time request for a certificate and cannot be re-used.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired state of the CertificateRequest resource.
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                duration:
+                  description: |-
+                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                    issuer may choose to ignore the requested duration, just like any other
+                    requested attribute.
+                  type: string
+                extra:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: |-
+                    Extra contains extra attributes of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: object
+                groups:
+                  description: |-
+                    Groups contains group membership of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                isCA:
+                  description: |-
+                    Requested basic constraints isCA value. Note that the issuer may choose
+                    to ignore the requested isCA value, just like any other requested attribute.
+
+                    NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+                    it must have the same isCA value as specified here.
+
+                    If true, this will automatically add the `cert sign` usage to the list
+                    of requested `usages`.
+                  type: boolean
+                issuerRef:
+                  description: |-
+                    Reference to the issuer responsible for issuing the certificate.
+                    If the issuer is namespace-scoped, it must be in the same namespace
+                    as the Certificate. If the issuer is cluster-scoped, it can be used
+                    from any namespace.
+
+                    The `name` field of the reference must always be specified.
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                request:
+                  description: |-
+                    The PEM-encoded X.509 certificate signing request to be submitted to the
+                    issuer for signing.
+
+                    If the CSR has a BasicConstraints extension, its isCA attribute must
+                    match the `isCA` value of this CertificateRequest.
+                    If the CSR has a KeyUsage extension, its key usages must match the
+                    key usages in the `usages` field of this CertificateRequest.
+                    If the CSR has a ExtKeyUsage extension, its extended key usages
+                    must match the extended key usages in the `usages` field of this
+                    CertificateRequest.
+                  format: byte
+                  type: string
+                uid:
+                  description: |-
+                    UID contains the uid of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+                usages:
+                  description: |-
+                    Requested key usages and extended key usages.
+
+                    NOTE: If the CSR in the `Request` field has uses the KeyUsage or
+                    ExtKeyUsage extension, these extensions must have the same values
+                    as specified here without any additional values.
+
+                    If unset, defaults to `digital signature` and `key encipherment`.
+                  items:
+                    description: |-
+                      KeyUsage specifies valid usage contexts for keys.
+                      See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                      Valid KeyUsage values are as follows:
+                      "signing",
+                      "digital signature",
+                      "content commitment",
+                      "key encipherment",
+                      "key agreement",
+                      "data encipherment",
+                      "cert sign",
+                      "crl sign",
+                      "encipher only",
+                      "decipher only",
+                      "any",
+                      "server auth",
+                      "client auth",
+                      "code signing",
+                      "email protection",
+                      "s/mime",
+                      "ipsec end system",
+                      "ipsec tunnel",
+                      "ipsec user",
+                      "timestamping",
+                      "ocsp signing",
+                      "microsoft sgc",
+                      "netscape sgc"
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+                    type: string
+                  type: array
+                username:
+                  description: |-
+                    Username contains the name of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+              required:
+                - issuerRef
+                - request
+              type: object
+            status:
+              description: |-
+                Status of the CertificateRequest.
+                This is set and managed automatically.
+                Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                ca:
+                  description: |-
+                    The PEM encoded X.509 certificate of the signer, also known as the CA
+                    (Certificate Authority).
+                    This is set on a best-effort basis by different issuers.
+                    If not set, the CA is assumed to be unknown/not available.
+                  format: byte
+                  type: string
+                certificate:
+                  description: |-
+                    The PEM encoded X.509 certificate resulting from the certificate
+                    signing request.
+                    If not set, the CertificateRequest has either not been completed or has
+                    failed. More information on failure can be found by checking the
+                    `conditions` field.
+                  format: byte
+                  type: string
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`, `InvalidRequest`, `Approved` and `Denied`.
+                  items:
+                    description: CertificateRequestCondition contains condition information for a CertificateRequest.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          Type of the condition, known values are (`Ready`, `InvalidRequest`,
+                          `Approved`, `Denied`).
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failureTime:
+                  description: |-
+                    FailureTime stores the time that this CertificateRequest failed. This is
+                    used to influence garbage collection and back-off.
+                  format: date-time
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/bases/certificates.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/certificates.cert-manager.io-crd.yaml
@@ -1,0 +1,762 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    helm.sh/resource-policy: keep
+  labels:
+    app: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v1.16.4
+  name: certificates.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    categories:
+      - cert-manager
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+    singular: certificate
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.secretName
+          name: Secret
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A Certificate resource should be created to ensure an up to date and signed
+            X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+            The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired state of the Certificate resource.
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                additionalOutputFormats:
+                  description: |-
+                    Defines extra output formats of the private key and signed certificate chain
+                    to be written to this Certificate's target Secret.
+
+                    This is a Beta Feature enabled by default. It can be disabled with the
+                    `--feature-gates=AdditionalCertificateOutputFormats=false` option set on both
+                    the controller and webhook components.
+                  items:
+                    description: |-
+                      CertificateAdditionalOutputFormat defines an additional output format of a
+                      Certificate resource. These contain supplementary data formats of the signed
+                      certificate chain and paired private key.
+                    properties:
+                      type:
+                        description: |-
+                          Type is the name of the format type that should be written to the
+                          Certificate's target Secret.
+                        enum:
+                          - DER
+                          - CombinedPEM
+                        type: string
+                    required:
+                      - type
+                    type: object
+                  type: array
+                commonName:
+                  description: |-
+                    Requested common name X509 certificate subject attribute.
+                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                    NOTE: TLS clients will ignore this value when any subject alternative name is
+                    set (see https://tools.ietf.org/html/rfc6125#section-6.4.4).
+
+                    Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                    Cannot be set if the `literalSubject` field is set.
+                  type: string
+                dnsNames:
+                  description: Requested DNS subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                duration:
+                  description: |-
+                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                    issuer may choose to ignore the requested duration, just like any other
+                    requested attribute.
+
+                    If unset, this defaults to 90 days.
+                    Minimum accepted duration is 1 hour.
+                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                  type: string
+                emailAddresses:
+                  description: Requested email subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                encodeUsagesInRequest:
+                  description: |-
+                    Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
+
+                    This option defaults to true, and should only be disabled if the target
+                    issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
+                  type: boolean
+                ipAddresses:
+                  description: Requested IP address subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                isCA:
+                  description: |-
+                    Requested basic constraints isCA value.
+                    The isCA value is used to set the `isCA` field on the created CertificateRequest
+                    resources. Note that the issuer may choose to ignore the requested isCA value, just
+                    like any other requested attribute.
+
+                    If true, this will automatically add the `cert sign` usage to the list
+                    of requested `usages`.
+                  type: boolean
+                issuerRef:
+                  description: |-
+                    Reference to the issuer responsible for issuing the certificate.
+                    If the issuer is namespace-scoped, it must be in the same namespace
+                    as the Certificate. If the issuer is cluster-scoped, it can be used
+                    from any namespace.
+
+                    The `name` field of the reference must always be specified.
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                keystores:
+                  description: Additional keystore output formats to be stored in the Certificate's Secret.
+                  properties:
+                    jks:
+                      description: |-
+                        JKS configures options for storing a JKS keystore in the
+                        `spec.secretName` Secret resource.
+                      properties:
+                        alias:
+                          description: |-
+                            Alias specifies the alias of the key in the keystore, required by the JKS format.
+                            If not provided, the default alias `certificate` will be used.
+                          type: string
+                        create:
+                          description: |-
+                            Create enables JKS keystore creation for the Certificate.
+                            If true, a file named `keystore.jks` will be created in the target
+                            Secret resource, encrypted using the password stored in
+                            `passwordSecretRef`.
+                            The keystore file will be updated immediately.
+                            If the issuer provided a CA certificate, a file named `truststore.jks`
+                            will also be created in the target Secret resource, encrypted using the
+                            password stored in `passwordSecretRef`
+                            containing the issuing Certificate Authority
+                          type: boolean
+                        passwordSecretRef:
+                          description: |-
+                            PasswordSecretRef is a reference to a key in a Secret resource
+                            containing the password used to encrypt the JKS keystore.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - create
+                        - passwordSecretRef
+                      type: object
+                    pkcs12:
+                      description: |-
+                        PKCS12 configures options for storing a PKCS12 keystore in the
+                        `spec.secretName` Secret resource.
+                      properties:
+                        create:
+                          description: |-
+                            Create enables PKCS12 keystore creation for the Certificate.
+                            If true, a file named `keystore.p12` will be created in the target
+                            Secret resource, encrypted using the password stored in
+                            `passwordSecretRef`.
+                            The keystore file will be updated immediately.
+                            If the issuer provided a CA certificate, a file named `truststore.p12` will
+                            also be created in the target Secret resource, encrypted using the
+                            password stored in `passwordSecretRef` containing the issuing Certificate
+                            Authority
+                          type: boolean
+                        passwordSecretRef:
+                          description: |-
+                            PasswordSecretRef is a reference to a key in a Secret resource
+                            containing the password used to encrypt the PKCS12 keystore.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        profile:
+                          description: |-
+                            Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+                            used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+
+                            If provided, allowed values are:
+                            `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                            `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                            `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+                            (eg. because of company policy). Please note that the security of the algorithm is not that important
+                            in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                          enum:
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
+                          type: string
+                      required:
+                        - create
+                        - passwordSecretRef
+                      type: object
+                  type: object
+                literalSubject:
+                  description: |-
+                    Requested X.509 certificate subject, represented using the LDAP "String
+                    Representation of a Distinguished Name" [1].
+                    Important: the LDAP string format also specifies the order of the attributes
+                    in the subject, this is important when issuing certs for LDAP authentication.
+                    Example: `CN=foo,DC=corp,DC=example,DC=com`
+                    More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+                    More info: https://github.com/cert-manager/cert-manager/issues/3203
+                    More info: https://github.com/cert-manager/cert-manager/issues/4424
+
+                    Cannot be set if the `subject` or `commonName` field is set.
+                  type: string
+                nameConstraints:
+                  description: |-
+                    x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.
+                    More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
+
+                    This is an Alpha Feature and is only enabled with the
+                    `--feature-gates=NameConstraints=true` option set on both
+                    the controller and webhook components.
+                  properties:
+                    critical:
+                      description: if true then the name constraints are marked critical.
+                      type: boolean
+                    excluded:
+                      description: |-
+                        Excluded contains the constraints which must be disallowed. Any name matching a
+                        restriction in the excluded field is invalid regardless
+                        of information appearing in the permitted
+                      properties:
+                        dnsDomains:
+                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                        emailAddresses:
+                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                        ipRanges:
+                          description: |-
+                            IPRanges is a list of IP Ranges that are permitted or excluded.
+                            This should be a valid CIDR notation.
+                          items:
+                            type: string
+                          type: array
+                        uriDomains:
+                          description: URIDomains is a list of URI domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    permitted:
+                      description: Permitted contains the constraints in which the names must be located.
+                      properties:
+                        dnsDomains:
+                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                        emailAddresses:
+                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                        ipRanges:
+                          description: |-
+                            IPRanges is a list of IP Ranges that are permitted or excluded.
+                            This should be a valid CIDR notation.
+                          items:
+                            type: string
+                          type: array
+                        uriDomains:
+                          description: URIDomains is a list of URI domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                otherNames:
+                  description: |-
+                    `otherNames` is an escape hatch for SAN that allows any type. We currently restrict the support to string like otherNames, cf RFC 5280 p 37
+                    Any UTF8 String valued otherName can be passed with by setting the keys oid: x.x.x.x and UTF8Value: somevalue for `otherName`.
+                    Most commonly this would be UPN set with oid: 1.3.6.1.4.1.311.20.2.3
+                    You should ensure that any OID passed is valid for the UTF8String type as we do not explicitly validate this.
+                  items:
+                    properties:
+                      oid:
+                        description: |-
+                          OID is the object identifier for the otherName SAN.
+                          The object identifier must be expressed as a dotted string, for
+                          example, "1.2.840.113556.1.4.221".
+                        type: string
+                      utf8Value:
+                        description: |-
+                          utf8Value is the string value of the otherName SAN.
+                          The utf8Value accepts any valid UTF8 string to set as value for the otherName SAN.
+                        type: string
+                    type: object
+                  type: array
+                privateKey:
+                  description: |-
+                    Private key options. These include the key algorithm and size, the used
+                    encoding and the rotation policy.
+                  properties:
+                    algorithm:
+                      description: |-
+                        Algorithm is the private key algorithm of the corresponding private key
+                        for this certificate.
+
+                        If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                        If `algorithm` is specified and `size` is not provided,
+                        key size of 2048 will be used for `RSA` key algorithm and
+                        key size of 256 will be used for `ECDSA` key algorithm.
+                        key size is ignored when using the `Ed25519` key algorithm.
+                      enum:
+                        - RSA
+                        - ECDSA
+                        - Ed25519
+                      type: string
+                    encoding:
+                      description: |-
+                        The private key cryptography standards (PKCS) encoding for this
+                        certificate's private key to be encoded in.
+
+                        If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                        and PKCS#8, respectively.
+                        Defaults to `PKCS1` if not specified.
+                      enum:
+                        - PKCS1
+                        - PKCS8
+                      type: string
+                    rotationPolicy:
+                      description: |-
+                        RotationPolicy controls how private keys should be regenerated when a
+                        re-issuance is being processed.
+
+                        If set to `Never`, a private key will only be generated if one does not
+                        already exist in the target `spec.secretName`. If one does exist but it
+                        does not have the correct algorithm or size, a warning will be raised
+                        to await user intervention.
+                        If set to `Always`, a private key matching the specified requirements
+                        will be generated whenever a re-issuance occurs.
+                        Default is `Never` for backward compatibility.
+                      enum:
+                        - Never
+                        - Always
+                      type: string
+                    size:
+                      description: |-
+                        Size is the key bit size of the corresponding private key for this certificate.
+
+                        If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                        and will default to `2048` if not specified.
+                        If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                        and will default to `256` if not specified.
+                        If `algorithm` is set to `Ed25519`, Size is ignored.
+                        No other values are allowed.
+                      type: integer
+                  type: object
+                renewBefore:
+                  description: |-
+                    How long before the currently issued certificate's expiry cert-manager should
+                    renew the certificate. For example, if a certificate is valid for 60 minutes,
+                    and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                    50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                    the certificate is no longer valid).
+
+                    NOTE: The actual lifetime of the issued certificate is used to determine the
+                    renewal time. If an issuer returns a certificate with a different lifetime than
+                    the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                    If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                    Minimum accepted value is 5 minutes.
+                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                    Cannot be set if the `renewBeforePercentage` field is set.
+                  type: string
+                renewBeforePercentage:
+                  description: |-
+                    `renewBeforePercentage` is like `renewBefore`, except it is a relative percentage
+                    rather than an absolute duration. For example, if a certificate is valid for 60
+                    minutes, and  `renewBeforePercentage=25`, cert-manager will begin to attempt to
+                    renew the certificate 45 minutes after it was issued (i.e. when there are 15
+                    minutes (25%) remaining until the certificate is no longer valid).
+
+                    NOTE: The actual lifetime of the issued certificate is used to determine the
+                    renewal time. If an issuer returns a certificate with a different lifetime than
+                    the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                    Value must be an integer in the range (0,100). The minimum effective
+                    `renewBefore` derived from the `renewBeforePercentage` and `duration` fields is 5
+                    minutes.
+                    Cannot be set if the `renewBefore` field is set.
+                  format: int32
+                  type: integer
+                revisionHistoryLimit:
+                  description: |-
+                    The maximum number of CertificateRequest revisions that are maintained in
+                    the Certificate's history. Each revision represents a single `CertificateRequest`
+                    created by this Certificate, either when it was created, renewed, or Spec
+                    was changed. Revisions will be removed by oldest first if the number of
+                    revisions exceeds this number.
+
+                    If set, revisionHistoryLimit must be a value of `1` or greater.
+                    If unset (`nil`), revisions will not be garbage collected.
+                    Default value is `nil`.
+                  format: int32
+                  type: integer
+                secretName:
+                  description: |-
+                    Name of the Secret resource that will be automatically created and
+                    managed by this Certificate resource. It will be populated with a
+                    private key and certificate, signed by the denoted issuer. The Secret
+                    resource lives in the same namespace as the Certificate resource.
+                  type: string
+                secretTemplate:
+                  description: |-
+                    Defines annotations and labels to be copied to the Certificate's Secret.
+                    Labels and annotations on the Secret will be changed as they appear on the
+                    SecretTemplate when added or removed. SecretTemplate annotations are added
+                    in conjunction with, and cannot overwrite, the base set of annotations
+                    cert-manager sets on the Certificate's Secret.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                  type: object
+                subject:
+                  description: |-
+                    Requested set of X509 certificate subject attributes.
+                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+
+                    The common name attribute is specified separately in the `commonName` field.
+                    Cannot be set if the `literalSubject` field is set.
+                  properties:
+                    countries:
+                      description: Countries to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                    localities:
+                      description: Cities to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                    organizationalUnits:
+                      description: Organizational Units to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                    organizations:
+                      description: Organizations to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                    postalCodes:
+                      description: Postal codes to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                    provinces:
+                      description: State/Provinces to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                    serialNumber:
+                      description: Serial number to be used on the Certificate.
+                      type: string
+                    streetAddresses:
+                      description: Street addresses to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                uris:
+                  description: Requested URI subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                usages:
+                  description: |-
+                    Requested key usages and extended key usages.
+                    These usages are used to set the `usages` field on the created CertificateRequest
+                    resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
+                    will additionally be encoded in the `request` field which contains the CSR blob.
+
+                    If unset, defaults to `digital signature` and `key encipherment`.
+                  items:
+                    description: |-
+                      KeyUsage specifies valid usage contexts for keys.
+                      See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                      Valid KeyUsage values are as follows:
+                      "signing",
+                      "digital signature",
+                      "content commitment",
+                      "key encipherment",
+                      "key agreement",
+                      "data encipherment",
+                      "cert sign",
+                      "crl sign",
+                      "encipher only",
+                      "decipher only",
+                      "any",
+                      "server auth",
+                      "client auth",
+                      "code signing",
+                      "email protection",
+                      "s/mime",
+                      "ipsec end system",
+                      "ipsec tunnel",
+                      "ipsec user",
+                      "timestamping",
+                      "ocsp signing",
+                      "microsoft sgc",
+                      "netscape sgc"
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+                    type: string
+                  type: array
+              required:
+                - issuerRef
+                - secretName
+              type: object
+            status:
+              description: |-
+                Status of the Certificate.
+                This is set and managed automatically.
+                Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of certificates.
+                    Known condition types are `Ready` and `Issuing`.
+                  items:
+                    description: CertificateCondition contains condition information for a Certificate.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Certificate.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failedIssuanceAttempts:
+                  description: |-
+                    The number of continuous failed issuance attempts up till now. This
+                    field gets removed (if set) on a successful issuance and gets set to
+                    1 if unset and an issuance has failed. If an issuance has failed, the
+                    delay till the next issuance will be calculated using formula
+                    time.Hour * 2 ^ (failedIssuanceAttempts - 1).
+                  type: integer
+                lastFailureTime:
+                  description: |-
+                    LastFailureTime is set only if the latest issuance for this
+                    Certificate failed and contains the time of the failure. If an
+                    issuance has failed, the delay till the next issuance will be
+                    calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts -
+                    1). If the latest issuance has succeeded this field will be unset.
+                  format: date-time
+                  type: string
+                nextPrivateKeySecretName:
+                  description: |-
+                    The name of the Secret resource containing the private key to be used
+                    for the next certificate iteration.
+                    The keymanager controller will automatically set this field if the
+                    `Issuing` condition is set to `True`.
+                    It will automatically unset this field when the Issuing condition is
+                    not set or False.
+                  type: string
+                notAfter:
+                  description: |-
+                    The expiration time of the certificate stored in the secret named
+                    by this resource in `spec.secretName`.
+                  format: date-time
+                  type: string
+                notBefore:
+                  description: |-
+                    The time after which the certificate stored in the secret named
+                    by this resource in `spec.secretName` is valid.
+                  format: date-time
+                  type: string
+                renewalTime:
+                  description: |-
+                    RenewalTime is the time at which the certificate will be next
+                    renewed.
+                    If not set, no upcoming renewal is scheduled.
+                  format: date-time
+                  type: string
+                revision:
+                  description: |-
+                    The current 'revision' of the certificate as issued.
+
+                    When a CertificateRequest resource is created, it will have the
+                    `cert-manager.io/certificate-revision` set to one greater than the
+                    current value of this field.
+
+                    Upon issuance, this field will be set to the value of the annotation
+                    on the CertificateRequest resource used to issue the certificate.
+
+                    Persisting the value on the CertificateRequest resource allows the
+                    certificates controller to know whether a request is part of an old
+                    issuance or if it is part of the ongoing revision's issuance by
+                    checking if the revision value in the annotation is greater than this
+                    field.
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/bases/challenges.acme.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/challenges.acme.cert-manager.io-crd.yaml
@@ -1,0 +1,3200 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    helm.sh/resource-policy: keep
+  labels:
+    app: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v1.16.4
+  name: challenges.acme.cert-manager.io
+spec:
+  group: acme.cert-manager.io
+  names:
+    categories:
+      - cert-manager
+      - cert-manager-acme
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                authorizationURL:
+                  description: |-
+                    The URL to the ACME Authorization resource that this
+                    challenge is a part of.
+                  type: string
+                dnsName:
+                  description: |-
+                    dnsName is the identifier that this challenge is for, e.g. example.com.
+                    If the requested DNSName is a 'wildcard', this field MUST be set to the
+                    non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: |-
+                    References a properly configured ACME-type Issuer which should
+                    be used to create this Challenge.
+                    If the Issuer does not exist, processing will be retried.
+                    If the Issuer is not an 'ACME' Issuer, an error will be returned and the
+                    Challenge will be marked as failed.
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                key:
+                  description: |-
+                    The ACME challenge key for this challenge
+                    For HTTP01 challenges, this is the value that must be responded with to
+                    complete the HTTP01 challenge in the format:
+                    `<private key JWK thumbprint>.<key from acme server for challenge>`.
+                    For DNS01 challenges, this is the base64 encoded SHA256 sum of the
+                    `<private key JWK thumbprint>.<key from acme server for challenge>`
+                    text that must be set as the TXT record content.
+                  type: string
+                solver:
+                  description: |-
+                    Contains the domain solving configuration that should be used to
+                    solve this challenge resource.
+                  properties:
+                    dns01:
+                      description: |-
+                        Configures cert-manager to attempt to complete authorizations by
+                        performing the DNS01 challenge flow.
+                      properties:
+                        acmeDNS:
+                          description: |-
+                            Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                            DNS01 challenge records.
+                          properties:
+                            accountSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            host:
+                              type: string
+                          required:
+                            - accountSecretRef
+                            - host
+                          type: object
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          properties:
+                            accessTokenSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            clientSecretSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            clientTokenSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceConsumerDomain:
+                              type: string
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          type: object
+                        azureDNS:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          properties:
+                            clientID:
+                              description: |-
+                                Auth: Azure Service Principal:
+                                The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                If set, ClientSecret and TenantID must also be set.
+                              type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                Auth: Azure Service Principal:
+                                A reference to a Secret containing the password associated with the Service Principal.
+                                If set, ClientID and TenantID must also be set.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                              type: string
+                            hostedZoneName:
+                              description: name of the DNS zone that should be used
+                              type: string
+                            managedIdentity:
+                              description: |-
+                                Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                If set, ClientID, ClientSecret and TenantID must not be set.
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: |-
+                                    resource ID of the managed identity, can not be used at the same time as clientID
+                                    Cannot be used for Azure Managed Service Identity
+                                  type: string
+                              type: object
+                            resourceGroupName:
+                              description: resource group the DNS zone is located in
+                              type: string
+                            subscriptionID:
+                              description: ID of the Azure subscription
+                              type: string
+                            tenantID:
+                              description: |-
+                                Auth: Azure Service Principal:
+                                The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                If set, ClientID and ClientSecret must also be set.
+                              type: string
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          type: object
+                        cloudDNS:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          properties:
+                            hostedZoneName:
+                              description: |-
+                                HostedZoneName is an optional field that tells cert-manager in which
+                                Cloud DNS zone the challenge record has to be created.
+                                If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - project
+                          type: object
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          properties:
+                            apiKeySecretRef:
+                              description: |-
+                                API key to use to authenticate with Cloudflare.
+                                Note: using an API token to authenticate is now the recommended method
+                                as it allows greater control of permissions.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                          type: object
+                        cnameStrategy:
+                          description: |-
+                            CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                            records when found in DNS zones.
+                          enum:
+                            - None
+                            - Follow
+                          type: string
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          properties:
+                            tokenSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - tokenSecretRef
+                          type: object
+                        rfc2136:
+                          description: |-
+                            Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                            to manage DNS01 challenge records.
+                          properties:
+                            nameserver:
+                              description: |-
+                                The IP address or hostname of an authoritative DNS server supporting
+                                RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: |-
+                                The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                              type: string
+                            tsigKeyName:
+                              description: |-
+                                The TSIG Key name configured in the DNS.
+                                If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: |-
+                                The name of the secret containing the TSIG value.
+                                If ``tsigKeyName`` is defined, this field is required.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - nameserver
+                          type: object
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          properties:
+                            accessKeyID:
+                              description: |-
+                                The AccessKeyID is used for authentication.
+                                Cannot be set when SecretAccessKeyID is set.
+                                If neither the Access Key nor Key ID are set, we fall-back to using env
+                                vars, shared credentials file or AWS Instance metadata,
+                                see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: string
+                            accessKeyIDSecretRef:
+                              description: |-
+                                The SecretAccessKey is used for authentication. If set, pull the AWS
+                                access key ID from a key within a Kubernetes Secret.
+                                Cannot be set when AccessKeyID is set.
+                                If neither the Access Key nor Key ID are set, we fall-back to using env
+                                vars, shared credentials file or AWS Instance metadata,
+                                see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            auth:
+                              description: Auth configures how cert-manager authenticates.
+                              properties:
+                                kubernetes:
+                                  description: |-
+                                    Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
+                                    by passing a bound ServiceAccount token.
+                                  properties:
+                                    serviceAccountRef:
+                                      description: |-
+                                        A reference to a service account that will be used to request a bound
+                                        token (also known as "projected token"). To use this field, you must
+                                        configure an RBAC rule to let cert-manager request a token.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            TokenAudiences is an optional list of audiences to include in the
+                                            token passed to AWS. The default token consisting of the issuer's namespace
+                                            and name is always included.
+                                            If unset the audience defaults to `sts.amazonaws.com`.
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: Name of the ServiceAccount used to request a token.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                              required:
+                                - kubernetes
+                              type: object
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: |-
+                                Override the AWS region.
+
+                                Route53 is a global service and does not have regional endpoints but the
+                                region specified here (or via environment variables) is used as a hint to
+                                help compute the correct AWS credential scope and partition when it
+                                connects to Route53. See:
+                                - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                If you omit this region field, cert-manager will use the region from
+                                AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                in the cert-manager controller Pod.
+
+                                The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                In this case this `region` field value is ignored.
+
+                                The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+                                In this case this `region` field value is ignored.
+                              type: string
+                            role:
+                              description: |-
+                                Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: |-
+                                The SecretAccessKey is used for authentication.
+                                If neither the Access Key nor Key ID are set, we fall-back to using env
+                                vars, shared credentials file or AWS Instance metadata,
+                                see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          type: object
+                        webhook:
+                          description: |-
+                            Configure an external webhook based DNS01 challenge solver to manage
+                            DNS01 challenge records.
+                          properties:
+                            config:
+                              description: |-
+                                Additional configuration that should be passed to the webhook apiserver
+                                when challenges are processed.
+                                This can contain arbitrary JSON data.
+                                Secret values should not be specified in this stanza.
+                                If secret values are needed (e.g. credentials for a DNS service), you
+                                should use a SecretKeySelector to reference a Secret resource.
+                                For details on the schema of this field, consult the webhook provider
+                                implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: |-
+                                The API group name that should be used when POSTing ChallengePayload
+                                resources to the webhook apiserver.
+                                This should be the same as the GroupName specified in the webhook
+                                provider implementation.
+                              type: string
+                            solverName:
+                              description: |-
+                                The name of the solver to use, as defined in the webhook provider
+                                implementation.
+                                This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                          required:
+                            - groupName
+                            - solverName
+                          type: object
+                      type: object
+                    http01:
+                      description: |-
+                        Configures cert-manager to attempt to complete authorizations by
+                        performing the HTTP01 challenge flow.
+                        It is not possible to obtain certificates for wildcard domain names
+                        (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      properties:
+                        gatewayHTTPRoute:
+                          description: |-
+                            The Gateway API is a sig-network community API that models service networking
+                            in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                            create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                            This solver is experimental, and fields / behaviour may change in the future.
+                          properties:
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                while solving HTTP-01 challenges.
+                              type: object
+                            parentRefs:
+                              description: |-
+                                When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                cert-manager needs to know which parentRefs should be used when creating
+                                the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                              items:
+                                description: |-
+                                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                                  a parent of this resource (usually a route). There are two kinds of parent resources
+                                  with "Core" support:
+
+                                  * Gateway (Gateway conformance profile)
+                                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                  This API may be extended in the future to support additional kinds of parent
+                                  resources.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+                                properties:
+                                  group:
+                                    default: gateway.networking.k8s.io
+                                    description: |-
+                                      Group is the group of the referent.
+                                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                                      To set the core API group (such as for a "Service" kind referent),
+                                      Group must be explicitly set to "" (empty string).
+
+                                      Support: Core
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Gateway
+                                    description: |-
+                                      Kind is kind of the referent.
+
+                                      There are two kinds of parent resources with "Core" support:
+
+                                      * Gateway (Gateway conformance profile)
+                                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                      Support for other resources is Implementation-Specific.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is the name of the referent.
+
+                                      Support: Core
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referent. When unspecified, this refers
+                                      to the local namespace of the Route.
+
+                                      Note that there are specific rules for ParentRefs which cross namespace
+                                      boundaries. Cross-namespace references are only valid if they are explicitly
+                                      allowed by something in the namespace they are referring to. For example:
+                                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                      generic way to enable any other kind of cross-namespace reference.
+
+                                      <gateway:experimental:description>
+                                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                                      routes, which apply default routing rules to inbound connections from
+                                      any namespace to the Service.
+
+                                      ParentRefs from a Route to a Service in a different namespace are
+                                      "consumer" routes, and these routing rules are only applied to outbound
+                                      connections originating from the same namespace as the Route, for which
+                                      the intended destination of the connections are a Service targeted as a
+                                      ParentRef of the Route.
+                                      </gateway:experimental:description>
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port is the network port this Route targets. It can be interpreted
+                                      differently based on the type of parent resource.
+
+                                      When the parent resource is a Gateway, this targets all listeners
+                                      listening on the specified port that also support this kind of Route(and
+                                      select this Route). It's not recommended to set `Port` unless the
+                                      networking behaviors specified in a Route must apply to a specific port
+                                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                      and SectionName are specified, the name and port of the selected listener
+                                      must match both specified values.
+
+                                      <gateway:experimental:description>
+                                      When the parent resource is a Service, this targets a specific port in the
+                                      Service spec. When both Port (experimental) and SectionName are specified,
+                                      the name and port of the selected port must match both specified values.
+                                      </gateway:experimental:description>
+
+                                      Implementations MAY choose to support other parent resources.
+                                      Implementations supporting other types of parent resources MUST clearly
+                                      document how/if Port is interpreted.
+
+                                      For the purpose of status, an attachment is considered successful as
+                                      long as the parent resource accepts it partially. For example, Gateway
+                                      listeners can restrict which Routes can attach to them by Route kind,
+                                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                      from the referencing Route, the Route MUST be considered successfully
+                                      attached. If no Gateway listeners accept attachment from this Route,
+                                      the Route MUST be considered detached from the Gateway.
+
+                                      Support: Extended
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                  sectionName:
+                                    description: |-
+                                      SectionName is the name of a section within the target resource. In the
+                                      following resources, SectionName is interpreted as the following:
+
+                                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                                      are specified, the name and port of the selected listener must match
+                                      both specified values.
+                                      * Service: Port name. When both Port (experimental) and SectionName
+                                      are specified, the name and port of the selected listener must match
+                                      both specified values.
+
+                                      Implementations MAY choose to support attaching Routes to other resources.
+                                      If that is the case, they MUST clearly document how SectionName is
+                                      interpreted.
+
+                                      When unspecified (empty string), this will reference the entire resource.
+                                      For the purpose of status, an attachment is considered successful if at
+                                      least one section in the parent resource accepts it. For example, Gateway
+                                      listeners can restrict which Routes can attach to them by Route kind,
+                                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                      the referencing Route, the Route MUST be considered successfully
+                                      attached. If no Gateway listeners accept attachment from this Route, the
+                                      Route MUST be considered detached from the Gateway.
+
+                                      Support: Core
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            podTemplate:
+                              description: |-
+                                Optional pod template used to configure the ACME challenge solver pods
+                                used for HTTP01 challenges.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                    Only the 'labels' and 'annotations' fields may be set.
+                                    If labels or annotations overlap with in-built values, the values here
+                                    will override the in-built values.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                  type: object
+                                spec:
+                                  description: |-
+                                    PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                    Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                    All other fields will be ignored.
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: |-
+                                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to an update), the system
+                                                may or may not try to eventually evict the pod from its node.
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  items:
+                                                    description: |-
+                                                      A null or empty node selector term matches no objects. The requirements of
+                                                      them are ANDed.
+                                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - nodeSelectorTerms
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the anti-affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the anti-affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the anti-affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                      type: object
+                                    imagePullSecrets:
+                                      description: If specified, the pod's imagePullSecrets
+                                      items:
+                                        description: |-
+                                          LocalObjectReference contains enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                      type: object
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    securityContext:
+                                      description: If specified, the pod's security context
+                                      properties:
+                                        fsGroup:
+                                          description: |-
+                                            A special supplemental group that applies to all containers in a pod.
+                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                            to be owned by the pod:
+
+                                            1. The owning GID will be the FSGroup
+                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                            3. The permission bits are OR'd with rw-rw----
+
+                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        fsGroupChangePolicy:
+                                          description: |-
+                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                            before being exposed inside Pod. This field will only apply to
+                                            volume types which support fsGroup based ownership(and permissions).
+                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                            and emptydir.
+                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to all containers.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in SecurityContext.  If set in
+                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                            takes precedence for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by the containers in this pod.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                            - type
+                                          type: object
+                                        supplementalGroups:
+                                          description: |-
+                                            A list of groups applied to the first process run in each container, in addition
+                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                            defined in the container image for the uid of the container process. If unspecified,
+                                            no additional groups are added to any container. Note that group memberships
+                                            defined in the container image for the uid of the container process are still effective,
+                                            even if they are not included in this list.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                        sysctls:
+                                          description: |-
+                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                            sysctls (by the container runtime) might fail to launch.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          items:
+                                            description: Sysctl defines a kernel parameter to be set
+                                            properties:
+                                              name:
+                                                description: Name of a property to set
+                                                type: string
+                                              value:
+                                                description: Value of a property to set
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      items:
+                                        description: |-
+                                          The pod this Toleration is attached to tolerates any taint that matches
+                                          the triple <key,value,effect> using the matching operator <operator>.
+                                        properties:
+                                          effect:
+                                            description: |-
+                                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: |-
+                                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Operator represents a key's relationship to the value.
+                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Exists is equivalent to wildcard for value, so that a pod can
+                                              tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: |-
+                                              TolerationSeconds represents the period of time the toleration (which must be
+                                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict immediately) by the system.
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            description: |-
+                                              Value is the taint value the toleration matches to.
+                                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            serviceType:
+                              description: |-
+                                Optional service type for Kubernetes solver service. Supported values
+                                are NodePort or ClusterIP. If unset, defaults to NodePort.
+                              type: string
+                          type: object
+                        ingress:
+                          description: |-
+                            The ingress based HTTP01 challenge solver will solve challenges by
+                            creating or modifying Ingress resources in order to route requests for
+                            '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                            provisioned by cert-manager for each Challenge to be completed.
+                          properties:
+                            class:
+                              description: |-
+                                This field configures the annotation `kubernetes.io/ingress.class` when
+                                creating Ingress resources to solve ACME challenges that use this
+                                challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                be specified.
+                              type: string
+                            ingressClassName:
+                              description: |-
+                                This field configures the field `ingressClassName` on the created Ingress
+                                resources used to solve ACME challenges that use this challenge solver.
+                                This is the recommended way of configuring the ingress class. Only one of
+                                `class`, `name` or `ingressClassName` may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: |-
+                                Optional ingress template used to configure the ACME challenge solver
+                                ingress used for HTTP01 challenges.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                    Only the 'labels' and 'annotations' fields may be set.
+                                    If labels or annotations overlap with in-built values, the values here
+                                    will override the in-built values.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                  type: object
+                              type: object
+                            name:
+                              description: |-
+                                The name of the ingress resource that should have ACME challenge solving
+                                routes inserted into it in order to solve HTTP01 challenges.
+                                This is typically used in conjunction with ingress controllers like
+                                ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                be specified.
+                              type: string
+                            podTemplate:
+                              description: |-
+                                Optional pod template used to configure the ACME challenge solver pods
+                                used for HTTP01 challenges.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                    Only the 'labels' and 'annotations' fields may be set.
+                                    If labels or annotations overlap with in-built values, the values here
+                                    will override the in-built values.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                  type: object
+                                spec:
+                                  description: |-
+                                    PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                    Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                    All other fields will be ignored.
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: |-
+                                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to an update), the system
+                                                may or may not try to eventually evict the pod from its node.
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  items:
+                                                    description: |-
+                                                      A null or empty node selector term matches no objects. The requirements of
+                                                      them are ANDed.
+                                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - nodeSelectorTerms
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the anti-affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the anti-affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the anti-affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                      type: object
+                                    imagePullSecrets:
+                                      description: If specified, the pod's imagePullSecrets
+                                      items:
+                                        description: |-
+                                          LocalObjectReference contains enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                      type: object
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    securityContext:
+                                      description: If specified, the pod's security context
+                                      properties:
+                                        fsGroup:
+                                          description: |-
+                                            A special supplemental group that applies to all containers in a pod.
+                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                            to be owned by the pod:
+
+                                            1. The owning GID will be the FSGroup
+                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                            3. The permission bits are OR'd with rw-rw----
+
+                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        fsGroupChangePolicy:
+                                          description: |-
+                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                            before being exposed inside Pod. This field will only apply to
+                                            volume types which support fsGroup based ownership(and permissions).
+                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                            and emptydir.
+                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to all containers.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in SecurityContext.  If set in
+                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                            takes precedence for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by the containers in this pod.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                            - type
+                                          type: object
+                                        supplementalGroups:
+                                          description: |-
+                                            A list of groups applied to the first process run in each container, in addition
+                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                            defined in the container image for the uid of the container process. If unspecified,
+                                            no additional groups are added to any container. Note that group memberships
+                                            defined in the container image for the uid of the container process are still effective,
+                                            even if they are not included in this list.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                        sysctls:
+                                          description: |-
+                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                            sysctls (by the container runtime) might fail to launch.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          items:
+                                            description: Sysctl defines a kernel parameter to be set
+                                            properties:
+                                              name:
+                                                description: Name of a property to set
+                                                type: string
+                                              value:
+                                                description: Value of a property to set
+                                                type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      items:
+                                        description: |-
+                                          The pod this Toleration is attached to tolerates any taint that matches
+                                          the triple <key,value,effect> using the matching operator <operator>.
+                                        properties:
+                                          effect:
+                                            description: |-
+                                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: |-
+                                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Operator represents a key's relationship to the value.
+                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Exists is equivalent to wildcard for value, so that a pod can
+                                              tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: |-
+                                              TolerationSeconds represents the period of time the toleration (which must be
+                                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict immediately) by the system.
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            description: |-
+                                              Value is the taint value the toleration matches to.
+                                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            serviceType:
+                              description: |-
+                                Optional service type for Kubernetes solver service. Supported values
+                                are NodePort or ClusterIP. If unset, defaults to NodePort.
+                              type: string
+                          type: object
+                      type: object
+                    selector:
+                      description: |-
+                        Selector selects a set of DNSNames on the Certificate resource that
+                        should be solved using this challenge solver.
+                        If not specified, the solver will be treated as the 'default' solver
+                        with the lowest priority, i.e. if any other solver has a more specific
+                        match, it will be used instead.
+                      properties:
+                        dnsNames:
+                          description: |-
+                            List of DNSNames that this solver will be used to solve.
+                            If specified and a match is found, a dnsNames selector will take
+                            precedence over a dnsZones selector.
+                            If multiple solvers match with the same dnsNames value, the solver
+                            with the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in the list
+                            will be selected.
+                          items:
+                            type: string
+                          type: array
+                        dnsZones:
+                          description: |-
+                            List of DNSZones that this solver will be used to solve.
+                            The most specific DNS zone match specified here will take precedence
+                            over other DNS zone matches, so a solver specifying sys.example.com
+                            will be selected over one specifying example.com for the domain
+                            www.sys.example.com.
+                            If multiple solvers match with the same dnsZones value, the solver
+                            with the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in the list
+                            will be selected.
+                          items:
+                            type: string
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            A label selector that is used to refine the set of certificate's that
+                            this challenge solver will apply to.
+                          type: object
+                      type: object
+                  type: object
+                token:
+                  description: |-
+                    The ACME challenge token for this challenge.
+                    This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: |-
+                    The type of ACME challenge this resource represents.
+                    One of "HTTP-01" or "DNS-01".
+                  enum:
+                    - HTTP-01
+                    - DNS-01
+                  type: string
+                url:
+                  description: |-
+                    The URL of the ACME Challenge resource for this challenge.
+                    This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: |-
+                    wildcard will be true if this challenge is for a wildcard identifier,
+                    for example '*.example.com'.
+                  type: boolean
+              required:
+                - authorizationURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              type: object
+            status:
+              properties:
+                presented:
+                  description: |-
+                    presented will be set to true if the challenge values for this challenge
+                    are currently 'presented'.
+                    This *does not* imply the self check is passing. Only that the values
+                    have been 'submitted' for the appropriate challenge mechanism (i.e. the
+                    DNS01 TXT record has been presented, or the HTTP01 configuration has been
+                    configured).
+                  type: boolean
+                processing:
+                  description: |-
+                    Used to denote whether this challenge should be processed or not.
+                    This field will only be set to true by the 'scheduling' component.
+                    It will only be set to false by the 'challenges' controller, after the
+                    challenge has reached a final state or timed out.
+                    If this field is set to false, the challenge controller will not take
+                    any more action.
+                  type: boolean
+                reason:
+                  description: |-
+                    Contains human readable information on why the Challenge is in the
+                    current state.
+                  type: string
+                state:
+                  description: |-
+                    Contains the current 'state' of the challenge.
+                    If not set, the state of the challenge is unknown.
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/bases/clusterissuers.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/clusterissuers.cert-manager.io-crd.yaml
@@ -1,0 +1,3720 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    helm.sh/resource-policy: keep
+  labels:
+    app: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v1.16.4
+  name: clusterissuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    categories:
+      - cert-manager
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A ClusterIssuer represents a certificate issuing authority which can be
+            referenced as part of `issuerRef` fields.
+            It is similar to an Issuer, however it is cluster-scoped and therefore can
+            be referenced by resources that exist in *any* namespace, not just the same
+            namespace as the referent.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              properties:
+                acme:
+                  description: |-
+                    ACME configures this issuer to communicate with a RFC8555 (ACME) server
+                    to obtain signed x509 certificates.
+                  properties:
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which can be used to validate the certificate
+                        chain presented by the ACME server.
+                        Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                      format: byte
+                      type: string
+                    disableAccountKeyGeneration:
+                      description: |-
+                        Enables or disables generating a new ACME account key.
+                        If true, the Issuer resource will *not* request a new account but will expect
+                        the account key to be supplied via an existing secret.
+                        If false, the cert-manager system will generate a new ACME account key
+                        for the Issuer.
+                        Defaults to false.
+                      type: boolean
+                    email:
+                      description: |-
+                        Email is the email address to be associated with the ACME account.
+                        This field is optional, but it is strongly recommended to be set.
+                        It will be used to contact you in case of issues with your account or
+                        certificates, including expiry notification emails.
+                        This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: |-
+                        Enables requesting a Not After date on certificates that matches the
+                        duration of the certificate. This is not supported by all ACME servers
+                        like Let's Encrypt. If set to true when the ACME server does not support
+                        it, it will create an error on the Order.
+                        Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: |-
+                        ExternalAccountBinding is a reference to a CA external account of the ACME
+                        server.
+                        If set, upon registration cert-manager will attempt to associate the given
+                        external account credentials with the registered ACME account.
+                      properties:
+                        keyAlgorithm:
+                          description: |-
+                            Deprecated: keyAlgorithm field exists for historical compatibility
+                            reasons and should not be used. The algorithm is now hardcoded to HS256
+                            in golang/x/crypto/acme.
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                          type: string
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: |-
+                            keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
+                            Secret which holds the symmetric MAC key of the External Account Binding.
+                            The `key` is the index string that is paired with the key data in the
+                            Secret and should not be confused with the key data itself, or indeed with
+                            the External Account Binding keyID above.
+                            The secret key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      type: object
+                    preferredChain:
+                      description: |-
+                        PreferredChain is the chain to use if the ACME server outputs multiple.
+                        PreferredChain is no guarantee that this one gets delivered by the ACME
+                        endpoint.
+                        For example, for Let's Encrypt's DST crosssign you would use:
+                        "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+                        This value picks the first certificate bundle in the combined set of
+                        ACME default and alternative chains that has a root-most certificate with
+                        this value as its issuer's commonname.
+                      maxLength: 64
+                      type: string
+                    privateKeySecretRef:
+                      description: |-
+                        PrivateKey is the name of a Kubernetes Secret resource that will be used to
+                        store the automatically generated ACME account private key.
+                        Optionally, a `key` may be specified to select a specific entry within
+                        the named Secret resource.
+                        If `key` is not specified, a default of `tls.key` will be used.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    server:
+                      description: |-
+                        Server is the URL used to access the ACME server's 'directory' endpoint.
+                        For example, for Let's Encrypt's staging endpoint, you would use:
+                        "https://acme-staging-v02.api.letsencrypt.org/directory".
+                        Only ACME v2 endpoints (i.e. RFC 8555) are supported.
+                      type: string
+                    skipTLSVerify:
+                      description: |-
+                        INSECURE: Enables or disables validation of the ACME server TLS certificate.
+                        If true, requests to the ACME server will not have the TLS certificate chain
+                        validated.
+                        Mutually exclusive with CABundle; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        Only enable this option in development environments.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                        Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: |-
+                        Solvers is a list of challenge solvers that will be used to solve
+                        ACME challenges for the matching domains.
+                        Solver configurations must be provided in order to obtain certificates
+                        from an ACME server.
+                        For more information, see: https://cert-manager.io/docs/configuration/acme/
+                      items:
+                        description: |-
+                          An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
+                          A selector may be provided to use different solving strategies for different DNS names.
+                          Only one of HTTP01 or DNS01 must be provided.
+                        properties:
+                          dns01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the DNS01 challenge flow.
+                            properties:
+                              acmeDNS:
+                                description: |-
+                                  Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                                  DNS01 challenge records.
+                                properties:
+                                  accountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  host:
+                                    type: string
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                type: object
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  clientTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  serviceConsumerDomain:
+                                    type: string
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                type: object
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                properties:
+                                  clientID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientSecret and TenantID must also be set.
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      A reference to a Secret containing the password associated with the Service Principal.
+                                      If set, ClientID and TenantID must also be set.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                    type: string
+                                  hostedZoneName:
+                                    description: name of the DNS zone that should be used
+                                    type: string
+                                  managedIdentity:
+                                    description: |-
+                                      Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                      Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                      If set, ClientID, ClientSecret and TenantID must not be set.
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: |-
+                                          resource ID of the managed identity, can not be used at the same time as clientID
+                                          Cannot be used for Azure Managed Service Identity
+                                        type: string
+                                    type: object
+                                  resourceGroupName:
+                                    description: resource group the DNS zone is located in
+                                    type: string
+                                  subscriptionID:
+                                    description: ID of the Azure subscription
+                                    type: string
+                                  tenantID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientID and ClientSecret must also be set.
+                                    type: string
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                type: object
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                properties:
+                                  hostedZoneName:
+                                    description: |-
+                                      HostedZoneName is an optional field that tells cert-manager in which
+                                      Cloud DNS zone the challenge record has to be created.
+                                      If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - project
+                                type: object
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                properties:
+                                  apiKeySecretRef:
+                                    description: |-
+                                      API key to use to authenticate with Cloudflare.
+                                      Note: using an API token to authenticate is now the recommended method
+                                      as it allows greater control of permissions.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                                type: object
+                              cnameStrategy:
+                                description: |-
+                                  CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                                  records when found in DNS zones.
+                                enum:
+                                  - None
+                                  - Follow
+                                type: string
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                properties:
+                                  tokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - tokenSecretRef
+                                type: object
+                              rfc2136:
+                                description: |-
+                                  Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                  to manage DNS01 challenge records.
+                                properties:
+                                  nameserver:
+                                    description: |-
+                                      The IP address or hostname of an authoritative DNS server supporting
+                                      RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: |-
+                                      The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                      when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                      Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                      ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                                    type: string
+                                  tsigKeyName:
+                                    description: |-
+                                      The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: |-
+                                      The name of the secret containing the TSIG value.
+                                      If ``tsigKeyName`` is defined, this field is required.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - nameserver
+                                type: object
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                properties:
+                                  accessKeyID:
+                                    description: |-
+                                      The AccessKeyID is used for authentication.
+                                      Cannot be set when SecretAccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: string
+                                  accessKeyIDSecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication. If set, pull the AWS
+                                      access key ID from a key within a Kubernetes Secret.
+                                      Cannot be set when AccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  auth:
+                                    description: Auth configures how cert-manager authenticates.
+                                    properties:
+                                      kubernetes:
+                                        description: |-
+                                          Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
+                                          by passing a bound ServiceAccount token.
+                                        properties:
+                                          serviceAccountRef:
+                                            description: |-
+                                              A reference to a service account that will be used to request a bound
+                                              token (also known as "projected token"). To use this field, you must
+                                              configure an RBAC rule to let cert-manager request a token.
+                                            properties:
+                                              audiences:
+                                                description: |-
+                                                  TokenAudiences is an optional list of audiences to include in the
+                                                  token passed to AWS. The default token consisting of the issuer's namespace
+                                                  and name is always included.
+                                                  If unset the audience defaults to `sts.amazonaws.com`.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              name:
+                                                description: Name of the ServiceAccount used to request a token.
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - serviceAccountRef
+                                        type: object
+                                    required:
+                                      - kubernetes
+                                    type: object
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: |-
+                                      Override the AWS region.
+
+                                      Route53 is a global service and does not have regional endpoints but the
+                                      region specified here (or via environment variables) is used as a hint to
+                                      help compute the correct AWS credential scope and partition when it
+                                      connects to Route53. See:
+                                      - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                      - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                      If you omit this region field, cert-manager will use the region from
+                                      AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                      in the cert-manager controller Pod.
+
+                                      The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                      In this case this `region` field value is ignored.
+
+                                      The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+                                      In this case this `region` field value is ignored.
+                                    type: string
+                                  role:
+                                    description: |-
+                                      Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                      or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                type: object
+                              webhook:
+                                description: |-
+                                  Configure an external webhook based DNS01 challenge solver to manage
+                                  DNS01 challenge records.
+                                properties:
+                                  config:
+                                    description: |-
+                                      Additional configuration that should be passed to the webhook apiserver
+                                      when challenges are processed.
+                                      This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for a DNS service), you
+                                      should use a SecretKeySelector to reference a Secret resource.
+                                      For details on the schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: |-
+                                      The API group name that should be used when POSTing ChallengePayload
+                                      resources to the webhook apiserver.
+                                      This should be the same as the GroupName specified in the webhook
+                                      provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: |-
+                                      The name of the solver to use, as defined in the webhook provider
+                                      implementation.
+                                      This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                                required:
+                                  - groupName
+                                  - solverName
+                                type: object
+                            type: object
+                          http01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the HTTP01 challenge flow.
+                              It is not possible to obtain certificates for wildcard domain names
+                              (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            properties:
+                              gatewayHTTPRoute:
+                                description: |-
+                                  The Gateway API is a sig-network community API that models service networking
+                                  in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                                  create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                                  This solver is experimental, and fields / behaviour may change in the future.
+                                properties:
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                      while solving HTTP-01 challenges.
+                                    type: object
+                                  parentRefs:
+                                    description: |-
+                                      When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                      cert-manager needs to know which parentRefs should be used when creating
+                                      the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                      https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                                    items:
+                                      description: |-
+                                        ParentReference identifies an API object (usually a Gateway) that can be considered
+                                        a parent of this resource (usually a route). There are two kinds of parent resources
+                                        with "Core" support:
+
+                                        * Gateway (Gateway conformance profile)
+                                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                        This API may be extended in the future to support additional kinds of parent
+                                        resources.
+
+                                        The API object must be valid in the cluster; the Group and Kind must
+                                        be registered in the cluster for this reference to be valid.
+                                      properties:
+                                        group:
+                                          default: gateway.networking.k8s.io
+                                          description: |-
+                                            Group is the group of the referent.
+                                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                                            To set the core API group (such as for a "Service" kind referent),
+                                            Group must be explicitly set to "" (empty string).
+
+                                            Support: Core
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Gateway
+                                          description: |-
+                                            Kind is kind of the referent.
+
+                                            There are two kinds of parent resources with "Core" support:
+
+                                            * Gateway (Gateway conformance profile)
+                                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                            Support for other resources is Implementation-Specific.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name is the name of the referent.
+
+                                            Support: Core
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the referent. When unspecified, this refers
+                                            to the local namespace of the Route.
+
+                                            Note that there are specific rules for ParentRefs which cross namespace
+                                            boundaries. Cross-namespace references are only valid if they are explicitly
+                                            allowed by something in the namespace they are referring to. For example:
+                                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                            generic way to enable any other kind of cross-namespace reference.
+
+                                            <gateway:experimental:description>
+                                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                                            routes, which apply default routing rules to inbound connections from
+                                            any namespace to the Service.
+
+                                            ParentRefs from a Route to a Service in a different namespace are
+                                            "consumer" routes, and these routing rules are only applied to outbound
+                                            connections originating from the same namespace as the Route, for which
+                                            the intended destination of the connections are a Service targeted as a
+                                            ParentRef of the Route.
+                                            </gateway:experimental:description>
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port is the network port this Route targets. It can be interpreted
+                                            differently based on the type of parent resource.
+
+                                            When the parent resource is a Gateway, this targets all listeners
+                                            listening on the specified port that also support this kind of Route(and
+                                            select this Route). It's not recommended to set `Port` unless the
+                                            networking behaviors specified in a Route must apply to a specific port
+                                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                            and SectionName are specified, the name and port of the selected listener
+                                            must match both specified values.
+
+                                            <gateway:experimental:description>
+                                            When the parent resource is a Service, this targets a specific port in the
+                                            Service spec. When both Port (experimental) and SectionName are specified,
+                                            the name and port of the selected port must match both specified values.
+                                            </gateway:experimental:description>
+
+                                            Implementations MAY choose to support other parent resources.
+                                            Implementations supporting other types of parent resources MUST clearly
+                                            document how/if Port is interpreted.
+
+                                            For the purpose of status, an attachment is considered successful as
+                                            long as the parent resource accepts it partially. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                            from the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route,
+                                            the Route MUST be considered detached from the Gateway.
+
+                                            Support: Extended
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        sectionName:
+                                          description: |-
+                                            SectionName is the name of a section within the target resource. In the
+                                            following resources, SectionName is interpreted as the following:
+
+                                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+                                            * Service: Port name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+
+                                            Implementations MAY choose to support attaching Routes to other resources.
+                                            If that is the case, they MUST clearly document how SectionName is
+                                            interpreted.
+
+                                            When unspecified (empty string), this will reference the entire resource.
+                                            For the purpose of status, an attachment is considered successful if at
+                                            least one section in the parent resource accepts it. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                            the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route, the
+                                            Route MUST be considered detached from the Gateway.
+
+                                            Support: Core
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                          nodeSelector:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                  - type
+                                                type: object
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  format: int64
+                                                  type: integer
+                                                type: array
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                                type: object
+                              ingress:
+                                description: |-
+                                  The ingress based HTTP01 challenge solver will solve challenges by
+                                  creating or modifying Ingress resources in order to route requests for
+                                  '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                                  provisioned by cert-manager for each Challenge to be completed.
+                                properties:
+                                  class:
+                                    description: |-
+                                      This field configures the annotation `kubernetes.io/ingress.class` when
+                                      creating Ingress resources to solve ACME challenges that use this
+                                      challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  ingressClassName:
+                                    description: |-
+                                      This field configures the field `ingressClassName` on the created Ingress
+                                      resources used to solve ACME challenges that use this challenge solver.
+                                      This is the recommended way of configuring the ingress class. Only one of
+                                      `class`, `name` or `ingressClassName` may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: |-
+                                      Optional ingress template used to configure the ACME challenge solver
+                                      ingress used for HTTP01 challenges.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                        type: object
+                                    type: object
+                                  name:
+                                    description: |-
+                                      The name of the ingress resource that should have ACME challenge solving
+                                      routes inserted into it in order to solve HTTP01 challenges.
+                                      This is typically used in conjunction with ingress controllers like
+                                      ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                      ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                          nodeSelector:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                  - type
+                                                type: object
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  format: int64
+                                                  type: integer
+                                                type: array
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                                type: object
+                            type: object
+                          selector:
+                            description: |-
+                              Selector selects a set of DNSNames on the Certificate resource that
+                              should be solved using this challenge solver.
+                              If not specified, the solver will be treated as the 'default' solver
+                              with the lowest priority, i.e. if any other solver has a more specific
+                              match, it will be used instead.
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  List of DNSNames that this solver will be used to solve.
+                                  If specified and a match is found, a dnsNames selector will take
+                                  precedence over a dnsZones selector.
+                                  If multiple solvers match with the same dnsNames value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                items:
+                                  type: string
+                                type: array
+                              dnsZones:
+                                description: |-
+                                  List of DNSZones that this solver will be used to solve.
+                                  The most specific DNS zone match specified here will take precedence
+                                  over other DNS zone matches, so a solver specifying sys.example.com
+                                  will be selected over one specifying example.com for the domain
+                                  www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                items:
+                                  type: string
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  A label selector that is used to refine the set of certificate's that
+                                  this challenge solver will apply to.
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  type: object
+                ca:
+                  description: |-
+                    CA configures this issuer to sign certificates using a signing CA keypair
+                    stored in a Secret resource.
+                    This is used to build internal PKIs that are managed by cert-manager.
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set, certificates will be issued without distribution points set.
+                      items:
+                        type: string
+                      type: array
+                    issuingCertificateURLs:
+                      description: |-
+                        IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
+                        it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
+                        As an example, such a URL might be "http://ca.domain.com/ca.crt".
+                      items:
+                        type: string
+                      type: array
+                    ocspServers:
+                      description: |-
+                        The OCSP server list is an X.509 v3 extension that defines a list of
+                        URLs of OCSP responders. The OCSP responders can be queried for the
+                        revocation status of an issued certificate. If not set, the
+                        certificate will be issued with no OCSP servers set. For example, an
+                        OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: |-
+                        SecretName is the name of the secret used to sign Certificates issued
+                        by this Issuer.
+                      type: string
+                  required:
+                    - secretName
+                  type: object
+                selfSigned:
+                  description: |-
+                    SelfSigned configures this issuer to 'self sign' certificates using the
+                    private key used to create the CertificateRequest object.
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set certificate will be issued without CDP. Values are strings.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                vault:
+                  description: |-
+                    Vault configures this issuer to sign certificates using a HashiCorp Vault
+                    PKI backend.
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      properties:
+                        appRole:
+                          description: |-
+                            AppRole authenticates with Vault using the App Role auth mechanism,
+                            with the role and secret stored in a Kubernetes Secret resource.
+                          properties:
+                            path:
+                              description: |-
+                                Path where the App Role authentication backend is mounted in Vault, e.g:
+                                "approle"
+                              type: string
+                            roleId:
+                              description: |-
+                                RoleID configured in the App Role authentication backend when setting
+                                up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: |-
+                                Reference to a key in a Secret that contains the App Role secret used
+                                to authenticate with Vault.
+                                The `key` field must be specified and denotes which entry within the Secret
+                                resource is used as the app role secret.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          type: object
+                        clientCertificate:
+                          description: |-
+                            ClientCertificate authenticates with Vault by presenting a client
+                            certificate during the request's TLS handshake.
+                            Works only when using HTTPS protocol.
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/cert" will be used.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the certificate role to authenticate against.
+                                If not set, matching any certificate role, if available.
+                              type: string
+                            secretName:
+                              description: |-
+                                Reference to Kubernetes Secret of type "kubernetes.io/tls" (hence containing
+                                tls.crt and tls.key) used to authenticate to Vault using TLS client
+                                authentication.
+                              type: string
+                          type: object
+                        kubernetes:
+                          description: |-
+                            Kubernetes authenticates with Vault by passing the ServiceAccount
+                            token stored in the named Secret resource to the Vault server.
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: |-
+                                A required field containing the Vault Role to assume. A Role binds a
+                                Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: |-
+                                The required Secret field containing a Kubernetes ServiceAccount JWT used
+                                for authenticating with Vault. Use of 'ambient credentials' is not
+                                supported.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountRef:
+                              description: |-
+                                A reference to a service account that will be used to request a bound
+                                token (also known as "projected token"). Compared to using "secretRef",
+                                using this field means that you don't rely on statically bound tokens. To
+                                use this field, you must configure an RBAC rule to let cert-manager
+                                request a token.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
+                                    consisting of the issuer's namespace and name is always included.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - role
+                          type: object
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                        chain presented by Vault. Only used if using HTTPS to connect to Vault and
+                        ignored for HTTP connections.
+                        Mutually exclusive with CABundleSecretRef.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                      format: byte
+                      type: string
+                    caBundleSecretRef:
+                      description: |-
+                        Reference to a Secret containing a bundle of PEM-encoded CAs to use when
+                        verifying the certificate chain presented by Vault when using HTTPS.
+                        Mutually exclusive with CABundle.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                        If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    clientCertSecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+                        Vault server requires mTLS.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    clientKeySecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+                        Vault server requires mTLS.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    namespace:
+                      description: |-
+                        Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+                        More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                      type: string
+                    path:
+                      description: |-
+                        Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
+                        "my_pki_mount/sign/my-role-name".
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                  required:
+                    - auth
+                    - path
+                    - server
+                  type: object
+                venafi:
+                  description: |-
+                    Venafi configures this issuer to sign certificates using a Venafi TPP
+                    or Venafi Cloud policy zone.
+                  properties:
+                    cloud:
+                      description: |-
+                        Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        url:
+                          description: |-
+                            URL is the base URL for Venafi Cloud.
+                            Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                      required:
+                        - apiTokenSecretRef
+                      type: object
+                    tpp:
+                      description: |-
+                        TPP specifies Trust Protection Platform configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      properties:
+                        caBundle:
+                          description: |-
+                            Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            If undefined, the certificate bundle in the cert-manager controller container
+                            is used to validate the chain.
+                          format: byte
+                          type: string
+                        caBundleSecretRef:
+                          description: |-
+                            Reference to a Secret containing a base64-encoded bundle of PEM CAs
+                            which will be used to validate the certificate chain presented by the TPP server.
+                            Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+                            If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+                            the cert-manager controller container is used to validate the TLS connection.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        credentialsRef:
+                          description: |-
+                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            The secret must contain the key 'access-token' for the Access Token Authentication,
+                            or two keys, 'username' and 'password' for the API Keys Authentication.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        url:
+                          description: |-
+                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            for example: "https://tpp.example.com/vedsdk".
+                          type: string
+                      required:
+                        - credentialsRef
+                        - url
+                      type: object
+                    zone:
+                      description: |-
+                        Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by the named
+                        zone policy.
+                        This field is required.
+                      type: string
+                  required:
+                    - zone
+                  type: object
+              type: object
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              properties:
+                acme:
+                  description: |-
+                    ACME specific status options.
+                    This field should only be set if the Issuer is configured to use an ACME
+                    server to issue certificates.
+                  properties:
+                    lastPrivateKeyHash:
+                      description: |-
+                        LastPrivateKeyHash is a hash of the private key associated with the latest
+                        registered ACME account, in order to track changes made to registered account
+                        associated with the Issuer
+                      type: string
+                    lastRegisteredEmail:
+                      description: |-
+                        LastRegisteredEmail is the email associated with the latest registered
+                        ACME account, in order to track changes made to registered account
+                        associated with the  Issuer
+                      type: string
+                    uri:
+                      description: |-
+                        URI is the unique account identifier, which can also be used to retrieve
+                        account details from the CA
+                      type: string
+                  type: object
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`.
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Issuer.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/bases/config.openshift.io_certmanagers.yaml
+++ b/assets/optional/cert-manager/crd/bases/config.openshift.io_certmanagers.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: certmanagers.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: CertManager
+    listKind: CertManagerList
+    plural: certmanagers
+    singular: certmanager
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CertManager specifies cluster-wide settings for cert-manager.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/assets/optional/cert-manager/crd/bases/issuers.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/issuers.cert-manager.io-crd.yaml
@@ -1,0 +1,3720 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    helm.sh/resource-policy: keep
+  labels:
+    app: cert-manager
+    app.kubernetes.io/component: crds
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v1.16.4
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    categories:
+      - cert-manager
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            An Issuer represents a certificate issuing authority which can be
+            referenced as part of `issuerRef` fields.
+            It is scoped to a single namespace and can therefore only be referenced by
+            resources within the same namespace.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Issuer resource.
+              properties:
+                acme:
+                  description: |-
+                    ACME configures this issuer to communicate with a RFC8555 (ACME) server
+                    to obtain signed x509 certificates.
+                  properties:
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which can be used to validate the certificate
+                        chain presented by the ACME server.
+                        Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                      format: byte
+                      type: string
+                    disableAccountKeyGeneration:
+                      description: |-
+                        Enables or disables generating a new ACME account key.
+                        If true, the Issuer resource will *not* request a new account but will expect
+                        the account key to be supplied via an existing secret.
+                        If false, the cert-manager system will generate a new ACME account key
+                        for the Issuer.
+                        Defaults to false.
+                      type: boolean
+                    email:
+                      description: |-
+                        Email is the email address to be associated with the ACME account.
+                        This field is optional, but it is strongly recommended to be set.
+                        It will be used to contact you in case of issues with your account or
+                        certificates, including expiry notification emails.
+                        This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: |-
+                        Enables requesting a Not After date on certificates that matches the
+                        duration of the certificate. This is not supported by all ACME servers
+                        like Let's Encrypt. If set to true when the ACME server does not support
+                        it, it will create an error on the Order.
+                        Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: |-
+                        ExternalAccountBinding is a reference to a CA external account of the ACME
+                        server.
+                        If set, upon registration cert-manager will attempt to associate the given
+                        external account credentials with the registered ACME account.
+                      properties:
+                        keyAlgorithm:
+                          description: |-
+                            Deprecated: keyAlgorithm field exists for historical compatibility
+                            reasons and should not be used. The algorithm is now hardcoded to HS256
+                            in golang/x/crypto/acme.
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                          type: string
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: |-
+                            keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
+                            Secret which holds the symmetric MAC key of the External Account Binding.
+                            The `key` is the index string that is paired with the key data in the
+                            Secret and should not be confused with the key data itself, or indeed with
+                            the External Account Binding keyID above.
+                            The secret key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      type: object
+                    preferredChain:
+                      description: |-
+                        PreferredChain is the chain to use if the ACME server outputs multiple.
+                        PreferredChain is no guarantee that this one gets delivered by the ACME
+                        endpoint.
+                        For example, for Let's Encrypt's DST crosssign you would use:
+                        "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+                        This value picks the first certificate bundle in the combined set of
+                        ACME default and alternative chains that has a root-most certificate with
+                        this value as its issuer's commonname.
+                      maxLength: 64
+                      type: string
+                    privateKeySecretRef:
+                      description: |-
+                        PrivateKey is the name of a Kubernetes Secret resource that will be used to
+                        store the automatically generated ACME account private key.
+                        Optionally, a `key` may be specified to select a specific entry within
+                        the named Secret resource.
+                        If `key` is not specified, a default of `tls.key` will be used.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    server:
+                      description: |-
+                        Server is the URL used to access the ACME server's 'directory' endpoint.
+                        For example, for Let's Encrypt's staging endpoint, you would use:
+                        "https://acme-staging-v02.api.letsencrypt.org/directory".
+                        Only ACME v2 endpoints (i.e. RFC 8555) are supported.
+                      type: string
+                    skipTLSVerify:
+                      description: |-
+                        INSECURE: Enables or disables validation of the ACME server TLS certificate.
+                        If true, requests to the ACME server will not have the TLS certificate chain
+                        validated.
+                        Mutually exclusive with CABundle; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        Only enable this option in development environments.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                        Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: |-
+                        Solvers is a list of challenge solvers that will be used to solve
+                        ACME challenges for the matching domains.
+                        Solver configurations must be provided in order to obtain certificates
+                        from an ACME server.
+                        For more information, see: https://cert-manager.io/docs/configuration/acme/
+                      items:
+                        description: |-
+                          An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
+                          A selector may be provided to use different solving strategies for different DNS names.
+                          Only one of HTTP01 or DNS01 must be provided.
+                        properties:
+                          dns01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the DNS01 challenge flow.
+                            properties:
+                              acmeDNS:
+                                description: |-
+                                  Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                                  DNS01 challenge records.
+                                properties:
+                                  accountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  host:
+                                    type: string
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                type: object
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  clientTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  serviceConsumerDomain:
+                                    type: string
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                type: object
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                properties:
+                                  clientID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientSecret and TenantID must also be set.
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      A reference to a Secret containing the password associated with the Service Principal.
+                                      If set, ClientID and TenantID must also be set.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                    type: string
+                                  hostedZoneName:
+                                    description: name of the DNS zone that should be used
+                                    type: string
+                                  managedIdentity:
+                                    description: |-
+                                      Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                      Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                      If set, ClientID, ClientSecret and TenantID must not be set.
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: |-
+                                          resource ID of the managed identity, can not be used at the same time as clientID
+                                          Cannot be used for Azure Managed Service Identity
+                                        type: string
+                                    type: object
+                                  resourceGroupName:
+                                    description: resource group the DNS zone is located in
+                                    type: string
+                                  subscriptionID:
+                                    description: ID of the Azure subscription
+                                    type: string
+                                  tenantID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientID and ClientSecret must also be set.
+                                    type: string
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                type: object
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                properties:
+                                  hostedZoneName:
+                                    description: |-
+                                      HostedZoneName is an optional field that tells cert-manager in which
+                                      Cloud DNS zone the challenge record has to be created.
+                                      If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - project
+                                type: object
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                properties:
+                                  apiKeySecretRef:
+                                    description: |-
+                                      API key to use to authenticate with Cloudflare.
+                                      Note: using an API token to authenticate is now the recommended method
+                                      as it allows greater control of permissions.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                                type: object
+                              cnameStrategy:
+                                description: |-
+                                  CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                                  records when found in DNS zones.
+                                enum:
+                                  - None
+                                  - Follow
+                                type: string
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                properties:
+                                  tokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - tokenSecretRef
+                                type: object
+                              rfc2136:
+                                description: |-
+                                  Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                  to manage DNS01 challenge records.
+                                properties:
+                                  nameserver:
+                                    description: |-
+                                      The IP address or hostname of an authoritative DNS server supporting
+                                      RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: |-
+                                      The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                      when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                      Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                      ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                                    type: string
+                                  tsigKeyName:
+                                    description: |-
+                                      The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: |-
+                                      The name of the secret containing the TSIG value.
+                                      If ``tsigKeyName`` is defined, this field is required.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - nameserver
+                                type: object
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                properties:
+                                  accessKeyID:
+                                    description: |-
+                                      The AccessKeyID is used for authentication.
+                                      Cannot be set when SecretAccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: string
+                                  accessKeyIDSecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication. If set, pull the AWS
+                                      access key ID from a key within a Kubernetes Secret.
+                                      Cannot be set when AccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  auth:
+                                    description: Auth configures how cert-manager authenticates.
+                                    properties:
+                                      kubernetes:
+                                        description: |-
+                                          Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
+                                          by passing a bound ServiceAccount token.
+                                        properties:
+                                          serviceAccountRef:
+                                            description: |-
+                                              A reference to a service account that will be used to request a bound
+                                              token (also known as "projected token"). To use this field, you must
+                                              configure an RBAC rule to let cert-manager request a token.
+                                            properties:
+                                              audiences:
+                                                description: |-
+                                                  TokenAudiences is an optional list of audiences to include in the
+                                                  token passed to AWS. The default token consisting of the issuer's namespace
+                                                  and name is always included.
+                                                  If unset the audience defaults to `sts.amazonaws.com`.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              name:
+                                                description: Name of the ServiceAccount used to request a token.
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - serviceAccountRef
+                                        type: object
+                                    required:
+                                      - kubernetes
+                                    type: object
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: |-
+                                      Override the AWS region.
+
+                                      Route53 is a global service and does not have regional endpoints but the
+                                      region specified here (or via environment variables) is used as a hint to
+                                      help compute the correct AWS credential scope and partition when it
+                                      connects to Route53. See:
+                                      - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                      - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                      If you omit this region field, cert-manager will use the region from
+                                      AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                      in the cert-manager controller Pod.
+
+                                      The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                      In this case this `region` field value is ignored.
+
+                                      The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+                                      In this case this `region` field value is ignored.
+                                    type: string
+                                  role:
+                                    description: |-
+                                      Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                      or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                type: object
+                              webhook:
+                                description: |-
+                                  Configure an external webhook based DNS01 challenge solver to manage
+                                  DNS01 challenge records.
+                                properties:
+                                  config:
+                                    description: |-
+                                      Additional configuration that should be passed to the webhook apiserver
+                                      when challenges are processed.
+                                      This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for a DNS service), you
+                                      should use a SecretKeySelector to reference a Secret resource.
+                                      For details on the schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: |-
+                                      The API group name that should be used when POSTing ChallengePayload
+                                      resources to the webhook apiserver.
+                                      This should be the same as the GroupName specified in the webhook
+                                      provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: |-
+                                      The name of the solver to use, as defined in the webhook provider
+                                      implementation.
+                                      This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                                required:
+                                  - groupName
+                                  - solverName
+                                type: object
+                            type: object
+                          http01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the HTTP01 challenge flow.
+                              It is not possible to obtain certificates for wildcard domain names
+                              (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            properties:
+                              gatewayHTTPRoute:
+                                description: |-
+                                  The Gateway API is a sig-network community API that models service networking
+                                  in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                                  create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                                  This solver is experimental, and fields / behaviour may change in the future.
+                                properties:
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                      while solving HTTP-01 challenges.
+                                    type: object
+                                  parentRefs:
+                                    description: |-
+                                      When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                      cert-manager needs to know which parentRefs should be used when creating
+                                      the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                      https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                                    items:
+                                      description: |-
+                                        ParentReference identifies an API object (usually a Gateway) that can be considered
+                                        a parent of this resource (usually a route). There are two kinds of parent resources
+                                        with "Core" support:
+
+                                        * Gateway (Gateway conformance profile)
+                                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                        This API may be extended in the future to support additional kinds of parent
+                                        resources.
+
+                                        The API object must be valid in the cluster; the Group and Kind must
+                                        be registered in the cluster for this reference to be valid.
+                                      properties:
+                                        group:
+                                          default: gateway.networking.k8s.io
+                                          description: |-
+                                            Group is the group of the referent.
+                                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                                            To set the core API group (such as for a "Service" kind referent),
+                                            Group must be explicitly set to "" (empty string).
+
+                                            Support: Core
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Gateway
+                                          description: |-
+                                            Kind is kind of the referent.
+
+                                            There are two kinds of parent resources with "Core" support:
+
+                                            * Gateway (Gateway conformance profile)
+                                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                            Support for other resources is Implementation-Specific.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: |-
+                                            Name is the name of the referent.
+
+                                            Support: Core
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the referent. When unspecified, this refers
+                                            to the local namespace of the Route.
+
+                                            Note that there are specific rules for ParentRefs which cross namespace
+                                            boundaries. Cross-namespace references are only valid if they are explicitly
+                                            allowed by something in the namespace they are referring to. For example:
+                                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                            generic way to enable any other kind of cross-namespace reference.
+
+                                            <gateway:experimental:description>
+                                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                                            routes, which apply default routing rules to inbound connections from
+                                            any namespace to the Service.
+
+                                            ParentRefs from a Route to a Service in a different namespace are
+                                            "consumer" routes, and these routing rules are only applied to outbound
+                                            connections originating from the same namespace as the Route, for which
+                                            the intended destination of the connections are a Service targeted as a
+                                            ParentRef of the Route.
+                                            </gateway:experimental:description>
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port is the network port this Route targets. It can be interpreted
+                                            differently based on the type of parent resource.
+
+                                            When the parent resource is a Gateway, this targets all listeners
+                                            listening on the specified port that also support this kind of Route(and
+                                            select this Route). It's not recommended to set `Port` unless the
+                                            networking behaviors specified in a Route must apply to a specific port
+                                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                            and SectionName are specified, the name and port of the selected listener
+                                            must match both specified values.
+
+                                            <gateway:experimental:description>
+                                            When the parent resource is a Service, this targets a specific port in the
+                                            Service spec. When both Port (experimental) and SectionName are specified,
+                                            the name and port of the selected port must match both specified values.
+                                            </gateway:experimental:description>
+
+                                            Implementations MAY choose to support other parent resources.
+                                            Implementations supporting other types of parent resources MUST clearly
+                                            document how/if Port is interpreted.
+
+                                            For the purpose of status, an attachment is considered successful as
+                                            long as the parent resource accepts it partially. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                            from the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route,
+                                            the Route MUST be considered detached from the Gateway.
+
+                                            Support: Extended
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                        sectionName:
+                                          description: |-
+                                            SectionName is the name of a section within the target resource. In the
+                                            following resources, SectionName is interpreted as the following:
+
+                                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+                                            * Service: Port name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+
+                                            Implementations MAY choose to support attaching Routes to other resources.
+                                            If that is the case, they MUST clearly document how SectionName is
+                                            interpreted.
+
+                                            When unspecified (empty string), this will reference the entire resource.
+                                            For the purpose of status, an attachment is considered successful if at
+                                            least one section in the parent resource accepts it. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                            the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route, the
+                                            Route MUST be considered detached from the Gateway.
+
+                                            Support: Core
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                          nodeSelector:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                  - type
+                                                type: object
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  format: int64
+                                                  type: integer
+                                                type: array
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                                type: object
+                              ingress:
+                                description: |-
+                                  The ingress based HTTP01 challenge solver will solve challenges by
+                                  creating or modifying Ingress resources in order to route requests for
+                                  '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                                  provisioned by cert-manager for each Challenge to be completed.
+                                properties:
+                                  class:
+                                    description: |-
+                                      This field configures the annotation `kubernetes.io/ingress.class` when
+                                      creating Ingress resources to solve ACME challenges that use this
+                                      challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  ingressClassName:
+                                    description: |-
+                                      This field configures the field `ingressClassName` on the created Ingress
+                                      resources used to solve ACME challenges that use this challenge solver.
+                                      This is the recommended way of configuring the ingress class. Only one of
+                                      `class`, `name` or `ingressClassName` may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: |-
+                                      Optional ingress template used to configure the ACME challenge solver
+                                      ingress used for HTTP01 challenges.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                        type: object
+                                    type: object
+                                  name:
+                                    description: |-
+                                      The name of the ingress resource that should have ACME challenge solving
+                                      routes inserted into it in order to solve HTTP01 challenges.
+                                      This is typically used in conjunction with ingress controllers like
+                                      ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                      ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        items:
+                                                                          type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                          nodeSelector:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                  - type
+                                                type: object
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  format: int64
+                                                  type: integer
+                                                type: array
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                                type: object
+                            type: object
+                          selector:
+                            description: |-
+                              Selector selects a set of DNSNames on the Certificate resource that
+                              should be solved using this challenge solver.
+                              If not specified, the solver will be treated as the 'default' solver
+                              with the lowest priority, i.e. if any other solver has a more specific
+                              match, it will be used instead.
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  List of DNSNames that this solver will be used to solve.
+                                  If specified and a match is found, a dnsNames selector will take
+                                  precedence over a dnsZones selector.
+                                  If multiple solvers match with the same dnsNames value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                items:
+                                  type: string
+                                type: array
+                              dnsZones:
+                                description: |-
+                                  List of DNSZones that this solver will be used to solve.
+                                  The most specific DNS zone match specified here will take precedence
+                                  over other DNS zone matches, so a solver specifying sys.example.com
+                                  will be selected over one specifying example.com for the domain
+                                  www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                items:
+                                  type: string
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  A label selector that is used to refine the set of certificate's that
+                                  this challenge solver will apply to.
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  type: object
+                ca:
+                  description: |-
+                    CA configures this issuer to sign certificates using a signing CA keypair
+                    stored in a Secret resource.
+                    This is used to build internal PKIs that are managed by cert-manager.
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set, certificates will be issued without distribution points set.
+                      items:
+                        type: string
+                      type: array
+                    issuingCertificateURLs:
+                      description: |-
+                        IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
+                        it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
+                        As an example, such a URL might be "http://ca.domain.com/ca.crt".
+                      items:
+                        type: string
+                      type: array
+                    ocspServers:
+                      description: |-
+                        The OCSP server list is an X.509 v3 extension that defines a list of
+                        URLs of OCSP responders. The OCSP responders can be queried for the
+                        revocation status of an issued certificate. If not set, the
+                        certificate will be issued with no OCSP servers set. For example, an
+                        OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: |-
+                        SecretName is the name of the secret used to sign Certificates issued
+                        by this Issuer.
+                      type: string
+                  required:
+                    - secretName
+                  type: object
+                selfSigned:
+                  description: |-
+                    SelfSigned configures this issuer to 'self sign' certificates using the
+                    private key used to create the CertificateRequest object.
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set certificate will be issued without CDP. Values are strings.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                vault:
+                  description: |-
+                    Vault configures this issuer to sign certificates using a HashiCorp Vault
+                    PKI backend.
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      properties:
+                        appRole:
+                          description: |-
+                            AppRole authenticates with Vault using the App Role auth mechanism,
+                            with the role and secret stored in a Kubernetes Secret resource.
+                          properties:
+                            path:
+                              description: |-
+                                Path where the App Role authentication backend is mounted in Vault, e.g:
+                                "approle"
+                              type: string
+                            roleId:
+                              description: |-
+                                RoleID configured in the App Role authentication backend when setting
+                                up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: |-
+                                Reference to a key in a Secret that contains the App Role secret used
+                                to authenticate with Vault.
+                                The `key` field must be specified and denotes which entry within the Secret
+                                resource is used as the app role secret.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          type: object
+                        clientCertificate:
+                          description: |-
+                            ClientCertificate authenticates with Vault by presenting a client
+                            certificate during the request's TLS handshake.
+                            Works only when using HTTPS protocol.
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/cert" will be used.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the certificate role to authenticate against.
+                                If not set, matching any certificate role, if available.
+                              type: string
+                            secretName:
+                              description: |-
+                                Reference to Kubernetes Secret of type "kubernetes.io/tls" (hence containing
+                                tls.crt and tls.key) used to authenticate to Vault using TLS client
+                                authentication.
+                              type: string
+                          type: object
+                        kubernetes:
+                          description: |-
+                            Kubernetes authenticates with Vault by passing the ServiceAccount
+                            token stored in the named Secret resource to the Vault server.
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: |-
+                                A required field containing the Vault Role to assume. A Role binds a
+                                Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: |-
+                                The required Secret field containing a Kubernetes ServiceAccount JWT used
+                                for authenticating with Vault. Use of 'ambient credentials' is not
+                                supported.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountRef:
+                              description: |-
+                                A reference to a service account that will be used to request a bound
+                                token (also known as "projected token"). Compared to using "secretRef",
+                                using this field means that you don't rely on statically bound tokens. To
+                                use this field, you must configure an RBAC rule to let cert-manager
+                                request a token.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
+                                    consisting of the issuer's namespace and name is always included.
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - role
+                          type: object
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                        chain presented by Vault. Only used if using HTTPS to connect to Vault and
+                        ignored for HTTP connections.
+                        Mutually exclusive with CABundleSecretRef.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                      format: byte
+                      type: string
+                    caBundleSecretRef:
+                      description: |-
+                        Reference to a Secret containing a bundle of PEM-encoded CAs to use when
+                        verifying the certificate chain presented by Vault when using HTTPS.
+                        Mutually exclusive with CABundle.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                        If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    clientCertSecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+                        Vault server requires mTLS.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    clientKeySecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+                        Vault server requires mTLS.
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    namespace:
+                      description: |-
+                        Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+                        More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                      type: string
+                    path:
+                      description: |-
+                        Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
+                        "my_pki_mount/sign/my-role-name".
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                  required:
+                    - auth
+                    - path
+                    - server
+                  type: object
+                venafi:
+                  description: |-
+                    Venafi configures this issuer to sign certificates using a Venafi TPP
+                    or Venafi Cloud policy zone.
+                  properties:
+                    cloud:
+                      description: |-
+                        Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        url:
+                          description: |-
+                            URL is the base URL for Venafi Cloud.
+                            Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                      required:
+                        - apiTokenSecretRef
+                      type: object
+                    tpp:
+                      description: |-
+                        TPP specifies Trust Protection Platform configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      properties:
+                        caBundle:
+                          description: |-
+                            Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            If undefined, the certificate bundle in the cert-manager controller container
+                            is used to validate the chain.
+                          format: byte
+                          type: string
+                        caBundleSecretRef:
+                          description: |-
+                            Reference to a Secret containing a base64-encoded bundle of PEM CAs
+                            which will be used to validate the certificate chain presented by the TPP server.
+                            Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+                            If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+                            the cert-manager controller container is used to validate the TLS connection.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        credentialsRef:
+                          description: |-
+                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            The secret must contain the key 'access-token' for the Access Token Authentication,
+                            or two keys, 'username' and 'password' for the API Keys Authentication.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        url:
+                          description: |-
+                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            for example: "https://tpp.example.com/vedsdk".
+                          type: string
+                      required:
+                        - credentialsRef
+                        - url
+                      type: object
+                    zone:
+                      description: |-
+                        Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by the named
+                        zone policy.
+                        This field is required.
+                      type: string
+                  required:
+                    - zone
+                  type: object
+              type: object
+            status:
+              description: Status of the Issuer. This is set and managed automatically.
+              properties:
+                acme:
+                  description: |-
+                    ACME specific status options.
+                    This field should only be set if the Issuer is configured to use an ACME
+                    server to issue certificates.
+                  properties:
+                    lastPrivateKeyHash:
+                      description: |-
+                        LastPrivateKeyHash is a hash of the private key associated with the latest
+                        registered ACME account, in order to track changes made to registered account
+                        associated with the Issuer
+                      type: string
+                    lastRegisteredEmail:
+                      description: |-
+                        LastRegisteredEmail is the email associated with the latest registered
+                        ACME account, in order to track changes made to registered account
+                        associated with the  Issuer
+                      type: string
+                    uri:
+                      description: |-
+                        URI is the unique account identifier, which can also be used to retrieve
+                        account details from the CA
+                      type: string
+                  type: object
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`.
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Issuer.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/bases/operator.openshift.io_certmanagers.yaml
+++ b/assets/optional/cert-manager/crd/bases/operator.openshift.io_certmanagers.yaml
@@ -1,0 +1,897 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: certmanagers.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: CertManager
+    listKind: CertManagerList
+    plural: certmanagers
+    singular: certmanager
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CertManager is the Schema for the certmanagers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CertManagerSpec defines the desired state of CertManager
+            properties:
+              cainjectorConfig:
+                description: |-
+                  CAInjectorConfig specifies further customization options for the cainjector's deployment spec.
+
+                  Possible customizations include the following,
+
+                  For OverrideArgs,
+                  --namespace string                          If set, this limits the scope of cainjector to a single namespace. If set, cainjector
+                                                              will not update resources with certificates outside of the configured namespace.
+                  --v Level                                   number for the log level verbosity
+                properties:
+                  overrideArgs:
+                    items:
+                      type: string
+                    type: array
+                  overrideEnv:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  overrideLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  overrideResources:
+                    description: |-
+                      CertManagerResourceRequirements describes the compute resource requirements for the cert-manager operands,
+                      namely the controller, webhook and cainjector.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  overrideScheduling:
+                    description: |-
+                      CertManagerScheduling describes the scheduling configurations for the cert-manager operands,
+                      namely the controller, webhook and cainjector.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      tolerations:
+                        description: |-
+                          Tolerations are attached to the pod to tolerate any taint that matches the
+                          taint's key, value and effect using the toleration's matching operator.
+                          More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              controllerConfig:
+                description: |-
+                  ControllerConfig specifies further customization options for the controller's deployment spec.
+
+                  Possible customizations include the following,
+
+                  For OverrideArgs,
+                  This field appends values to .spec.template.spec.containers[...].args. The container
+                  that will be selected will be based on image present on the spec. Possible values are,
+                  Eg:
+                    - "--acme-http01-solver-nameservers="8.8.8.8:53,1.1.1.1:53"
+                    - "--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"
+                    - "--dns01-recursive-nameservers-only"
+
+                  For OverrideEnvs,
+                  This field appends values to .spec.template.spec.containers[...].env. The container
+                  that will be selected will be based on image present on the spec. Possible values are,
+                  Eg:
+                    - "HTTP_PROXY": "http://proxy:8080"
+                properties:
+                  overrideArgs:
+                    items:
+                      type: string
+                    type: array
+                  overrideEnv:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  overrideLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  overrideResources:
+                    description: |-
+                      CertManagerResourceRequirements describes the compute resource requirements for the cert-manager operands,
+                      namely the controller, webhook and cainjector.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  overrideScheduling:
+                    description: |-
+                      CertManagerScheduling describes the scheduling configurations for the cert-manager operands,
+                      namely the controller, webhook and cainjector.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      tolerations:
+                        description: |-
+                          Tolerations are attached to the pod to tolerate any taint that matches the
+                          taint's key, value and effect using the toleration's matching operator.
+                          More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              logLevel:
+                default: Normal
+                description: |-
+                  logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a
+                  simple way to manage coarse grained logging choices that operators have to interpret for their operands.
+
+                  Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  Defaults to "Normal".
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: |-
+                  observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: |-
+                  operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a
+                  simple way to manage coarse grained logging choices that operators have to interpret for themselves.
+
+                  Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  Defaults to "Normal".
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: |-
+                  unsupportedConfigOverrides overrides the final configuration that was computed by the operator.
+                  Red Hat does not support the use of this field.
+                  Misuse of this field could lead to unexpected behavior or conflict with other configuration options.
+                  Seek guidance from the Red Hat support before using this field.
+                  Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              webhookConfig:
+                description: |-
+                  WebhookConfig specifies further customization options for the webhook's deployment spec.
+
+                  Possible customizations include the following,
+
+                  For OverrideArgs,
+                  --config string                                Path to a file containing a WebhookConfiguration object used to configure the webhook
+                  --dynamic-serving-ca-secret-name string        name of the secret used to store the CA that signs serving certificates certificates
+                  --dynamic-serving-ca-secret-namespace string   namespace of the secret used to store the CA that signs serving certificates
+                  --dynamic-serving-dns-names strings            DNS names that should be present on certificates generated by the dynamic serving CA
+                  --v Level                                      number for the log level verbosity
+                properties:
+                  overrideArgs:
+                    items:
+                      type: string
+                    type: array
+                  overrideEnv:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  overrideLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  overrideResources:
+                    description: |-
+                      CertManagerResourceRequirements describes the compute resource requirements for the cert-manager operands,
+                      namely the controller, webhook and cainjector.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  overrideScheduling:
+                    description: |-
+                      CertManagerScheduling describes the scheduling configurations for the cert-manager operands,
+                      namely the controller, webhook and cainjector.
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      tolerations:
+                        description: |-
+                          Tolerations are attached to the pod to tolerate any taint that matches the
+                          taint's key, value and effect using the toleration's matching operator.
+                          More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+            type: object
+          status:
+            description: CertManagerStatus defines the observed state of CertManager
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/assets/optional/cert-manager/crd/bases/operator.openshift.io_istiocsrs.yaml
+++ b/assets/optional/cert-manager/crd/bases/operator.openshift.io_istiocsrs.yaml
@@ -1,0 +1,1379 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: istiocsrs.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: IstioCSR
+    listKind: IstioCSRList
+    plural: istiocsrs
+    singular: istiocsr
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.istioCSRGRPCEndpoint
+      name: GRPC Endpoint
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          IstioCSR describes configuration and information about the managed istio-csr
+          agent. The name must be `default` to make istiocsr a singleton that is, to
+          allow only one instance of istiocsr per namespace.
+
+          When an IstioCSR is created, a new deployment is created which manages the
+          istio-csr agent and keeps it in the desired state.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              IstioCSR.
+            properties:
+              controllerConfig:
+                description: |-
+                  controllerConfig is for configuring the controller for setting up
+                  defaults to enable istio-csr agent.
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: labels to apply to all resources created for istio-csr
+                      agent deployment.
+                    type: object
+                    x-kubernetes-map-type: granular
+                type: object
+              istioCSRConfig:
+                description: istioCSRConfig is for configuring the istio-csr agent
+                  behavior.
+                properties:
+                  affinity:
+                    description: |-
+                      affinity is for setting scheduling affinity rules.
+                      ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  certManager:
+                    description: certManager is for configuring cert-manager specifics.
+                    properties:
+                      issuerRef:
+                        description: |-
+                          issuerRef contains details to the referenced object used for
+                          obtaining the certificates. When issuerRef.Kind is Issuer, it must exist in the
+                          .spec.istioCSRConfig.istio.namespace.
+                        properties:
+                          group:
+                            description: Group of the resource being referred to.
+                            type: string
+                          kind:
+                            description: Kind of the resource being referred to.
+                            type: string
+                          name:
+                            description: Name of the resource being referred to.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: issuerRef is immutable once set
+                          rule: self == oldSelf
+                        - message: kind must be either 'Issuer' or 'ClusterIssuer'
+                          rule: self.kind.lowerAscii() == 'issuer' || self.kind.lowerAscii()
+                            == 'clusterissuer'
+                        - message: group must be 'cert-manager.io'
+                          rule: self.group.lowerAscii() == 'cert-manager.io'
+                    required:
+                    - issuerRef
+                    type: object
+                    x-kubernetes-validations:
+                    - message: issuerRef may only be configured during creation
+                      rule: '!has(oldSelf.issuerRef) && !has(self.issuerRef) || has(oldSelf.issuerRef)
+                        && has(self.issuerRef)'
+                  istio:
+                    description: istio is for configuring the istio specifics.
+                    properties:
+                      namespace:
+                        description: namespace of the istio control-plane.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: namespace is immutable once set
+                          rule: self == oldSelf
+                      revisions:
+                        default:
+                        - default
+                        description: |-
+                          revisions are the istio revisions that are currently installed in the cluster.
+                          Changing this field will modify the DNS names that will be requested for
+                          the istiod certificate.
+                        items:
+                          type: string
+                        maxItems: 10
+                        type: array
+                        x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: revisions is immutable once set
+                          rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                    required:
+                    - namespace
+                    type: object
+                  istiodTLSConfig:
+                    description: istiodTLSConfig is for configuring istiod certificate
+                      specifics.
+                    properties:
+                      certificateDNSNames:
+                        description: certificateDNSNames contains the additional DNS
+                          names to be added to the istiod certificate SAN.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      certificateDuration:
+                        default: 1h
+                        description: certificateDuration is the istio-csr and the
+                          istiod certificates validity period.
+                        type: string
+                      certificateRenewBefore:
+                        default: 30m
+                        description: |-
+                          certificateRenewBefore is the ahead time to renew the istio-csr and the istiod certificates
+                          before expiry.
+                        type: string
+                      commonName:
+                        description: |-
+                          commonName is the common name to be set in the certificate.cert-manager.io
+                          created for istiod. CommonName will be of the form `istiod.<istio_namespace>.svc`
+                          when not set.
+                        type: string
+                      maxCertificateDuration:
+                        default: 1h
+                        description: |-
+                          MaxCertificateDuration is the maximum validity duration that can be
+                          requested for a certificate.
+                        type: string
+                      privateKeySize:
+                        default: 2048
+                        description: |-
+                          privateKeySize is the istio-csr and the istiod certificate's key size. When the SignatureAlgorithm
+                          is RSA, must be >= 2048 and for ECDSA, can only be 256 or 384, corresponding to P-256 and P-384 respectively.
+                        type: integer
+                        x-kubernetes-validations:
+                        - message: privateKeySize is immutable once set
+                          rule: oldSelf == 0 || self == oldSelf
+                      signatureAlgorithm:
+                        default: RSA
+                        description: |-
+                          signatureAlgorithm is the signature algorithm to use when generating
+                          private keys. At present only RSA and ECDSA are supported.
+                        enum:
+                        - RSA
+                        - ECDSA
+                        type: string
+                        x-kubernetes-validations:
+                        - message: signatureAlgorithm is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
+                      trustDomain:
+                        description: |-
+                          trustDomain is the istio cluster's trust domain, which will also be used for deriving
+                          spiffe URI.
+                        type: string
+                    required:
+                    - trustDomain
+                    type: object
+                    x-kubernetes-validations:
+                    - message: signatureAlgorithm may only be configured during creation
+                      rule: '!has(oldSelf.signatureAlgorithm) && !has(self.signatureAlgorithm)
+                        || has(oldSelf.signatureAlgorithm) && has(self.signatureAlgorithm)'
+                    - message: privateKeySize may only be configured during creation
+                      rule: '!has(oldSelf.privateKeySize) && !has(self.privateKeySize)
+                        || has(oldSelf.privateKeySize) && has(self.privateKeySize)'
+                  logFormat:
+                    default: text
+                    description: |-
+                      logFormat is for specifying the output format of istio-csr agent logging.
+                      Support log formats are text and json.
+                    type: string
+                  logLevel:
+                    default: 1
+                    description: logLevel supports value range as per [kubernetes
+                      logging guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use).
+                    format: int32
+                    maximum: 5
+                    minimum: 1
+                    type: integer
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      nodeSelector is for defining the scheduling criteria using node labels.
+                      ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  resources:
+                    description: |-
+                      resources is for defining the resource requirements.
+                      Cannot be updated.
+                      ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  server:
+                    description: |-
+                      server is for configuring the server endpoint used by istio
+                      for obtaining the certificates.
+                    properties:
+                      port:
+                        default: 443
+                        description: port to serve istio-csr gRPC service.
+                        format: int32
+                        type: integer
+                        x-kubernetes-validations:
+                        - message: port is immutable once set
+                          rule: oldSelf == 0 || self == oldSelf
+                    type: object
+                  tolerations:
+                    description: |-
+                      tolerations is for setting the pod tolerations.
+                      ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - certManager
+                - istio
+                - istiodTLSConfig
+                type: object
+            required:
+            - istioCSRConfig
+            type: object
+          status:
+            description: status is the most recently observed status of the IstioCSR.
+            properties:
+              clusterRole:
+                description: clusterRole created by the controller for the istio-csr
+                  agent.
+                type: string
+              clusterRoleBinding:
+                description: clusterRoleBinding created by the controller for the
+                  istio-csr agent.
+                type: string
+              conditions:
+                description: conditions holds information of the current state of
+                  the istio-csr agent deployment.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              istioCSRGRPCEndpoint:
+                description: |-
+                  istioCSRGRPCEndpoint is the service endpoint of istio-csr made available for user
+                  to configure the same in istiod config to enable istio to use istio-csr for
+                  certificate requests.
+                type: string
+              istioCSRImage:
+                description: istioCSRImage is the name of the image and the tag used
+                  for deploying istio-csr.
+                type: string
+              serviceAccount:
+                description: serviceAccount created by the controller for the istio-csr
+                  agent.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: istiocsr is a singleton, .metadata.name must be 'default'
+          rule: self.metadata.name == 'default'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/assets/optional/cert-manager/crd/bases/orders.acme.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/orders.acme.cert-manager.io-crd.yaml
@@ -1,0 +1,262 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    helm.sh/resource-policy: keep
+  labels:
+    app: cert-manager
+    app.kubernetes.io/component: crds
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v1.16.4
+  name: orders.acme.cert-manager.io
+spec:
+  group: acme.cert-manager.io
+  names:
+    categories:
+      - cert-manager
+      - cert-manager-acme
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                commonName:
+                  description: |-
+                    CommonName is the common name as specified on the DER encoded CSR.
+                    If specified, this value must also be present in `dnsNames` or `ipAddresses`.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                dnsNames:
+                  description: |-
+                    DNSNames is a list of DNS names that should be included as part of the Order
+                    validation process.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  items:
+                    type: string
+                  type: array
+                duration:
+                  description: |-
+                    Duration is the duration for the not after date for the requested certificate.
+                    this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: |-
+                    IPAddresses is a list of IP addresses that should be included as part of the Order
+                    validation process.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  items:
+                    type: string
+                  type: array
+                issuerRef:
+                  description: |-
+                    IssuerRef references a properly configured ACME-type Issuer which should
+                    be used to create this Order.
+                    If the Issuer does not exist, processing will be retried.
+                    If the Issuer is not an 'ACME' Issuer, an error will be returned and the
+                    Order will be marked as failed.
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                request:
+                  description: |-
+                    Certificate signing request bytes in DER encoding.
+                    This will be used when finalizing the order.
+                    This field must be set on the order.
+                  format: byte
+                  type: string
+              required:
+                - issuerRef
+                - request
+              type: object
+            status:
+              properties:
+                authorizations:
+                  description: |-
+                    Authorizations contains data returned from the ACME server on what
+                    authorizations must be completed in order to validate the DNS names
+                    specified on the Order.
+                  items:
+                    description: |-
+                      ACMEAuthorization contains data returned from the ACME server on an
+                      authorization that must be completed in order validate a DNS name on an ACME
+                      Order resource.
+                    properties:
+                      challenges:
+                        description: |-
+                          Challenges specifies the challenge types offered by the ACME server.
+                          One of these challenge types will be selected when validating the DNS
+                          name and an appropriate Challenge resource will be created to perform
+                          the ACME challenge process.
+                        items:
+                          description: |-
+                            Challenge specifies a challenge offered by the ACME server for an Order.
+                            An appropriate Challenge resource can be created to perform the ACME
+                            challenge process.
+                          properties:
+                            token:
+                              description: |-
+                                Token is the token that must be presented for this challenge.
+                                This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: |-
+                                Type is the type of challenge being offered, e.g. 'http-01', 'dns-01',
+                                'tls-sni-01', etc.
+                                This is the raw value retrieved from the ACME server.
+                                Only 'http-01' and 'dns-01' are supported by cert-manager, other values
+                                will be ignored.
+                              type: string
+                            url:
+                              description: |-
+                                URL is the URL of this challenge. It can be used to retrieve additional
+                                metadata about the Challenge from the ACME server.
+                              type: string
+                          required:
+                            - token
+                            - type
+                            - url
+                          type: object
+                        type: array
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: |-
+                          InitialState is the initial state of the ACME authorization when first
+                          fetched from the ACME server.
+                          If an Authorization is already 'valid', the Order controller will not
+                          create a Challenge resource for the authorization. This will occur when
+                          working with an ACME server that enables 'authz reuse' (such as Let's
+                          Encrypt's production endpoint).
+                          If not set and 'identifier' is set, the state is assumed to be pending
+                          and a Challenge will be created.
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                        type: string
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: |-
+                          Wildcard will be true if this authorization is for a wildcard DNS name.
+                          If this is true, the identifier will be the *non-wildcard* version of
+                          the DNS name.
+                          For example, if '*.example.com' is the DNS name being validated, this
+                          field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                    required:
+                      - url
+                    type: object
+                  type: array
+                certificate:
+                  description: |-
+                    Certificate is a copy of the PEM encoded certificate for this Order.
+                    This field will be populated after the order has been successfully
+                    finalized with the ACME server, and the order has transitioned to the
+                    'valid' state.
+                  format: byte
+                  type: string
+                failureTime:
+                  description: |-
+                    FailureTime stores the time that this order failed.
+                    This is used to influence garbage collection and back-off.
+                  format: date-time
+                  type: string
+                finalizeURL:
+                  description: |-
+                    FinalizeURL of the Order.
+                    This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: |-
+                    Reason optionally provides more information about a why the order is in
+                    the current state.
+                  type: string
+                state:
+                  description: |-
+                    State contains the current state of this Order resource.
+                    States 'success' and 'expired' are 'final'
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                  type: string
+                url:
+                  description: |-
+                    URL of the Order.
+                    This will initially be empty when the resource is first created.
+                    The Order controller will populate this field when the Order is first processed.
+                    This field will be immutable after it is initially set.
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/kustomization.yaml
+++ b/assets/optional/cert-manager/crd/kustomization.yaml
@@ -1,0 +1,28 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/operator.openshift.io_certmanagers.yaml
+- bases/certificaterequests.cert-manager.io-crd.yaml
+- bases/certificates.cert-manager.io-crd.yaml
+- bases/challenges.acme.cert-manager.io-crd.yaml
+- bases/clusterissuers.cert-manager.io-crd.yaml
+- bases/issuers.cert-manager.io-crd.yaml
+- bases/orders.acme.cert-manager.io-crd.yaml
+- bases/operator.openshift.io_istiocsrs.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_certmanagers.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_certmanagers.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/assets/optional/cert-manager/crd/kustomizeconfig.yaml
+++ b/assets/optional/cert-manager/crd/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  version: v1
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhook/clientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations

--- a/assets/optional/cert-manager/crd/patches/cainjection_in_certmanagers.yaml
+++ b/assets/optional/cert-manager/crd/patches/cainjection_in_certmanagers.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: certmanagers.operator.openshift.io.openshift.io

--- a/assets/optional/cert-manager/crd/patches/webhook_in_certmanagers.yaml
+++ b/assets/optional/cert-manager/crd/patches/webhook_in_certmanagers.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certmanagers.operator.openshift.io.openshift.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/assets/optional/cert-manager/kustomization.yaml
+++ b/assets/optional/cert-manager/kustomization.yaml
@@ -1,0 +1,65 @@
+# Adds namespace to all resources.
+namespace: cert-manager-operator
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: cert-manager-operator-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ./crd
+- ./rbac
+- ./manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars: []
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/assets/optional/cert-manager/manager/kustomization.yaml
+++ b/assets/optional/cert-manager/manager/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/eslutsky/cert-manager-operator-rhel9
+  newTag: latest
+  

--- a/assets/optional/cert-manager/manager/kustomization.yaml
+++ b/assets/optional/cert-manager/manager/kustomization.yaml
@@ -4,6 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/eslutsky/cert-manager-operator-rhel9
+  newName: quay.io/microshift/cert-manager
   newTag: latest
-  

--- a/assets/optional/cert-manager/manager/manager.yaml
+++ b/assets/optional/cert-manager/manager/manager.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      name: cert-manager-operator
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: cert-manager-operator
+      labels:
+        name: cert-manager-operator
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - command:
+            - /usr/bin/cert-manager-operator
+          args:
+            - start
+            - '--v=$(OPERATOR_LOG_LEVEL)'
+            - '--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)'
+            - '--cloud-credentials-secret=$(CLOUD_CREDENTIALS_SECRET_NAME)'
+            - '--unsupported-addon-features=$(UNSUPPORTED_ADDON_FEATURES)'
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: cert-manager-operator
+            - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4
+            - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4
+            - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4
+            - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
+              value: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:438d487c6b644319094f92250d43e0becf1bd0cc4b7d2864f4de72bacd1b9daf
+            - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
+              value: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e
+            - name: OPERAND_IMAGE_VERSION
+              value: 1.16.4
+            - name: ISTIOCSR_OPERAND_IMAGE_VERSION
+              value: 0.14.0
+            - name: OPERATOR_IMAGE_VERSION
+              value: 1.16.0
+            - name: OPERATOR_LOG_LEVEL
+              value: '2'
+            - name: TRUSTED_CA_CONFIGMAP_NAME
+            - name: CLOUD_CREDENTIALS_SECRET_NAME
+            - name: UNSUPPORTED_ADDON_FEATURES
+          image: controller:latest
+          imagePullPolicy: IfNotPresent
+          name: cert-manager-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - 'ALL'
+            privileged: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: 'RuntimeDefault'
+          ports:
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10

--- a/assets/optional/cert-manager/rbac/auth_proxy_client_clusterrole.yaml
+++ b/assets/optional/cert-manager/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/assets/optional/cert-manager/rbac/auth_proxy_role.yaml
+++ b/assets/optional/cert-manager/rbac/auth_proxy_role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/assets/optional/cert-manager/rbac/auth_proxy_role_binding.yaml
+++ b/assets/optional/cert-manager/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/assets/optional/cert-manager/rbac/auth_proxy_service.yaml
+++ b/assets/optional/cert-manager/rbac/auth_proxy_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: service
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/assets/optional/cert-manager/rbac/certmanager_editor_role.yaml
+++ b/assets/optional/cert-manager/rbac/certmanager_editor_role.yaml
@@ -1,0 +1,31 @@
+# permissions for end users to edit certmanagers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: certmanager-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: certmanager-editor-role
+rules:
+- apiGroups:
+  - operator.openshift.io.openshift.io
+  resources:
+  - certmanagers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.openshift.io.openshift.io
+  resources:
+  - certmanagers/status
+  verbs:
+  - get

--- a/assets/optional/cert-manager/rbac/certmanager_viewer_role.yaml
+++ b/assets/optional/cert-manager/rbac/certmanager_viewer_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to view certmanagers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: certmanager-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: certmanager-viewer-role
+rules:
+- apiGroups:
+  - operator.openshift.io.openshift.io
+  resources:
+  - certmanagers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io.openshift.io
+  resources:
+  - certmanagers/status
+  verbs:
+  - get

--- a/assets/optional/cert-manager/rbac/kustomization.yaml
+++ b/assets/optional/cert-manager/rbac/kustomization.yaml
@@ -1,0 +1,17 @@
+resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# The /metrics endpoint protected by AuthenticationAuthorizer 
+# part of the operator, require SAR and token reviews.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml

--- a/assets/optional/cert-manager/rbac/leader_election_role.yaml
+++ b/assets/optional/cert-manager/rbac/leader_election_role.yaml
@@ -1,0 +1,44 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/assets/optional/cert-manager/rbac/leader_election_role_binding.yaml
+++ b/assets/optional/cert-manager/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/assets/optional/cert-manager/rbac/role.yaml
+++ b/assets/optional/cert-manager/rbac/role.yaml
@@ -1,0 +1,276 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - namespaces
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  - challenges/finalizers
+  - challenges/status
+  - orders
+  - orders/finalizers
+  - orders/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificaterequests
+  - certificaterequests/finalizers
+  - certificaterequests/status
+  - certificates
+  - certificates/finalizers
+  - certificates/status
+  - clusterissuers
+  - clusterissuers/status
+  - issuers
+  - issuers/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resourceNames:
+  - clusterissuers.cert-manager.io/*
+  - issuers.cert-manager.io/*
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - sign
+  - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - certmanagers
+  - clusteroperators
+  - clusteroperators/status
+  - infrastructures
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - gateways/finalizers
+  - httproutes
+  - httproutes/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - certmanagers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - certmanagers/finalizers
+  - istiocsrs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - certmanagers/status
+  - istiocsrs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - istiocsrs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/assets/optional/cert-manager/rbac/role_binding.yaml
+++ b/assets/optional/cert-manager/rbac/role_binding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/assets/optional/cert-manager/rbac/service_account.yaml
+++ b/assets/optional/cert-manager/rbac/service_account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager
+  namespace: system

--- a/assets/optional/cert-manager/release-cert-manager-aarch64.json
+++ b/assets/optional/cert-manager/release-cert-manager-aarch64.json
@@ -1,0 +1,13 @@
+{
+  "release": {
+    "base": "4.19"
+  },
+  "images": {
+    "cert-manager-operator": "registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:41146965b3344b008ff0f6d119c1cb071efa7f02c742ce9af303b896ae43bff7",
+    "cert-manager-webhook": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4",
+    "cert-manager-ca-injector": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4",
+    "cert-manager-controller": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4",
+    "cert-manager-acmesolver": "registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:438d487c6b644319094f92250d43e0becf1bd0cc4b7d2864f4de72bacd1b9daf",
+    "cert-manager-istiocsr": "registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e"
+  }
+}

--- a/assets/optional/cert-manager/release-cert-manager-aarch64.json
+++ b/assets/optional/cert-manager/release-cert-manager-aarch64.json
@@ -1,6 +1,6 @@
 {
   "release": {
-    "base": "4.19"
+    "base": "4.20"
   },
   "images": {
     "cert-manager-operator": "registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:41146965b3344b008ff0f6d119c1cb071efa7f02c742ce9af303b896ae43bff7",

--- a/assets/optional/cert-manager/release-cert-manager-x86_64.json
+++ b/assets/optional/cert-manager/release-cert-manager-x86_64.json
@@ -1,0 +1,13 @@
+{
+  "release": {
+    "base": "4.19"
+  },
+  "images": {
+    "cert-manager-operator": "registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:41146965b3344b008ff0f6d119c1cb071efa7f02c742ce9af303b896ae43bff7",
+    "cert-manager-webhook": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4",
+    "cert-manager-ca-injector": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4",
+    "cert-manager-controller": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:408a5c91e6066d33801456db5b0c214095ab7e47a0af1dcb91b5c88bfbcca4d4",
+    "cert-manager-acmesolver": "registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:438d487c6b644319094f92250d43e0becf1bd0cc4b7d2864f4de72bacd1b9daf",
+    "cert-manager-istiocsr": "registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:9ea2c29a384b964cef14f853278821df3cd30320f25afab8823897192f67fc7e"
+  }
+}

--- a/assets/optional/cert-manager/release-cert-manager-x86_64.json
+++ b/assets/optional/cert-manager/release-cert-manager-x86_64.json
@@ -1,6 +1,6 @@
 {
   "release": {
-    "base": "4.19"
+    "base": "4.20"
   },
   "images": {
     "cert-manager-operator": "registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:41146965b3344b008ff0f6d119c1cb071efa7f02c742ce9af303b896ae43bff7",

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -824,7 +824,7 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
-* Thu Jul 2 2025 Evgeny Slutsky <eslutsky@redhat.com> 4.20.0
+* Wed Jul 02 2025 Evgeny Slutsky <eslutsky@redhat.com> 4.20.0
 - Add an optional microshift-cert-manager RPM
 
 * Thu Jun 12 2025 Evgeny Slutsky <eslutsky@redhat.com> 4.20.0

--- a/scripts/auto-rebase/assets_cert_manager.yaml
+++ b/scripts/auto-rebase/assets_cert_manager.yaml
@@ -1,0 +1,52 @@
+assets:
+  - dir: optional/cert-manager/
+    no_clean: True
+    files:
+      - file: kustomization.yaml
+        ignore: "Provided by MicroShift"
+      - file: release-cert-manager-aarch64.json
+        ignore: "Provided by MicroShift"
+      - file: release-cert-manager-x86_64.json
+        ignore: "Provided by MicroShift"
+  - dir: optional/cert-manager/crd/
+    src: cert-manager-operator/config/crd/
+    files:
+      - file: kustomization.yaml
+      - file: kustomizeconfig.yaml
+  - dir: optional/cert-manager/crd/bases/
+    src: cert-manager-operator/config/crd/bases/
+    files:
+      - file: certificaterequests.cert-manager.io-crd.yaml
+      - file: certificates.cert-manager.io-crd.yaml
+      - file: challenges.acme.cert-manager.io-crd.yaml
+      - file: clusterissuers.cert-manager.io-crd.yaml
+      - file: config.openshift.io_certmanagers.yaml
+      - file: issuers.cert-manager.io-crd.yaml
+      - file: operator.openshift.io_certmanagers.yaml
+      - file: operator.openshift.io_istiocsrs.yaml
+      - file: orders.acme.cert-manager.io-crd.yaml
+  - dir: optional/cert-manager/crd/patches/
+    src: cert-manager-operator/config/crd/patches/
+    files:
+      - file: cainjection_in_certmanagers.yaml
+      - file: webhook_in_certmanagers.yaml
+  - dir: optional/cert-manager/manager/
+    src: cert-manager-operator/config/manager/
+    files:
+      - file: kustomization.yaml
+      - file: manager.yaml
+  - dir: optional/cert-manager/rbac/
+    src: cert-manager-operator/config/rbac/
+    files:
+      - file: auth_proxy_client_clusterrole.yaml
+      - file: auth_proxy_role.yaml
+      - file: auth_proxy_role_binding.yaml
+      - file: auth_proxy_service.yaml
+      - file: certmanager_editor_role.yaml
+      - file: certmanager_viewer_role.yaml
+      - file: kustomization.yaml
+      - file: leader_election_role.yaml
+      - file: leader_election_role_binding.yaml
+      - file: role.yaml
+      - file: role_binding.yaml
+      - file: service_account.yaml

--- a/scripts/auto-rebase/presubmit.py
+++ b/scripts/auto-rebase/presubmit.py
@@ -27,6 +27,7 @@ RECIPE_FILEPATHS = [
     "./scripts/auto-rebase/lvms_assets.yaml",
     "./scripts/auto-rebase/ossm_assets.yaml",
     "./scripts/auto-rebase/assets_ai_model_serving.yaml",
+    "./scripts/auto-rebase/assets_cert_manager.yaml",
 ]
 
 

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -382,8 +382,8 @@ MICROSHIFT_Y1_OPTIONAL_RPMS_LIST=(
 )
 MICROSHIFT_OPTIONAL_RPMS_LIST=(
     "${MICROSHIFT_Y1_OPTIONAL_RPMS_LIST[@]}"
+    microshift-cert-manager
 )
-
 MICROSHIFT_Y1_X86_64_RPMS_LIST=(
     microshift-ai-model-serving
     microshift-ai-model-serving-release-info

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -1,0 +1,137 @@
+*** Settings ***
+Documentation       Test suite for generating certificates using cert-manager with YAML manifests
+
+Library             Collections
+Library             OperatingSystem
+Library             String
+Resource            ../../resources/common.resource
+Resource            ../../resources/kubeconfig.resource
+Resource            ../../resources/oc.resource
+Resource            ../../resources/microshift-network.resource
+
+Suite Setup         Setup Suite With Namespace
+Suite Teardown      Teardown Suite With Namespace
+
+Test Tags           cert-manager    certificates    tls
+
+
+*** Variables ***
+${CERT_NAME}                test-certificate
+${SECRET_NAME}              test-cert-secret
+${ISSUER_NAME}              test-issuer
+${CERT_COMMON_NAME}         example.com
+${CERT_DNS_NAME}            example.com
+${CERTS_NAMESPACE}          test-certs
+${ROUTE_NAME}               hello-app
+${CERT_ISSUER_YAML}         SEPARATOR=\n
+...                         ---
+...                         apiVersion: cert-manager.io/v1
+...                         kind: ClusterIssuer
+...                         metadata:
+...                         \ \ name: ${ISSUER_NAME}
+...                         spec:
+...                         \ \ selfSigned: {}
+
+${CERT_YAML}                SEPARATOR=\n
+...                         ---
+...                         apiVersion: cert-manager.io/v1
+...                         kind: Certificate
+...                         metadata:
+...                         \ \ name: ${CERT_NAME}
+...                         \ \ namespace: ${CERTS_NAMESPACE}
+...                         spec:
+...                         \ \ secretName: ${SECRET_NAME}
+...                         \ \ issuerRef:
+...                         \ \ \ \ name: ${ISSUER_NAME}
+...                         \ \ \ \ kind: ClusterIssuer
+...                         \ \ commonName: ${CERT_COMMON_NAME}
+...                         \ \ dnsNames:
+...                         \ \ - ${CERT_DNS_NAME}
+...                         \ \ - www.${CERT_DNS_NAME}
+${INGRESS_RBAC_YAML}        SEPARATOR=\n
+...                         ---
+...                         apiVersion: rbac.authorization.k8s.io/v1
+...                         kind: Role
+...                         metadata:
+...                         \ \ name: secret-reader
+...                         \ \ namespace: ${CERTS_NAMESPACE}
+...                         rules:
+...                         - apiGroups: [""]
+...                         \ \ resources: ["secrets"]
+...                         \ \ resourceNames: ["${SECRET_NAME}"]
+...                         \ \ verbs: ["get", "list", "watch"]
+...                         ---
+...                         apiVersion: rbac.authorization.k8s.io/v1
+...                         kind: RoleBinding
+...                         metadata:
+...                         \ \ name: ingress-secret-reader
+...                         \ \ namespace: ${CERTS_NAMESPACE}
+...                         roleRef:
+...                         \ \ apiGroup: rbac.authorization.k8s.io
+...                         \ \ kind: Role
+...                         \ \ name: secret-reader
+...                         subjects:
+...                         - kind: ServiceAccount
+...                         \ \ name: router
+...                         \ \ namespace: openshift-ingress
+
+${INGRESS_ROUTE_YAML}       SEPARATOR=\n
+...                         ---
+...                         apiVersion: route.openshift.io/v1
+...                         kind: Route
+...                         metadata:
+...                         \ \ name: ${ROUTE_NAME}
+...                         \ \ namespace: ${CERTS_NAMESPACE}
+...                         spec:
+...                         \ \ port:
+...                         \ \ \ \ targetPort: 8080
+...                         \ \ tls:
+...                         \ \ \ \ externalCertificate:
+...                         \ \ \ \ \ \ name: ${SECRET_NAME}
+...                         \ \ \ \ termination: edge
+...                         \ \ to:
+...                         \ \ \ \ kind: Service
+...                         \ \ \ \ name: hello-microshift
+
+
+*** Test Cases ***
+Create Ingress route with Custom certificate
+    [Documentation]    Create route with a custom certificate
+    [Setup]    Run Keywords
+    ...    Setup Namespace
+    Apply YAML Manifest    ${CERT_ISSUER_YAML}
+    Oc Wait    -n ${CERTS_NAMESPACE} clusterissuer ${ISSUER_NAME}    --for="condition=Ready" --timeout=120s
+    Apply YAML Manifest    ${CERT_YAML}
+    Oc Wait    -n ${CERTS_NAMESPACE} certificate ${CERT_NAME}    --for="condition=Ready" --timeout=60s
+    Apply YAML Manifest    ${INGRESS_RBAC_YAML}
+    Deploy Hello MicroShift
+    Apply YAML Manifest    ${INGRESS_ROUTE_YAML}
+    Oc Wait    -n ${CERTS_NAMESPACE} route ${ROUTE_NAME}    --for=jsonpath='.status.ingress' --timeout=60s
+    [Teardown]    Run Keywords
+    ...    Remove ClusterIssuer
+
+
+*** Keywords ***
+Deploy Hello MicroShift
+    [Documentation]    Deploys the hello microshift application (service included)
+    ...    in the given namespace.
+    Create Hello MicroShift Pod
+    Expose Hello MicroShift
+
+Remove ClusterIssuer
+    [Documentation]    Remove the cluster issuer
+    Oc Delete    clusterissuer/${ISSUER_NAME}
+
+Apply YAML Manifest
+    [Documentation]    Apply YAML manifest to the cluster
+    [Arguments]    ${yaml_content}
+    ${temp_file}=    Create Random Temp File    ${yaml_content}
+    ${result}=    Run With Kubeconfig    oc apply -f ${temp_file}
+    Remove File    ${temp_file}
+    Should Contain    ${result}    created    msg=Failed to apply YAML manifest
+    Log    Applied manifest: ${result}
+
+Setup Namespace
+    [Documentation]    Setup namespace for cert-manager tests
+    Set Suite Variable    \${NAMESPACE}    ${CERTS_NAMESPACE}
+    Create Namespace    ${CERTS_NAMESPACE}


### PR DESCRIPTION
this  PR introduces:
-  cert-manager manifests , based on :
   -  `operator` - manually built  from cert-manager 1.17.0 sources (arm64 and amd64)    and pushed  to `http://quay.io/microshift/cert-manager:latest`
   -  `images` -  extracted from  opm (redhat operator catalog ) - latest relesed images 1.16.4 
-  RPM creation code
- RF tests

<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
