### PR TITLE
NO-ISSUE: Update regex to match release job names more accurately

### DIFF
--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -92,7 +92,7 @@ update_build_cache() {
 run_image_build() {
     if [ -v CI_JOB_NAME ] ; then
         # Skip all image builds for release testing CI jobs because all the images are fetched from the cache.
-        if [[ "${CI_JOB_NAME}" =~ .*release.* ]]; then
+        if [[ "${CI_JOB_NAME}" =~ .*release(-arm)?$ ]]; then
             $(dry_run) bash -x ./bin/build_images.sh -X
             return
         fi
@@ -117,7 +117,7 @@ run_bootc_image_build() {
 
     if [ -v CI_JOB_NAME ] ; then
         # Skip all image builds for release testing CI jobs because all the images are fetched from the cache.
-        if [[ "${CI_JOB_NAME}" =~ .*release.* ]]; then
+        if [[ "${CI_JOB_NAME}" =~ .*release(-arm)?$ ]]; then
             $(dry_run) bash -x ./bin/build_bootc_images.sh -X
             return
         fi


### PR DESCRIPTION
Changes expression to match release jobs because on branches different from `main` (e.g. `release-4.20`) the expression always match.