### PR TITLE
USHIFT-5746: Allow `healthcheck` to be executed by non-root users

### DIFF
--- a/pkg/cmd/healthcheck.go
+++ b/pkg/cmd/healthcheck.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/openshift/microshift/pkg/healthcheck"
@@ -40,10 +39,6 @@ Checking health of a custom workloads can be achieved in two ways:
 `,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if os.Geteuid() > 0 {
-				return fmt.Errorf("command must be run with root privileges")
-			}
-
 			if namespace != "" && custom != "" {
 				return fmt.Errorf("only --namespace or --custom can be provided")
 			}


### PR DESCRIPTION
If runs as regular user attempts to use file defined by KUBECONFIG env var or `~/.kube/config`.