### PR TITLE
USHIFT-6492: Simplified topolvm storage configuration to use the microshift default

### DIFF
--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -25,5 +25,6 @@ install_packages:
   - tar
   - vnstat
 
-vg_name: rhel
+default_vg_name: microshift
+vg_name: "{{ default_vg_name }}"
 lvm_disk: /dev/xvdb

--- a/ansible/roles/setup-microshift-host/tasks/main.yml
+++ b/ansible/roles/setup-microshift-host/tasks/main.yml
@@ -72,9 +72,17 @@
     - lvm_disk_stat is defined
     - not lvm_disk_stat.stat.exists
 
+- name: Check if volume group exists
+  ansible.builtin.command: vgdisplay -s {{ vg_name }}
+  register: vg_exists
+  changed_when: false
+  failed_when: false
+
 - name: Configure TopoLVM storage
   include_tasks: storage.yml
-  when: rhel_vg_present.rc == 0 or (lvm_disk_stat is defined and lvm_disk_stat.stat.exists)
+  when:
+    - vg_name != default_vg_name
+    - vg_exists.rc == 0
 
 - name: upgrade all packages
   ansible.builtin.dnf:

--- a/ansible/roles/setup-microshift-host/tasks/storage.yml
+++ b/ansible/roles/setup-microshift-host/tasks/storage.yml
@@ -1,29 +1,23 @@
 ---
 # Configure TopoLVM storage for MicroShift
+# Only needed when using a non-default volume group name.
+# MicroShift auto-detects a VG named "microshift" without explicit config.
 
-- name: Detect largest volume group for TopoLVM
-  ansible.builtin.shell: |
-    vgs --noheadings --units g -o vg_name,vg_size --sort -vg_size | head -1 | awk '{print $1}'
-  register: largest_vg
-  changed_when: false
-  failed_when: false
+- name: Ensure /etc/microshift directory exists
+  ansible.builtin.file:
+    path: /etc/microshift
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
 
-- name: Configure TopoLVM with detected volume group
-  when: 
-    - largest_vg.rc == 0
-    - largest_vg.stdout | length > 0
-  block:
-    - name: Display detected volume group
-      ansible.builtin.debug:
-        msg: "Configuring TopoLVM to use volume group: {{ largest_vg.stdout }}"
-
-    - name: Deploy lvmd.yaml configuration
-      ansible.builtin.template:
-        src: lvmd.yaml.j2
-        dest: /etc/microshift/lvmd.yaml
-        owner: root
-        group: root
-        mode: '0644'
-        backup: yes
-      vars:
-        topolvm_vg: "{{ largest_vg.stdout }}"
+- name: Deploy lvmd.yaml configuration
+  ansible.builtin.template:
+    src: lvmd.yaml.j2
+    dest: /etc/microshift/lvmd.yaml
+    owner: root
+    group: root
+    mode: '0644'
+    backup: yes
+  vars:
+    topolvm_vg: "{{ vg_name }}"


### PR DESCRIPTION
Improve the handling of default `vg_name`