### PR TITLE
USHIFT-6364: Cache management new functionality

### DIFF
--- a/test/bin/manage_build_cache.sh
+++ b/test/bin/manage_build_cache.sh
@@ -25,33 +25,33 @@ The cache directory structure is '${AWS_BUCKET_NAME}/<branch>/<arch>/<tag>'.
   -h        Show this help.
 
   upload:   Upload build artifacts from the local disk to the specified
-            '${AWS_BUCKET_NAME}/<branch>/<uname>/<tag>' AWS S3 bucket.
+            '${AWS_BUCKET_NAME}/<branch>/<arch>/<tag>' AWS S3 bucket.
             The 'verify' operation is run before the upload attempt. If
             data already exists at the destination, the upload is skipped
             and the script exits with 0 status.
 
   download: Download build artifacts from the specified
-            '${AWS_BUCKET_NAME}/<branch>/<uname>/<tag>' AWS S3 bucket
+            '${AWS_BUCKET_NAME}/<branch>/<arch>/<tag>' AWS S3 bucket
             to the local disk.
 
   verify:   Exit with 0 status if the specified
-            '${AWS_BUCKET_NAME}/<branch>/<uname>/<tag>' sub-directory
+            '${AWS_BUCKET_NAME}/<branch>/<arch>/<tag>' sub-directory
             exists and contains files, 1 otherwise.
 
-  setlast:  Update the '${AWS_BUCKET_NAME}/<branch>/<uname>/last' file
+  setlast:  Update the '${AWS_BUCKET_NAME}/<branch>/<arch>/last' file
             contents in the AWS S3 bucket with the specified '<tag>'.
 
-  getlast:  Retrieve the '${AWS_BUCKET_NAME}/<branch>/<uname>/last'
+  getlast:  Retrieve the '${AWS_BUCKET_NAME}/<branch>/<arch>/last'
             file contents from the AWS S3 bucket. The output format is
             "LAST: <tag>" for easy parsing. The script returns the
             specified '<tag>' as a fallback if the bucket file does
             not exist.
 
-  dellast:  Delete the data pointed by the '${AWS_BUCKET_NAME}/<branch>/<uname>/last'
+  dellast:  Delete the data pointed by the '${AWS_BUCKET_NAME}/<branch>/<arch>/last'
             file contents and update the 'last' file contents in the AWS S3 bucket
             with the specified '<tag>'
 
-  keep:     Delete all data from the '${AWS_BUCKET_NAME}/<branch>/<uname>'
+  keep:     Delete all data from the '${AWS_BUCKET_NAME}/<branch>/<arch>'
             AWS S3 bucket, only keeping the 'last' and the specified
             '<tag>' sub-directories.
 


### PR DESCRIPTION
* Add an optional `uname` override 
* Add `dellast` function
* Prevent deletion of the only cache tag
* Prevent reset to a non-existing cache tag

Co-authored-by: @agullon 

## Testing error handling

```
$ export AWS_BUCKET_NAME=microshift-build-cache-us-west-2

# Cannot delete the current 'last' without resetting it
$ ./test/bin/manage_build_cache.sh dellast -b release-4.21 -t 251207
You can now run: /home/microshift/microshift/_output/bin/aws --version
ERROR: Cannot delete 'last' tag because it is the same as the new '251207' tag

# Cannot set the 'last' to a non-existent tag
$ ./test/bin/manage_build_cache.sh dellast -b release-4.21 -t 251205
Checking contents of 's3://microshift-build-cache-us-west-2/release-4.21/x86_64/251205'
ERROR: Cannot reset 'last' tag to a non-existent '251205' tag
```

## Testing with the default architecture
```
$ export AWS_BUCKET_NAME=microshift-build-cache-us-west-2

$ ./test/bin/manage_build_cache.sh dellast -b release-4.21 -t 251206
Checking contents of 's3://microshift-build-cache-us-west-2/release-4.21/x86_64/251206'
Updating 's3://microshift-build-cache-us-west-2/release-4.21/x86_64/last' with the '251206' tag
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/vm-storage/rhel96-bootc-brew-ec-with-optional.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/vm-storage/rhel-9.6.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/vm-storage/rhel100-bootc.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/brew-rpms.tar
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/repo.tar
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/vm-storage/rhel96-bootc.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/vm-storage/rhel-9.6-microshift-4.20.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/x86_64/251207/mirror-registry.tar
```

## Testing with non-default architecture
```
$ export AWS_BUCKET_NAME=microshift-build-cache-us-west-2

$ ./test/bin/manage_build_cache.sh dellast -b release-4.21 -t 251206 -a aarch64
Checking contents of 's3://microshift-build-cache-us-west-2/release-4.21/aarch64/251206'
Updating 's3://microshift-build-cache-us-west-2/release-4.21/aarch64/last' with the '251206' tag
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/vm-storage/rhel-9.6.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/vm-storage/rhel-9.6-microshift-4.20.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/vm-storage/rhel96-bootc-brew-ec-with-optional.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/brew-rpms.tar
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/vm-storage/rhel100-bootc.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/repo.tar
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/vm-storage/rhel96-bootc.iso
delete: s3://microshift-build-cache-us-west-2/release-4.21/aarch64/251207/mirror-registry.tar
```