### PR TITLE
[release-4.20] NO-ISSUE: Increase timeout to wait for cert-manager kustomization log

### DIFF
--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -376,5 +376,5 @@ Verify Cert Manager Kustomization Success
     ...    ${cursor}
     ...    Applying kustomization at /usr/lib/microshift/manifests.d/060-microshift-cert-manager was successful
     ...    unit=microshift
-    ...    retries=6
-    ...    wait=5
+    ...    retries=30
+    ...    wait=10


### PR DESCRIPTION
Manual cherrypick from https://github.com/openshift/microshift/pull/5807