### PR TITLE
USHIFT-5723: Add test to verify count in GDP config

### DIFF
--- a/test/assets/generic-device-plugin/fuse-test-pod.yaml
+++ b/test/assets/generic-device-plugin/fuse-test-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fuse-test-pod
+spec:
+  containers:
+  - name: fuse-app-container
+    image: registry.access.redhat.com/ubi9/ubi:9.6
+    command: ["sleep", "infinity"]
+    resources:
+      limits:
+        device.microshift.io/fuse: "4"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: "RuntimeDefault"

--- a/test/suites/optional/strings.py
+++ b/test/suites/optional/strings.py
@@ -29,6 +29,18 @@ genericDevicePlugin:
              - path: /dev/ttyUSB*
 '''
 
+GDP_CONFIG_FUSE_COUNT = '''
+genericDevicePlugin:
+  status: Enabled
+  devices:
+     - name: fuse
+       groups:
+         - count: 10
+           paths:
+             - path: /dev/fuse
+'''
+
+
 CONFIGMAP_PREAMBLE = '''
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**: Verify a Pod can request multiple instances of a device when count is specified in the GDP configuration.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
