### PR TITLE
USHIFT-6007: Auto etcd 3.6 migration

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -1223,6 +1223,17 @@ check_for_manifests_changes() {
     return 1
 }
 
+etcd_migration_to_3_6() {
+    if grep -E 'Version\s+= "3.5' "${REPOROOT}/etcd/vendor/go.etcd.io/etcd/api/v3/version/version.go" && grep -E 'Version\s+= "3.6' "${REPOROOT}/_output/staging/etcd/api/version/version.go"; then
+        title "Detected etcd 3.5 -> 3.6 migration - patching"
+        git apply --reject "${REPOROOT}/scripts/auto-rebase/rebase_migration_patches/etcd-3.5-to-3.6.patch" || exit 1
+        pushd "${REPOROOT}" >/dev/null
+        git add etcd/cmd/microshift-etcd/run.go etcd/go.mod
+        git commit -m "apply etcd 3.5 -> 3.6 migration patch"
+        popd >/dev/null
+    fi
+}
+
 # Runs each OCP rebase step in sequence, commiting the step's output to git
 rebase_to() {
     local release_image_amd64=$1
@@ -1236,6 +1247,9 @@ rebase_to() {
     update_last_rebase "${release_image_amd64}" "${release_image_arm64}"
 
     update_changelog
+
+    etcd_migration_to_3_6
+
     update_go_mods
     for dirpath in "${GO_MOD_DIRS[@]}"; do
         dirname=$(basename "${dirpath}")

--- a/scripts/auto-rebase/rebase_migration_patches/etcd-3.5-to-3.6.patch
+++ b/scripts/auto-rebase/rebase_migration_patches/etcd-3.5-to-3.6.patch
@@ -1,0 +1,25 @@
+diff --git a/etcd/cmd/microshift-etcd/run.go b/etcd/cmd/microshift-etcd/run.go
+index 018b129a7..b36bf4a06 100644
+--- a/etcd/cmd/microshift-etcd/run.go
++++ b/etcd/cmd/microshift-etcd/run.go
+@@ -19,7 +19,7 @@ import (
+ 
+ 	"github.com/spf13/cobra"
+ 	etcd "go.etcd.io/etcd/server/v3/embed"
+-	"go.etcd.io/etcd/server/v3/mvcc/backend"
++	"go.etcd.io/etcd/server/v3/storage/backend"
+ 	"k8s.io/klog/v2"
+ )
+ 
+diff --git a/etcd/go.mod b/etcd/go.mod
+index b1c7f1fea..d1d486f02 100644
+--- a/etcd/go.mod
++++ b/etcd/go.mod
+@@ -154,7 +154,6 @@ replace (
+ 	go.etcd.io/etcd/client/pkg/v3 => github.com/openshift/etcd/client/pkg/v3 v3.5.1-0.20251027135311-239c469ebe0b // from etcd
+ 	go.etcd.io/etcd/client/v3 => github.com/openshift/etcd/client/v3 v3.5.1-0.20251027135311-239c469ebe0b // from etcd
+ 	go.etcd.io/etcd/pkg/v3 => github.com/openshift/etcd/pkg/v3 v3.5.1-0.20251027135311-239c469ebe0b // from etcd
+-	go.etcd.io/etcd/raft/v3 => github.com/openshift/etcd/raft/v3 v3.5.1-0.20251027135311-239c469ebe0b // from etcd
+ 	go.etcd.io/etcd/server/v3 => github.com/openshift/etcd/server/v3 v3.5.1-0.20251027135311-239c469ebe0b // from etcd
+ )
+ 


### PR DESCRIPTION
- `go.etcd.io/etcd/server/v3/mvcc/backend` was moved to `go.etcd.io/etcd/server/v3/storage/backend`
- Raft was migrated to a separate [repository](https://github.com/etcd-io/raft)