### PR TITLE
USHIFT-6086: Add upstream build support in ci_phase_iso_build.sh

### DIFF
--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -114,10 +114,14 @@ run_bootc_image_build() {
         if [[ "${CI_JOB_NAME}" =~ .*periodic.* ]]; then
             $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/layer3-periodic
         fi
+        if [[ "${CI_JOB_NAME}" =~ .*upstream.* ]]; then
+            $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/layer4-upstream
+        fi
     else
         $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/layer1-base
         $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/layer2-presubmit
         $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/layer3-periodic
+        $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/layer4-upstream
     fi
 }
 


### PR DESCRIPTION
Required by https://github.com/openshift/release/pull/69123
