### PR TITLE
USHIFT-6147: Revert optional build of microshift-observability package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ SRC_ROOT :=$(shell pwd)
 
 WITH_KINDNET ?= 0
 WITH_TOPOLVM ?= 0
-WITH_OBSERVABILITY ?= 0
 OUTPUT_DIR :=_output
 RPM_BUILD_DIR :=$(OUTPUT_DIR)/rpmbuild
 CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
@@ -272,7 +271,6 @@ rpm:
 	SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
 	WITH_KINDNET=${WITH_KINDNET} \
 	WITH_TOPOLVM=${WITH_TOPOLVM} \
-	WITH_OBSERVABILITY=${WITH_OBSERVABILITY} \
 	./packaging/rpm/make-rpm.sh rpm local
 .PHONY: rpm
 
@@ -284,7 +282,6 @@ srpm:
 	SOURCE_GIT_TREE_STATE=${SOURCE_GIT_TREE_STATE} \
 	WITH_KINDNET=${WITH_KINDNET} \
 	WITH_TOPOLVM=${WITH_TOPOLVM} \
-	WITH_OBSERVABILITY=${WITH_OBSERVABILITY} \
 	./packaging/rpm/make-rpm.sh srpm local
 .PHONY: srpm
 
@@ -303,7 +300,6 @@ rpm-podman:
 		--env TARGET_ARCH=$(TARGET_ARCH) \
 		--env WITH_KINDNET=$(WITH_KINDNET) \
 		--env WITH_TOPOLVM=$(WITH_TOPOLVM) \
-		--env WITH_OBSERVABILITY=$(WITH_OBSERVABILITY) \
 		microshift-builder:$(RPM_BUILDER_IMAGE_TAG) \
 		bash -ilc 'cd /opt/microshift && make rpm & pid=$$! ; \
 				   trap "echo Killing make PID $${pid}; kill $${pid}" INT ; \

--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -73,7 +73,6 @@ EOF
    --define "_binary_payload w19T8.zstdio" \
    --define "with_kindnet ${WITH_KINDNET}" \
    --define "with_topolvm ${WITH_TOPOLVM}" \
-   --define "with_observability ${WITH_OBSERVABILITY}" \
    "${RPMBUILD_DIR}"SPECS/microshift.spec
 }
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -39,8 +39,6 @@
 %{!?with_kindnet: %global with_kindnet 0}
 # Don't build topolvm subpackage by default
 %{!?with_topolvm: %global with_topolvm 0}
-# Don't build observability subpackage by default
-%{!?with_observability: %global with_observability 0}
 
 Name: microshift
 Version: %{version}
@@ -255,7 +253,6 @@ The microshift-ai-model-serving-release-info package provides release informatio
 release. These files contain the list of container image references used by Model Serving
 and can be used to embed those images into osbuilder blueprints or bootc containerfiles.
 
-%if %{with_observability}
 %package observability
 Summary: OpenTelemetry-Collector configured for MicroShift
 BuildArch: noarch
@@ -266,7 +263,6 @@ Requires: opentelemetry-collector
 Deploys the Red Hat build of OpenTelemetry-Collector as a systemd service on host. MicroShift provides client
 certificates to permit access to the kube-apiserver metrics endpoints. If a user-defined OpenTelemetry-Collector exists
 at /etc/microshift/opentelemetry-collector.yaml, this config is used. Otherwise, a default config is provided.
-%endif
 
 %package cert-manager
 Summary: Cert Manager for MicroShift
@@ -581,7 +577,6 @@ mkdir -p -m755 %{buildroot}%{_datadir}/microshift/release
 install -p -m644 assets/optional/ai-model-serving/release-ai-model-serving-x86_64.json %{buildroot}%{_datadir}/microshift/release/
 
 # observability
-%if %{with_observability}
 install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/observability
 install -p -m644 packaging/observability/*.yaml -D %{buildroot}%{_sysconfdir}/microshift/observability/
 # Explicit copy of large config as default. Not using symlink to avoid accidental package upgrade overwriting user config if the user edits the config without copying (i.e. edits the target of symlink).
@@ -589,7 +584,7 @@ install -p -m644 packaging/observability/opentelemetry-collector-large.yaml -D %
 install -p -m644 packaging/observability/microshift-observability.service %{buildroot}%{_unitdir}/
 install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/003-microshift-observability/
 install -p -m644 assets/optional/observability/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/003-microshift-observability/
-%endif
+
 
 # cert-manager
 install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager
@@ -667,13 +662,11 @@ if [ $1 -eq 1 ]; then
 	systemctl is-active --quiet crio && systemctl restart --quiet crio || true
 fi
 
-%if %{with_observability}
 %post observability
 %systemd_post microshift-observability.service
 
 %preun observability
 %systemd_preun microshift-observability.service
-%endif
 
 %files
 %license LICENSE
@@ -795,7 +788,6 @@ fi
 %files ai-model-serving-release-info
 %{_datadir}/microshift/release/release-ai-model-serving-x86_64.json
 
-%if %{with_observability}
 %files observability
 %dir %{_prefix}/lib/microshift/manifests.d/003-microshift-observability
 %dir %{_sysconfdir}/microshift/observability/
@@ -803,7 +795,6 @@ fi
 %config(noreplace) %{_sysconfdir}/microshift/observability/opentelemetry-collector.yaml
 %{_sysconfdir}/microshift/observability/opentelemetry-collector-*.yaml
 %{_prefix}/lib/microshift/manifests.d/003-microshift-observability/*
-%endif
 
 %files cert-manager
 %dir %{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager

--- a/test/bin/build_rpms.sh
+++ b/test/bin/build_rpms.sh
@@ -10,8 +10,6 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WITH_KINDNET=${WITH_KINDNET:-1}
 # Build the upstream TopoLVM RPM unless overridden explicitly
 WITH_TOPOLVM=${WITH_TOPOLVM:-1}
-# Build the OpenTelemetry RPM unless overridden explicitly
-WITH_OBSERVABILITY=${WITH_OBSERVABILITY:-1}
 
 # shellcheck source=test/bin/common.sh
 source "${SCRIPTDIR}/common.sh"
@@ -22,11 +20,11 @@ build_rpms() {
     rm -rf _output/rpmbuild*
 
     # Normal build of current branch from source
-    local build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} WITH_OBSERVABILITY=${WITH_OBSERVABILITY} rpm")
+    local build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} rpm")
 
     # In CI, build the current branch from source with the build tools using used by OCP
     if [ -v CI_JOB_NAME ]; then
-        build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} WITH_OBSERVABILITY=${WITH_OBSERVABILITY} rpm-podman")
+        build_cmds=("make WITH_KINDNET=${WITH_KINDNET} WITH_TOPOLVM=${WITH_TOPOLVM} rpm-podman")
     fi
 
     build_cmds+=(


### PR DESCRIPTION
This reverts commit ccf7d5c4c1a16a4953d649f63f60bb18e87cee0a.

USHIFT-5548 refers to the telemetry defined [here](https://github.com/openshift/microshift/blob/main/pkg/config/config.go#L57), which is not installed through an RPM but activated in the config yaml. We need to find a proper way of disabling it optionally.