### PR TITLE
TRT-1854: test name has a trailing space

### DIFF
--- a/origin/skip.txt
+++ b/origin/skip.txt
@@ -81,7 +81,7 @@
 "[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access [Suite:openshift/conformance/parallel] [Suite:k8s]"
 "[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PV and a pre-bound PVC: test write access"
 "[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access  [Suite:openshift/conformance/parallel] [Suite:k8s]"
-"[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access"
+"[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access "
 "[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access [Suite:openshift/conformance/parallel] [Suite:k8s]"
 "[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs create a PVC and a pre-bound PV: test write access"
 "[sig-storage] PersistentVolumes NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access [Suite:openshift/conformance/parallel] [Suite:k8s]"


### PR DESCRIPTION
Follow up to https://github.com/openshift/microshift/pull/5704

Tests like [this](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/30459/pull-ci-openshift-origin-main-e2e-aws-ovn-microshift/1986743548011089920) one are still failing because the test name (`[sig-storage] PersistentVolumes NFS with Single PV - PVC pairs should create a non-pre-bound PV and PVC: test write access `) has a trailing space. See the [junit](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/30459/pull-ci-openshift-origin-main-e2e-aws-ovn-microshift/1986743548011089920/artifacts/e2e-aws-ovn-microshift/openshift-microshift-e2e-origin-conformance/artifacts/junit/junit_e2e__20251107-113006.xml)