### PR TITLE
[release-4.21] OCPBUGS-78399: Align release-4.21 featureGate validation with main

### DIFF
--- a/pkg/config/apiserver.go
+++ b/pkg/config/apiserver.go
@@ -194,9 +194,6 @@ func (fg *FeatureGates) validateFeatureGates() error {
 
 	switch fg.FeatureSet {
 	case "":
-		if len(fg.CustomNoUpgrade.Enabled) > 0 || len(fg.CustomNoUpgrade.Disabled) > 0 {
-			return fmt.Errorf("CustomNoUpgrade enabled/disabled lists must be empty when FeatureSet is empty")
-		}
 		return nil
 	case FeatureSetCustomNoUpgrade:
 		// Valid - continue with validation

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -838,7 +838,7 @@ func TestValidate(t *testing.T) {
 				c.ApiServer.FeatureGates.CustomNoUpgrade.Disabled = []string{"feature2"}
 				return c
 			}(),
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			name: "feature-gates-custom-no-upgrade-enabled-and-disabled-have-same-feature-gate",


### PR DESCRIPTION
Align release-4.21 featureGate validation with main by removing:
- The check that rejects Enabled/Disabled lists when FeatureSet is empty
- The check that rejects explicitly enabling required feature gates

These validations were unintentionally preserved during cherry-picks from main, where they had already been removed.