### PR TITLE
NO-ISSUE: kindnet: Add plugin dir for crio config

### DIFF
--- a/packaging/crio.conf.d/13-microshift-kindnet.conf
+++ b/packaging/crio.conf.d/13-microshift-kindnet.conf
@@ -2,3 +2,7 @@
 # kindnet is the name configured by kindnet in /etc/cni/net.d/ config file
 # by declaring this CRI-O will wait until that network is configured.
 cni_default_network = "kindnet"
+plugin_dirs = [
+        "/usr/libexec/cni",
+        "/run/cni/bin"
+]


### PR DESCRIPTION
With https://github.com/openshift/microshift/pull/5186 "/usr/libexec/cni" is removed from plugin dir which makes kindnet to failed since it checks the plugins from that directory. This pr should add it back only for kindnet usecase.

