### PR TITLE
Fail container build on skopeo copy error

### DIFF
--- a/docs/config/Containerfile.bootc-embedded-rhel9
+++ b/docs/config/Containerfile.bootc-embedded-rhel9
@@ -17,7 +17,8 @@ RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
         sha="$(echo "${img}" | sha256sum | awk '{print $1}')" ; \
         skopeo copy --all --preserve-digests \
             --authfile /run/secrets/pull-secret.json \
-            "docker://${img}" "dir:$IMAGE_STORAGE_DIR/${sha}" ; \
+            "docker://${img}" "dir:$IMAGE_STORAGE_DIR/${sha}" \
+            || { echo '!!! skopeo copy failed' ; exit 1; } ; \
         echo "${img},${sha}" >> "${IMAGE_LIST_FILE}" ; \
     done
 


### PR DESCRIPTION
During my demo prep, skopeo copy sometimes failed due to registry issues. Which led to inconsistent bootc images which failed to run, because only partially available embedded containers. This PR makes the container build fail on skopeo errors to address this 