### PR TITLE
NO-ISSUE: Increase timeout to wait for cert-manager kustomization log

### DIFF
--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -383,8 +383,8 @@ Verify Cert Manager Kustomization Success
     ...    ${cursor}
     ...    Applying kustomization at /usr/lib/microshift/manifests.d/060-microshift-cert-manager was successful
     ...    unit=microshift
-    ...    retries=6
-    ...    wait=5
+    ...    retries=30
+    ...    wait=10
 
 Resolve Host From Pod
     [Documentation]    Resolve host from pod


### PR DESCRIPTION
Increased wait time as cert-manager is always  the last to be applied.