### PR TITLE
[release-4.19] USHIFT-5817: RHEL 9.6 upgrade scenarios

### DIFF
--- a/test/scenarios-bootc/periodics/el94-prel@el96-crel@upgrade-ok.sh
+++ b/test/scenarios-bootc/periodics/el94-prel@el96-crel@upgrade-ok.sh
@@ -9,7 +9,7 @@ scenario_create_vms() {
         echo "Image '${dest_image}' not found - skipping test"
         return 0
     fi
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel96-bootc-prel
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-prel
     launch_vm --boot_blueprint rhel94-bootc
 }
 

--- a/test/scenarios-bootc/periodics/el94-prel@el96-src@upgrade-fails-and-rolls-back.sh
+++ b/test/scenarios-bootc/periodics/el94-prel@el96-src@upgrade-fails-and-rolls-back.sh
@@ -3,8 +3,8 @@
 # Sourced from scenario.sh and uses functions defined there.
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel96-bootc-prel
-    launch_vm --boot_blueprint rhel96-bootc
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel94-bootc-prel
+    launch_vm --boot_blueprint rhel94-bootc
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
Manual backport of #5053 
See [this document](https://docs.google.com/document/d/1RGgnfqDAj74KqRP6Qm00GL0_-EKHOnGV8JOOIYOswS8/edit?tab=t.2luqyior39ky) for more information.