### PR TITLE
USHIFT-5983: Update scenario.sh script to run gingko tests

### DIFF
--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -63,7 +63,7 @@ BOOT_TEST_JOB_LOG="${IMAGEDIR}/boot_test_jobs.txt"
 cd "${TESTDIR}"
 
 if [ ! -d "${RF_VENV}" ]; then
-    "${ROOTDIR}/scripts/fetch_tools.sh" robotframework
+    "${ROOTDIR}/scripts/fetch_tools.sh" robotframework ginkgo
 fi
 
 # Tell scenario.sh to merge stderr into stdout

--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -25,6 +25,9 @@ KICKSTART_TEMPLATE_DIR="${TESTDIR}/kickstart-templates"
 # The location the web server should serve.
 export IMAGEDIR="${OUTPUTDIR}/test-images"
 
+# Ginkgo test binary path
+export GINKGO_TEST_BINARY="${OUTPUTDIR}/bin/extended-platform-tests"
+
 # The storage pool base name for VMs.
 # The actual pool names will be '${VM_POOL_BASENAME}-${SCENARIO}'.
 VM_POOL_BASENAME="vm-storage"

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -939,23 +939,33 @@ stress_testing() {
     fi
 }
 
-# Run the tests for the current scenario
-run_tests() {
-    local vmname="${1}"
-    local full_vmname
-    full_vmname="$(full_vm_name "${vmname}")"
+# Apply RUN_HOST_OVERRIDE logic if needed
+apply_host_override() {
+    local -r original_vmname="$1"
+    local vmname="${original_vmname}"
+
     if [[ -n "${RUN_HOST_OVERRIDE}" ]]; then
-	vmname="${RUN_HOST_OVERRIDE}"
-	full_vmname="$(full_vm_name "${vmname}")"
+        vmname="${RUN_HOST_OVERRIDE}"
+        local full_vmname
+        local ip
+        full_vmname="$(full_vm_name "${vmname}")"
         ip=$(get_vm_ip "${full_vmname}")
-	set_vm_property "${vmname}" "ip" "${ip}"
+        set_vm_property "${vmname}" "ip" "${ip}"
         set_vm_property "${vmname}" "ssh_port" "22"
         set_vm_property "${vmname}" "api_port" "6443"
         set_vm_property "${vmname}" "lb_port" "5678"
     fi
 
-    shift
+    echo "${vmname}"
+}
 
+# Run the tests for the current scenario
+run_tests() {
+    local vmname="${1}"
+    # Handle RUN_HOST_OVERRIDE
+    vmname=$(apply_host_override "${vmname}")
+
+    shift
     echo "Running tests with $# args" "$@"
 
     if [ ! -d "${RF_VENV}" ]; then
@@ -1016,6 +1026,7 @@ run_tests() {
         local -r api_port=$(get_vm_property "${vmname}" "api_port")
         local -r lb_port=$(get_vm_property "${vmname}" "lb_port")
         local -r vm_ip=$(get_vm_property "${vmname}" "ip")
+        local -r full_vmname="$(full_vm_name "${vmname}")"
 
         local variable_file="${SCENARIO_INFO_DIR}/${SCENARIO}/variables.yaml"
         echo "Writing variables to ${variable_file}"
@@ -1066,6 +1077,69 @@ EOF
             record_junit "${vmname}" "run_test_timed_out_${TEST_EXECUTION_TIMEOUT}" "FAILED"
         fi
         return 1
+    fi
+}
+
+# Implementation of Gingko tests
+run_gingko_tests() {
+    local vmname="${1}"
+    shift
+
+    # Handle RUN_HOST_OVERRIDE
+    vmname=$(apply_host_override "${vmname}")
+
+    # Save current directory
+    pushd . &>/dev/null
+
+    # Check/install oc
+    "${ROOTDIR}/scripts/fetch_tools.sh" "oc" || {
+        record_junit "${vmname}" "oc_installed" "FAILED"
+        exit 1
+    }
+
+    # Check/get openshift-tests-binary
+    if ! "${ROOTDIR}/scripts/fetch_tools.sh" "ginkgo"; then
+        record_junit "${vmname}" "build_test_binary" "FAILED"
+        exit 1
+    fi
+    record_junit "${vmname}" "build_test_binary" "OK"
+
+    # Set up test environment variables
+    local kubeconfig="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig"
+    local -r test_results_dir="${SCENARIO_INFO_DIR}/${SCENARIO}/gingko-results"
+    mkdir -p "${test_results_dir}"
+
+    # Set up kubeconfig for tests
+    local -r vm_ip=$(get_vm_property "${vmname}" "ip")
+    local -r full_vmname="$(full_vm_name "${vmname}")"
+
+    # Wait for MicroShift to be ready
+    if ! wait_for_greenboot "${full_vmname}" "${vm_ip}"; then
+        record_junit "${vmname}" "pre_test_greenboot_check" "FAILED"
+        popd &>/dev/null
+        exit 1
+    fi
+    record_junit "${vmname}" "pre_test_greenboot_check" "OK"
+
+    # Get kubeconfig from VM
+    run_command_on_vm "${vmname}" "sudo cat /var/lib/microshift/resources/kubeadmin/${vm_ip}/kubeconfig" > "${kubeconfig}"
+    export KUBECONFIG="${kubeconfig}"
+    record_junit "${vmname}" "setup_kubeconfig" "OK"
+
+    # Run the tests and capture output
+    if ! "${GINKGO_TEST_BINARY}" run all --dry-run | grep "MicroShift" | "${GINKGO_TEST_BINARY}" run -f - --timeout 60m 2>&1 | tee "${test_results_dir}/test-output.log"; then
+        record_junit "${vmname}" "run_gingko_tests" "FAILED"
+        return 1
+    fi
+
+    record_junit "${vmname}" "run_gingko_tests" "OK"
+    popd &>/dev/null
+
+    # Display results summary
+    echo "Gingko test execution completed"
+    echo "Results are available in: ${test_results_dir}"
+    if [[ -f "${test_results_dir}/test-output.log" ]]; then
+        echo "Test output log: ${test_results_dir}/test-output.log"
     fi
 }
 
@@ -1224,11 +1298,10 @@ action_run() {
 
     if [ $# -eq 0 ]; then
         RUN_HOST_OVERRIDE=""
-	check_dependencies
+        check_dependencies
     else
         RUN_HOST_OVERRIDE="$1"
     fi
-
     scenario_run_tests
     record_junit "run" "scenario_run_tests" "OK"
 }

--- a/test/scenarios-bootc/releases/el96-lrel@ginkgo-tests.sh
+++ b/test/scenarios-bootc/releases/el96-lrel@ginkgo-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart-bootc.ks.template "rhel96-bootc-brew-${LATEST_RELEASE_TYPE}-with-optional"
+    launch_vm --boot_blueprint rhel96-bootc
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_gingko_tests host1
+}

--- a/test/scenarios/releases/el96-lrel@ginkgo-tests.sh
+++ b/test/scenarios/releases/el96-lrel@ginkgo-tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart.ks.template "rhel-9.6-microshift-brew-optionals-4.${MINOR_VERSION}-${LATEST_RELEASE_TYPE}"
+    launch_vm
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_gingko_tests host1
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**: Currently scenario.sh does not have support to run gingko test cases(openshift-qe-test-private cases), this PR enables user to run the same on the created microshift vm.

Define function in any of the scenario file using the below way
```
scenario_run_tests() {
    run_gingko_tests host1
}
```
And use the command below to run the same. when gingko is not specified it will run robot framework cases
`./test/bin/scenario.sh run ./test/scenarios/presubmits/el96-src@gingko-tests.sh <host>`
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #[USHIFT-5983](https://issues.redhat.com//browse/USHIFT-5983)
