### PR TITLE
NO-ISSUE chore: bump builder image to golang 1.25 / openshift 4.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ GO_TEST_PACKAGES=./cmd/... ./pkg/...
 export CGO_ENABLED ?= 1
 
 # Specify OCP build tools image tag when building rpm with podman
-RPM_BUILDER_IMAGE_TAG := rhel-9-golang-1.24-openshift-4.20
+RPM_BUILDER_IMAGE_TAG := rhel-9-golang-1.25-openshift-4.21
 
 all: generate-config microshift etcd
 


### PR DESCRIPTION
Update golang build image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain configuration for RPM builds: Go upgraded from version 1.24 to 1.25 and OpenShift components updated from version 4.20 to 4.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->