### PR TITLE
USHIFT-5897: Observability test: remove debug exporter and journal log matching

### DIFF
--- a/test/assets/observability/otel_config.yaml
+++ b/test/assets/observability/otel_config.yaml
@@ -49,7 +49,6 @@ processors:
         value: kube_events
 
 exporters:
-  debug: # exports metrics only in journalctl log
   prometheus:
     endpoint: "[{{NODE_IP}}]:{{PROM_EXPORTER_PORT}}"
     send_timestamps: true
@@ -69,15 +68,15 @@ service:
     metrics/hostmetrics:
       receivers: [ hostmetrics ]
       processors: [ resourcedetection/system ]
-      exporters: [ debug, prometheus, prometheusremotewrite ]
+      exporters: [ prometheus, prometheusremotewrite ]
     metrics/kubeletstats:
       receivers: [ kubeletstats ]
-      exporters: [ debug, prometheus, prometheusremotewrite ]
+      exporters: [ prometheus, prometheusremotewrite ]
     logs/journald:
       receivers: [ journald ]
       processors: [ batch, resource/journald ]
-      exporters: [ debug, loki ]
+      exporters: [ loki ]
     logs/kube_events:
       receivers: [ k8s_events ]
       processors: [ batch, resource/kube_events ]
-      exporters: [ debug, loki ]
+      exporters: [ loki ]

--- a/test/suites/optional/observability.robot
+++ b/test/suites/optional/observability.robot
@@ -27,22 +27,12 @@ ${TEST_CONFIG_PATH}         assets/observability/otel_config.yaml
 Host Metrics Are Exported
     [Documentation]    The opentelemetry-collector should be able to export host metrics.
 
-    ${pattern}    Catenate    SEPARATOR=
-    ...    info\\s+MetricsExporter\\s+{"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics":
-    ...    \ [0-9]+, "metrics": [0-9]+, "data points": [0-9]+}
-    Pattern Should Appear In Log Output    ${JOURNAL_CUR}    ${pattern}    unit="microshift-observability"
-
     Set Test Variable    ${METRIC}    system_cpu_time_seconds_total{cpu="cpu0",state="idle"}
     Check Prometheus Query    ${PROMETHEUS_HOST}    ${PROMETHEUS_PORT}    ${METRIC}
     Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    ${METRIC}
 
 Kube Metrics Are Exported
     [Documentation]    The opentelemetry-collector should be able to export kube metrics.
-
-    ${pattern}    Catenate    SEPARATOR=
-    ...    info\\s+MetricsExporter\\s+{"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics":
-    ...    \ [0-9]+, "metrics": [0-9]+, "data points": [0-9]+}
-    Pattern Should Appear In Log Output    ${JOURNAL_CUR}    ${pattern}    unit="microshift-observability"
 
     Set Test Variable    ${METRIC}    container_cpu_time_seconds_total
     Check Prometheus Query    ${PROMETHEUS_HOST}    ${PROMETHEUS_PORT}    ${METRIC}
@@ -53,24 +43,12 @@ Kube Metrics Are Exported
     Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    ${METRIC}
 
 Journald Logs Are Exported
-    [Documentation]    The opentelemetry-collector should be able to export logs to journald.
-
-    ${pattern}    Catenate
-    ...    SEPARATOR=
-    ...    info\\s+LogsExporter\\s+\\{"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": [0-9]+,
-    ...    \ "log records": [0-9]+\\}
-    Pattern Should Appear In Log Output    ${JOURNAL_CUR}    ${pattern}    unit="microshift-observability"
+    [Documentation]    The opentelemetry-collector should be able to export journald logs.
 
     Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {job="journald",exporter="OTLP"}
 
 Kube Events Logs Are Exported
-    [Documentation]    The opentelemetry-collector should be able to export logs to journald.
-
-    ${pattern}    Catenate
-    ...    SEPARATOR=
-    ...    info\\s+LogsExporter\\s+\\{"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": [0-9]+,
-    ...    \ "log records": [0-9]+\\}
-    Pattern Should Appear In Log Output    ${JOURNAL_CUR}    ${pattern}    unit="microshift-observability"
+    [Documentation]    The opentelemetry-collector should be able to export Kubernetes events.
 
     Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {job="kube_events",exporter="OTLP"}
 
@@ -94,8 +72,6 @@ Setup Suite And Prepare Test Host
     Set Test OTEL Configuration
     ${cur}    Get Journal Cursor    unit=microshift-observability
     Set Suite Variable    ${JOURNAL_CUR}    ${cur}
-    Wait Until Keyword Succeeds    5 min    10 sec
-    ...    Journal Contains Enough Lines To Test
 
 Check Required Observability Variables
     [Documentation]    Check if the required proxy variables are set
@@ -107,16 +83,6 @@ Check Required Observability Variables
     Should Not Be Empty    ${string_value}    LOKI_PORT variable is required
     ${string_value}    Convert To String    ${PROM_EXPORTER_PORT}
     Should Not Be Empty    ${string_value}    PROM_EXPORTER_PORT variable is required
-
-Journal Contains Enough Lines To Test
-    [Documentation]    Execution should wait until there are at least 20 lines of journal data to process. This is
-    ...    necessary because opentelemetry-collector will write debug output in batches. Thus, it can often happen
-    ...    that there is not enough log data to gain an accurate read of the process's state, resulting in a false
-    ...    negative signal (the opentelemetry-collector is healthy, but did not yet write data to journal.
-
-    ${output}    ${rc}    Get Log Output With Pattern    ${JOURNAL_CUR}    .*    microshift-observability
-    ${line_cnt}    Get Line Count    ${output}
-    Should Be True    ${line_cnt} > 20
 
 Set Test OTEL Configuration
     [Documentation]    Set Test OTEL Configuration


### PR DESCRIPTION
centos9 observability test started failing with what appears to be changed logging schema. Because we already have verification of the exporters' capabilities in form of querying Loki and Prometheus, we can remove the journal log matching.