### PR TITLE
USHIFT-6448: Add pip package check before installing python package via dnf

### DIFF
--- a/ansible/roles/setup-localhost/defaults/main.yml
+++ b/ansible/roles/setup-localhost/defaults/main.yml
@@ -5,5 +5,6 @@ known_hosts:
   - '^localhost'
   - '^microshift-'
 local_packages:
-  - python3-kubernetes
+  - rpm: python3-kubernetes
+    pip: kubernetes
 microshift_pass: microshift

--- a/ansible/roles/setup-localhost/tasks/main.yml
+++ b/ansible/roles/setup-localhost/tasks/main.yml
@@ -27,10 +27,23 @@
   with_inventory_hostnames:
     - microshift
 
-- name: install local ansible prereq pacakges
+- name: check if python packages are installed via pip
+  ansible.builtin.command: "pip3 show {{ item.pip }}"
+  register: pip_check
+  ignore_errors: true
+  changed_when: false
+  loop: "{{ local_packages }}"
+
+- name: build list of packages not installed via pip
+  ansible.builtin.set_fact:
+    packages_to_install: "{{ pip_check.results | selectattr('rc', 'ne', 0) | map(attribute='item.rpm') | list }}"
+
+- name: install local ansible prereq packages
   ansible.builtin.dnf:
-    name: "{{ local_packages }}"
+    name: "{{ packages_to_install }}"
     state: present
     update_cache: true
-  when: (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat") or (ansible_distribution == "Fedora")
+  when:
+    - packages_to_install | length > 0
+    - (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat") or (ansible_distribution == "Fedora")
   become: yes


### PR DESCRIPTION
Rework to support checking for python package with `pip` first before trying to install via `dnf`.