### PR TITLE
USHIFT-5548: Exclude telemetry from community builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ SRC_ROOT :=$(shell pwd)
 
 WITH_KINDNET ?= 0
 WITH_TOPOLVM ?= 0
+WITH_OBSERVABILITY ?= 0
 OUTPUT_DIR :=_output
 RPM_BUILD_DIR :=$(OUTPUT_DIR)/rpmbuild
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
@@ -271,6 +272,7 @@ rpm:
 	SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
 	WITH_KINDNET=${WITH_KINDNET} \
 	WITH_TOPOLVM=${WITH_TOPOLVM} \
+	WITH_OBSERVABILITY=${WITH_OBSERVABILITY} \
 	./packaging/rpm/make-rpm.sh rpm local
 .PHONY: rpm
 
@@ -282,6 +284,7 @@ srpm:
 	SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
 	WITH_KINDNET=${WITH_KINDNET} \
 	WITH_TOPOLVM=${WITH_TOPOLVM} \
+	WITH_OBSERVABILITY=${WITH_OBSERVABILITY} \
 	./packaging/rpm/make-rpm.sh srpm local
 .PHONY: srpm
 
@@ -300,6 +303,7 @@ rpm-podman:
 		--env TARGET_ARCH=$(TARGET_ARCH) \
 		--env WITH_KINDNET=$(WITH_KINDNET) \
 		--env WITH_TOPOLVM=$(WITH_TOPOLVM) \
+		--env WITH_OBSERVABILITY=$(WITH_OBSERVABILITY) \
 		microshift-builder:$(RPM_BUILDER_IMAGE_TAG) \
 		bash -ilc 'cd /opt/microshift && make rpm & pid=$$! ; \
 				   trap "echo Killing make PID $${pid}; kill $${pid}" INT ; \

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -73,6 +73,7 @@ EOF
    --define "_binary_payload w19T8.zstdio" \
    --define "with_kindnet ${WITH_KINDNET}" \
    --define "with_topolvm ${WITH_TOPOLVM}" \
+   --define "with_observability ${WITH_OBSERVABILITY}" \
    "${RPMBUILD_DIR}"SPECS/microshift.spec
 }
 

--- a/test/bin/build_rpms.sh
+++ b/test/bin/build_rpms.sh
@@ -10,6 +10,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WITH_KINDNET=${WITH_KINDNET:-1}
 # Build the upstream TopoLVM RPM unless overridden explicitly
 WITH_TOPOLVM=${WITH_TOPOLVM:-1}
+# Build the OpenTelemetry RPM unless overridden explicitly
+WITH_OBSERVABILITY=${WITH_OBSERVABILITY:-1}
 
 # shellcheck source=test/bin/common.sh
 source "${SCRIPTDIR}/common.sh"
@@ -20,11 +22,11 @@ build_rpms() {
     rm -rf _output/rpmbuild*
 
     # Normal build of current branch from source
-    local build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} rpm")
+    local build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} WITH_OBSERVABILITY=${WITH_OBSERVABILITY} rpm")
 
     # In CI, build the current branch from source with the build tools using used by OCP
     if [ -v CI_JOB_NAME ]; then
-        build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} rpm-podman")
+        build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} WITH_OBSERVABILITY=${WITH_OBSERVABILITY} rpm-podman")
     fi
 
     build_cmds+=(


### PR DESCRIPTION
Make building the microshift-observabilty package optional.