### PR TITLE
[release-4.20] USHIFT-6447: Unpin multus images

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -1031,9 +1031,6 @@ checkout_rebase_branch() {
 update_multus_images() {
     title "Rebasing Multus images"
 
-    # Pin multus images until https://issues.redhat.com//browse/OCPBUGS-73737 is solved and images updated.
-    return
-
     for goarch in amd64 arm64; do
         arch=${GOARCH_TO_UNAME_MAP["${goarch}"]:-noarch}
 


### PR DESCRIPTION
This reverts commit bf9eb1aae5120aec27aec46d8d1ae0834a9c3450.

Allow the next rebase to pick up the new images.