### PR TITLE
USHIFT-6404: Persist microshift_variant macro in specfile

### DIFF
--- a/packaging/rpm/make-rpm.sh
+++ b/packaging/rpm/make-rpm.sh
@@ -57,6 +57,7 @@ build_commit() {
 %global commit ${1}
 %global embedded_git_tag ${SOURCE_GIT_TAG}
 %global embedded_git_tree_state ${SOURCE_GIT_TREE_STATE}
+%global microshift_variant ${MICROSHIFT_VARIANT}
 EOF
   cat "${SCRIPT_DIR}/microshift.spec" >> "${RPMBUILD_DIR}SPECS/microshift.spec"
 
@@ -71,7 +72,6 @@ EOF
   rpmbuild --quiet ${RPMBUILD_OPT} \
    --define "_topdir ${RPMBUILD_DIR}" \
    --define "_binary_payload w19T8.zstdio" \
-   --define "microshift_variant ${MICROSHIFT_VARIANT}" \
    "${RPMBUILD_DIR}"SPECS/microshift.spec
 }
 


### PR DESCRIPTION
If not persisted, there's no way to override it when rebuilding the RPMs from SRPM (see https://github.com/microshift-io/microshift/pull/164)