### PR TITLE
NO-ISSUE: new Claude command to get info about MicroShift versions availability

### DIFF
--- a/.claude/commands/microshift-release-versions.md
+++ b/.claude/commands/microshift-release-versions.md
@@ -109,7 +109,7 @@ Parsed:
 **Actions**:
 
 **For EC versions**:
-1. Check mirror.openshift.com for dev-preview packages:
+1. Check mirror.openshift.com, EC packages are under `ocp-dev-preview/`, see:
    ```
    https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/<version>/el9/os/Packages/
    https://mirror.openshift.com/pub/openshift-v4/aarch64/microshift/ocp-dev-preview/<version>/el9/os/Packages/
@@ -117,11 +117,12 @@ Parsed:
 2. Use WebFetch to verify the directory exists and list packages
 
 **For RC versions**:
-1. Check mirror.openshift.com for ocp packages:
+1. Check mirror.openshift.com, RC packages are under `ocp/`, see:
    ```
    https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp/<version>/el9/os/Packages/
    https://mirror.openshift.com/pub/openshift-v4/aarch64/microshift/ocp/<version>/el9/os/Packages/
    ```
+2. Use WebFetch to verify the directory exists and list packages
 
 **For GA/Z-stream versions**:
 1. Check on brew:


### PR DESCRIPTION
Example: 
`/microshift-release-versions 4.21-RC`

Output:

# MicroShift Version Availability: 4.21 RC

## Status
- **Version**: 4.21.x-rc.x
- **Type**: Release Candidate (RC)
- **Status**: **Not Yet Available**
- **Current Phase**: Engineering Candidate (EC)

## Current State

MicroShift 4.21 is currently in the **EC phase**. No RC versions have been created yet.

### Available EC Versions
The following EC versions are available:
- [4.21.0-ec.3](https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/4.21.0-ec.3/el9/os/Packages/) (Accepted)
- [4.21.0-ec.2](https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/4.21.0-ec.2/el9/os/Packages/) (Accepted)
- [4.21.0-ec.1](https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/4.21.0-ec.1/el9/os/Packages/) (Accepted)
- [4.21.0-ec.0](https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp-dev-preview/4.21.0-ec.0/el9/os/Packages/) (Accepted)

## When Will RC Versions Be Available?

RC (Release Candidate) versions are created **after branch cutoff** until GA. The 4.21 branch has not cut off yet, so RC versions are not expected at this time.

**Timeline**:
1. **Current**: EC phase (4.21.0-ec.x)
2. **Next**: Branch cutoff (date TBD)
3. **Then**: RC phase begins (4.21.0-rc.x)
4. **Finally**: GA release (4.21.0)

## How to Track Progress

Monitor the [OpenShift Release Status](https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/) page for:
- RC version creation
- Acceptance status of new builds

## Notes
- RC versions will appear in the [mirror repository](https://mirror.openshift.com/pub/openshift-v4/x86_64/microshift/ocp/) once created
- Until then, use the latest EC version (4.21.0-ec.3) for testing
- GA release is expected approximately 4 months after the previous major release (4.20)