### PR TITLE
NO-ISSUE: Fix variable name in scenario.sh

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -400,7 +400,7 @@ exit_if_commit_not_found() {
     local -r commit="${1}"
     if ! does_commit_exist "${commit}"; then
         echo "Commit '${commit}' not found in ostree repo - VM can't be created"
-        record_junit "${vm_name}" "build_vm_commit_not_found" "SKIPPED"
+        record_junit "${commit}" "build_vm_commit_not_found" "SKIPPED"
         exit 0
     fi
 }
@@ -410,7 +410,7 @@ exit_if_image_not_found() {
     local -r image="${1}"
     if ! does_image_exist "${image}"; then
         echo "Image '${image}' not found in mirror registry - VM can't be created"
-        record_junit "${vm_name}" "build_vm_image_not_found" "SKIPPED"
+        record_junit "${image}" "build_vm_image_not_found" "SKIPPED"
         exit 0
     fi
 }


### PR DESCRIPTION
Example of an error:
```
+ 19:06:16.635786725 ./bin/scenario.sh:412 	echo 'Image '\''rhel96-bootc-brew-rc-with-optional'\'' not found in mirror registry - VM can'\''t be created'
Image 'rhel96-bootc-brew-rc-with-optional' not found in mirror registry - VM can't be created
./bin/scenario.sh: line 413: vm_name: unbound variable
```

/cherry-pick release-4.21