### PR TITLE
USHIFT-1669: remove firewalld  iptables flushing workaround

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -400,16 +400,6 @@ install -p -m644 packaging/systemd/microshift-ovs-init.service %{buildroot}%{_un
 install -p -m755 packaging/systemd/configure-ovs.sh %{buildroot}%{_bindir}/configure-ovs.sh
 install -p -m755 packaging/systemd/configure-ovs-microshift.sh %{buildroot}%{_bindir}/configure-ovs-microshift.sh
 
-# Avoid firewalld manipulation and flushing of iptable rules,
-# this is a workaround for https://issues.redhat.com/browse/NP-641
-# It will trigger some warnings on the selinux audit log when restarting firewalld.
-# In the future firewalld should stop flushing iptables unless we use any firewalld rule with direct
-# iptables rules, once that's available in RHEL we can remove this workaround
-# see https://github.com/firewalld/firewalld/issues/863#issuecomment-1407059938
-
-mkdir -p -m755 %{buildroot}%{_sysconfdir}/systemd/system/firewalld.service.d
-install -p -m644 packaging/systemd/firewalld-no-iptables.conf %{buildroot}%{_sysconfdir}/systemd/system/firewalld.service.d/firewalld-no-iptables.conf
-
 mkdir -p -m755 %{buildroot}/var/lib/kubelet/pods
 
 install -d %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}
@@ -727,7 +717,6 @@ fi
 %{_sysconfdir}/crio/crio.conf.d/11-microshift-ovn.conf
 %{_sysconfdir}/systemd/system/ovs-vswitchd.service.d/microshift-cpuaffinity.conf
 %{_sysconfdir}/systemd/system/ovsdb-server.service.d/microshift-cpuaffinity.conf
-%{_sysconfdir}/systemd/system/firewalld.service.d/firewalld-no-iptables.conf
 
 # OpensvSwitch oneshot configuration script which handles ovn-k8s gateway mode setup
 %{_unitdir}/microshift-ovs-init.service
@@ -828,6 +817,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Wed Aug 06 2025 Evgeny Slutsky <eslutsky@rehat.com> 4.20.0
+- Remove firewalld service override configuration to avoid flushing of iptables
+
 * Thu Jul 24 2025 Evgeny Slutsky <eslutsky@redhat.com> 4.20.0
 - Update microshift-cert-manager with greenboot script
 

--- a/packaging/systemd/firewalld-no-iptables.conf
+++ b/packaging/systemd/firewalld-no-iptables.conf
@@ -1,3 +1,0 @@
-# This override avoids firewalld flushing of iptables
-[Service]
-InaccessiblePaths=/usr/sbin/xtables-nft-multi


### PR DESCRIPTION
since  RHEL9.3  with  `Firewalld 1.2.5-1` that includes that fix https://github.com/firewalld/firewalld/pull/1082,

```
[root@i-0f3d2b2a517dceaa9 ~]#  rpm -q --changelog firewalld
* Thu Oct 26 2023 Eric Garver <egarver@redhat.com> - 1.3.4-1
- package rebase to v1.3.4

* Mon Apr 24 2023 Eric Garver <egarver@redhat.com> - 1.2.5-1
- package rebase to v1.2.5
- feat(direct): avoid iptables flush if using nftables backend

```
- can be verified with reloading firewall and verifying   that the nodeport still exists in the iptables.
```
# oc get service -n openshift-ingress
NAME                      TYPE           CLUSTER-IP      EXTERNAL-IP                         PORT(S)                      AGE
router-default            LoadBalancer   10.43.22.136    10.192.10.240,10.42.0.2,10.44.0.0   80:31742/TCP,443:30090/TCP   41h
router-internal-default   ClusterIP      10.43.100.179   <none>                              80/TCP,443/TCP,1936/TCP      41h

# firewall-cmd --reload
# iptables-save | grep 31742
-A OVN-KUBE-ETP -d 10.44.0.0/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 169.254.169.3:31742
-A OVN-KUBE-ETP -d 10.42.0.2/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 169.254.169.3:31742
-A OVN-KUBE-ETP -d 10.192.10.240/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 169.254.169.3:31742
-A OVN-KUBE-ETP -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 31742 -j DNAT --to-destination 169.254.169.3:31742
-A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 31742 -j DNAT --to-destination 10.43.22.136:80



```