### PR TITLE
NO-ISSUE: Set multiprocessing start method to fork

### DIFF
--- a/test/bin/pyutils/build_bootc_images.py
+++ b/test/bin/pyutils/build_bootc_images.py
@@ -4,6 +4,7 @@ import argparse
 import concurrent.futures
 import getpass
 import glob
+import multiprocessing
 import os
 import platform
 import re
@@ -674,5 +675,6 @@ def main():
 
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("fork")
     _ = common.MeasureRunTimeInScope("[MAIN] Building Images")
     main()


### PR DESCRIPTION
Python 3.14 changed the default start method from fork to spawn.
That results in global variables not being available in subprocesses spawned with futures.

This affects only recent enough systems (like Fedora 43) used as the hypervisor.