### PR TITLE
NO-ISSUE: Remove test case 62738 from ginkgo tests

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -1192,6 +1192,9 @@ run_ginkgo_tests() {
         echo "Running Ginkgo tests with MicroShift filter..."
     fi
 
+    echo "----------------Remove 62738 test case---------------"
+    sed -i "/62738/d" "${case_selected}"
+    echo "-----------------------------------------------------"
     echo "------------------Selected test cases------------------"
     cat "${case_selected}"
     echo "-----------------------------------------------------"


### PR DESCRIPTION
- This PR will unblock https://github.com/openshift/microshift/pull/5695 by fixing the Ginkgo failures.
- This PR adds a line to remove the ETCD test: 62738