### PR TITLE
USHIFT-6517: Use host network for bootc image builds for proxy access

### DIFF
--- a/test/bin/common.sh
+++ b/test/bin/common.sh
@@ -187,7 +187,7 @@ get_vm_bridge_ip() {
 VM_BRIDGE_IP="$(get_vm_bridge_ip "default")"
 
 # Web server port number
-WEB_SERVER_PORT=8080
+export WEB_SERVER_PORT=8080
 
 # Web server URL using VM bridge IP with fallback to host name
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/package-sources-bootc/rhel98-mirror.repo
+++ b/test/package-sources-bootc/rhel98-mirror.repo
@@ -1,7 +1,7 @@
 [rhel-9.8-appstream]
 name = rhel-9.8-appstream
 
-baseurl = {{ .Env.WEB_SERVER_URL }}/ocp-mirror/reposync/4.22{{ if eq .Env.UNAME_M "aarch64" }}_aarch64{{ end }}/rhel-98-appstream
+baseurl = http://localhost:{{ .Env.WEB_SERVER_PORT }}/ocp-mirror/reposync/4.22{{ if eq .Env.UNAME_M "aarch64" }}_aarch64{{ end }}/rhel-98-appstream
 enabled = 1
 sslverify = false
 gpgcheck = 0
@@ -9,7 +9,7 @@ skip_if_unavailable = false
 
 [rhel-9.8-baseos]
 name = rhel-9.8-baseos
-baseurl = {{ .Env.WEB_SERVER_URL }}/ocp-mirror/reposync/4.22{{ if eq .Env.UNAME_M "aarch64" }}_aarch64{{ end }}/rhel-98-baseos
+baseurl = http://localhost:{{ .Env.WEB_SERVER_PORT }}/ocp-mirror/reposync/4.22{{ if eq .Env.UNAME_M "aarch64" }}_aarch64{{ end }}/rhel-98-baseos
 enabled = 1
 sslverify = false
 gpgcheck = 0


### PR DESCRIPTION
Since we do not delete RHEL 9.8 repo from the images, it must be reusable from cache. 
Previously, we embedded `WEB_SERVER_URL`, which might be pointing to a specific host name or IP.

To make the `.repo` configuration reusable, we can refer to `localhost` and use `--network host` argument **only** when building images.