### PR TITLE
OCPEDGE-2034: Configure etcd to allow 2 learners

### DIFF
--- a/etcd/cmd/microshift-etcd/run.go
+++ b/etcd/cmd/microshift-etcd/run.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// MaxLearners determines the maximum number of etcd learners in the cluster. This is
+	// needed to support topology transitions without losing high availability.
+	MaxLearners = 2
+)
+
 func NewRunEtcdCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "run",
@@ -95,6 +101,8 @@ func (s *EtcdService) configure(cfg *config.Config) {
 	s.etcdCfg.PeerTLSInfo.CertFile = cryptomaterial.PeerCertPath(etcdPeerCertDir)
 	s.etcdCfg.PeerTLSInfo.KeyFile = cryptomaterial.PeerKeyPath(etcdPeerCertDir)
 	s.etcdCfg.PeerTLSInfo.TrustedCAFile = etcdSignerCertPath
+
+	s.etcdCfg.ExperimentalMaxLearners = MaxLearners
 }
 
 func (s *EtcdService) Run() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
