### PR TITLE
USHIFT-6335: Skip tests on versions where core dns feature is not enabled

### DIFF
--- a/test/suites/standard1/dns.robot
+++ b/test/suites/standard1/dns.robot
@@ -8,7 +8,9 @@ Resource            ../../resources/microshift-config.resource
 Resource            ../../resources/microshift-process.resource
 Resource            ../../resources/hosts.resource
 
-Suite Setup         Setup Suite With Namespace
+Suite Setup         Run Keywords
+...                     Setup Suite With Namespace
+...                     AND    Check CoreDNS Hosts Feature
 Suite Teardown      Teardown Suite With Namespace
 
 Test Tags           slow
@@ -96,3 +98,12 @@ Remove Fake IP From NIC
     ...    sudo=True    return_rc=True    return_stderr=True    return_stdout=True
     Log Many    ${stdout}    ${stderr}
     Should Be Equal As Integers    0    ${rc}
+
+Check CoreDNS Hosts Feature
+    [Documentation]    Skip suite if CoreDNS hosts feature is not available
+    ${config}=    Show Config    default
+    TRY
+        VAR    ${hosts}=    ${config}[dns][hosts]
+    EXCEPT
+        Skip    CoreDNS hosts feature not available in this MicroShift version
+    END


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
If the PR is not yet ready for review, prefix [WIP] in the title.  Once prepared, remove the prefix.
-->
**Which issue(s) this PR addresses**: skip tests on versions where core dns feature is not enabled.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #<Issue Number>
