### PR TITLE
USHIFT-6282: 'brew download-build' command fails

### DIFF
--- a/test/bin/manage_brew_rpms.sh
+++ b/test/bin/manage_brew_rpms.sh
@@ -77,10 +77,44 @@ action_download() {
         mkdir -p "${adir}"
         pushd "${adir}" &>/dev/null
         if ! brew download-build --arch="${arch}" --arch="noarch" "${package}" ; then
-            echo "ERROR: Failed to download '${package}' packages from brew"
-            exit 1
+            echo "WARNING: Failed to download '${package}' packages using brew download-build command, using curl as a fallback mechanism"
+            if ! brew_curl_download "${package}" "${arch}" ; then
+                echo "ERROR: Failed to download '${package}' packages using curl command"
+                popd &>/dev/null
+                exit 1
+            fi
         fi
         popd &>/dev/null
+    done
+}
+
+brew_curl_download() {
+    local package=$1
+    local arch=$2
+
+    # Parse package to extract version and build release
+    local version_and_release="${package#microshift-}"
+    local pkg_version="${version_and_release%%-*}"
+    local pkg_release="${version_and_release#*-}"
+
+    for current_arch in ${arch} noarch; do
+        local base_url="https://download-01.beak-001.prod.iad2.dc.redhat.com/rhel-9/brew/packages/microshift/${pkg_version}/${pkg_release}/${current_arch}/"
+
+        local rpm_files
+        rpm_files=$(curl -k -s "${base_url}" | sed -n 's/.*href="\([^"]*\.rpm\)".*/\1/p') || true
+        if [ -z "${rpm_files}" ]; then
+            echo "ERROR: No RPM files found at ${base_url}"
+            return 1
+        fi
+
+        echo "Downloading from: ${base_url}"
+        for rpm_file in ${rpm_files}; do
+            echo "Downloading: ${rpm_file}"
+            if ! curl -k -s -O "${base_url}${rpm_file}"; then
+                echo "ERROR: Failed to download ${rpm_file}"
+                return 1
+            fi
+        done
     done
 }
 


### PR DESCRIPTION
Add a fallback mechanism to download the RPMs using `curl` command with `-k` option to ignore invalid and self-signed certificate errors.