### PR TITLE
[release-4.18] OCPBUGS-58139: Upgrade openvswitch package to 3.5.

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -114,7 +114,8 @@ Summary: Networking components for MicroShift
 Requires: microshift = %{version}
 Obsoletes: openvswitch3.1 < 3.3
 Obsoletes: openvswitch3.3 < 3.4
-Requires: (openvswitch3.4 or openvswitch >= 3.4)
+Obsoletes: openvswitch3.4 < 3.5
+Requires: (openvswitch3.5 or openvswitch >= 3.5)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -650,6 +651,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Thu Jun 26 2025 Ilya Maximets <i.maximets@ovn.org> 4.18.z
+- Upgrade openvswitch package to 3.5.
+
 * Tue Apr 01 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.18.z
 - Add hostname package dependency to microshift RPM
 


### PR DESCRIPTION
ovn-kubernetes container image moved to OVS 3.5 in: https://github.com/openshift/ovn-kubernetes/pull/2593 as part of 4.19 to 4.18 sync: https://issues.redhat.com//browse/OCPBUGS-48710

We should keep OVS versions between microshift and ovn-k in sync.