### PR TITLE
USHIFT-5984: Rollup of Ansible script updates as of MicroShift 4.19

### DIFF
--- a/ansible/roles/add-kubelet-logging/tasks/main.yml
+++ b/ansible/roles/add-kubelet-logging/tasks/main.yml
@@ -1,45 +1,48 @@
 ---
 # add-kubelet-logging tasks
 
-- name: check to ensure promdir target exists
+- name: Check to ensure promdir target exists
   ansible.builtin.stat:
     path: "{{ prometheus_dir }}"
   register: promdir
 
-- name: check if the file exists
+- name: Check if the file exists
   ansible.builtin.stat:
     path: "{{ sa_token_file }}"
   register: token_file
 
-- block:
-  - name: load sa-token file from localhost
-    ansible.builtin.slurp:
-      src: "{{ sa_token_file }}"
-    register: bearer_token_slurp
-    delegate_to: localhost
-
-  - name: decode bearer token
-    set_fact:
-      bearer_token: "{{ bearer_token_slurp.content | b64decode }}"
-
-  - name: create metrics service account token file in prometheus folder
-    ansible.builtin.copy:
-      content: "{{ bearer_token }}"
-      dest: "{{ kubelet_auth_token_file }}"
-    when: promdir.stat.exists
-
-  - name: remove the sa-token file
-    ansible.builtin.file:
-      path: "{{ sa_token_file }}"
-      state: absent
+- name: Deal with metrics service account token file
   when: token_file.stat.exists
+  block:
+    - name: Load sa-token file from localhost
+      ansible.builtin.slurp:
+        src: "{{ sa_token_file }}"
+      register: bearer_token_slurp
+      delegate_to: localhost
 
-- name: append kubelet scrape config target to prometheus config
+    - name: Decode bearer token
+      ansible.builtin.set_fact:
+        bearer_token: "{{ bearer_token_slurp.content | b64decode }}"
+
+    - name: Create metrics service account token file in prometheus folder
+      ansible.builtin.copy:
+        content: "{{ bearer_token }}"
+        dest: "{{ kubelet_auth_token_file }}"
+        mode: '0644'
+      when: promdir.stat.exists
+
+    - name: Remove the sa-token file
+      ansible.builtin.file:
+        path: "{{ sa_token_file }}"
+        state: absent
+
+- name: Append kubelet scrape config target to prometheus config
   ansible.builtin.blockinfile:
     path: "{{ prometheus_config }}"
     block: |
       # kubelet targets
-        - job_name: kubelet
+      {% for host in groups['microshift'] %}
+        - job_name: kubelet-{{ host }}
           scheme: https
           authorization:
             credentials_file: "{{ kubelet_auth_token_file }}"
@@ -47,9 +50,9 @@
             insecure_skip_verify: true
           static_configs:
             - targets:
-              - microshift-dev:10250
+              - {{ hostvars[host].ansible_host }}:10250
 
-        - job_name: kubelet cadvisor
+        - job_name: kubelet-{{ host }}-cadvisor
           scheme: https
           authorization:
             credentials_file: "{{ kubelet_auth_token_file }}"
@@ -58,9 +61,10 @@
           metrics_path: /metrics/cadvisor
           static_configs:
             - targets:
-              - microshift-dev:10250
+              - {{ hostvars[host].ansible_host }}:10250
+      {% endfor %}
 
-- name: restart prometheus to pick up new target
+- name: Restart prometheus to pick up new target
   ansible.builtin.systemd:
     state: restarted
     name: prometheus

--- a/ansible/roles/common/tasks/boot.yml
+++ b/ansible/roles/common/tasks/boot.yml
@@ -1,6 +1,11 @@
 ---
 # common microshift boot start time script
 
+# Include shared microshift version configuration
+- name: Include shared microshift version configuration
+  include_vars:
+    file: "{{ playbook_dir }}/vars/microshift_versions.yml"
+
 - block:
   - name: find microshift cleanup script
     ansible.builtin.find:
@@ -16,13 +21,13 @@
       microshift_cleanup_bin: "{{ find_cleanup.files[0].path if find_cleanup.files }}"
 
   - name: cleanup microshift data
-    become: yes
+    become: true
     ansible.builtin.shell: echo 1 | {{ microshift_cleanup_bin }} --all
   when: cleanup_microshift | default('false') | bool
 
 - block:
   - name: reboot machine
-    become: yes
+    become: true
     ansible.builtin.reboot:
       reboot_timeout: 600
   
@@ -31,9 +36,26 @@
       seconds: 60
   when: reboot | default('false') | bool
 
+- name: Extract major version for pod counts
+  set_fact:
+    microshift_major_version: "{{ microshift_version.split('.')[:2] | join('.') }}"
+
+- name: Validate that version exists in config
+  fail:
+    msg: "Error: MicroShift version {{ microshift_major_version }} not found in microshift_versions dictionary. Please update the defaults/main.yml file."
+  when: microshift_major_version not in microshift_versions
+
+- name: Set expected pod counts
+  set_fact:
+    expected_pods: "{{ microshift_versions[microshift_major_version].expected_pods }}"
+    all_pods: "{{ microshift_versions[microshift_major_version].all_pods }}"
+
 - name: run the microshift boot script
   ansible.builtin.script:
-    cmd: ready.sh
+    cmd: >
+      ready.sh
+      {{ expected_pods }}
+      {{ all_pods }}
   register: script_output
 
 - name: display script output

--- a/ansible/roles/configure-firewall/defaults/main.yml
+++ b/ansible/roles/configure-firewall/defaults/main.yml
@@ -27,4 +27,5 @@ firewall_ports:
 firewall_trusted_cidr:
   - 10.42.0.0/16
   - 169.254.169.1/32
+  - fd01::/48
 

--- a/ansible/roles/install-logging/defaults/main.yml
+++ b/ansible/roles/install-logging/defaults/main.yml
@@ -12,6 +12,7 @@ logging_services:
 grafana_setup: false
 grafana_username: admin
 grafana_password: admin
+grafana_host_address: "192.168.1.100"
 grafana_port: 3000
 
 prometheus_port: 9091

--- a/ansible/roles/install-logging/files/microshift_perf.json
+++ b/ansible/roles/install-logging/files/microshift_perf.json
@@ -60,9 +60,22 @@
   "liveNow": false,
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Node Metrics",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+	"uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -76,7 +89,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -112,23 +125,277 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 13,
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (mode)(irate(node_cpu_seconds_total{job=~\".*\"}[$interval]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_Active_bytes",
+          "legendFormat": "Active",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemTotal_bytes",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes",
+          "hide": false,
+          "legendFormat": "Cached + Buffers",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemAvailable_bytes",
+          "hide": false,
+          "legendFormat": "Available",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Node Memory",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 9
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Process Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 10
       },
       "id": 2,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -142,7 +409,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(groupname) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"conmon|crio|coredns|csi.*|haproxy|kube-rbac-proxy|livenessprobe|lvmd|microshift|openshift-route|ovn.*|ovs.*|service-ca-oper|topolvm.*\"}[$__interval]))) * 100",
+          "expr": "topk(20, sum by(groupname) (irate(namedprocess_namegroup_cpu_seconds_total{groupname!~\"auditd|bash|crond|dbus.*|dnf|sshd|systemd.*|process-.*|prometheus.*|vnstat.*\"}[$interval]))) > 0",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -168,7 +435,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -204,23 +471,30 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "decmbytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 13,
-        "w": 24,
-        "x": 0,
-        "y": 13
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 10
       },
       "id": 4,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -234,7 +508,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by(groupname) (namedprocess_namegroup_memory_bytes{groupname=~\"conmon|crio|coredns|csi.*|haproxy|kube-rbac-proxy|livenessprobe|lvmd|microshift|openshift-route|ovn.*|ovs.*|service-ca-oper|topolvm.*\",memtype=\"resident\"}) / 1024 / 1024)",
+          "expr": "topk(12, sum by(groupname) (namedprocess_namegroup_memory_bytes{groupname!~\"auditd|bash|crond|dbus.*|sshd|systemd.*|process-.*|prometheus.*|vnstat.*\",memtype=\"resident\"}) / 1024 / 1024)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -260,7 +534,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -296,23 +570,30 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 22
       },
       "id": 6,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -326,7 +607,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"ov.*\"}[$__interval])) * 100",
+          "expr": "sum by(job) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"ov.*\"}[$interval]))",
           "legendFormat": "cni",
           "range": true,
           "refId": "A"
@@ -337,7 +618,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"csi.*|topo.*|lvmd|livenessprobe\"}[$__interval])) * 100",
+          "expr": "sum by(job) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"csi.*|topo.*|lvmd|livenessprobe\"}[$interval]))",
           "hide": false,
           "legendFormat": "csi",
           "range": true,
@@ -349,7 +630,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"haproxy|openshift-route\"}[$__interval])) * 100",
+          "expr": "sum by(job) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"haproxy|openshift-route\"}[$interval]))",
           "hide": false,
           "legendFormat": "ingress",
           "range": true,
@@ -361,7 +642,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"coredns|kube-rbac-proxy\"}[$__interval])) * 100",
+          "expr": "sum by(job) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"coredns|kube-rbac-proxy\"}[$interval]))",
           "hide": false,
           "legendFormat": "dns",
           "range": true,
@@ -373,7 +654,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"service-ca-oper\"}[$__interval])) * 100",
+          "expr": "sum by(job) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"service-ca-oper\"}[$interval]))",
           "hide": false,
           "legendFormat": "service-ca",
           "range": true,
@@ -385,7 +666,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"microshift\"}[$__interval])) * 100",
+          "expr": "sum by(job) (irate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"microshift\"}[$interval]))",
           "hide": false,
           "legendFormat": "microshift",
           "range": true,
@@ -397,7 +678,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"crio|conmon\"}[$__interval])) * 100",
+          "expr": "sum by(job) (rate(namedprocess_namegroup_cpu_seconds_total{groupname=~\"crio|conmon\"}[$interval]))",
           "hide": false,
           "legendFormat": "runtime",
           "range": true,
@@ -424,7 +705,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -460,23 +741,30 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "decmbytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 22
       },
       "id": 8,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -588,7 +876,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -616,14 +904,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "decmbytes"
         },
         "overrides": []
       },
@@ -631,15 +921,21 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 32
       },
       "id": 10,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -666,6 +962,1130 @@
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(groupname) (namedprocess_namegroup_memory_bytes{groupname=~\"csi.*|topo.*|lvmd|livenessprobe\", memtype=\"resident\"}) / 1024 / 1024",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CSI RSS Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 39,
+      "panels": [],
+      "title": "Container Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,sum(irate(container_cpu_usage_seconds_total{container!=\"\",namespace!=\"\"}[1m])) by (pod,container,namespace))",
+          "legendFormat": "{{ pod }}: {{container}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, container_memory_rss{container!=\"\",namespace!=\"\"})",
+          "hide": false,
+          "legendFormat": "{{pod}}: {{container}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Container Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "irate(container_runtime_crio_operations_latency_seconds[$interval])",
+          "hide": false,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Container Runtime Operations Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(container_runtime_crio_operations_latency_seconds_total{quantile=\"0.99\"}[$interval]) > 0",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Container Runtime Operations Latency (99th pct)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Kubelet Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "yellow",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,irate(process_cpu_seconds_total[$interval]))",
+          "legendFormat": "{{ job }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,process_resident_memory_bytes)",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 30,
+      "panels": [],
+      "title": "API Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{subresource!=\"log\",verb!~\"WATCH|WATCHLIST|PROXY\"}[$interval])) by(verb,le))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Duration (99th latency)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 67
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{verb=~\"POST|PUT|DELETE|PATCH\", subresource!~\"log|exec|portforward|attach|proxy\"}[$interval])) by (le, resource, verb, scope)) > 0",
+          "legendFormat": "{{verb}} {{resource}} {{scope}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mutating API Call (99th latency)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{component=\"apiserver\",verb=~\"LIST|GET\", subresource!~\"log|exec|portforward|attach|proxy\"}[$interval])) by (resource, le, verb)) > 0",
+          "legendFormat": "{{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Read Only API Calls (Resource, 99th latency)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(apiserver_request_total{verb!=\"WATCH\"}[$interval])) by (verb,resource,code) > 0",
+          "legendFormat": "{{verb}} {{resource}} {{code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -707,30 +2127,37 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 34
+        "x": 0,
+        "y": 83
       },
-      "id": 12,
+      "id": 35,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -741,28 +2168,127 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+	    "uid": "${DS_PROMETHEUS}"
           },
-          "editorMode": "builder",
-          "expr": "sum by(groupname) (namedprocess_namegroup_memory_bytes{groupname=~\"csi.*|topo.*|lvmd|livenessprobe\", memtype=\"resident\"}) / 1024 / 1024",
-          "legendFormat": "__auto",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{component=\"apiserver\", scope=\"namespace\", verb=~\"LIST|GET\", subresource!~\"log|exec|portforward|attach|proxy\"}[$interval])) by (le, resource, verb)) > 0",
+          "legendFormat": "{{verb}} {{resource}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "CSI RSS Usage",
+      "title": "Read Only API Calls (Namespace, 99th latency)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+	"uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 83
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+	    "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{component=\"apiserver\", scope=\"cluster\", verb=~\"LIST|GET\", subresource!~\"log|exec|portforward|attach|proxy\"}[$interval])) by (le, resource, verb)) > 0",
+          "legendFormat": "{{verb}} {{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Read Only API Calls (Cluster, 99th latency)",
       "type": "timeseries"
     }
   ],
   "refresh": false,
-  "schemaVersion": 37,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus",
           "value": "Prometheus"
         },
@@ -777,6 +2303,65 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "30s",
+          "value": "30s"
+        },
+        "hide": 0,
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "10s",
+            "value": "10s"
+          },
+          {
+            "selected": true,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "3m",
+            "value": "3m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          }
+        ],
+        "query": "10s,30s,1m,3m,5m,10m,30m,1h",
+        "queryValue": "",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
       }
     ]
   },
@@ -788,6 +2373,6 @@
   "timezone": "",
   "title": "MicroShift Perf",
   "uid": "_eYa3wVVk",
-  "version": 1,
+  "version": 51,
   "weekStart": ""
 }

--- a/ansible/roles/install-logging/tasks/main.yml
+++ b/ansible/roles/install-logging/tasks/main.yml
@@ -1,73 +1,75 @@
 ---
 # install-logging tasks
 
-- name: rpm tasks
+- name: RPM tasks
+  when: (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat") or (ansible_distribution == "Fedora")
   block:
-    - name: install prometheus & grafana
+    - name: Install prometheus & grafana
       ansible.builtin.dnf:
         name: "{{ logging_packages }}"
         state: present
         update_cache: true
 
-    - name: check that the prometheus cli vars file exists
+    - name: Check that the prometheus cli vars file exists
       ansible.builtin.stat:
         path: "{{ prometheus_vars_file }}"
       register: prometheus_vars
 
-    - name: set prometheus args to change listen port
+    - name: Set prometheus args to change listen port
       ansible.builtin.replace:
         path: "{{ prometheus_vars_file }}"
         regexp: "ARGS=''"
         replace: "ARGS='--web.listen-address=0.0.0.0:{{ prometheus_port }}'"
       when: prometheus_vars.stat.exists
-  when: (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat") or (ansible_distribution == "Fedora")
 
-- name: copy prometheus config
+- name: Copy prometheus config
   ansible.builtin.template:
     src: prometheus.yml.j2
     dest: /etc/prometheus/prometheus.yml
+    mode: '0640'
     backup: true
 
-- name: start and enable prometheus & grafana service(s)
+- name: Start and enable prometheus & grafana service(s)
   ansible.builtin.systemd:
     name: "{{ item }}"
     state: restarted
-    enabled: yes
+    enabled: true
   loop: "{{ logging_services }}"
 
-- block:
-  - name: get content of microshift grafana dashboard
-    ansible.builtin.set_fact:
-      microshift_dashboard: "{{ lookup('ansible.builtin.file', 'microshift_perf.json') }}"
-
-  # The following URI commands fail without accessing some external network
-  - name: wake up network access
-    ansible.builtin.command: curl github.com
-
-  - name: create prometheus datasource in grafana
-    ansible.builtin.uri:
-      url: http://{{ ansible_default_ipv4.address }}:{{ grafana_port }}/api/datasources
-      url_username: "{{ grafana_username }}"
-      url_password: "{{ grafana_password }}"
-      status_code: [200, 409]
-      force_basic_auth: yes
-      method: POST
-      body_format: json
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      body: "{{ lookup('ansible.builtin.template', 'prometheus_datasource.json.j2') }}"
-
-  - name: create microshift perf dashboard in grafana
-    ansible.builtin.uri:
-      url: http://{{ ansible_default_ipv4.address }}:{{ grafana_port }}/api/dashboards/db
-      url_username: "{{ grafana_username }}"
-      url_password: "{{ grafana_password }}"
-      force_basic_auth: yes
-      method: POST
-      body_format: json
-      headers:
-        Accept: application/json
-        Content-Type: application/json
-      body: "{{ lookup('ansible.builtin.template', 'grafana_dashboard.json.j2') }}"
+- name: Configure Grafana dashboards and datasources
   when: grafana_setup
+  block:
+    - name: Get content of microshift grafana dashboard
+      ansible.builtin.set_fact:
+        microshift_dashboard: "{{ lookup('ansible.builtin.file', 'microshift_perf.json') }}"
+
+    # The following URI commands fail without accessing some external network
+    - name: Wake up network access
+      ansible.builtin.command: curl github.com
+
+    - name: Create prometheus datasource in grafana
+      ansible.builtin.uri:
+        url: http://{{ grafana_host_address | default(ansible_default_ipv4.address) }}:{{ grafana_port }}/api/datasources
+        url_username: "{{ grafana_username }}"
+        url_password: "{{ grafana_password }}"
+        status_code: [200, 409]
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        body: "{{ lookup('ansible.builtin.template', 'prometheus_datasource.json.j2') }}"
+
+    - name: Create microshift perf dashboard in grafana
+      ansible.builtin.uri:
+        url: http://{{ grafana_host_address | default(ansible_default_ipv4.address) }}:{{ grafana_port }}/api/dashboards/db
+        url_username: "{{ grafana_username }}"
+        url_password: "{{ grafana_password }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        headers:
+          Accept: application/json
+          Content-Type: application/json
+        body: "{{ lookup('ansible.builtin.template', 'grafana_dashboard.json.j2') }}"

--- a/ansible/roles/manage-repos/defaults/main.yml
+++ b/ansible/roles/manage-repos/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # manage-repos default vars
 
-microshift_version: 4.18.0-rc.3
+microshift_version: 4.19
 ocp_version: "{{ microshift_version.split('.')[0] }}.{{ microshift_version.split('.')[1] }}"
 repo_list:
   - { repo_name: 'microshift-{{ ocp_version }}-for-rhel-{{ ansible_distribution_major_version }}-mirrorbeta-{{ ansible_architecture }}-rpms', repo_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/microshift/ocp/{{ microshift_version }}/el9/os/"}

--- a/ansible/roles/manage-repos/tasks/create-mirrors.yaml
+++ b/ansible/roles/manage-repos/tasks/create-mirrors.yaml
@@ -1,13 +1,14 @@
-- name: create mirrors block
+- name: Create mirrors block
   block:
-    - name: check if microshift_version is valid for pre-release
+    - name: Check if microshift_version is valid for pre-release
       ansible.builtin.uri:
         url: "{{ item.repo_url }}"
         method: GET
         status_code: 200
         timeout: 5
 
-    - name: install microshift mirror repo for pre-releases
+    - name: Install microshift mirror repo for pre-releases
       ansible.builtin.template:
         src: ocpbeta.repo.j2
         dest: "/etc/yum.repos.d/{{ item.repo_name }}.repo"
+        mode: '0644'

--- a/ansible/roles/manage-repos/tasks/main.yml
+++ b/ansible/roles/manage-repos/tasks/main.yml
@@ -5,62 +5,62 @@
   block:
   - name: subscription-manager tasks
     block:
-      - name: check if we have subscription-manager installed
+      - name: Check if we have subscription-manager installed
         ansible.builtin.command: which subscription-manager
         register: sm_present
         ignore_errors: true
 
-      - name: install subscription-manager
+      - name: Install subscription-manager
         ansible.builtin.dnf:
           name:
           - subscription-manager
         when: sm_present.rc != 0
 
-      - name: register host with subscription manager
+      - name: Register host with subscription manager
         community.general.redhat_subscription:
           state: present
           username: "{{ rhel_username }}"
           password: "{{ rhel_password }}"
 
-      - name: enable repo management from subscription-manager
+      - name: Enable repo management from subscription-manager
         ansible.builtin.command: subscription-manager config --rhsm.manage_repos=1
     when: manage_subscription
 
-  - name: slurp redhat-release
+  - name: Slurp redhat-release
     ansible.builtin.slurp:
       src: /etc/redhat-release
     register: redhat_release_slurp
 
-  - name: set beta release of RHEL
+  - name: Set beta release of RHEL
     ansible.builtin.set_fact:
       rhel_beta: beta-
     when: "'Beta' in (redhat_release_slurp['content'] | b64decode)"
 
-  - name: set microshift_prerelease if microshift_version is a prerelease
+  - name: Set microshift_prerelease if microshift_version is a prerelease
     ansible.builtin.set_fact:
       microshift_prerelease: "{{ 'rc' in microshift_version or 'ec' in microshift_version }}"
 
-  - name: create microshift prerelease mirrors
+  - name: Create microshift prerelease mirrors
     include_tasks: roles/manage-repos/tasks/create-mirrors.yaml
     loop: "{{ repo_list }}"
     when:
       - microshift_prerelease
       - not build_microshift
 
-  - name: enable required repos for microshift
+  - name: Enable required repos for microshift
     community.general.rhsm_repository:
       name: "{{ rhel_repos }}"
     when:
       - not microshift_prerelease
 
-  - name: install EPEL repo
+  - name: Install EPEL repo
     ansible.builtin.dnf:
       name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
       disable_gpg_check: true
       state: present
   when: ansible_distribution == "RedHat"
 
-- name: gather the package facts
+- name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto
 

--- a/ansible/roles/run-workloads/defaults/main.yml
+++ b/ansible/roles/run-workloads/defaults/main.yml
@@ -7,10 +7,8 @@ tarball_name: "kube-burner-0.14.2-Linux-x86_64.tar.gz"
 e2e_path: "{{ temp_dest }}/e2e-benchmarking"
 e2e_repo: "https://github.com/cloud-bulldozer/e2e-benchmarking.git"
 local_tarball_path: "{{ temp_dest }}/{{ tarball_name }}"
-kube_burner_burst: 10
 kube_burner_indexing: false
 kube_burner_pod_ready: "10000ms"
-kube_burner_qps: 10
 kube_burner_url: "https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.14.2/{{ tarball_name }}"
 pre_delete_pause_duration: 60
 post_run_pause_duration: 180
@@ -18,6 +16,23 @@ delete_grace_period: 600
 delete_wait_timeout: 600
 delete_label_selectors:
   - kube-burner-job
+
 workloads_to_run:
-  - node-density
-  - node-density-cni-networkpolicy
+  - { name: node-density, qps: 2, burst: 2 }
+  - { name: node-density, qps: 4, burst: 4 }
+  - { name: node-density, qps: 6, burst: 6 }
+  - { name: node-density, qps: 8, burst: 8 }
+  - { name: node-density, qps: 10, burst: 10 }
+  - { name: node-density, qps: 12, burst: 12 }
+  - { name: node-density-cni, qps: 2, burst: 2 }
+  - { name: node-density-cni, qps: 4, burst: 4 }
+  - { name: node-density-cni, qps: 6, burst: 6 }
+  - { name: node-density-cni, qps: 8, burst: 8 }
+  - { name: node-density-cni, qps: 10, burst: 10 }
+  - { name: node-density-cni, qps: 12, burst: 12 }
+  - { name: node-density-cni-networkpolicy, qps: 2, burst: 2 }
+  - { name: node-density-cni-networkpolicy, qps: 4, burst: 4 }
+  - { name: node-density-cni-networkpolicy, qps: 6, burst: 6 }
+  - { name: node-density-cni-networkpolicy, qps: 8, burst: 8 }
+  - { name: node-density-cni-networkpolicy, qps: 10, burst: 10 }
+  - { name: node-density-cni-networkpolicy, qps: 12, burst: 12 }

--- a/ansible/roles/run-workloads/tasks/kube-burner.yml
+++ b/ansible/roles/run-workloads/tasks/kube-burner.yml
@@ -1,16 +1,20 @@
 ---
 # kube-burner tasks
 
-- name: "run kube-kube burner workload {{ kube_burner_workload }}"
+- name: "run kube-burner workload {{ kube_burner_workload.name }} with QPS={{ kube_burner_workload.qps }}"
   ansible.builtin.command:
     cmd: ./run.sh
     chdir: "{{ e2e_path }}/workloads/kube-burner"
   environment:
-    BURST: "{{ kube_burner_burst }}"
+    BURST: "{{ kube_burner_workload.burst }}"
     INDEXING: "{{ kube_burner_indexing }}"
     POD_READY_THRESHOLD: "{{ kube_burner_pod_ready }}"
-    QPS: "{{ kube_burner_qps }}"
-    WORKLOAD: "{{ kube_burner_workload }}"
+    QPS: "{{ kube_burner_workload.qps }}"
+    WORKLOAD: "{{ kube_burner_workload.name }}"
+
+- name: "log workload execution details"
+  ansible.builtin.debug:
+    msg: "Completed {{ kube_burner_workload.name }} with QPS={{ kube_burner_workload.qps }}, BURST={{ kube_burner_workload.burst }}"
 
 - ansible.builtin.pause:
     seconds: "{{ pre_delete_pause_duration }}"

--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -5,10 +5,11 @@ go_arch: arm64
 go_files:
   - go
   - gofmt
-go_version: 1.20.3
+go_version: 1.24.4
 go_install_dir: /usr/local/go{{ go_version }}
 
 install_packages:
+  - avahi-tools
   - bash-completion
   - firewalld
   - git

--- a/ansible/vars/microshift_versions.yml
+++ b/ansible/vars/microshift_versions.yml
@@ -1,0 +1,20 @@
+---
+# Shared microshift version-specific configuration
+# This file is included by multiple roles
+
+# Version-specific pod counts
+# expected_pods is the number of non-storage pods that should be running first
+# all_pods is the total number of pods that should be running after the boot script has completed
+microshift_versions:
+  "4.16":
+    expected_pods: 6
+    all_pods: 10
+  "4.17":
+    expected_pods: 6
+    all_pods: 10
+  "4.18":
+    expected_pods: 6
+    all_pods: 9 
+  "4.19":
+    expected_pods: 6
+    all_pods: 9 


### PR DESCRIPTION
- Improve pod readiness script, predefined pod counts per release
- Update manage-repos task syntax, and version bump
- Add IPv6 ULA to trusted firewall CIDR
- Bump go version and add avahi-tools
- Update run-workloads to define QPS per run
- Make kubelet logging role support multiple hosts
- Enhance monitoring with node and container metrics, updated dashboard