### PR TITLE
[release-4.18] USHIFT-5527: Revert Skip 'default config' test on crel

### DIFF
--- a/test/scenarios-bootc/periodics/el94-crel@published-images-standard2.sh
+++ b/test/scenarios-bootc/periodics/el94-crel@published-images-standard2.sh
@@ -43,10 +43,7 @@ scenario_run_tests() {
         # TODO: While 4.19-ec is not available, it needs to exit without an error.
         exit 0
     fi
-    # Until 4.19 EC starts including correct default config,
-    # the test 'MicroShift Starts Using Default Config' needs to be skipped.
     run_tests host1 \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
-        --exclude defaultcfg \
         suites/standard2/
 }

--- a/test/suites/standard2/configuration.robot
+++ b/test/suites/standard2/configuration.robot
@@ -56,7 +56,6 @@ MicroShift Starts Using Default Config
     ...    and prevent MicroShift from starting.
     # Copy existing config.yaml as a drop-in because it has subjectAltNames
     # required by the `Restart MicroShift` keyword (sets up required kubeconfig).
-    [Tags]    defaultcfg
     [Setup]    Run Keywords
     ...    Save Default MicroShift Config
     ...    AND


### PR DESCRIPTION
Revert of the 8ddd520d470301d31c6f6e6f6f408a3591e27e44 commit