### PR TITLE
OCPBUGS-73946: Ignore (Dev|Tech)PreviewNoUpgrade FeatureSets

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -874,6 +874,17 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "feature-gates-custom-no-upgrade-with-empty-enabled-and-disabled-lists",
+			config: func() *Config {
+				c := mkDefaultConfig()
+				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
+				c.ApiServer.FeatureGates.CustomNoUpgrade.Enabled = []string{}
+				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{}
+				return c
+			}(),
+			expectErr: false,
+		},
+		{
 			name: "feature-gates-preview-feature-sets-not-supported",
 			config: func() *Config {
 				c := mkDefaultConfig()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -819,7 +819,7 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "feature-gates-custom-no-upgrade-with-feature-set",
+			name: "feature-gates-custom-no-upgrade-valid",
 			config: func() *Config {
 				c := mkDefaultConfig()
 				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
@@ -827,6 +827,7 @@ func TestValidate(t *testing.T) {
 				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{"feature2"}
 				return c
 			}(),
+			expectErr: false,
 		},
 		{
 			name: "feature-gates-custom-no-upgrade-with-feature-set-empty",
@@ -840,23 +841,43 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "feature-gates-custom-no-upgrade-with-empty-enabled-and-disabled-lists",
-			config: func() *Config {
-				c := mkDefaultConfig()
-				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
-				c.ApiServer.FeatureGates.CustomNoUpgrade.Enabled = []string{}
-				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{}
-				return c
-			}(),
-			expectErr: true,
-		},
-		{
 			name: "feature-gates-custom-no-upgrade-enabled-and-disabled-have-same-feature-gate",
 			config: func() *Config {
 				c := mkDefaultConfig()
 				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
 				c.ApiServer.FeatureGates.CustomNoUpgrade.Enabled = []string{"feature1"}
 				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{"feature1"}
+				return c
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "feature-gates-required-feature-gate-cannot-be-disabled",
+			config: func() *Config {
+				c := mkDefaultConfig()
+				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
+				c.ApiServer.FeatureGates.CustomNoUpgrade.Enabled = []string{"feature1"}
+				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{"UserNamespacesSupport"}
+				return c
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "feature-gates-required-feature-gate-cannot-be-explicitly-enabled",
+			config: func() *Config {
+				c := mkDefaultConfig()
+				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
+				c.ApiServer.FeatureGates.CustomNoUpgrade.Enabled = []string{"UserNamespacesSupport"}
+				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{"feature2"}
+				return c
+			}(),
+			expectErr: true,
+		},
+		{
+			name: "feature-gates-preview-feature-sets-not-supported",
+			config: func() *Config {
+				c := mkDefaultConfig()
+				c.ApiServer.FeatureGates.FeatureSet = "TechPreviewNoUpgrade"
 				return c
 			}(),
 			expectErr: true,

--- a/scripts/aws/cf-gen.yaml
+++ b/scripts/aws/cf-gen.yaml
@@ -32,8 +32,8 @@ Parameters:
     Description: Current RHEL AMI to use.
     Type: AWS::EC2::Image::Id
   Machinename:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
-    MaxLength: 27
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]*)$
+    MaxLength: 64
     MinLength: 1
     ConstraintDescription: Machinename
     Description: Machinename


### PR DESCRIPTION
If microshift config contains `apiServer.featureGates.featureSet: DevPreviewNoUpgrade`, microshift will refuse to start.

After the prohibited featureset is removed from the config, microshift will once again start.