### PR TITLE
NO-ISSUE release-4.21 temporary fix for olm kustomization

### DIFF
--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -1111,6 +1111,14 @@ EOF
 update_olm_images() {
     title "Rebasing operator-lifecycle-manager manifests"
 
+    # Temporary fix, remove once OCPBUGS-77006 is solved.
+    local olm_kustomization="${REPOROOT}/assets/optional/operator-lifecycle-manager/kustomization.yaml"
+    sed -i \
+        -e '/0000_50_olm_00-pprof-config\.yaml/d' \
+        -e '/0000_50_olm_00-pprof-rbac\.yaml/d' \
+        -e '/0000_50_olm_00-pprof-secret\.yaml/d' \
+        "${olm_kustomization}"
+
     # Replace hardcoded image refs with variables. Variables will be provided via kustomize's patches (added to `env`).
     # Expr with --util-image finds line with --util-image and edits the line after.
     sed -i \


### PR DESCRIPTION
Cherry-pick of commit c2d47ca62dca162963279757067077450b7d4af7 from PR #6251.

## Summary
Temporary fix for OLM kustomization that removes pprof-related YAML files.

## Changes
- Modified `scripts/auto-rebase/rebase.sh` to remove problematic pprof configuration files from OLM kustomization
- This is a temporary workaround until the underlying issue is resolved

## Testing
- ✅ `make test` passed
- ✅ Cherry-pick applied cleanly

Original commit by Pablo Acevedo Montserrat <pacevedo@redhat.com>

Made with [Cursor](https://cursor.com)