### PR TITLE
USHIFT-6445: Add quick-microshift-boot ansible role

### DIFF
--- a/ansible/roles/quick-microshift-boot/defaults/main.yml
+++ b/ansible/roles/quick-microshift-boot/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# quick-microshift-boot default vars
+
+boot_output_filename: "boot1.txt"
+cleanup_microshift: false
+reboot: true

--- a/ansible/roles/quick-microshift-boot/tasks/main.yml
+++ b/ansible/roles/quick-microshift-boot/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# quick-microshift-boot tasks - measures warm boot time
+
+- name: measure microshift service boot time
+  include_tasks: roles/common/tasks/boot.yml
+  vars:
+    boot_output_filename: "{{ boot_output_filename }}"
+    cleanup_microshift: "{{ cleanup_microshift }}"
+    reboot: "{{ reboot }}"


### PR DESCRIPTION
Used to measure & record warm MicroShift boot times.