### PR TITLE
USHIFT-6362: Updating scenarios to use the right image

### DIFF
--- a/test/scenarios/releases/el96-lrel@iso-standard1.sh
+++ b/test/scenarios/releases/el96-lrel@iso-standard1.sh
@@ -8,7 +8,7 @@ scenario_create_vms() {
     exit_if_commit_not_found "${start_image}"
 
     prepare_kickstart host1 kickstart.ks.template "${start_image}"
-    launch_vm --vm_vcpus 4
+    launch_vm --boot_blueprint "${start_image}" --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios/releases/el96-lrel@iso-standard2.sh
+++ b/test/scenarios/releases/el96-lrel@iso-standard2.sh
@@ -8,7 +8,7 @@ scenario_create_vms() {
     exit_if_commit_not_found "${start_image}"
 
     prepare_kickstart host1 kickstart.ks.template "${start_image}"
-    launch_vm --vm_vcpus 4
+    launch_vm --boot_blueprint "${start_image}" --vm_vcpus 4
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
with out the change in this PR i see the scenarios are not actually using the right iso to boot up, issue has been discovered when running the tests on 4.21 branch, so updating the code here as well.