### PR TITLE
[USHIFT-6106] - Add RHEL 10.0 support to bootc containerfiles, image blueprints, and repo config

### DIFF
--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew-ec-with-optional.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew-ec-with-optional.containerfile
@@ -1,0 +1,53 @@
+# {{- if env.Getenv "BREW_EC_RELEASE_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-brew
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift, test agent and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_EC_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ range (env.Getenv "MICROSHIFT_OPTIONAL_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_EC_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ if and (env.Getenv "UNAME_M" "") (eq "x86_64" .Env.UNAME_M) -}}
+        {{ range (env.Getenv "MICROSHIFT_X86_64_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_EC_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ end -}}
+        && \
+    systemctl enable microshift microshift-test-agent && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=8889/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+
+# Prepare system for testing Generic Device Plugin
+#COPY --chmod=755 ./bootc-images/build-serialsim.sh /tmp/build-serialsim.sh
+#RUN /tmp/build-serialsim.sh && rm -f /tmp/build-serialsim.sh
+# {{- end -}}

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew-rc-with-optional.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew-rc-with-optional.containerfile
@@ -1,0 +1,53 @@
+# {{- if env.Getenv "BREW_RC_RELEASE_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-brew
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift, test agent and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_RC_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ range (env.Getenv "MICROSHIFT_OPTIONAL_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_RC_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ if and (env.Getenv "UNAME_M" "") (eq "x86_64" .Env.UNAME_M) -}}
+        {{ range (env.Getenv "MICROSHIFT_X86_64_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_RC_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ end -}}
+        && \
+    systemctl enable microshift microshift-test-agent && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=8889/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+
+# Prepare system for testing Generic Device Plugin
+#COPY --chmod=755 ./bootc-images/build-serialsim.sh /tmp/build-serialsim.sh
+#RUN /tmp/build-serialsim.sh && rm -f /tmp/build-serialsim.sh
+# {{- end -}}

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew-zstream-with-optional.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew-zstream-with-optional.containerfile
@@ -1,0 +1,53 @@
+# {{- if env.Getenv "BREW_Y0_RELEASE_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-brew
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift, test agent and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_Y0_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ range (env.Getenv "MICROSHIFT_OPTIONAL_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_Y0_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ if and (env.Getenv "UNAME_M" "") (eq "x86_64" .Env.UNAME_M) -}}
+        {{ range (env.Getenv "MICROSHIFT_X86_64_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_Y0_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ end -}}
+        && \
+    systemctl enable microshift microshift-test-agent && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=8889/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+
+# Prepare system for testing Generic Device Plugin
+#COPY --chmod=755 ./bootc-images/build-serialsim.sh /tmp/build-serialsim.sh
+#RUN /tmp/build-serialsim.sh && rm -f /tmp/build-serialsim.sh
+# {{- end -}}

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-brew.containerfile
@@ -1,0 +1,40 @@
+# {{- if env.Getenv "BREW_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-brew
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift, test agent and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_VERSION" }}" \
+        {{ end -}}
+        && \
+    systemctl enable microshift microshift-test-agent && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+# {{- end -}}

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-crel-isolated.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-crel-isolated.containerfile
@@ -1,0 +1,48 @@
+# {{- if env.Getenv "CURRENT_RELEASE_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Copy repository configuration
+COPY ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-crel.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "CURRENT_RELEASE_VERSION" }}" \
+        {{ end -}}
+        && \
+    systemctl enable microshift && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    dnf clean all
+
+# Embed images based on contents of release-info RPMs
+COPY --chmod=755 ./bootc-images/microshift-copy-images.sh /usr/bin/microshift-copy-images
+RUN --mount=type=secret,id=pullsecret,dst=/run/secrets/pull-secret.json \
+    images="$(jq -r ".images[]" /usr/share/microshift/release/release-"$(uname -m)".json)" ; \
+    images="${images} quay.io/microshift/busybox:1.36" ; \
+    IMAGE_PULL_LIST="${images}" /usr/bin/microshift-copy-images pull
+
+# Install a systemd drop-in unit to address the problem with image upgrades
+# overwriting the container images in additional store. The workaround is to
+# copy the images from the pre-loaded to the main container storage.
+# In this case, it is not necessary to update /etc/containers/storage.conf with
+# the additional store path.
+# See https://issues.redhat.com/browse/RHEL-75827
+RUN mkdir -p /usr/lib/systemd/system/microshift.service.d
+COPY --chmod=644 ./bootc-images/microshift-copy-images.conf /usr/lib/systemd/system/microshift.service.d/microshift-copy-images.conf
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp    
+# {{- end -}}

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-crel-optionals.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-crel-optionals.containerfile
@@ -1,0 +1,40 @@
+# {{- if env.Getenv "CURRENT_RELEASE_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Copy repository configuration
+COPY ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-crel.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift with optional components and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "CURRENT_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ range (env.Getenv "MICROSHIFT_OPTIONAL_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "CURRENT_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ if and (env.Getenv "UNAME_M" "") (eq "x86_64" .Env.UNAME_M) -}}
+        {{ range (env.Getenv "MICROSHIFT_X86_64_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "CURRENT_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ end -}}
+        && \
+    systemctl enable microshift && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+# {{- end -}}

--- a/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-crel.containerfile
+++ b/test/image-blueprints-bootc/layer1-base/group2/rhel100-bootc-crel.containerfile
@@ -1,0 +1,32 @@
+# {{- if env.Getenv "CURRENT_RELEASE_VERSION" "" -}}
+# Note: This comment makes templating add a new line before the code
+FROM localhost/rhel100-test-agent:latest
+
+# Copy repository configuration
+COPY ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-crel.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Print repository configuration contents.
+# Install MicroShift and cleanup.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "CURRENT_RELEASE_VERSION" }}" \
+        {{ end -}}
+        && \
+    systemctl enable microshift && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+# {{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**: Add RHEL 10.0 support to bootc containerfiles, image blueprints, and repo config
- Add 7 bootc containerfiles for RHEL 10.0 (brew, brew-ec, brew-rc, brew-zstream, crel variants)
- Only includes current version (4.21) support, no Y-1/Y-2 support as RHEL 10 is new
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
