### PR TITLE
USHIFT-5526: Renable default config test on for the current release

### DIFF
--- a/test/scenarios-bootc/periodics/el96-crel@published-images-standard2.sh
+++ b/test/scenarios-bootc/periodics/el96-crel@published-images-standard2.sh
@@ -52,10 +52,7 @@ scenario_run_tests() {
         # Empty string means there's no EC build yet, so the test needs to be skipped.
         exit 0
     fi
-    # Until 4.19 EC starts including correct default config,
-    # the test 'MicroShift Starts Using Default Config' needs to be skipped.
     run_tests host1 \
-        --exclude defaultcfg \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard2/
 }

--- a/test/suites/standard2/configuration.robot
+++ b/test/suites/standard2/configuration.robot
@@ -57,7 +57,6 @@ MicroShift Starts Using Default Config
     ...    and prevent MicroShift from starting.
     # Copy existing config.yaml as a drop-in because it has subjectAltNames
     # required by the `Restart MicroShift` keyword (sets up required kubeconfig).
-    [Tags]    defaultcfg
     [Setup]    Run Keywords
     ...    Save Default MicroShift Config
     ...    AND


### PR DESCRIPTION
Manual revert of https://github.com/openshift/microshift/pull/4487/commits/aa1552d98563e99ed415619434014c51e8abfbe0