### PR TITLE
USHIFT-6101: Add standard scenario bootc tests on CentOS 10

### DIFF
--- a/packaging/crio.conf.d/13-microshift-kindnet.conf
+++ b/packaging/crio.conf.d/13-microshift-kindnet.conf
@@ -1,8 +1,10 @@
 [crio.network]
-# kindnet is the name configured by kindnet in /etc/cni/net.d/ config file
-# by declaring this CRI-O will wait until that network is configured.
+# The kindnet network name is configured in /etc/cni/net.d/10-kindnet.conflist.
+# By declaring this, CRI-O will wait until that network is up and running.
 cni_default_network = "kindnet"
+
+# Use the containernetworking-plugins package from /usr/libexec/cni on RHEL 9.
+# TODO: RHEL 10 obsoletes the containernetworking-plugins package.
 plugin_dirs = [
-        "/usr/libexec/cni",
-        "/run/cni/bin"
+        "/usr/libexec/cni"
 ]

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -70,6 +70,11 @@ BuildRequires: golang
 
 Requires: cri-o >= 1.34.0, cri-o < 1.35.0
 Requires: cri-tools >= 1.34.0, cri-tools < 1.35.0
+# The container networking plugins package has been removed from RHEL 10 and
+# cri-o no longer has an explicit dependency on it.
+# Ensure that the package is installed on RHEL 9 as a weak dependency, skipping
+# the missing package when it is not available.
+Recommends: containernetworking-plugins
 Requires: iptables
 Requires: microshift-selinux = %{version}
 Requires: microshift-networking = %{version}
@@ -813,6 +818,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Mon Sep 29 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.21.0
+- Ensure containernetworking-plugins package is installed on RHEL 9 as a weak dependency
+
 * Sun Sep 28 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.21.0
 - Ensure greenboot-healthcheck service is enabled
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -657,6 +657,10 @@ systemctl enable --now --quiet openvswitch || true
 
 %systemd_preun microshift.service
 
+%post greenboot
+# Make sure that the greenboot-healthcheck service is enabled
+systemctl is-enabled --quiet greenboot-healthcheck || systemctl enable --now --quiet greenboot-healthcheck
+
 %post multus
 # only for install, not on upgrades
 if [ $1 -eq 1 ]; then
@@ -809,6 +813,9 @@ fi
 # Use Git command to generate the log and replace the VERSION string
 # LANG=C git log --date="format:%a %b %d %Y" --pretty="tformat:* %cd %an <%ae> VERSION%n- %s%n" packaging/rpm/microshift.spec
 %changelog
+* Sun Sep 28 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.21.0
+- Ensure greenboot-healthcheck service is enabled
+
 * Thu Sep 18 2025 Gregory Giguashvili <ggiguash@redhat.com> 4.21.0
 - Upgrade cri-o and cri-tools to v1.34
 

--- a/test/image-blueprints-bootc/layer4-upstream/group1/centos10-bootc.image-bootc
+++ b/test/image-blueprints-bootc/layer4-upstream/group1/centos10-bootc.image-bootc
@@ -1,0 +1,1 @@
+quay.io/centos-bootc/centos-bootc:stream10

--- a/test/image-blueprints-bootc/layer4-upstream/group1/cos10-bootc-source.containerfile
+++ b/test/image-blueprints-bootc/layer4-upstream/group1/cos10-bootc-source.containerfile
@@ -1,0 +1,37 @@
+FROM quay.io/centos-bootc/centos-bootc:stream10
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-local
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-centos10-nfv.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "SOURCE_VERSION" }}" \
+        {{ end -}}
+        && \
+    systemctl enable microshift && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp

--- a/test/package-sources-bootc/microshift-centos10-nfv.repo
+++ b/test/package-sources-bootc/microshift-centos10-nfv.repo
@@ -1,0 +1,7 @@
+[nfv-sig]
+name = CentOS Stream 10 - SIG NFV
+baseurl = http://mirror.stream.centos.org/SIGs/10-stream/nfv/{{ .Env.UNAME_M }}/openvswitch-2/
+enabled = 1
+gpgcheck = 0
+sslverify = 1
+skip_if_unavailable = 0

--- a/test/scenarios-bootc/upstream/cos10-src@standard-suite1.sh
+++ b/test/scenarios-bootc/upstream/cos10-src@standard-suite1.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart-bootc.ks.template cos10-bootc-source
+    launch_vm --boot_blueprint centos10-bootc
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:10" \
+        suites/standard1/ suites/selinux/validate-selinux-policy.robot
+}

--- a/test/scenarios-bootc/upstream/cos10-src@standard-suite2.sh
+++ b/test/scenarios-bootc/upstream/cos10-src@standard-suite2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+scenario_create_vms() {
+    prepare_kickstart host1 kickstart-bootc.ks.template cos10-bootc-source
+    launch_vm --boot_blueprint centos10-bootc
+}
+
+scenario_remove_vms() {
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    run_tests host1 suites/standard2
+}

--- a/test/scenarios-bootc/upstream/cos9-src@kindnet.sh
+++ b/test/scenarios-bootc/upstream/cos9-src@kindnet.sh
@@ -5,13 +5,6 @@
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template cos9-bootc-source-kindnet
     launch_vm --boot_blueprint centos9-bootc
-
-    # Open the firewall ports. Other scenarios get this behavior by
-    # embedding settings in the blueprint, but there is no blueprint
-    # for this scenario. We need do this step before running the RF
-    # suite so that suite can assume it can reach all of the same
-    # ports as for any other test.
-    configure_vm_firewall host1
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
Also addresses [USHIFT-6186](https://issues.redhat.com//browse/USHIFT-6186)

Note that kindnet-related scenarios require more work. See [USHIFT-6190](https://issues.redhat.com/browse/USHIFT-6190)