### PR TITLE
USHIFT-6336: Prometheus server port cannot be reused in the same CI job

### DIFF
--- a/test/scenarios-bootc/periodics/el96-src@telemetry.sh
+++ b/test/scenarios-bootc/periodics/el96-src@telemetry.sh
@@ -16,6 +16,6 @@ scenario_run_tests() {
         --variable "PROXY_HOST:${VM_BRIDGE_IP}" \
         --variable "PROXY_PORT:9001" \
         --variable "PROMETHEUS_HOST:$(hostname)" \
-        --variable "PROMETHEUS_PORT:9092" \
+        --variable "PROMETHEUS_PORT:9093" \
         suites/telemetry/telemetry.robot
 }

--- a/test/scenarios-bootc/releases/el96-lrel@telemetry.sh
+++ b/test/scenarios-bootc/releases/el96-lrel@telemetry.sh
@@ -33,6 +33,6 @@ scenario_run_tests() {
         --variable "PROXY_HOST:${VM_BRIDGE_IP}" \
         --variable "PROXY_PORT:9001" \
         --variable "PROMETHEUS_HOST:$(hostname)" \
-        --variable "PROMETHEUS_PORT:9092" \
+        --variable "PROMETHEUS_PORT:9093" \
         suites/telemetry/telemetry.robot
 }

--- a/test/scenarios-bootc/upstream/cos10-src@optional.sh
+++ b/test/scenarios-bootc/upstream/cos10-src@optional.sh
@@ -29,7 +29,7 @@ scenario_run_tests() {
         --variable "PROMETHEUS_HOST:$(hostname)" \
         --variable "PROMETHEUS_PORT:9093" \
         --variable "LOKI_HOST:$(hostname)" \
-        --variable "LOKI_PORT:3200" \
+        --variable "LOKI_PORT:3201" \
         --variable "PROM_EXPORTER_PORT:8889" \
         suites/optional/
 }

--- a/test/scenarios-bootc/upstream/cos9-src@optional.sh
+++ b/test/scenarios-bootc/upstream/cos9-src@optional.sh
@@ -25,9 +25,9 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
-        run_tests host1 \
+    run_tests host1 \
         --variable "PROMETHEUS_HOST:$(hostname)" \
-        --variable "PROMETHEUS_PORT:9093" \
+        --variable "PROMETHEUS_PORT:9092" \
         --variable "LOKI_HOST:$(hostname)" \
         --variable "LOKI_PORT:3200" \
         --variable "PROM_EXPORTER_PORT:8889" \


### PR DESCRIPTION
Update Prometheus and Loki server ports in the scenarios that run in parallel with other scenarios that also start a Prometheus and Loki server.