### PR TITLE
USHIFT-6028: ansible: few more fixes across roles

### DIFF
--- a/ansible/roles/common/tasks/disk.yml
+++ b/ansible/roles/common/tasks/disk.yml
@@ -13,10 +13,12 @@
     - name: Add disk info to local file
       lineinfile:
         path: "{{ filename }}"
-        line: "{{ item }}"
+        line: "{{ disk_item }}"
         create: yes
       delegate_to: localhost
       with_items:
         - "{{ item }}:"
         - "{{ disk_usage.stdout_lines }}"
+      loop_control:
+        loop_var: disk_item
 

--- a/ansible/roles/configure-firewall/tasks/main.yml
+++ b/ansible/roles/configure-firewall/tasks/main.yml
@@ -1,30 +1,44 @@
 ---
 # configure-firewall tasks
 
-- name: permit traffic in trusted zone from CIDR
-  ansible.posix.firewalld:
-    source: "{{ item }}"
-    state: enabled
-    immediate: yes
-    permanent: yes
-    zone: trusted
-  with_items: "{{ firewall_trusted_cidr }}"
+- name: check firewalld service status
+  ansible.builtin.systemd:
+    name: firewalld
+  register: firewalld_status
+  ignore_errors: true
 
-- name: permit traffic in public zone for services
-  ansible.posix.firewalld:
-    service: "{{ item }}"
-    state: enabled
-    immediate: yes
-    permanent: yes
-    zone: public
-  with_items: "{{ firewall_services }}"
+- name: Configure firewall rules
+  when: firewalld_status.status.UnitFileState is not defined or firewalld_status.status.UnitFileState != 'masked'
+  block:
+    - name: permit traffic in trusted zone from CIDR
+      ansible.posix.firewalld:
+        source: "{{ item }}"
+        state: enabled
+        immediate: yes
+        permanent: yes
+        zone: trusted
+      with_items: "{{ firewall_trusted_cidr }}"
 
-- name: permit traffic in public zone for ports
-  ansible.posix.firewalld:
-    port: "{{ item }}"
-    state: enabled
-    immediate: yes
-    permanent: yes
-    zone: public
-  with_items: "{{ firewall_ports }}"
+    - name: permit traffic in public zone for services
+      ansible.posix.firewalld:
+        service: "{{ item }}"
+        state: enabled
+        immediate: yes
+        permanent: yes
+        zone: public
+      with_items: "{{ firewall_services }}"
+
+    - name: permit traffic in public zone for ports
+      ansible.posix.firewalld:
+        port: "{{ item }}"
+        state: enabled
+        immediate: yes
+        permanent: yes
+        zone: public
+      with_items: "{{ firewall_ports }}"
+
+- name: skip firewall configuration if masked
+  ansible.builtin.debug:
+    msg: "Firewalld is masked, skipping firewall configuration"
+  when: firewalld_status.status.UnitFileState is defined and firewalld_status.status.UnitFileState == 'masked'
 

--- a/ansible/roles/fetch-kubeconfig/defaults/main.yml
+++ b/ansible/roles/fetch-kubeconfig/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # install-microshift default vars
 
-kubeconfig_directory: "{{ local_home }}/.kube"
+kubeconfig_directory: "{{ lookup('env', 'HOME') }}/.kube"
 kubeconfig_local_file: "{{ kubeconfig_directory }}/config"
 kubeconfig_remote_file: "/var/lib/microshift/resources/kubeadmin/{{ ansible_fqdn }}/kubeconfig"

--- a/ansible/roles/fetch-kubeconfig/tasks/main.yml
+++ b/ansible/roles/fetch-kubeconfig/tasks/main.yml
@@ -1,39 +1,78 @@
 ---
 # fetch-kubeconfig tasks
 
-- name: set local kubeconfig path
+- name: Set local kubeconfig path
   ansible.builtin.set_fact:
-    local_home: "{{ lookup('env', 'HOME') }}"
+    kubeconfig_dest_file: "{{ kubeconfig_directory }}/kubeconfig.{{ inventory_hostname }}"
 
-- name: check if kubeconfig directory exists on local machine
+- name: Check if kubeconfig directory exists on local machine
   ansible.builtin.stat:
     path: "{{ kubeconfig_directory }}"
   delegate_to: localhost
   register: kubeconfig_directory_check
 
-- name: create .kube folder in home directory if missing
+- name: Create .kube folder in home directory if missing
   ansible.builtin.file:
     path: "{{ kubeconfig_directory }}"
     state: directory
   delegate_to: localhost
   when: not kubeconfig_directory_check.stat.exists
 
-- name: check a kubeconfig file exists on local machine
+- name: Fetch remote kubeconfig to a host-specific file (always overwrites)
+  become: yes
+  ansible.builtin.fetch:
+    src: "{{ kubeconfig_remote_file }}"
+    dest: "{{ kubeconfig_dest_file }}"
+    flat: yes
+    force: yes
+
+- name: Check if a default kubeconfig file exists on local machine
   ansible.builtin.stat:
     path: "{{ kubeconfig_local_file }}"
   delegate_to: localhost
   register: kubeconfig_local_file_check
 
-- name: backup existing kubeconfig_local_file
-  ansible.builtin.copy:
-    src: "{{ kubeconfig_local_file }}"
-    dest: "{{ kubeconfig_local_file }}.old"
-  delegate_to: localhost
-  when: kubeconfig_local_file_check.stat.exists
-
-- name: try to fetch remote kubeconfig to local
-  become: yes
-  ansible.builtin.fetch:
-    src: "{{ kubeconfig_remote_file }}"
+- name: Create/overwrite symbolic link if default is not a regular file
+  ansible.builtin.file:
+    src: "{{ kubeconfig_dest_file }}"
     dest: "{{ kubeconfig_local_file }}"
-    flat: yes
+    state: link
+    force: yes
+  delegate_to: localhost
+  when: not kubeconfig_local_file_check.stat.exists or (kubeconfig_local_file_check.stat.islnk | default(false))
+
+- name: Notify user if default kubeconfig is a regular file and was not overwritten
+  ansible.builtin.debug:
+    msg: |
+      The default kubeconfig at '{{ kubeconfig_local_file }}' is a regular file and was not overwritten.
+      A new kubeconfig has been saved to '{{ kubeconfig_dest_file }}'.
+      Please update your KUBECONFIG environment variable or switch contexts manually.
+  delegate_to: localhost
+  when: kubeconfig_local_file_check.stat.exists and (kubeconfig_local_file_check.stat.isreg | default(false))
+
+- name: Verify connectivity to MicroShift cluster
+  block:
+    - name: Test cluster connectivity with oc
+      ansible.builtin.command: oc get nodes --kubeconfig={{ kubeconfig_dest_file }}
+      delegate_to: localhost
+      register: oc_test
+      changed_when: false
+      failed_when: false
+
+    - name: Display cluster connectivity status
+      ansible.builtin.debug:
+        msg: "Successfully connected to MicroShift cluster - Node is ready"
+      delegate_to: localhost
+      when: oc_test.rc == 0
+
+    - name: Fail if cluster is not accessible
+      ansible.builtin.fail:
+        msg: |
+          Failed to connect to MicroShift cluster!
+          Error: {{ oc_test.stderr | default('Unknown error') }}
+          
+          Please check:
+          1. Port 6443 is accessible from this host (firewall/iptables rules)
+          2. MicroShift service is running on the remote host
+          3. The kubeconfig file is valid
+      when: oc_test.rc != 0

--- a/ansible/roles/microshift-start/tasks/main.yml
+++ b/ansible/roles/microshift-start/tasks/main.yml
@@ -149,8 +149,8 @@
       register: vnstat
 
     - name: record network usage to file
-      local_action:
-        module: copy
+      ansible.builtin.copy:
         content: "{{ vnstat.stdout }}"
         dest: network.txt
+      delegate_to: localhost
   when: vnstat_check.rc == 0

--- a/ansible/roles/setup-microshift-host/tasks/main.yml
+++ b/ansible/roles/setup-microshift-host/tasks/main.yml
@@ -32,22 +32,49 @@
     state: link
   with_items: "{{ go_files }}"
 
+- name: check firewalld service status
+  ansible.builtin.systemd:
+    name: firewalld
+  register: firewalld_status
+  ignore_errors: true
+
 - name: start and enable firewalld
   ansible.builtin.systemd:
     name: firewalld
     state: started
     enabled: yes
+  when: firewalld_status.status.UnitFileState is not defined or firewalld_status.status.UnitFileState != 'masked'
 
 - name: check if rhel vg exists
   ansible.builtin.command: vgdisplay -s {{ vg_name }}
   register: rhel_vg_present
   ignore_errors: true
 
+- name: check if lvm disk exists
+  ansible.builtin.stat:
+    path: "{{ lvm_disk }}"
+  register: lvm_disk_stat
+  when: rhel_vg_present.rc != 0
+
 - name: create a volume group on top of secondary disk for topolvm
   community.general.lvg:
     vg: "{{ vg_name }}"
     pvs: "{{ lvm_disk }}"
-  when: rhel_vg_present.rc != 0
+  when:
+    - rhel_vg_present.rc != 0
+    - lvm_disk_stat.stat.exists
+
+- name: notify about missing lvm disk
+  ansible.builtin.debug:
+    msg: "LVM disk {{ lvm_disk }} not found, skipping TopoLVM volume group creation"
+  when:
+    - rhel_vg_present.rc != 0
+    - lvm_disk_stat is defined
+    - not lvm_disk_stat.stat.exists
+
+- name: Configure TopoLVM storage
+  include_tasks: storage.yml
+  when: rhel_vg_present.rc == 0 or (lvm_disk_stat is defined and lvm_disk_stat.stat.exists)
 
 - name: upgrade all packages
   ansible.builtin.dnf:

--- a/ansible/roles/setup-microshift-host/tasks/storage.yml
+++ b/ansible/roles/setup-microshift-host/tasks/storage.yml
@@ -1,0 +1,29 @@
+---
+# Configure TopoLVM storage for MicroShift
+
+- name: Detect largest volume group for TopoLVM
+  ansible.builtin.shell: |
+    vgs --noheadings --units g -o vg_name,vg_size --sort -vg_size | head -1 | awk '{print $1}'
+  register: largest_vg
+  changed_when: false
+  failed_when: false
+
+- name: Configure TopoLVM with detected volume group
+  when: 
+    - largest_vg.rc == 0
+    - largest_vg.stdout | length > 0
+  block:
+    - name: Display detected volume group
+      ansible.builtin.debug:
+        msg: "Configuring TopoLVM to use volume group: {{ largest_vg.stdout }}"
+
+    - name: Deploy lvmd.yaml configuration
+      ansible.builtin.template:
+        src: lvmd.yaml.j2
+        dest: /etc/microshift/lvmd.yaml
+        owner: root
+        group: root
+        mode: '0644'
+        backup: yes
+      vars:
+        topolvm_vg: "{{ largest_vg.stdout }}"

--- a/ansible/roles/setup-microshift-host/templates/lvmd.yaml.j2
+++ b/ansible/roles/setup-microshift-host/templates/lvmd.yaml.j2
@@ -1,0 +1,7 @@
+socket-name: /run/lvmd/lvmd.socket
+
+device-classes:
+  - name: default
+    volume-group: {{ topolvm_vg }}
+    spare-gb: 0
+    default: true


### PR DESCRIPTION
- Fix disk.yaml variable names for clarity
- Rework local kubeconfig management in fetch-kubeconfig role
- Handle if firewalld is masked
- local_action is being depricated
- More robust lvm handling and support for configuring lvmd.conf
