### PR TITLE
Upgrade openvswitch package to 3.5.

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -110,7 +110,8 @@ Summary: Networking components for MicroShift
 Requires: microshift = %{version}
 Obsoletes: openvswitch3.1 < 3.3
 Obsoletes: openvswitch3.3 < 3.4
-Requires: (openvswitch3.4 or openvswitch >= 3.4)
+Obsoletes: openvswitch3.4 < 3.5
+Requires: (openvswitch3.5 or openvswitch >= 3.5)
 Requires: NetworkManager
 Requires: NetworkManager-ovs
 Requires: jq
@@ -520,6 +521,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Fri Jul 04 2025 Ilya Maximets <i.maximets@ovn.org> 4.17.z
+- Upgrade openvswitch package to 3.5.
+
 * Thu Sep 12 2024 Gregory Giguashvili <ggiguash@redhat.com> 4.17.0
 - Declare openvswitch3.3 package as obsolete to allow seemless upgrade to openvswitch3.4
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/microshift/pull/5107 due to merge conflicts in RPM changelog.

ovn-kubernetes container image moved to OVS 3.5 version for 4.17 in: https://github.com/openshift/ovn-kubernetes/pull/2647.

We should keep OVS versions between microshift and ovn-k in sync.