### PR TITLE
OCPNODE-3467: Remove containernetworking-plugins dependencies from crio.conf

### DIFF
--- a/packaging/crio.conf.d/10-microshift_amd64.conf
+++ b/packaging/crio.conf.d/10-microshift_amd64.conf
@@ -16,7 +16,6 @@ absent_mount_sources_to_reject = [
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
-        "/usr/libexec/cni",
         "/run/cni/bin"
 ]
 

--- a/packaging/crio.conf.d/10-microshift_arm64.conf
+++ b/packaging/crio.conf.d/10-microshift_arm64.conf
@@ -16,7 +16,6 @@ absent_mount_sources_to_reject = [
 [crio.network]
 # rhel8 crio is configured to only look at /usr/libexec/cni, we override that here
 plugin_dirs = [
-        "/usr/libexec/cni",
         "/run/cni/bin"
 ]
 

--- a/packaging/crio.conf.d/12-microshift-multus.conf
+++ b/packaging/crio.conf.d/12-microshift-multus.conf
@@ -2,9 +2,6 @@
 # Override default network so CRI-O waits for and calls Multus CNI instead of ovn-kubernetes.
 cni_default_network = "multus-cni-network"
 
-# Change the order, so the CNIs from the container-networking-plugins (copied to host's /run/cni/bin)
-# are picked over CNIs from containernetworking-plugins RPM (which a dependency of CRI-O).
 plugin_dirs = [
         "/run/cni/bin",
-        "/usr/libexec/cni"
 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #OCPNODE-3467

Since RHEL has dropped the containernetworking-plugins package because podman stopped using it, cri-o is also going to install it as a dependency.
cri-o already stopped using containernetworking-plugins, so we remove dependencies from crio.conf as well.