### PR TITLE
OCPBUGS-78022: Write version file after prerun checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,18 @@
 {
   "permissions": {
     "allow": [
-      "Agent(openshift-ci-analyzis)",
-      "Bash(cat *)",
-      "Bash(echo *)",
-      "Bash(find *)",
-      "Bash(gcloud storage cp *)",
+      "Read(//tmp/**)",
+      "Bash(mktemp:*)",
+      "Bash(curl:*)",
+      "Bash(gcloud storage cp:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(tar:*)",
       "Bash(gh pr checks:*)",
-      "Bash(gh pr diff *)",
-      "Bash(gh pr view *)",
-      "Bash(gh)",
-      "Bash(grep *)",
-      "Bash(ls *)",
-      "Bash(tar *)",
-      "Glob",
-      "Grep",
-      "Read",
-      "WebFetch(domain:prow.ci.openshift.org)"
+      "WebFetch(domain:prow.ci.openshift.org)",
+      "Bash(gh issue list:*)"
     ],
-    "deny": [
-      "Bash(curl*)"
-    ],
-    "ask": [
-      "Edit"
-    ]
+    "deny": [],
+    "ask": []
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,18 +1,28 @@
 {
   "permissions": {
     "allow": [
-      "Read(//tmp/**)",
-      "Bash(mktemp:*)",
-      "Bash(curl:*)",
-      "Bash(gcloud storage cp:*)",
-      "Bash(gh pr view:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(tar:*)",
+      "Agent(openshift-ci-analyzis)",
+      "Bash(cat *)",
+      "Bash(echo *)",
+      "Bash(find *)",
+      "Bash(gcloud storage cp *)",
       "Bash(gh pr checks:*)",
-      "WebFetch(domain:prow.ci.openshift.org)",
-      "Bash(gh issue list:*)"
+      "Bash(gh pr diff *)",
+      "Bash(gh pr view *)",
+      "Bash(gh)",
+      "Bash(grep *)",
+      "Bash(ls *)",
+      "Bash(tar *)",
+      "Glob",
+      "Grep",
+      "Read",
+      "WebFetch(domain:prow.ci.openshift.org)"
     ],
-    "deny": [],
-    "ask": []
+    "deny": [
+      "Bash(curl*)"
+    ],
+    "ask": [
+      "Edit"
+    ]
   }
 }

--- a/pkg/admin/prerun/featuregate_lock_test.go
+++ b/pkg/admin/prerun/featuregate_lock_test.go
@@ -575,3 +575,163 @@ func TestFeatureGateLockManagement_NoCustomFeatureGates(t *testing.T) {
 		t.Error("Lock file should not have been created without custom feature gates")
 	}
 }
+
+// TestUpgradeThenRollbackWithFeatureGateLock simulates the scenario where:
+// 1. MicroShift 4.21.0 runs with CustomNoUpgrade + FeatureA
+// 2. RPM is upgraded to 4.22.0 and MicroShift is restarted
+// 3. FeatureGateLockManagement blocks startup due to version mismatch
+// 4. User rolls back to 4.21.0
+//
+// The test verifies that VersionMetadataManagement does not write the
+// version file, so when FeatureGateLockManagement fails the rollback
+// path described in the error message remains viable.
+func TestUpgradeThenRollbackWithFeatureGateLock(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerun-rollback-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	originalVersionPath := versionFilePath
+	versionFilePath = filepath.Join(tmpDir, "version")
+	defer func() { versionFilePath = originalVersionPath }()
+
+	originalLockPath := featureGateLockFilePath
+	featureGateLockFilePath = filepath.Join(tmpDir, "no-upgrade")
+	defer func() { featureGateLockFilePath = originalLockPath }()
+
+	originalGetExecVer := getExecutableVersion
+	defer func() { getExecutableVersion = originalGetExecVer }()
+
+	v421 := versionMetadata{Major: 4, Minor: 21, Patch: 0}
+	v422 := versionMetadata{Major: 4, Minor: 22, Patch: 0}
+
+	cfg := &config.Config{
+		ApiServer: config.ApiServer{
+			FeatureGates: config.FeatureGates{
+				FeatureSet: config.FeatureSetCustomNoUpgrade,
+				CustomNoUpgrade: config.EnableDisableFeatures{
+					Enabled: []string{"FeatureA"},
+				},
+			},
+		},
+	}
+
+	// --- Phase 1: Initial run at 4.21.0 ---
+	getExecutableVersion = func() (versionMetadata, error) { return v421, nil }
+
+	if err := os.WriteFile(versionFilePath, []byte(`{"version":"4.21.0","boot_id":"boot-1"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := FeatureGateLockManagement(cfg); err != nil {
+		t.Fatalf("Phase 1: FeatureGateLockManagement should succeed on first run: %v", err)
+	}
+
+	lockFile, err := readFeatureGateLockFile(featureGateLockFilePath)
+	if err != nil {
+		t.Fatalf("Phase 1: failed to read lock file: %v", err)
+	}
+	if lockFile.Version != v421 {
+		t.Fatalf("Phase 1: lock file version = %s, want %s", lockFile.Version.String(), v421.String())
+	}
+
+	// --- Phase 2: Upgrade to 4.22.0 ---
+	getExecutableVersion = func() (versionMetadata, error) { return v422, nil }
+
+	// VersionMetadataManagement validates but does not write the version file
+	if err := VersionMetadataManagement(); err != nil {
+		t.Fatalf("Phase 2: VersionMetadataManagement should succeed: %v", err)
+	}
+
+	// FeatureGateLockManagement should FAIL (locked=4.21, exec=4.22)
+	err = FeatureGateLockManagement(cfg)
+	if err == nil {
+		t.Fatal("Phase 2: FeatureGateLockManagement should fail due to version mismatch")
+	}
+
+	// Because FeatureGateLockManagement failed, WriteVersionMetadata is NOT
+	// called. Verify the version file still contains 4.21.0.
+	dataVer, err := getVersionOfData()
+	if err != nil {
+		t.Fatalf("Phase 2: failed to read version file: %v", err)
+	}
+	if dataVer != v421 {
+		t.Fatalf("Phase 2: version file should still be %s after failed pre-run, got %s", v421.String(), dataVer.String())
+	}
+
+	// --- Phase 3: Roll back to 4.21.0 ---
+	getExecutableVersion = func() (versionMetadata, error) { return v421, nil }
+
+	if err := VersionMetadataManagement(); err != nil {
+		t.Fatalf("Phase 3: VersionMetadataManagement should succeed after rollback: %v", err)
+	}
+
+	if err := FeatureGateLockManagement(cfg); err != nil {
+		t.Fatalf("Phase 3: FeatureGateLockManagement should succeed after rollback: %v", err)
+	}
+
+	if err := WriteVersionMetadata(); err != nil {
+		t.Fatalf("Phase 3: WriteVersionMetadata should succeed: %v", err)
+	}
+
+	dataVer, err = getVersionOfData()
+	if err != nil {
+		t.Fatalf("Phase 3: failed to read version file after write: %v", err)
+	}
+	if dataVer != v421 {
+		t.Fatalf("Phase 3: version file should be %s after rollback, got %s", v421.String(), dataVer.String())
+	}
+}
+
+// TestVersionMetadataManagementDoesNotWriteVersionFile verifies that
+// VersionMetadataManagement is read-only and WriteVersionMetadata is
+// required to persist the version.
+func TestVersionMetadataManagementDoesNotWriteVersionFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "prerun-no-write-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	originalVersionPath := versionFilePath
+	versionFilePath = filepath.Join(tmpDir, "version")
+	defer func() { versionFilePath = originalVersionPath }()
+
+	originalGetExecVer := getExecutableVersion
+	defer func() { getExecutableVersion = originalGetExecVer }()
+
+	v414 := versionMetadata{Major: 4, Minor: 14, Patch: 0}
+	v415 := versionMetadata{Major: 4, Minor: 15, Patch: 0}
+
+	if err := os.WriteFile(versionFilePath, []byte(`{"version":"4.14.0","boot_id":"b"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	getExecutableVersion = func() (versionMetadata, error) { return v415, nil }
+
+	if err := VersionMetadataManagement(); err != nil {
+		t.Fatalf("VersionMetadataManagement should succeed: %v", err)
+	}
+
+	// Version file should still be 4.14.0 — no write happened yet
+	dataVer, err := getVersionOfData()
+	if err != nil {
+		t.Fatalf("failed to read version file: %v", err)
+	}
+	if dataVer != v414 {
+		t.Fatalf("version file should still be %s after management, got %s", v414.String(), dataVer.String())
+	}
+
+	if err := WriteVersionMetadata(); err != nil {
+		t.Fatalf("WriteVersionMetadata should succeed: %v", err)
+	}
+
+	dataVer, err = getVersionOfData()
+	if err != nil {
+		t.Fatalf("failed to read version file after write: %v", err)
+	}
+	if dataVer != v415 {
+		t.Fatalf("version file should be %s after write, got %s", v415.String(), dataVer.String())
+	}
+}

--- a/pkg/admin/prerun/version.go
+++ b/pkg/admin/prerun/version.go
@@ -71,13 +71,23 @@ func versionMetadataManagement() error {
 		klog.InfoS("END checking if version upgrade is blocked")
 	}
 
+	return nil
+}
+
+// WriteVersionMetadata persists the current executable version to the
+// version file. It must be called only after all pre-run checks have
+// passed to avoid poisoning the version file on a failed startup.
+func WriteVersionMetadata() error {
 	klog.InfoS("START updating version file")
-	if err := updateVersionFile(ver.exec); err != nil {
+	execVer, err := getExecutableVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get executable version: %w", err)
+	}
+	if err := updateVersionFile(execVer); err != nil {
 		klog.ErrorS(err, "FAIL updating version file")
 		return err
 	}
 	klog.InfoS("END updating version file")
-
 	return nil
 }
 
@@ -89,7 +99,7 @@ type versions struct {
 // getVersions obtains and returns versions of executable and data dir.
 // Version of data will be nil if the MicroShift data does not exist yet.
 func getVersions() (versions, error) {
-	execVer, err := GetVersionOfExecutable()
+	execVer, err := getExecutableVersion()
 	if err != nil {
 		return versions{}, fmt.Errorf("failed to get version of MicroShift executable: %w", err)
 	}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -197,6 +197,11 @@ func RunMicroshift(cfg *config.Config) error {
 		return err
 	}
 
+	if err := prerun.WriteVersionMetadata(); err != nil {
+		writeLogFileError(preRunFailedLogPath, err)
+		return err
+	}
+
 	// TODO: change to only initialize what is strictly necessary for the selected role(s)
 	certChains, err := initCerts(cfg)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -435,6 +435,13 @@ func (c *Config) incorporateUserSettings(u *Config) {
 	if len(u.ApiServer.FeatureGates.CustomNoUpgrade.Disabled) > 0 {
 		c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = u.ApiServer.FeatureGates.CustomNoUpgrade.Disabled
 	}
+	if len(u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Enabled) > 0 {
+		c.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Enabled = u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Enabled
+	}
+	if len(u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled) > 0 {
+		c.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled = u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled
+	}
+
 }
 
 // updateComputedValues examins the existing settings and converts any

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -441,7 +441,6 @@ func (c *Config) incorporateUserSettings(u *Config) {
 	if len(u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled) > 0 {
 		c.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled = u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled
 	}
-
 }
 
 // updateComputedValues examins the existing settings and converts any

--- a/test/suites/standard2/feature-gates.robot
+++ b/test/suites/standard2/feature-gates.robot
@@ -2,6 +2,7 @@
 Documentation       Verify that that MicroShift feature gate configuration is correctly integrated into the kube-apiserver.
 ...                 Validation testing is handled by prerun unit tests and is not included here.
 
+Library             Collections
 Resource            ../../resources/common.resource
 Resource            ../../resources/microshift-config.resource
 Resource            ../../resources/microshift-process.resource
@@ -24,6 +25,16 @@ ${CUSTOM_FEATURE_GATES}         SEPARATOR=\n
 ...                             \ \ \ \ \ \ \ \ - TestFeatureEnabled
 ...                             \ \ \ \ \ \ disabled:
 ...                             \ \ \ \ \ \ \ \ - TestFeatureDisabled
+${CUSTOM_FEATURE_GATES_WITH_EXEMPTIONS}    SEPARATOR=\n
+...                             apiServer:
+...                             \ \ featureGates:
+...                             \ \ \ \ featureSet: CustomNoUpgrade
+...                             \ \ \ \ customNoUpgrade:
+...                             \ \ \ \ \ \ enabled:
+...                             \ \ \ \ \ \ \ \ - TestFeatureEnabled
+...                             \ \ \ \ specialHandlingSupportExceptionRequired:
+...                             \ \ \ \ \ \ enabled:
+...                             \ \ \ \ \ \ \ \ - TestFeatureEnabled
 ${FEATURE_GATE_LOCK_FILE}       /var/lib/microshift/no-upgrade
 
 
@@ -54,6 +65,16 @@ Feature Gate Lock File Persists Across Restarts With Same Config
     Feature Gate Lock File Should Exist
     [Teardown]    Teardown Custom Feature Gates Test
 
+SpecialHandlingSupportExceptionRequired Config Is Applied
+    [Documentation]    Verify that specialHandlingSupportExceptionRequired feature gate values
+    ...    from the config are correctly parsed and appear in the effective configuration.
+    [Setup]    Setup Custom Feature Gates Test    ${CUSTOM_FEATURE_GATES_WITH_EXEMPTIONS}
+    ${config}=    Show Config    effective
+    List Should Contain Value
+    ...    ${config.apiServer.featureGates.specialHandlingSupportExceptionRequired.enabled}
+    ...    TestFeatureEnabled
+    [Teardown]    Teardown Custom Feature Gates Test
+
 
 *** Keywords ***
 Setup
@@ -76,8 +97,9 @@ Save Journal Cursor
 
 Setup Custom Feature Gates Test
     [Documentation]    Drop in custom feature gates config and restart MicroShift
+    [Arguments]    ${config}=${CUSTOM_FEATURE_GATES}
     Stop MicroShift
-    Drop In MicroShift Config    ${CUSTOM_FEATURE_GATES}    10-featuregates
+    Drop In MicroShift Config    ${config}    10-featuregates
     Save Journal Cursor
     Start MicroShift
     Feature Gate Lock File Should Exist

--- a/test/suites/standard2/feature-gates.robot
+++ b/test/suites/standard2/feature-gates.robot
@@ -15,27 +15,27 @@ Test Tags           restart    slow
 
 
 *** Variables ***
-${CURSOR}                       ${EMPTY}    # The journal cursor before restarting MicroShift
-${CUSTOM_FEATURE_GATES}         SEPARATOR=\n
-...                             apiServer:
-...                             \ \ featureGates:
-...                             \ \ \ \ featureSet: CustomNoUpgrade
-...                             \ \ \ \ customNoUpgrade:
-...                             \ \ \ \ \ \ enabled:
-...                             \ \ \ \ \ \ \ \ - TestFeatureEnabled
-...                             \ \ \ \ \ \ disabled:
-...                             \ \ \ \ \ \ \ \ - TestFeatureDisabled
-${CUSTOM_FEATURE_GATES_WITH_EXEMPTIONS}    SEPARATOR=\n
-...                             apiServer:
-...                             \ \ featureGates:
-...                             \ \ \ \ featureSet: CustomNoUpgrade
-...                             \ \ \ \ customNoUpgrade:
-...                             \ \ \ \ \ \ enabled:
-...                             \ \ \ \ \ \ \ \ - TestFeatureEnabled
-...                             \ \ \ \ specialHandlingSupportExceptionRequired:
-...                             \ \ \ \ \ \ enabled:
-...                             \ \ \ \ \ \ \ \ - TestFeatureEnabled
-${FEATURE_GATE_LOCK_FILE}       /var/lib/microshift/no-upgrade
+${CURSOR}                                   ${EMPTY}    # The journal cursor before restarting MicroShift
+${CUSTOM_FEATURE_GATES}                     SEPARATOR=\n
+...                                         apiServer:
+...                                         \ \ featureGates:
+...                                         \ \ \ \ featureSet: CustomNoUpgrade
+...                                         \ \ \ \ customNoUpgrade:
+...                                         \ \ \ \ \ \ enabled:
+...                                         \ \ \ \ \ \ \ \ - TestFeatureEnabled
+...                                         \ \ \ \ \ \ disabled:
+...                                         \ \ \ \ \ \ \ \ - TestFeatureDisabled
+${CUSTOM_FEATURE_GATES_WITH_EXEMPTIONS}     SEPARATOR=\n
+...                                         apiServer:
+...                                         \ \ featureGates:
+...                                         \ \ \ \ featureSet: CustomNoUpgrade
+...                                         \ \ \ \ customNoUpgrade:
+...                                         \ \ \ \ \ \ enabled:
+...                                         \ \ \ \ \ \ \ \ - TestFeatureEnabled
+...                                         \ \ \ \ specialHandlingSupportExceptionRequired:
+...                                         \ \ \ \ \ \ enabled:
+...                                         \ \ \ \ \ \ \ \ - TestFeatureEnabled
+${FEATURE_GATE_LOCK_FILE}                   /var/lib/microshift/no-upgrade
 
 
 *** Test Cases ***


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for SpecialHandlingSupportExceptionRequired feature-gate exemptions added
  * Version metadata is now explicitly persisted during startup and upgrade/rollback flows

* **Tests**
  * Added coverage for upgrade/rollback scenarios involving feature-gate locking and rollback behavior
  * Added tests verifying version metadata persistence behavior and effective config handling for specialHandlingSupportExceptionRequired
<!-- end of auto-generated comment: release notes by coderabbit.ai -->