### PR TITLE
[release-4.18] NO-ISSUE: Sync vendor/ to be consistent with content of deps/

### DIFF
--- a/vendor/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
+++ b/vendor/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
@@ -359,8 +359,9 @@ const (
 // 4) simpleLetterEqualFold, no specials, no non-letters.
 //
 // The letters S and K are special because they map to 3 runes, not just 2:
-//  * S maps to s and to U+017F 'ſ' Latin small letter long s
-//  * k maps to K and to U+212A 'K' Kelvin sign
+//   - S maps to s and to U+017F 'ſ' Latin small letter long s
+//   - k maps to K and to U+212A 'K' Kelvin sign
+//
 // See http://play.golang.org/p/tTxjOc0OGo
 //
 // The returned function is specialized for matching against s and

--- a/vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
@@ -1,6 +1,6 @@
-//This package is copied from Go library text/template.
-//The original private functions indirect and printableValue
-//are exported as public functions.
+// This package is copied from Go library text/template.
+// The original private functions indirect and printableValue
+// are exported as public functions.
 package template
 
 import (

--- a/vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
@@ -1,6 +1,6 @@
-//This package is copied from Go library text/template.
-//The original private functions eq, ge, gt, le, lt, and ne
-//are exported as public functions.
+// This package is copied from Go library text/template.
+// The original private functions eq, ge, gt, le, lt, and ne
+// are exported as public functions.
 package template
 
 import (


### PR DESCRIPTION
prefetch-dependencies task is failing when building microshift-bootc hermetically because of modified `vendor/` directory (ART internal build [URL](https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/ocp-art-tenant/applications/openshift-4-18/pipelineruns/ose-4-18-microshift-bootc-z5d6d/logs?task=prefetch-dependencies))

```
  2025-11-27 10:49:04,050 ERROR [mode:STRICT] vendor directory changed after vendoring:
  M	vendor/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
  M	vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
  M	vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
  2025-11-27 10:49:04,200 DEBUG Running `/usr/local/go/go1.21/bin/go clean -modcache`
  2025-11-27 10:49:08,850 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
  Error: PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
    Please try running `go mod vendor` and committing the changes.
    Note that you may need to `git add --force` ignored files in the vendor/ dir.
    Docs: https://github.com/hermetoproject/hermeto/blob/main/docs/gomod.md#vendoring
```

This PR ensures that there's no diff after running `go mod vendor`