### PR TITLE
[release-4.21] OCPBUGS-77907: Allow custom feature gates to be exempted from upgrade blocking

### DIFF
--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -64,10 +64,12 @@
           "type": "object",
           "required": [
             "customNoUpgrade",
-            "featureSet"
+            "featureSet",
+            "specialHandlingSupportExceptionRequired"
           ],
           "properties": {
             "customNoUpgrade": {
+              "description": "CustomNoUpgrade is used to enable/disable feature gates that block x- and y-stream upgrades.",
               "type": "object",
               "required": [
                 "disabled",
@@ -90,6 +92,28 @@
             },
             "featureSet": {
               "type": "string"
+            },
+            "specialHandlingSupportExceptionRequired": {
+              "description": "SpecialHandlingSupportExceptionRequired is used to enable/disable feature gates that are exempt from blocking x- and y-stream upgrades.\nFeatures listed here do not need to be duplicated in CustomNoUpgrade.",
+              "type": "object",
+              "required": [
+                "disabled",
+                "enabled"
+              ],
+              "properties": {
+                "disabled": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         },

--- a/docs/user/howto_config.md
+++ b/docs/user/howto_config.md
@@ -19,6 +19,9 @@ apiServer:
             disabled: []
             enabled: []
         featureSet: ""
+        specialHandlingSupportExceptionRequired:
+            disabled: []
+            enabled: []
     namedCertificates:
         - certPath: ""
           keyPath: ""
@@ -168,6 +171,9 @@ apiServer:
             disabled: []
             enabled: []
         featureSet: ""
+        specialHandlingSupportExceptionRequired:
+            disabled: []
+            enabled: []
     namedCertificates:
         - certPath: ""
           keyPath: ""

--- a/etcd/vendor/github.com/openshift/microshift/pkg/config/apiserver.go
+++ b/etcd/vendor/github.com/openshift/microshift/pkg/config/apiserver.go
@@ -139,7 +139,7 @@ const (
 	FeatureSetDevPreviewNoUpgrade  = "DevPreviewNoUpgrade"
 )
 
-type CustomNoUpgrade struct {
+type EnableDisableFeatures struct {
 	Enabled  []string `json:"enabled"`
 	Disabled []string `json:"disabled"`
 }
@@ -149,8 +149,12 @@ type CustomNoUpgrade struct {
 var RequiredFeatureGates = []string{"UserNamespacesSupport", "UserNamespacesPodSecurityStandards"}
 
 type FeatureGates struct {
-	FeatureSet      string          `json:"featureSet"`
-	CustomNoUpgrade CustomNoUpgrade `json:"customNoUpgrade"`
+	FeatureSet string `json:"featureSet"`
+	// CustomNoUpgrade is used to enable/disable feature gates. When the enabled or disable lists are not empty, x- and y-stream upgrades will be blocked.
+	// Use this field exclusively for custom feature gates, unless you are certain that the feature gate is a SpecialHandlingSupportExceptionRequired feature.
+	CustomNoUpgrade EnableDisableFeatures `json:"customNoUpgrade"`
+	// SpecialHandlingSupportExceptionRequired allows for feature gates to be exempted from blocking x- and y-stream upgrades.
+	SpecialHandlingSupportExceptionRequired EnableDisableFeatures `json:"specialHandlingSupportExceptionRequired"`
 }
 
 func (fg FeatureGates) ToApiserverArgs() ([]string, error) {

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -15,10 +15,16 @@ apiServer:
         # profile is the OpenShift profile specifying a specific logging policy
         profile: Default
     featureGates:
+        # CustomNoUpgrade is used to enable/disable feature gates that block x- and y-stream upgrades.
         customNoUpgrade:
             disabled: []
             enabled: []
         featureSet: ""
+        # SpecialHandlingSupportExceptionRequired is used to enable/disable feature gates that are exempt from blocking x- and y-stream upgrades.
+        # Features listed here do not need to be duplicated in CustomNoUpgrade.
+        specialHandlingSupportExceptionRequired:
+            disabled: []
+            enabled: []
     # List of custom certificates used to secure requests to specific host names
     namedCertificates:
         - certPath: ""

--- a/pkg/admin/prerun/featuregate_lock.go
+++ b/pkg/admin/prerun/featuregate_lock.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/microshift/pkg/config"
 	"github.com/openshift/microshift/pkg/util"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
@@ -22,16 +23,18 @@ var (
 // featureGateLockFile represents the structure of the lock file
 // that tracks custom feature gate configuration and prevents changes/upgrades
 type featureGateLockFile struct {
-	FeatureSet      string                 `json:"featureSet"`
-	CustomNoUpgrade config.CustomNoUpgrade `json:"customNoUpgrade"`
-	Version         versionMetadata        `json:"version"`
+	FeatureSet      string                       `json:"featureSet"`
+	CustomNoUpgrade config.EnableDisableFeatures `json:"customNoUpgrade"`
+	Version         versionMetadata              `json:"version"`
 }
 
 // FeatureGateLockManagement manages the feature gate lock file
 // that prevents upgrades and config changes when custom feature gates are configured
 func FeatureGateLockManagement(cfg *config.Config) error {
 	klog.InfoS("START feature gate lock management")
-	if err := featureGateLockManagement(cfg); err != nil {
+
+	fgCfg := &cfg.ApiServer.FeatureGates
+	if err := featureGateLockManagement(fgCfg); err != nil {
 		klog.ErrorS(err, "FAIL feature gate lock management")
 		return err
 	}
@@ -39,7 +42,7 @@ func FeatureGateLockManagement(cfg *config.Config) error {
 	return nil
 }
 
-func featureGateLockManagement(cfg *config.Config) error {
+func featureGateLockManagement(fgCfg *config.FeatureGates) error {
 	// If a lock file exists, it must be validated regardless of current config
 	// This prevents users from removing feature gates from config in order to block upgrades and configuration changes
 	lockExists, err := util.PathExists(featureGateLockFilePath)
@@ -48,18 +51,18 @@ func featureGateLockManagement(cfg *config.Config) error {
 	}
 	// Lock file exists - validate configuration
 	if lockExists {
-		return runValidationsChecks(cfg)
+		return runValidationsChecks(fgCfg)
 	}
 	// No lock file exists yet and custom feature gates are configured, so this is the first time configuring custom feature gates
-	if cfg.ApiServer.FeatureGates.FeatureSet != "" {
-		return createFeatureGateLockFile(cfg)
+	if fgCfg.FeatureSet != "" {
+		return createFeatureGateLockFile(fgCfg)
 	}
 	// No lock file and no custom feature gates - normal operation
 	return nil
 }
 
 // createFeatureGateLockFile creates the lock file with current configuration
-func createFeatureGateLockFile(cfg *config.Config) error {
+func createFeatureGateLockFile(fgCfg *config.FeatureGates) error {
 	klog.InfoS("Creating feature gate lock file - this cluster can no longer be upgraded",
 		"path", featureGateLockFilePath)
 
@@ -70,8 +73,8 @@ func createFeatureGateLockFile(cfg *config.Config) error {
 	}
 
 	lockFile := featureGateLockFile{
-		FeatureSet:      cfg.ApiServer.FeatureGates.FeatureSet,
-		CustomNoUpgrade: cfg.ApiServer.FeatureGates.CustomNoUpgrade,
+		FeatureSet:      fgCfg.FeatureSet,
+		CustomNoUpgrade: fgCfg.CustomNoUpgrade,
 		Version:         currentVersion,
 	}
 
@@ -88,7 +91,7 @@ func createFeatureGateLockFile(cfg *config.Config) error {
 
 // runValidationsChecks validates the feature gate lock file and the current configuration
 // It returns an error if the configuration is invalid or if an x or y stream version upgrade has occurred.
-func runValidationsChecks(cfg *config.Config) error {
+func runValidationsChecks(fgCfg *config.FeatureGates) error {
 	klog.InfoS("Validating feature gate lock file", "path", featureGateLockFilePath)
 
 	lockFile, err := readFeatureGateLockFile(featureGateLockFilePath)
@@ -97,7 +100,7 @@ func runValidationsChecks(cfg *config.Config) error {
 	}
 
 	// Check if feature gate configuration has changed
-	if err := configValidationChecksPass(lockFile, cfg.ApiServer.FeatureGates); err != nil {
+	if err := configValidationChecksPass(lockFile, fgCfg); err != nil {
 		return fmt.Errorf("detected invalid changes in feature gate configuration: %w\n\n"+
 			"To restore MicroShift to a supported state, you must:\n"+
 			"1. Run: sudo microshift-cleanup-data --all\n"+
@@ -105,37 +108,62 @@ func runValidationsChecks(cfg *config.Config) error {
 			"3. Restart MicroShift: sudo systemctl restart microshift", err)
 	}
 
-	// Check if version has changed (upgrade attempted)
-	currentExecutableVersion, err := getExecutableVersion()
-	if err != nil {
-		return fmt.Errorf("failed to get current executable version: %w", err)
-	}
-
-	if lockFile.Version.Major != currentExecutableVersion.Major || lockFile.Version.Minor != currentExecutableVersion.Minor {
-		return fmt.Errorf("version upgrade detected with custom feature gates: locked version %s, current version %s\n\n"+
-			"Upgrades are not supported when custom feature gates are configured.\n"+
-			"Custom feature gates (%s) were configured in version %s.\n"+
-			"To restore MicroShift to a supported state, you must:\n"+
-			"1. Roll back to version %s, OR\n"+
-			"2. Run: sudo microshift-cleanup-data --all\n"+
-			"3. Remove custom feature gates from /etc/microshift/config.yaml\n"+
-			"4. Restart MicroShift: sudo systemctl restart microshift",
-			lockFile.Version.String(), currentExecutableVersion.String(),
-			lockFile.FeatureSet, lockFile.Version.String(), lockFile.Version.String())
+	if err := upgradeChecksPass(lockFile, fgCfg); err != nil {
+		return err
 	}
 
 	klog.InfoS("Feature gate lock file validation successful")
 	return nil
 }
 
-func configValidationChecksPass(prev featureGateLockFile, current config.FeatureGates) error {
-	if prev.FeatureSet != "" && current.FeatureSet == "" {
+func configValidationChecksPass(prev featureGateLockFile, fgCfg *config.FeatureGates) error {
+	if prev.FeatureSet != "" && fgCfg.FeatureSet == "" {
 		// Disallow changing from feature set to no feature set
 		return fmt.Errorf("cannot unset feature set. Previous config had feature set %q, current config has no feature set configured", prev.FeatureSet)
 	}
-	if prev.FeatureSet == config.FeatureSetCustomNoUpgrade && current.FeatureSet != config.FeatureSetCustomNoUpgrade {
+	if prev.FeatureSet == config.FeatureSetCustomNoUpgrade && fgCfg.FeatureSet != config.FeatureSetCustomNoUpgrade {
 		// Disallow changing from custom feature gates to any other feature set
-		return fmt.Errorf("cannot change CustomNoUpgrade feature set. Previous feature set was %q, current feature set is %q", prev.FeatureSet, current.FeatureSet)
+		return fmt.Errorf("cannot change CustomNoUpgrade feature set. Previous feature set was %q, current feature set is %q", prev.FeatureSet, fgCfg.FeatureSet)
+	}
+	return nil
+}
+
+func upgradeChecksPass(lockFile featureGateLockFile, fgCfg *config.FeatureGates) error {
+	currentExecutableVersion, err := getExecutableVersion()
+	lockedVersion := lockFile.Version
+	if err != nil {
+		return fmt.Errorf("failed to get current executable version: %w", err)
+	}
+
+	if lockedVersion.Major != currentExecutableVersion.Major || lockedVersion.Minor != currentExecutableVersion.Minor {
+		extractFeatureGatesWithoutExemptions := func(lhs []string, rhs []string) []string {
+			lhsSet := sets.New(lhs...)
+			rhsSet := sets.New(rhs...)
+			return lhsSet.Difference(rhsSet).UnsortedList()
+		}
+
+		// Parse out featureGates from the last known cluster state and filter them by the latest config. This allows users to update
+		// the feature gate config and upgrade the cluster simultaneously if they want. In the typical case where the config does not change
+		// between upgrades, non-exempt featureGates are still validated and will still block the upgrade.
+		customNoUpgradeEnabled := extractFeatureGatesWithoutExemptions(lockFile.CustomNoUpgrade.Enabled, fgCfg.SpecialHandlingSupportExceptionRequired.Enabled)
+		customNoUpgradeDisabled := extractFeatureGatesWithoutExemptions(lockFile.CustomNoUpgrade.Disabled, fgCfg.SpecialHandlingSupportExceptionRequired.Disabled)
+
+		// If there are any gates that lack a special handling support exception, return an error.
+		if len(customNoUpgradeEnabled) > 0 || len(customNoUpgradeDisabled) > 0 {
+			return fmt.Errorf("version upgrade detected with custom feature gates: locked version %s, current version %s\n\n"+
+				"Upgrades are not supported when custom feature gates are configured.\n"+
+				"Custom feature gates were configured in version %s.\n"+
+				"Gates Enabled: %s\n"+
+				"Gates Disabled: %s\n"+
+				"To restore MicroShift to a supported state, you must:\n"+
+				"1. Roll back to version %s, OR\n"+
+				"2. Run: sudo microshift-cleanup-data --all\n"+
+				"3. Remove custom feature gates from /etc/microshift/config.yaml\n"+
+				"4. Restart MicroShift: sudo systemctl restart microshift",
+				lockedVersion.String(), currentExecutableVersion.String(),
+				lockedVersion.String(), customNoUpgradeEnabled,
+				customNoUpgradeDisabled, lockedVersion.String())
+		}
 	}
 	return nil
 }

--- a/pkg/admin/prerun/featuregate_lock_test.go
+++ b/pkg/admin/prerun/featuregate_lock_test.go
@@ -1,7 +1,6 @@
 package prerun
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"

--- a/pkg/admin/prerun/featuregate_lock_test.go
+++ b/pkg/admin/prerun/featuregate_lock_test.go
@@ -22,7 +22,7 @@ func TestFeatureGateLockFile_Marshal(t *testing.T) {
 			name: "custom feature gates with enabled and disabled",
 			lockFile: featureGateLockFile{
 				FeatureSet: config.FeatureSetCustomNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{
+				CustomNoUpgrade: config.EnableDisableFeatures{
 					Enabled:  []string{"FeatureA", "FeatureB"},
 					Disabled: []string{"FeatureC"},
 				},
@@ -33,7 +33,7 @@ func TestFeatureGateLockFile_Marshal(t *testing.T) {
 			name: "TechPreviewNoUpgrade",
 			lockFile: featureGateLockFile{
 				FeatureSet:      config.FeatureSetTechPreviewNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{},
+				CustomNoUpgrade: config.EnableDisableFeatures{},
 			},
 			wantErr: false,
 		},
@@ -41,7 +41,7 @@ func TestFeatureGateLockFile_Marshal(t *testing.T) {
 			name: "DevPreviewNoUpgrade",
 			lockFile: featureGateLockFile{
 				FeatureSet:      config.FeatureSetDevPreviewNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{},
+				CustomNoUpgrade: config.EnableDisableFeatures{},
 			},
 			wantErr: false,
 		},
@@ -49,7 +49,7 @@ func TestFeatureGateLockFile_Marshal(t *testing.T) {
 			name: "empty feature gates",
 			lockFile: featureGateLockFile{
 				FeatureSet:      "",
-				CustomNoUpgrade: config.CustomNoUpgrade{},
+				CustomNoUpgrade: config.EnableDisableFeatures{},
 			},
 			wantErr: false,
 		},
@@ -86,7 +86,7 @@ func TestIsCustomFeatureGatesConfigured(t *testing.T) {
 			name: "CustomNoUpgrade with enabled features",
 			fg: config.FeatureGates{
 				FeatureSet: config.FeatureSetCustomNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{
+				CustomNoUpgrade: config.EnableDisableFeatures{
 					Enabled: []string{"FeatureA"},
 				},
 			},
@@ -111,15 +111,15 @@ func TestIsCustomFeatureGatesConfigured(t *testing.T) {
 			fg: config.FeatureGates{
 				FeatureSet: "",
 			},
-			want: false,
+			want: true, // validation passes when prev and current both have no feature set
 		},
 		{
 			name: "CustomNoUpgrade without any enabled/disabled",
 			fg: config.FeatureGates{
 				FeatureSet:      config.FeatureSetCustomNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{},
+				CustomNoUpgrade: config.EnableDisableFeatures{},
 			},
-			want: false,
+			want: true, // validation passes when prev and current match
 		},
 	}
 
@@ -128,12 +128,10 @@ func TestIsCustomFeatureGatesConfigured(t *testing.T) {
 			err := configValidationChecksPass(featureGateLockFile{
 				FeatureSet:      tt.fg.FeatureSet,
 				CustomNoUpgrade: tt.fg.CustomNoUpgrade,
-			}, tt.fg)
-			if err != nil {
-				t.Errorf("featureValidationsPass() error = %v", err)
-			}
-			if err != nil {
-				t.Errorf("featureValidationsPass() error = %v", err)
+			}, &tt.fg)
+			got := err == nil
+			if got != tt.want {
+				t.Errorf("configValidationChecksPass() got pass = %v, want %v (err = %v)", got, tt.want, err)
 			}
 		})
 	}
@@ -157,7 +155,7 @@ func TestFeatureGateLockFile_ReadWrite(t *testing.T) {
 			name: "write and read custom feature gates",
 			lockFile: featureGateLockFile{
 				FeatureSet: config.FeatureSetCustomNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{
+				CustomNoUpgrade: config.EnableDisableFeatures{
 					Enabled:  []string{"FeatureA", "FeatureB"},
 					Disabled: []string{"FeatureC"},
 				},
@@ -243,7 +241,7 @@ func TestConfigValidationChecksPass(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := configValidationChecksPass(tt.lockFile, tt.current)
+			err := configValidationChecksPass(tt.lockFile, &tt.current)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("configValidationChecksPass() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -278,7 +276,7 @@ func TestFeatureGateLockManagement_FirstRun(t *testing.T) {
 		ApiServer: config.ApiServer{
 			FeatureGates: config.FeatureGates{
 				FeatureSet: config.FeatureSetCustomNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{
+				CustomNoUpgrade: config.EnableDisableFeatures{
 					Enabled: []string{"FeatureA"},
 				},
 			},
@@ -327,7 +325,7 @@ func TestFeatureGateLockManagement_ConfigChange(t *testing.T) {
 	// Create lockFile file with initial config (CustomNoUpgrade feature set)
 	initialLock := featureGateLockFile{
 		FeatureSet: config.FeatureSetCustomNoUpgrade,
-		CustomNoUpgrade: config.CustomNoUpgrade{
+		CustomNoUpgrade: config.EnableDisableFeatures{
 			Enabled: []string{"FeatureA"},
 		},
 		Version: testVersion,
@@ -366,18 +364,24 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		lockFileVer versionMetadata
-		currentVer  versionMetadata
-		wantErr     bool
-		description string
+		name                            string
+		lockFileVer                     versionMetadata
+		currentVer                      versionMetadata
+		customNoUpgrade                 *config.EnableDisableFeatures
+		specialHandlingSupportException *config.EnableDisableFeatures
+		wantErr                         bool
+		description                     string
 	}{
 		{
-			name:        "minor version upgrade should fail",
-			lockFileVer: getVersion(0, 0, 0),
-			currentVer:  getVersion(0, 1, 0),
-			wantErr:     true,
-			description: "Minor version upgrade (4.21.0 -> 4.22.0) should be blocked",
+			name:                            "minor version upgrade should fail",
+			lockFileVer:                     getVersion(0, 0, 0),
+			currentVer:                      getVersion(0, 1, 0),
+			wantErr:                         true,
+			specialHandlingSupportException: &config.EnableDisableFeatures{},
+			description:                     "Minor version upgrade (4.21.0 -> 4.22.0) should be blocked",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
 		},
 		{
 			name:        "major version upgrade should fail",
@@ -385,6 +389,10 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			currentVer:  getVersion(1, 0, 0),
 			wantErr:     true,
 			description: "Major version upgrade (4.21.0 -> 5.0.0) should be blocked",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{},
 		},
 		{
 			name:        "patch version change should succeed",
@@ -392,6 +400,10 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			currentVer:  getVersion(0, 0, 1),
 			wantErr:     false,
 			description: "Patch version change (4.21.0 -> 4.21.1) should be allowed",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{},
 		},
 		{
 			name:        "same version should succeed",
@@ -399,6 +411,10 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			currentVer:  getVersion(0, 0, 0),
 			wantErr:     false,
 			description: "Same version (4.21.0 -> 4.21.0) should be allowed",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{},
 		},
 		{
 			name:        "minor version downgrade should fail",
@@ -406,6 +422,10 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			currentVer:  getVersion(0, 0, 0),
 			wantErr:     true,
 			description: "Minor version downgrade (4.22.0 -> 4.21.0) should be blocked",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{},
 		},
 		{
 			name:        "major version downgrade should fail",
@@ -413,6 +433,58 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			currentVer:  getVersion(0, 0, 0),
 			wantErr:     true,
 			description: "Major version downgrade (5.0.0 -> 4.21.0) should be blocked",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{},
+		},
+		{
+			name:        "major version upgrade with special handling support exception should succeed",
+			lockFileVer: getVersion(0, 0, 0),
+			currentVer:  getVersion(1, -21, 0),
+			wantErr:     false,
+			description: "major version upgrade (4.21.0 -> 5.0.0) with special handling support exception should succeed",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+		},
+		{
+			name:        "minor version upgrade with special handling support exception should succeed",
+			lockFileVer: getVersion(0, 0, 0),
+			currentVer:  getVersion(0, 1, 0),
+			wantErr:     false,
+			description: "minor version upgrade (4.21.0 -> 4.22.0) with special handling support exception should succeed",
+			customNoUpgrade: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+			specialHandlingSupportException: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+		},
+		{
+			name:            "minor version upgrade with feature only in special handling should succeed",
+			lockFileVer:     getVersion(0, 0, 0),
+			currentVer:      getVersion(0, 1, 0),
+			wantErr:         false,
+			description:     "feature only in SpecialHandlingSupportExceptionRequired should not block upgrades",
+			customNoUpgrade: &config.EnableDisableFeatures{},
+			specialHandlingSupportException: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
+		},
+		{
+			name:            "major version upgrade with feature only in special handling should succeed",
+			lockFileVer:     getVersion(0, 0, 0),
+			currentVer:      getVersion(1, -21, 0),
+			wantErr:         false,
+			description:     "feature only in SpecialHandlingSupportExceptionRequired should not block major upgrades",
+			customNoUpgrade: &config.EnableDisableFeatures{},
+			specialHandlingSupportException: &config.EnableDisableFeatures{
+				Enabled: []string{"FeatureA"},
+			},
 		},
 	}
 
@@ -435,23 +507,19 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			versionFilePath = filepath.Join(tmpDir, "version")
 			defer func() { versionFilePath = originalVersionPath }()
 
-			// Create a version file with current version (version file uses JSON format)
-			versionData := versionFile{
-				Version: tt.currentVer,
-				BootID:  "test-boot",
+			// Create lockFile file with locked version. Lock file does not store the special handling support exception.
+			customNoUpgrade := config.EnableDisableFeatures{}
+			if tt.customNoUpgrade != nil {
+				customNoUpgrade = *tt.customNoUpgrade
 			}
-			versionJSON, _ := json.Marshal(versionData)
-			if err := os.WriteFile(versionFilePath, versionJSON, 0600); err != nil {
-				t.Fatal(err)
+			specialHandling := config.EnableDisableFeatures{}
+			if tt.specialHandlingSupportException != nil {
+				specialHandling = *tt.specialHandlingSupportException
 			}
-
-			// Create lockFile file with OLD version
 			lockFile := featureGateLockFile{
-				FeatureSet: config.FeatureSetCustomNoUpgrade,
-				CustomNoUpgrade: config.CustomNoUpgrade{
-					Enabled: []string{"FeatureA"},
-				},
-				Version: versionMetadata{Major: 4, Minor: 18, Patch: 0}, // Older version
+				FeatureSet:      config.FeatureSetCustomNoUpgrade,
+				CustomNoUpgrade: customNoUpgrade,
+				Version:         tt.lockFileVer,
 			}
 			if err := writeFeatureGateLockFile(featureGateLockFilePath, lockFile); err != nil {
 				t.Fatal(err)
@@ -460,10 +528,9 @@ func TestFeatureGateLockManagement_VersionChange(t *testing.T) {
 			cfg := &config.Config{
 				ApiServer: config.ApiServer{
 					FeatureGates: config.FeatureGates{
-						FeatureSet: config.FeatureSetCustomNoUpgrade,
-						CustomNoUpgrade: config.CustomNoUpgrade{
-							Enabled: []string{"FeatureA"},
-						},
+						FeatureSet:                              config.FeatureSetCustomNoUpgrade,
+						CustomNoUpgrade:                         customNoUpgrade,
+						SpecialHandlingSupportExceptionRequired: specialHandling,
 					},
 				},
 			}

--- a/pkg/config/apiserver.go
+++ b/pkg/config/apiserver.go
@@ -139,7 +139,7 @@ const (
 	FeatureSetDevPreviewNoUpgrade  = "DevPreviewNoUpgrade"
 )
 
-type CustomNoUpgrade struct {
+type EnableDisableFeatures struct {
 	Enabled  []string `json:"enabled"`
 	Disabled []string `json:"disabled"`
 }
@@ -149,10 +149,17 @@ type CustomNoUpgrade struct {
 var RequiredFeatureGates = []string{"UserNamespacesSupport", "UserNamespacesPodSecurityStandards"}
 
 type FeatureGates struct {
-	FeatureSet      string          `json:"featureSet"`
-	CustomNoUpgrade CustomNoUpgrade `json:"customNoUpgrade"`
+	FeatureSet string `json:"featureSet"`
+	// CustomNoUpgrade is used to enable/disable feature gates that block x- and y-stream upgrades.
+	CustomNoUpgrade EnableDisableFeatures `json:"customNoUpgrade"`
+	// SpecialHandlingSupportExceptionRequired is used to enable/disable feature gates that are exempt from blocking x- and y-stream upgrades.
+	// Features listed here do not need to be duplicated in CustomNoUpgrade.
+	SpecialHandlingSupportExceptionRequired EnableDisableFeatures `json:"specialHandlingSupportExceptionRequired"`
 }
 
+// ToApiserverArgs converts the FeatureGates struct to a list of feature-gates arguments for the kube-apiserver.
+// Features from both CustomNoUpgrade and SpecialHandlingSupportExceptionRequired are included.
+// Validation checks should be performed before calling this function to ensure the FeatureGates struct is valid.
 func (fg FeatureGates) ToApiserverArgs() ([]string, error) {
 	ret := sets.NewString()
 	addFeatures := func(features []string, enabled bool) {
@@ -163,12 +170,14 @@ func (fg FeatureGates) ToApiserverArgs() ([]string, error) {
 
 	addFeatures(fg.CustomNoUpgrade.Enabled, true)
 	addFeatures(fg.CustomNoUpgrade.Disabled, false)
+	addFeatures(fg.SpecialHandlingSupportExceptionRequired.Enabled, true)
+	addFeatures(fg.SpecialHandlingSupportExceptionRequired.Disabled, false)
 	return ret.List(), nil
 }
 
-// Implement the GoStringer interface for better %#v printing
 func (fg FeatureGates) GoString() string {
-	return fmt.Sprintf("FeatureGates{FeatureSet: %q, CustomNoUpgrade: %#v}", fg.FeatureSet, fg.CustomNoUpgrade)
+	return fmt.Sprintf("FeatureGates{FeatureSet: %q, CustomNoUpgrade: %#v, SpecialHandlingSupportExceptionRequired: %#v}",
+		fg.FeatureSet, fg.CustomNoUpgrade, fg.SpecialHandlingSupportExceptionRequired)
 }
 
 // validateFeatureGates validates the FeatureGates struct according to the following rules:
@@ -199,8 +208,9 @@ func (fg *FeatureGates) validateFeatureGates() error {
 
 	enabledCustom := sets.New(fg.CustomNoUpgrade.Enabled...)
 	disabledCustom := sets.New(fg.CustomNoUpgrade.Disabled...)
+	enabledSpecial := sets.New(fg.SpecialHandlingSupportExceptionRequired.Enabled...)
+	disabledSpecial := sets.New(fg.SpecialHandlingSupportExceptionRequired.Disabled...)
 
-	// checkFeatureGateConflict checks if two sets of feature gates have any intersection and returns an error if they do.
 	checkFeatureGateConflict := func(a, b sets.Set[string], errorMsg string) error {
 		if intersect := a.Intersection(b); intersect.Len() > 0 {
 			return fmt.Errorf("%s: %s", errorMsg, intersect.UnsortedList())
@@ -208,14 +218,18 @@ func (fg *FeatureGates) validateFeatureGates() error {
 		return nil
 	}
 
+	requiredGates := sets.New(RequiredFeatureGates...)
 	conflictChecks := []struct {
 		setA sets.Set[string]
 		setB sets.Set[string]
 		msg  string
 	}{
-		{disabledCustom, sets.New(RequiredFeatureGates...), "required feature gates cannot be disabled"},
-		{enabledCustom, sets.New(RequiredFeatureGates...), "required feature gates cannot be explicitly enabled"},
-		{enabledCustom, disabledCustom, "feature gates cannot be both enabled and disabled"},
+		{disabledCustom, requiredGates, "required feature gates cannot be disabled"},
+		{disabledSpecial, requiredGates, "required feature gates cannot be disabled"},
+		{enabledCustom, disabledCustom, "feature gates cannot be both enabled and disabled in customNoUpgrade"},
+		{enabledSpecial, disabledSpecial, "feature gates cannot be both enabled and disabled in specialHandlingSupportExceptionRequired"},
+		{enabledCustom, disabledSpecial, "feature gates cannot be enabled in customNoUpgrade and disabled in specialHandlingSupportExceptionRequired"},
+		{disabledCustom, enabledSpecial, "feature gates cannot be disabled in customNoUpgrade and enabled in specialHandlingSupportExceptionRequired"},
 	}
 
 	for _, check := range conflictChecks {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -863,17 +863,6 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "feature-gates-required-feature-gate-cannot-be-explicitly-enabled",
-			config: func() *Config {
-				c := mkDefaultConfig()
-				c.ApiServer.FeatureGates.FeatureSet = "CustomNoUpgrade"
-				c.ApiServer.FeatureGates.CustomNoUpgrade.Enabled = []string{"UserNamespacesSupport"}
-				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{"feature2"}
-				return c
-			}(),
-			expectErr: true,
-		},
-		{
 			name: "feature-gates-custom-no-upgrade-with-empty-enabled-and-disabled-lists",
 			config: func() *Config {
 				c := mkDefaultConfig()


### PR DESCRIPTION
OCPBUGS-73945: Allow custom feature gates to be exempted from upgrade blocking