### PR TITLE
USHIFT-6319: add uncore-cache e2e test kubelet config on  Microshift

### DIFF
--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -138,3 +138,14 @@ Local Command Should Work
     Log    ${stdout}
     Should Be Equal As Integers    0    ${rc}
     RETURN    ${stdout}
+
+Remove Files
+    [Documentation]    removes files from the microshift host
+    [Arguments]    @{files}
+    Log    ${files}
+    FOR    ${file}    IN    @{files}
+        ${stdout}    ${stderr}    ${rc}=    Execute Command
+        ...    rm -f "${file}"
+        ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+        Should Be Equal As Integers    ${rc}    0
+    END

--- a/test/scenarios/presubmits/el96-src@low-latency.sh
+++ b/test/scenarios/presubmits/el96-src@low-latency.sh
@@ -38,5 +38,6 @@ scenario_run_tests() {
         --exitonfailure \
         suites/tuned/profile.robot \
         suites/tuned/microshift-tuned.robot \
-        suites/tuned/workload-partitioning.robot
+        suites/tuned/workload-partitioning.robot \
+        suites/tuned/uncore-cache.robot
 }

--- a/test/scenarios/releases/el96-lrel@low-latency.sh
+++ b/test/scenarios/releases/el96-lrel@low-latency.sh
@@ -46,5 +46,6 @@ scenario_run_tests() {
         --exitonfailure \
         suites/tuned/profile.robot \
         suites/tuned/microshift-tuned.robot \
-        suites/tuned/workload-partitioning.robot
+        suites/tuned/workload-partitioning.robot \
+        suites/tuned/uncore-cache.robot
 }

--- a/test/suites/tuned/uncore-cache.robot
+++ b/test/suites/tuned/uncore-cache.robot
@@ -1,0 +1,86 @@
+*** Settings ***
+Documentation       Tests for Workload partitioning
+
+Library             ../../resources/journalctl.py
+Resource            ../../resources/microshift-config.resource
+Resource            ../../resources/common.resource
+Resource            ../../resources/microshift-process.resource
+
+Suite Setup         Run Keywords
+...                     Setup Suite
+...                     AND    Check FeatureGates Is Enabled
+Suite Teardown      Teardown Suite
+
+
+*** Variables ***
+${MANAGEMENT_CPU}               0
+${KUBELET_CPU_STATE_FILE}       /var/lib/kubelet/cpu_manager_state
+
+
+*** Test Cases ***
+Workload Partitioning Should Work With Uncore-cache
+    [Documentation]    Verify that all the Control Plane pods are properly annotated.
+    [Setup]    Configure Kubelet For Uncore-Cache    ${MANAGEMENT_CPU}
+    Verify Uncore-cache Feature Is Enabled
+    [Teardown]    Teardown For Workload Partitioning With Uncore-cache
+
+
+*** Keywords ***
+Teardown For Workload Partitioning With Uncore-cache
+    [Documentation]    Teardown for Workload Partitioning with Uncore-cache
+    Remove Drop In MicroShift Config    11-kubelet-uncore-cache
+    Cleanup CPU State
+    Restart MicroShift
+
+Configure Kubelet For Uncore-Cache
+    [Documentation]    configure microshift with kubelet CPU configuration
+    [Arguments]    ${cpus}
+
+    ${kubelet_config}=    CATENATE    SEPARATOR=\n
+    ...    ---
+    ...    apiServer:
+    ...    \ \ featureGates:
+    ...    \ \ \ \ featureSet: "CustomNoUpgrade"
+    ...    \ \ \ \ customNoUpgrade:
+    ...    \ \ \ \ \ \ enabled: ["CPUManagerPolicyBetaOptions"]
+    ...    kubelet:
+    ...    \ \ reservedSystemCPUs: "${cpus}"
+    ...    \ \ cpuManagerPolicy: static
+    ...    \ \ cpuManagerPolicyOptions:
+    ...    \ \ \ \ prefer-align-cpus-by-uncorecache: "true"
+    Drop In MicroShift Config    ${kubelet_config}    11-kubelet-uncore-cache
+    Cleanup CPU State
+
+Verify Uncore-cache Feature Is Enabled
+    [Documentation]    Verify that the kubelet uncore-cache feature is enabled
+    ${cursor}=    Get Journal Cursor
+    Restart MicroShift
+    Pattern Should Appear In Log Output
+    ...    ${cursor}
+    ...    kube-apiserver I.*CPUManagerPolicyBetaOptions=true
+    ...    unit=microshift
+    ...    wait=5
+    Pattern Should Appear In Log Output
+    ...    ${cursor}
+    ...    kubelet I.*CPUManagerPolicyBetaOptions:true
+    ...    unit=microshift
+    ...    wait=5
+    Pattern Should Appear In Log Output
+    ...    ${cursor}
+    ...    kubelet I.*prefer-align-cpus-by-uncorecache":"true"
+    ...    unit=microshift
+    ...    wait=5
+
+Cleanup CPU State
+    [Documentation]    cleanup microshift and recreate the namespace for workloads
+    Cleanup MicroShift    --all    --keep-images
+    Remove Files    ${KUBELET_CPU_STATE_FILE}
+
+Check FeatureGates Is Enabled
+    [Documentation]    Skip suite if CoreDNS hosts feature is not available
+    ${config}=    Show Config    default
+    TRY
+        VAR    ${featuregates}=    ${config}[apiServer][featureGates]
+    EXCEPT
+        Skip    CoreDNS hosts feature not available in this MicroShift version
+    END

--- a/test/suites/tuned/workload-partitioning.robot
+++ b/test/suites/tuned/workload-partitioning.robot
@@ -247,16 +247,6 @@ Crio Process ID
     Log    ${stderr}
     RETURN    ${stdout}
 
-Remove Files
-    [Documentation]    removes files from the microshit host
-    [Arguments]    @{files}
-    Log    ${files}
-    ${files_path}=    Catenate    SEPARATOR=${SPACE}    @{files}
-    ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    rm -f ${files_path}
-    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
-    Should Be Equal As Integers    ${rc}    0
-
 Cleanup And Create NS
     [Documentation]    cleanup microshift and recreate the namespace for workloads
     Cleanup MicroShift    --all    --keep-images


### PR DESCRIPTION
this feature dependent on:

1.  https://github.com/openshift/microshift/pull/5723 , which will allow enabling optional feature gates  
2.  kubelet configuration that  will enable the cpuManager policy in kubelet.

configuration example:
```yaml
api:
  featureGates:
    customNoUpgrade:
      enabled: CPUManagerPolicyBetaOptions
kubelet:
  reservedSystemCPUs: "0" 
  cpuManagerPolicy: static
  cpuManagerPolicyOptions:
    prefer-align-cpus-by-uncorecache: "true"
```