### PR TITLE
USHIFT-6596: introduce trust-manager operand to the cert-manager

### DIFF
--- a/assets/optional/cert-manager/crd/bases/certificaterequests.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/certificaterequests.cert-manager.io-crd.yaml
@@ -6,9 +6,10 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app: cert-manager
+    app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.18.4
+    app.kubernetes.io/version: v1.19.2
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io
@@ -25,13 +26,13 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Approved")].status
+        - jsonPath: .status.conditions[?(@.type == "Approved")].status
           name: Approved
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Denied")].status
+        - jsonPath: .status.conditions[?(@.type == "Denied")].status
           name: Denied
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
           name: Ready
           type: string
         - jsonPath: .spec.issuerRef.name
@@ -40,7 +41,7 @@ spec:
         - jsonPath: .spec.username
           name: Requester
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
           name: Status
           priority: 1
           type: string
@@ -128,13 +129,17 @@ spec:
                     The `name` field of the reference must always be specified.
                   properties:
                     group:
-                      description: Group of the resource being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      description: Kind of the resource being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
-                      description: Name of the resource being referred to.
+                      description: Name of the issuer being referred to.
                       type: string
                   required:
                     - name
@@ -224,6 +229,7 @@ spec:
                       - netscape sgc
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 username:
                   description: |-
                     Username contains the name of the user that created the CertificateRequest.

--- a/assets/optional/cert-manager/crd/bases/certificates.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/certificates.cert-manager.io-crd.yaml
@@ -6,9 +6,10 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app: cert-manager
+    app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.18.4
+    app.kubernetes.io/version: v1.19.2
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io
@@ -25,7 +26,7 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
           name: Ready
           type: string
         - jsonPath: .spec.secretName
@@ -35,7 +36,7 @@ spec:
           name: Issuer
           priority: 1
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
           name: Status
           priority: 1
           type: string
@@ -96,6 +97,7 @@ spec:
                       - type
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 commonName:
                   description: |-
                     Requested common name X509 certificate subject attribute.
@@ -111,6 +113,7 @@ spec:
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 duration:
                   description: |-
                     Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
@@ -126,6 +129,7 @@ spec:
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 encodeUsagesInRequest:
                   description: |-
                     Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
@@ -138,6 +142,7 @@ spec:
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 isCA:
                   description: |-
                     Requested basic constraints isCA value.
@@ -158,13 +163,17 @@ spec:
                     The `name` field of the reference must always be specified.
                   properties:
                     group:
-                      description: Group of the resource being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      description: Kind of the resource being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
-                      description: Name of the resource being referred to.
+                      description: Name of the issuer being referred to.
                       type: string
                   required:
                     - name
@@ -324,11 +333,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         emailAddresses:
                           description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         ipRanges:
                           description: |-
                             IPRanges is a list of IP Ranges that are permitted or excluded.
@@ -336,11 +347,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         uriDomains:
                           description: URIDomains is a list of URI domains that are permitted or excluded.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     permitted:
                       description: Permitted contains the constraints in which the names must be located.
@@ -350,11 +363,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         emailAddresses:
                           description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         ipRanges:
                           description: |-
                             IPRanges is a list of IP Ranges that are permitted or excluded.
@@ -362,11 +377,13 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         uriDomains:
                           description: URIDomains is a list of URI domains that are permitted or excluded.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                   type: object
                 otherNames:
@@ -390,6 +407,7 @@ spec:
                         type: string
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 privateKey:
                   description: |-
                     Private key options. These include the key algorithm and size, the used
@@ -555,31 +573,37 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     localities:
                       description: Cities to be used on the Certificate.
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     organizationalUnits:
                       description: Organizational Units to be used on the Certificate.
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     organizations:
                       description: Organizations to be used on the Certificate.
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     postalCodes:
                       description: Postal codes to be used on the Certificate.
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     provinces:
                       description: State/Provinces to be used on the Certificate.
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     serialNumber:
                       description: Serial number to be used on the Certificate.
                       type: string
@@ -588,12 +612,14 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 uris:
                   description: Requested URI subject alternative names.
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 usages:
                   description: |-
                     Requested key usages and extended key usages.
@@ -659,6 +685,7 @@ spec:
                       - netscape sgc
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
               required:
                 - issuerRef
                 - secretName

--- a/assets/optional/cert-manager/crd/bases/challenges.acme.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/challenges.acme.cert-manager.io-crd.yaml
@@ -6,9 +6,10 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app: cert-manager
+    app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.18.4
+    app.kubernetes.io/version: v1.19.2
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -81,13 +82,17 @@ spec:
                     Challenge will be marked as failed.
                   properties:
                     group:
-                      description: Group of the resource being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      description: Kind of the resource being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
-                      description: Name of the resource being referred to.
+                      description: Name of the issuer being referred to.
                       type: string
                   required:
                     - name
@@ -406,6 +411,12 @@ spec:
                                 enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                 This field is required.
                               type: string
+                            protocol:
+                              description: Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) ``TCP`` and ``UDP``; ``UDP`` (default).
+                              enum:
+                                - TCP
+                                - UDP
+                              type: string
                             tsigAlgorithm:
                               description: |-
                                 The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
@@ -497,6 +508,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         name:
                                           description: Name of the ServiceAccount used to request a token.
                                           type: string
@@ -773,6 +785,7 @@ spec:
                                   - name
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             podTemplate:
                               description: |-
                                 Optional pod template used to configure the ACME challenge solver pods
@@ -1068,7 +1081,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -1083,7 +1095,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -1244,7 +1255,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -1259,7 +1269,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -1348,8 +1357,8 @@ spec:
                                                 most preferred is the one with the greatest sum of weights, i.e.
                                                 for each node that meets all of the scheduling requirements (resource
                                                 request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                compute a sum by iterating through the elements of this field and adding
-                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                compute a sum by iterating through the elements of this field and subtracting
+                                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
                                               items:
                                                 description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
@@ -1413,7 +1422,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -1428,7 +1436,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -1589,7 +1596,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -1604,7 +1610,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -1702,6 +1707,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     nodeSelector:
                                       additionalProperties:
                                         type: string
@@ -1713,6 +1721,40 @@ spec:
                                     priorityClassName:
                                       description: If specified, the pod's priorityClassName.
                                       type: string
+                                    resources:
+                                      description: |-
+                                        If specified, the pod's resource requirements.
+                                        These values override the global resource configuration flags.
+                                        Note that when only specifying resource limits, ensure they are greater than or equal
+                                        to the corresponding global resource requests configured via controller flags
+                                        (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                        Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
                                     securityContext:
                                       description: If specified, the pod's security context
                                       properties:
@@ -1828,6 +1870,7 @@ spec:
                                             format: int64
                                             type: integer
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         sysctls:
                                           description: |-
                                             Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -1847,6 +1890,7 @@ spec:
                                               - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     serviceAccountName:
                                       description: If specified, the pod's service account
@@ -1890,6 +1934,7 @@ spec:
                                             type: string
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                               type: object
                             serviceType:
@@ -2247,7 +2292,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -2262,7 +2306,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -2423,7 +2466,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -2438,7 +2480,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -2527,8 +2568,8 @@ spec:
                                                 most preferred is the one with the greatest sum of weights, i.e.
                                                 for each node that meets all of the scheduling requirements (resource
                                                 request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                compute a sum by iterating through the elements of this field and adding
-                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                compute a sum by iterating through the elements of this field and subtracting
+                                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
                                               items:
                                                 description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
@@ -2592,7 +2633,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -2607,7 +2647,6 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                         items:
                                                           type: string
                                                         type: array
@@ -2768,7 +2807,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -2783,7 +2821,6 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                     items:
                                                       type: string
                                                     type: array
@@ -2881,6 +2918,9 @@ spec:
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     nodeSelector:
                                       additionalProperties:
                                         type: string
@@ -2892,6 +2932,40 @@ spec:
                                     priorityClassName:
                                       description: If specified, the pod's priorityClassName.
                                       type: string
+                                    resources:
+                                      description: |-
+                                        If specified, the pod's resource requirements.
+                                        These values override the global resource configuration flags.
+                                        Note that when only specifying resource limits, ensure they are greater than or equal
+                                        to the corresponding global resource requests configured via controller flags
+                                        (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                        Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
                                     securityContext:
                                       description: If specified, the pod's security context
                                       properties:
@@ -3007,6 +3081,7 @@ spec:
                                             format: int64
                                             type: integer
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         sysctls:
                                           description: |-
                                             Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -3026,6 +3101,7 @@ spec:
                                               - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       type: object
                                     serviceAccountName:
                                       description: If specified, the pod's service account
@@ -3069,6 +3145,7 @@ spec:
                                             type: string
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                               type: object
                             serviceType:
@@ -3098,6 +3175,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         dnsZones:
                           description: |-
                             List of DNSZones that this solver will be used to solve.
@@ -3112,6 +3190,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
                           additionalProperties:
                             type: string

--- a/assets/optional/cert-manager/crd/bases/clusterissuers.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/clusterissuers.cert-manager.io-crd.yaml
@@ -6,9 +6,10 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app: cert-manager
+    app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.18.4
+    app.kubernetes.io/version: v1.19.2
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -24,10 +25,10 @@ spec:
   scope: Cluster
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
           name: Status
           priority: 1
           type: string
@@ -523,6 +524,12 @@ spec:
                                       enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                       This field is required.
                                     type: string
+                                  protocol:
+                                    description: Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) ``TCP`` and ``UDP``; ``UDP`` (default).
+                                    enum:
+                                      - TCP
+                                      - UDP
+                                    type: string
                                   tsigAlgorithm:
                                     description: |-
                                       The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
@@ -614,6 +621,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               name:
                                                 description: Name of the ServiceAccount used to request a token.
                                                 type: string
@@ -890,6 +898,7 @@ spec:
                                         - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   podTemplate:
                                     description: |-
                                       Optional pod template used to configure the ACME challenge solver pods
@@ -1185,7 +1194,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1200,7 +1208,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1361,7 +1368,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1376,7 +1382,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1465,8 +1470,8 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
@@ -1530,7 +1535,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1545,7 +1549,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1706,7 +1709,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1721,7 +1723,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1819,6 +1820,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
                                             additionalProperties:
                                               type: string
@@ -1830,6 +1834,40 @@ spec:
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
                                             properties:
@@ -1945,6 +1983,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -1964,6 +2003,7 @@ spec:
                                                     - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
@@ -2007,6 +2047,7 @@ spec:
                                                   type: string
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                     type: object
                                   serviceType:
@@ -2364,7 +2405,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2379,7 +2419,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2540,7 +2579,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2555,7 +2593,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2644,8 +2681,8 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
@@ -2709,7 +2746,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2724,7 +2760,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2885,7 +2920,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2900,7 +2934,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2998,6 +3031,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
                                             additionalProperties:
                                               type: string
@@ -3009,6 +3045,40 @@ spec:
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
                                             properties:
@@ -3124,6 +3194,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -3143,6 +3214,7 @@ spec:
                                                     - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
@@ -3186,6 +3258,7 @@ spec:
                                                   type: string
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                     type: object
                                   serviceType:
@@ -3215,6 +3288,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               dnsZones:
                                 description: |-
                                   List of DNSZones that this solver will be used to solve.
@@ -3229,6 +3303,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
@@ -3239,6 +3314,7 @@ spec:
                             type: object
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                     - privateKeySecretRef
                     - server
@@ -3257,6 +3333,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     issuingCertificateURLs:
                       description: |-
                         IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
@@ -3265,6 +3342,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     ocspServers:
                       description: |-
                         The OCSP server list is an X.509 v3 extension that defines a list of
@@ -3275,6 +3353,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     secretName:
                       description: |-
                         SecretName is the name of the secret used to sign Certificates issued
@@ -3296,6 +3375,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 vault:
                   description: |-
@@ -3423,6 +3503,7 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 name:
                                   description: Name of the ServiceAccount used to request a token.
                                   type: string

--- a/assets/optional/cert-manager/crd/bases/customresourcedefinition_bundles.trust.cert-manager.io.yml
+++ b/assets/optional/cert-manager/crd/bases/customresourcedefinition_bundles.trust.cert-manager.io.yml
@@ -1,0 +1,477 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "bundles.trust.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: cert-manager-trust-manager
+    app.kubernetes.io/instance: cert-manager-trust-manager
+    app.kubernetes.io/version: "v0.20.3"
+    app.kubernetes.io/managed-by: cert-manager-operator
+    app.kubernetes.io/part-of: cert-manager-operator
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Bundle resource.
+              properties:
+                sources:
+                  description: Sources is a set of references to data whose data will sync to the target.
+                  items:
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
+                    properties:
+                      configMap:
+                        description: |-
+                          ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                          list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `Key` is set.
+                            type: boolean
+                          key:
+                            description: Key of the entry in the object's `data` field to be used.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      inLine:
+                        description: InLine is a simple string to append as the source data.
+                        type: string
+                      secret:
+                        description: |-
+                          Secret is a reference (by name) to a Secret's `data` key(s), or to a
+                          list of Secret's `data` key(s) using label selector, in the trust Namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `Key` is set.
+                            type: boolean
+                          key:
+                            description: Key of the entry in the object's `data` field to be used.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      useDefaultCAs:
+                        description: |-
+                          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+                          Default CAs are available if trust-manager was installed via Helm
+                          or was otherwise set up to include a package-injecting init container by using the
+                          "--default-package-location" flag when starting the trust-manager controller.
+                          If default CAs were not configured at start-up, any request to use the default
+                          CAs will fail.
+                          The version of the default CA package which is used for a Bundle is stored in the
+                          defaultCAPackageVersion field of the Bundle's status field.
+                        type: boolean
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  maxItems: 100
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                target:
+                  description: Target is the target location in all namespaces to sync source data to.
+                  properties:
+                    additionalFormats:
+                      description: AdditionalFormats specifies any additional formats to write to the target
+                      properties:
+                        jks:
+                          description: |-
+                            JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                            Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+                            PKCS#12 trust stores created by trust-manager are compatible with Java.
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              minLength: 1
+                              type: string
+                            password:
+                              default: changeit
+                              description: Password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        pkcs12:
+                          description: |-
+                            PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
+                            The bundle is by default created without a password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              minLength: 1
+                              type: string
+                            password:
+                              default: ""
+                              description: Password for PKCS12 trust store
+                              maxLength: 128
+                              type: string
+                            profile:
+                              description: |-
+                                Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                used to create the PKCS12 trust store.
+
+                                If provided, allowed values are:
+                                `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                Default value is `LegacyRC2` for backward compatibility.
+                              enum:
+                                - LegacyRC2
+                                - LegacyDES
+                                - Modern2023
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    configMap:
+                      description: |-
+                        ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: Metadata is an optional set of labels and annotations to be copied to the target.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target.
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secret:
+                      description: |-
+                        Secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: Metadata is an optional set of labels and annotations to be copied to the target.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations is a key value map to be copied to the target.
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: Labels is a key value map to be copied to the target.
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                  type: object
+              required:
+                - sources
+              type: object
+            status:
+              description: Status of the Bundle. This is set and managed automatically.
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of the Bundle.
+                    Known condition types are `Bundle`.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    DefaultCAPackageVersion, if set and non-empty, indicates the version information
+                    which was retrieved when the set of default CAs was requested in the bundle
+                    source. This should only be set if useDefaultCAs was set to "true" on a source,
+                    and will be the same for the same version of a bundle with identical certificates.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/assets/optional/cert-manager/crd/bases/issuers.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/issuers.cert-manager.io-crd.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.18.4
+    app.kubernetes.io/version: v1.19.2
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io
@@ -25,10 +25,10 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
           name: Status
           priority: 1
           type: string
@@ -523,6 +523,12 @@ spec:
                                       enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
                                       This field is required.
                                     type: string
+                                  protocol:
+                                    description: Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) ``TCP`` and ``UDP``; ``UDP`` (default).
+                                    enum:
+                                      - TCP
+                                      - UDP
+                                    type: string
                                   tsigAlgorithm:
                                     description: |-
                                       The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
@@ -614,6 +620,7 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               name:
                                                 description: Name of the ServiceAccount used to request a token.
                                                 type: string
@@ -890,6 +897,7 @@ spec:
                                         - name
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   podTemplate:
                                     description: |-
                                       Optional pod template used to configure the ACME challenge solver pods
@@ -1185,7 +1193,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1200,7 +1207,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1361,7 +1367,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1376,7 +1381,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1465,8 +1469,8 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
@@ -1530,7 +1534,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1545,7 +1548,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -1706,7 +1708,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1721,7 +1722,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -1819,6 +1819,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
                                             additionalProperties:
                                               type: string
@@ -1830,6 +1833,40 @@ spec:
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
                                             properties:
@@ -1945,6 +1982,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -1964,6 +2002,7 @@ spec:
                                                     - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
@@ -2007,6 +2046,7 @@ spec:
                                                   type: string
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                     type: object
                                   serviceType:
@@ -2364,7 +2404,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2379,7 +2418,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2540,7 +2578,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2555,7 +2592,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2644,8 +2680,8 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
@@ -2709,7 +2745,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2724,7 +2759,6 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                               items:
                                                                 type: string
                                                               type: array
@@ -2885,7 +2919,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2900,7 +2933,6 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                                           items:
                                                             type: string
                                                           type: array
@@ -2998,6 +3030,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
                                             additionalProperties:
                                               type: string
@@ -3009,6 +3044,40 @@ spec:
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
                                             properties:
@@ -3124,6 +3193,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -3143,6 +3213,7 @@ spec:
                                                     - value
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                             type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
@@ -3186,6 +3257,7 @@ spec:
                                                   type: string
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                     type: object
                                   serviceType:
@@ -3215,6 +3287,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               dnsZones:
                                 description: |-
                                   List of DNSZones that this solver will be used to solve.
@@ -3229,6 +3302,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
                                 additionalProperties:
                                   type: string
@@ -3239,6 +3313,7 @@ spec:
                             type: object
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   required:
                     - privateKeySecretRef
                     - server
@@ -3257,6 +3332,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     issuingCertificateURLs:
                       description: |-
                         IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
@@ -3265,6 +3341,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     ocspServers:
                       description: |-
                         The OCSP server list is an X.509 v3 extension that defines a list of
@@ -3275,6 +3352,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     secretName:
                       description: |-
                         SecretName is the name of the secret used to sign Certificates issued
@@ -3296,6 +3374,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 vault:
                   description: |-
@@ -3423,6 +3502,7 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 name:
                                   description: Name of the ServiceAccount used to request a token.
                                   type: string

--- a/assets/optional/cert-manager/crd/bases/operator.openshift.io_certmanagers.yaml
+++ b/assets/optional/cert-manager/crd/bases/operator.openshift.io_certmanagers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: certmanagers.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CertManagerSpec defines the desired state of CertManager
+            description: CertManagerSpec defines the desired state of CertManager.
             properties:
               cainjectorConfig:
                 description: |-
@@ -60,8 +60,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -117,6 +118,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -303,8 +341,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -360,6 +399,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -630,7 +706,6 @@ spec:
                                     If present, only traffic on the specified protocol AND port will be matched.
                                   x-kubernetes-int-or-string: true
                                 protocol:
-                                  default: TCP
                                   description: |-
                                     protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
                                     If not specified, this field defaults to TCP.
@@ -846,7 +921,7 @@ spec:
 
                   For OverrideArgs,
                   --config string                                Path to a file containing a WebhookConfiguration object used to configure the webhook
-                  --dynamic-serving-ca-secret-name string        name of the secret used to store the CA that signs serving certificates certificates
+                  --dynamic-serving-ca-secret-name string        name of the secret used to store the CA that signs serving certificates
                   --dynamic-serving-ca-secret-namespace string   namespace of the secret used to store the CA that signs serving certificates
                   --dynamic-serving-dns-names strings            DNS names that should be present on certificates generated by the dynamic serving CA
                   --v Level                                      number for the log level verbosity
@@ -861,8 +936,9 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
                           description: |-
@@ -918,6 +994,43 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -1076,7 +1189,7 @@ spec:
                 type: object
             type: object
           status:
-            description: CertManagerStatus defines the observed state of CertManager
+            description: CertManagerStatus defines the observed state of CertManager.
             properties:
               conditions:
                 description: conditions is a list of conditions and their status

--- a/assets/optional/cert-manager/crd/bases/operator.openshift.io_trustmanagers.yaml
+++ b/assets/optional/cert-manager/crd/bases/operator.openshift.io_trustmanagers.yaml
@@ -5,26 +5,25 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
-    app.kubernetes.io/name: istiocsr
+    app.kubernetes.io/name: trustmanager
     app.kubernetes.io/part-of: cert-manager-operator
-  name: istiocsrs.operator.openshift.io
+  name: trustmanagers.operator.openshift.io
 spec:
   group: operator.openshift.io
   names:
     categories:
     - cert-manager-operator
-    - istio-csr
-    - istiocsr
-    kind: IstioCSR
-    listKind: IstioCSRList
-    plural: istiocsrs
-    singular: istiocsr
-  scope: Namespaced
+    - trust-manager
+    kind: TrustManager
+    listKind: TrustManagerList
+    plural: trustmanagers
+    shortNames:
+    - trustmanager
+    - tm
+    singular: trustmanager
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.istioCSRGRPCEndpoint
-      name: GRPC Endpoint
-      type: string
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
@@ -38,10 +37,9 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          IstioCSR describes the configuration and information about the managed istio-csr agent.
-          The name must be `default` to make IstioCSR a singleton that is, to allow only one instance of IstioCSR per namespace.
-
-          When an IstioCSR is created, istio-csr agent is deployed in the IstioCSR-created namespace.
+          TrustManager describes the configuration and information about the managed trust-manager deployment.
+          The name must be `cluster` to make TrustManager a singleton, allowing only one instance per cluster.
+          When a TrustManager CR is created, trust-manager operand is deployed in the cert-manager namespace.
         properties:
           apiVersion:
             description: |-
@@ -62,29 +60,38 @@ spec:
             type: object
           spec:
             description: spec is the specification of the desired behavior of the
-              IstioCSR.
+              TrustManager.
             properties:
               controllerConfig:
-                description: controllerConfig configures the controller for setting
-                  up defaults to enable the istio-csr agent.
+                description: controllerConfig configures the operator's behavior for
+                  resource creation.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: annotations to apply to all resources created for
+                      the trust-manager deployment.
+                    maxProperties: 25
+                    minProperties: 0
+                    type: object
+                    x-kubernetes-map-type: granular
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      labels to apply to all resources created for the istio-csr agent deployment.
-                      This field can have a maximum of 20 entries.
-                    maxProperties: 20
+                    description: labels to apply to all resources created for the
+                      trust-manager deployment.
+                    maxProperties: 25
                     minProperties: 0
                     type: object
                     x-kubernetes-map-type: granular
                 type: object
-              istioCSRConfig:
-                description: istioCSRConfig configures the istio-csr agent's behavior.
+              trustManagerConfig:
+                description: trustManagerConfig configures the trust-manager operand's
+                  behavior.
                 properties:
                   affinity:
                     description: |-
-                      affinity is for setting scheduling affinity rules.
+                      affinity defines scheduling constraints for the trust-manager pod.
                       ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
                     properties:
                       nodeAffinity:
@@ -1003,215 +1010,48 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                     type: object
-                  certManager:
-                    description: certManager is for configuring cert-manager specifics.
-                    properties:
-                      issuerRef:
-                        description: |-
-                          issuerRef contains details of the referenced object used for obtaining certificates.
-                          When `issuerRef.Kind` is `Issuer`, it must exist in the `.spec.istioCSRConfig.istio.namespace`.
-                          This field is immutable once set.
-                        properties:
-                          group:
-                            description: |-
-                              Group of the issuer being referred to.
-                              Defaults to 'cert-manager.io'.
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the issuer being referred to.
-                              Defaults to 'Issuer'.
-                            type: string
-                          name:
-                            description: Name of the issuer being referred to.
-                            type: string
-                        required:
-                        - name
-                        type: object
-                        x-kubernetes-validations:
-                        - message: issuerRef is immutable once set
-                          rule: self == oldSelf
-                        - message: kind must be either 'Issuer' or 'ClusterIssuer'
-                          rule: self.kind.lowerAscii() == 'issuer' || self.kind.lowerAscii()
-                            == 'clusterissuer'
-                        - message: group must be 'cert-manager.io'
-                          rule: self.group.lowerAscii() == 'cert-manager.io'
-                      istioCACertificate:
-                        description: |-
-                          istioCACertificate when provided, the operator will use the CA certificate from the specified ConfigMap.
-                          If empty, the operator will automatically extract the CA certificate from the Secret containing the istiod certificate obtained from cert-manager.
-                        properties:
-                          key:
-                            description: key name holding the required data.
-                            maxLength: 253
-                            minLength: 1
-                            pattern: ^[-._a-zA-Z0-9]+$
-                            type: string
-                          name:
-                            description: name of the ConfigMap.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: namespace in which the ConfigMap exists.
-                              If empty, ConfigMap will be looked up in IstioCSR created
-                              namespace.
-                            maxLength: 63
-                            minLength: 0
-                            type: string
-                        required:
-                        - key
-                        - name
-                        type: object
-                    required:
-                    - issuerRef
-                    type: object
-                    x-kubernetes-validations:
-                    - message: issuerRef may only be configured during creation
-                      rule: '!has(oldSelf.issuerRef) && !has(self.issuerRef) || has(oldSelf.issuerRef)
-                        && has(self.issuerRef)'
-                  istio:
-                    description: istio is for configuring the istio specifics.
-                    properties:
-                      namespace:
-                        description: |-
-                          namespace of the Istio control plane.
-                          This field can have a maximum of 63 characters.
-                        maxLength: 63
-                        minLength: 1
-                        type: string
-                        x-kubernetes-validations:
-                        - message: namespace is immutable once set
-                          rule: self == oldSelf
-                      revisions:
-                        default:
-                        - default
-                        description: |-
-                          revisions are the Istio revisions that are currently installed in the cluster.
-                          Changing this field will modify the DNS names that will be requested for the istiod certificate.
-                          This field can have a maximum of 25 entries.
-                        items:
-                          maxLength: 63
-                          minLength: 1
-                          type: string
-                        maxItems: 25
-                        minItems: 0
-                        type: array
-                        x-kubernetes-list-type: set
-                    required:
-                    - namespace
-                    type: object
-                  istioDataPlaneNamespaceSelector:
+                  defaultCAPackage:
                     description: |-
-                      Istio-csr creates a ConfigMap named `istio-ca-root-cert` containing the root CA certificate, which the Istio data plane uses to verify server certificates. Its default behavior is to create and monitor ConfigMaps in all namespaces.
-                      The istioDataPlaneNamespaceSelector restricts the namespaces where the ConfigMap is created by using label selectors, such as maistra.io/member-of=istio-system. This selector is also attached to all desired namespaces that are part of the data plane.
-                      This field can have a maximum of 4096 characters.
-                    example: maistra.io/member-of=istio-system
-                    maxLength: 4096
-                    minLength: 0
-                    type: string
-                  istiodTLSConfig:
-                    description: istiodTLSConfig is for configuring istiod certificate
-                      specifics.
+                      defaultCAPackage configures the default CA package for trust-manager.
+                      When enabled, the operator will use OpenShift's trusted CA bundle injection mechanism.
                     properties:
-                      certificateDNSNames:
+                      policy:
+                        default: Disabled
                         description: |-
-                          certificateDNSNames contains the additional DNS names to be added to the istiod certificate SAN.
-                          This field can have a maximum of 25 entries.
-                        items:
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        maxItems: 25
-                        minItems: 0
-                        type: array
-                        x-kubernetes-list-type: set
-                      certificateDuration:
-                        default: 1h
-                        description: certificateDuration is the validity period for
-                          the istio-csr and istiod certificates.
-                        type: string
-                      certificateRenewBefore:
-                        default: 30m
-                        description: certificateRenewBefore is the time before expiry
-                          to renew the istio-csr and istiod certificates.
-                        type: string
-                      commonName:
-                        description: |-
-                          commonName is the common name to be set in the cert-manager.io Certificate created for istiod.
-                          The commonName will be of the form istiod.<istio_namespace>.svc when not set.
-                          This field can have a maximum of 64 characters.
-                        example: istiod.istio-system.svc
-                        maxLength: 64
-                        minLength: 0
-                        type: string
-                      maxCertificateDuration:
-                        default: 1h
-                        description: MaxCertificateDuration is the maximum validity
-                          duration that can be requested for a certificate.
-                        type: string
-                      privateKeyAlgorithm:
-                        default: RSA
-                        description: |-
-                          privateKeyAlgorithm is the algorithm to use when generating private keys. Allowed values are RSA, and ECDSA.
-                          This field is immutable once set.
+                          policy controls whether the default CA package feature is enabled.
+                          When set to "Enabled", the operator will inject OpenShift's trusted CA bundle
+                          into trust-manager, enabling the "useDefaultCAs: true" source in Bundle resources.
+                          When set to "Disabled", no default CA package is configured and Bundles cannot use useDefaultCAs (default behavior).
                         enum:
-                        - RSA
-                        - ECDSA
+                        - Enabled
+                        - Disabled
                         type: string
-                        x-kubernetes-validations:
-                        - message: privateKeyAlgorithm is immutable once set
-                          rule: oldSelf == '' || self == oldSelf
-                      privateKeySize:
-                        default: 2048
-                        description: |-
-                          privateKeySize is the key size for the istio-csr and istiod certificates. Allowed values when privateKeyAlgorithm is RSA are 2048, 4096, 8192; and for ECDSA, they are 256, 384.
-                          This field is immutable once set.
-                        enum:
-                        - 256
-                        - 384
-                        - 2048
-                        - 4096
-                        - 8192
-                        format: int32
-                        type: integer
-                        x-kubernetes-validations:
-                        - message: privateKeySize is immutable once set
-                          rule: oldSelf == 0 || self == oldSelf
-                      trustDomain:
-                        description: |-
-                          trustDomain is the Istio cluster's trust domain, which will also be used for deriving the SPIFFE URI.
-                          This field can have a maximum of 63 characters.
-                        maxLength: 63
-                        minLength: 1
-                        type: string
-                    required:
-                    - trustDomain
                     type: object
-                    x-kubernetes-validations:
-                    - message: privateKeyAlgorithm may only be configured during creation
-                      rule: '!has(oldSelf.privateKeyAlgorithm) && !has(self.privateKeyAlgorithm)
-                        || has(oldSelf.privateKeyAlgorithm) && has(self.privateKeyAlgorithm)'
-                    - message: privateKeySize may only be configured during creation
-                      rule: '!has(oldSelf.privateKeySize) && !has(self.privateKeySize)
-                        || has(oldSelf.privateKeySize) && has(self.privateKeySize)'
-                    - message: privateKeySize must match with configured privateKeyAlgorithm
-                      rule: '(!has(self.privateKeyAlgorithm) || self.privateKeyAlgorithm
-                        == ''RSA'') ? (self.privateKeySize in [2048,4096,8192]) :
-                        (self.privateKeySize in [256,384])'
+                  filterExpiredCertificates:
+                    default: Disabled
+                    description: |-
+                      filterExpiredCertificates controls whether trust-manager filters out
+                      expired certificates from trust bundles before distributing them.
+                      When set to "Enabled", expired certificates are removed from bundles.
+                      When set to "Disabled", expired certificates are included (default behavior).
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   logFormat:
                     default: text
                     description: |-
-                      logFormat specifies the output format for istio-csr agent logging.
-                      Supported log formats are text and json.
+                      logFormat specifies the output format for trust-manager logging.
+                      Supported formats are "text" and "json".
                     enum:
                     - text
                     - json
                     type: string
                   logLevel:
                     default: 1
-                    description: logLevel supports a value range as per [Kubernetes
-                      logging guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use).
+                    description: |-
+                      logLevel configures the verbosity of trust-manager logging.
+                      Follows [Kubernetes logging guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use).
                     format: int32
                     maximum: 5
                     minimum: 1
@@ -1220,8 +1060,7 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      nodeSelector is for defining the scheduling criteria using node labels.
-                      This field can have a maximum of 50 entries.
+                      nodeSelector restricts which nodes the trust-manager pod can be scheduled on.
                       ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                     maxProperties: 50
                     minProperties: 0
@@ -1229,8 +1068,7 @@ spec:
                     x-kubernetes-map-type: atomic
                   resources:
                     description: |-
-                      resources is for defining the resource requirements.
-                      Cannot be updated.
+                      resources defines the compute resource requirements for the trust-manager pod.
                       ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     properties:
                       claims:
@@ -1289,33 +1127,44 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
-                  server:
-                    description: server is for configuring the server endpoint used
-                      by istio for obtaining the certificates.
+                  secretTargets:
+                    description: secretTargets configures whether trust-manager can
+                      write trust bundles to Secrets.
                     properties:
-                      clusterID:
-                        default: Kubernetes
+                      authorizedSecrets:
                         description: |-
-                          clusterID is the Istio cluster ID used to verify incoming CSRs.
-                          This field can have a maximum of 253 characters.
-                        maxLength: 253
-                        minLength: 0
+                          authorizedSecrets is a list of specific secret names that trust-manager
+                          is authorized to create and update. This field is only valid when policy is "Custom".
+                        items:
+                          minLength: 1
+                          type: string
+                        minItems: 0
+                        type: array
+                        x-kubernetes-list-type: set
+                      policy:
+                        default: Disabled
+                        description: |-
+                          policy controls whether and how trust-manager can write trust bundles to Secrets.
+                          Allowed values are "Disabled" or "Custom".
+                          "Disabled" means trust-manager cannot write trust bundles to Secrets (default behavior).
+                          "Custom" grants trust-manager permission to create and update only the secrets listed in authorizedSecrets.
+                        enum:
+                        - Disabled
+                        - Custom
                         type: string
-                      port:
-                        default: 443
-                        description: port to serve the istio-csr gRPC service.
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                        x-kubernetes-validations:
-                        - message: port is immutable once set
-                          rule: oldSelf == 0 || self == oldSelf
                     type: object
+                    x-kubernetes-validations:
+                    - message: authorizedSecrets must not be empty when policy is
+                        Custom
+                      rule: self.policy != 'Custom' || (has(self.authorizedSecrets)
+                        && size(self.authorizedSecrets) > 0)
+                    - message: authorizedSecrets must be empty when policy is not
+                        Custom
+                      rule: self.policy == 'Custom' || !has(self.authorizedSecrets)
+                        || size(self.authorizedSecrets) == 0
                   tolerations:
                     description: |-
-                      tolerations is for setting the pod tolerations.
-                      This field can have a maximum of 50 entries.
+                      tolerations allows the trust-manager pod to be scheduled on tainted nodes.
                       ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
                     items:
                       description: |-
@@ -1357,25 +1206,27 @@ spec:
                     minItems: 0
                     type: array
                     x-kubernetes-list-type: atomic
-                required:
-                - certManager
-                - istio
-                - istiodTLSConfig
+                  trustNamespace:
+                    default: cert-manager
+                    description: |-
+                      trustNamespace is the namespace where trust-manager looks for trust sources
+                      (ConfigMaps and Secrets containing CA certificates).
+                      Defaults to "cert-manager" if not specified.
+                      This field is immutable once set.
+                      This field can have a maximum of 63 characters.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: trustNamespace is immutable once set
+                      rule: oldSelf == '' || self == oldSelf
                 type: object
             required:
-            - istioCSRConfig
+            - trustManagerConfig
             type: object
           status:
-            description: status is the most recently observed status of the IstioCSR.
+            description: status is the most recently observed status of the TrustManager.
             properties:
-              clusterRole:
-                description: clusterRole created by the controller for the istio-csr
-                  agent.
-                type: string
-              clusterRoleBinding:
-                description: clusterRoleBinding created by the controller for the
-                  istio-csr agent.
-                type: string
               conditions:
                 description: conditions holds information about the current state
                   of the operand deployment.
@@ -1437,26 +1288,43 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              istioCSRGRPCEndpoint:
-                description: istioCSRGRPCEndpoint is the service endpoint of istio-csr,
-                  made available for users to configure in the istiod config to enable
-                  Istio to use istio-csr for certificate requests.
+              defaultCAPackagePolicy:
+                description: defaultCAPackagePolicy indicates the current default
+                  CA package policy.
+                enum:
+                - Enabled
+                - Disabled
                 type: string
-              istioCSRImage:
-                description: istioCSRImage is the name of the image and the tag used
-                  for deploying istio-csr.
+              filterExpiredCertificatesPolicy:
+                description: filterExpiredCertificatesPolicy indicates the current
+                  policy for filtering expired certificates.
+                enum:
+                - Enabled
+                - Disabled
                 type: string
-              serviceAccount:
-                description: serviceAccount created by the controller for the istio-csr
-                  agent.
+              secretTargetsPolicy:
+                description: secretTargetsPolicy indicates the current secret targets
+                  policy.
+                enum:
+                - Disabled
+                - Custom
+                type: string
+              trustManagerImage:
+                description: trustManagerImage is the container image (name:tag) used
+                  for trust-manager.
+                type: string
+              trustNamespace:
+                description: trustNamespace is the namespace where trust-manager looks
+                  for trust sources.
                 type: string
             type: object
         required:
+        - metadata
         - spec
         type: object
         x-kubernetes-validations:
-        - message: istiocsr is a singleton, .metadata.name must be 'default'
-          rule: self.metadata.name == 'default'
+        - message: TrustManager is a singleton, .metadata.name must be 'cluster'
+          rule: self.metadata.name == 'cluster'
     served: true
     storage: true
     subresources:

--- a/assets/optional/cert-manager/crd/bases/orders.acme.cert-manager.io-crd.yaml
+++ b/assets/optional/cert-manager/crd/bases/orders.acme.cert-manager.io-crd.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.18.4
+    app.kubernetes.io/version: v1.19.2
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io
@@ -77,6 +77,7 @@ spec:
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 duration:
                   description: |-
                     Duration is the duration for the not after date for the requested certificate.
@@ -90,6 +91,7 @@ spec:
                   items:
                     type: string
                   type: array
+                  x-kubernetes-list-type: atomic
                 issuerRef:
                   description: |-
                     IssuerRef references a properly configured ACME-type Issuer which should
@@ -99,13 +101,17 @@ spec:
                     Order will be marked as failed.
                   properties:
                     group:
-                      description: Group of the resource being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      description: Kind of the resource being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
-                      description: Name of the resource being referred to.
+                      description: Name of the issuer being referred to.
                       type: string
                   required:
                     - name
@@ -175,6 +181,7 @@ spec:
                             - url
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       identifier:
                         description: Identifier is the DNS name to be validated as part of this authorization
                         type: string
@@ -212,6 +219,7 @@ spec:
                       - url
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 certificate:
                   description: |-
                     Certificate is a copy of the PEM encoded certificate for this Order.

--- a/assets/optional/cert-manager/crd/kustomization.yaml
+++ b/assets/optional/cert-manager/crd/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
 - bases/issuers.cert-manager.io-crd.yaml
 - bases/orders.acme.cert-manager.io-crd.yaml
 - bases/operator.openshift.io_istiocsrs.yaml
+- bases/operator.openshift.io_trustmanagers.yaml
+- bases/customresourcedefinition_bundles.trust.cert-manager.io.yml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/assets/optional/cert-manager/manager/images-aarch64.yaml
+++ b/assets/optional/cert-manager/manager/images-aarch64.yaml
@@ -4,9 +4,11 @@ metadata:
   name: cert-manager-images
   namespace: cert-manager
 data:
-  cert-manager-webhook: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f1b903ff69100fa938d6bdf4d730d35158eec905351344a246e30ef14c847222
-  cert-manager-ca-injector: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f1b903ff69100fa938d6bdf4d730d35158eec905351344a246e30ef14c847222
-  cert-manager-controller: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:f1b903ff69100fa938d6bdf4d730d35158eec905351344a246e30ef14c847222
-  cert-manager-acmesolver: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:3258027c0fb9426c9ee3567f6dc0d02b85cb661c23300b230f5b1400b43bac25
-  cert-manager-istiocsr: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:95f5dfa4331fcfb96357ed28f4d7f0fd00d9419d9252e3cff3962aec6cedbeb9
-  controller: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:22f4e686a81fc809e70e3f73206ec221f8081e842243f173308dc1fbc7f02a3e
+  cert-manager-webhook: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:8227c8925d00d1c81c95e7017209fdc6b5b1925cde2fa4fe3752fb6c81510a2d
+  cert-manager-ca-injector: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:8227c8925d00d1c81c95e7017209fdc6b5b1925cde2fa4fe3752fb6c81510a2d
+  cert-manager-controller: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:8227c8925d00d1c81c95e7017209fdc6b5b1925cde2fa4fe3752fb6c81510a2d
+  cert-manager-acmesolver: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:b001612ad6362a1b7273e178d9870ab3d020a40ee3339a0f95fef1cd3913356e
+  cert-manager-istiocsr: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:78564158857ed7f1534597f3ee7faaee23b692f9ed5aa0259e19196f5400167d
+  controller: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:9f37a838089d2e3c199a4fd97bea028cb6b66b4214e8233884716efe0a998298
+  cert-manager-trust-manager: quay.io/jetstack/trust-manager:v0.20.3
+  unsupported-addon-features: TrustManager=true

--- a/assets/optional/cert-manager/manager/images-x86_64.yaml
+++ b/assets/optional/cert-manager/manager/images-x86_64.yaml
@@ -4,9 +4,11 @@ metadata:
   name: cert-manager-images
   namespace: cert-manager
 data:
-  cert-manager-webhook: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:09c857f0c20721d6b447f5f567182befc1ca6157128225849117a5c830feab23
-  cert-manager-ca-injector: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:09c857f0c20721d6b447f5f567182befc1ca6157128225849117a5c830feab23
-  cert-manager-controller: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:09c857f0c20721d6b447f5f567182befc1ca6157128225849117a5c830feab23
-  cert-manager-acmesolver: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:155383c4664ea3ed18d0f079be720ad68a5de044448a744d7579af7ff0fc7e0a
-  cert-manager-istiocsr: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:41df7aabbce42599bad7fdc721cd12aa6e12d17e1c0658fb3294a1f68483d656
-  controller: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:57a1aea49d7cc275b37b8f52d602a3a9d1601ec6a21a3268dd4903566cb2e335
+  cert-manager-webhook: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:40b47054e42363a365b491ccfe0d86f109e19fc317058ba834ffe0f5c733880b
+  cert-manager-ca-injector: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:40b47054e42363a365b491ccfe0d86f109e19fc317058ba834ffe0f5c733880b
+  cert-manager-controller: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:40b47054e42363a365b491ccfe0d86f109e19fc317058ba834ffe0f5c733880b
+  cert-manager-acmesolver: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:3a40eb434e032fb2135f369b6fc65266ae0f409db92fd65d12cf13c7f32b5020
+  cert-manager-istiocsr: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:0f20d178f980a3fa4527bc1613b8639385e36c367e30c93b4cbb4c4a434d3405
+  controller: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:8eecb53c8c81c0fa8f198260acb273759c0d12b5c01642a128923c5716df19d2
+  cert-manager-trust-manager: quay.io/jetstack/trust-manager:v0.20.3
+  unsupported-addon-features: TrustManager=true

--- a/assets/optional/cert-manager/manager/images-x86_64.yaml
+++ b/assets/optional/cert-manager/manager/images-x86_64.yaml
@@ -4,11 +4,11 @@ metadata:
   name: cert-manager-images
   namespace: cert-manager
 data:
-  cert-manager-webhook: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:40b47054e42363a365b491ccfe0d86f109e19fc317058ba834ffe0f5c733880b
-  cert-manager-ca-injector: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:40b47054e42363a365b491ccfe0d86f109e19fc317058ba834ffe0f5c733880b
-  cert-manager-controller: registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:40b47054e42363a365b491ccfe0d86f109e19fc317058ba834ffe0f5c733880b
-  cert-manager-acmesolver: registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:3a40eb434e032fb2135f369b6fc65266ae0f409db92fd65d12cf13c7f32b5020
-  cert-manager-istiocsr: registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:0f20d178f980a3fa4527bc1613b8639385e36c367e30c93b4cbb4c4a434d3405
-  controller: registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:8eecb53c8c81c0fa8f198260acb273759c0d12b5c01642a128923c5716df19d2
-  cert-manager-trust-manager: quay.io/jetstack/trust-manager:v0.20.3
+  cert-manager-webhook: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+  cert-manager-ca-injector: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+  cert-manager-controller: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c
+  cert-manager-acmesolver: registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5
+  cert-manager-istiocsr: registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f
+  controller: registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9
+  cert-manager-trust-manager: registry.stage.redhat.io/cert-manager/cert-manager-trust-manager-rhel9@sha256:d6107f05754823ac3a2645d0f555471ee3f8958261e30935c0d60b39851cb98d
   unsupported-addon-features: TrustManager=true

--- a/assets/optional/cert-manager/manager/images.yaml
+++ b/assets/optional/cert-manager/manager/images.yaml
@@ -1,0 +1,1 @@
+images-x86_64.yaml

--- a/assets/optional/cert-manager/manager/kustomization.yaml
+++ b/assets/optional/cert-manager/manager/kustomization.yaml
@@ -4,6 +4,23 @@ resources:
   - manager.yaml
   - images.yaml
 
+# Add value field so replacement can target UNSUPPORTED_ADDON_FEATURES (base has only name)
+patches:
+  - target:
+      kind: Deployment
+      name: controller-manager
+    patch: |-
+      - op: add
+          path: /spec/template/spec/containers/0/env/-
+          value:
+            name: UNSUPPORTED_ADDON_FEATURES
+            value: ''
+      - op: add
+          path: /spec/template/spec/containers/0/env/-
+          value:
+            name: RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER
+            value: ''
+            
 replacements:
   - source:
       kind: ConfigMap
@@ -48,6 +65,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: cert-manager-images
+      fieldPath: data.unsupported-addon-features
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=cert-manager-operator].env.[name=UNSUPPORTED_ADDON_FEATURES].value
+  - source:
+      kind: ConfigMap
+      name: cert-manager-images
       fieldPath: data.cert-manager-istiocsr
     targets:
       - select:
@@ -55,6 +82,16 @@ replacements:
           name: controller-manager
         fieldPaths:
           - spec.template.spec.containers.[name=cert-manager-operator].env.[name=RELATED_IMAGE_CERT_MANAGER_ISTIOCSR].value
+  - source:
+      kind: ConfigMap
+      name: cert-manager-images
+      fieldPath: data.cert-manager-trust-manager
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=cert-manager-operator].env.[name=RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER].value          
   - source:
       kind: ConfigMap
       name: cert-manager-images

--- a/assets/optional/cert-manager/manager/manager.yaml
+++ b/assets/optional/cert-manager/manager/manager.yaml
@@ -75,21 +75,21 @@ spec:
             - name: OPERATOR_NAME
               value: cert-manager-operator
             - name: RELATED_IMAGE_CERT_MANAGER_WEBHOOK
-              value: quay.io/jetstack/cert-manager-webhook:latest
+              value: quay.io/jetstack/cert-manager-webhook:v1.19.2
             - name: RELATED_IMAGE_CERT_MANAGER_CA_INJECTOR
-              value: quay.io/jetstack/cert-manager-cainjector:latest
+              value: quay.io/jetstack/cert-manager-cainjector:v1.19.2
             - name: RELATED_IMAGE_CERT_MANAGER_CONTROLLER
-              value: quay.io/jetstack/cert-manager-controller:latest
+              value: quay.io/jetstack/cert-manager-controller:v1.19.2
             - name: RELATED_IMAGE_CERT_MANAGER_ACMESOLVER
-              value: quay.io/jetstack/cert-manager-acmesolver:v1.18.4
+              value: quay.io/jetstack/cert-manager-acmesolver:v1.19.2
             - name: RELATED_IMAGE_CERT_MANAGER_ISTIOCSR
-              value: quay.io/jetstack/cert-manager-istio-csr:v0.14.2
+              value: quay.io/jetstack/cert-manager-istio-csr:v0.15.0
             - name: OPERAND_IMAGE_VERSION
-              value: 1.18.4
+              value: 1.19.2
             - name: ISTIOCSR_OPERAND_IMAGE_VERSION
-              value: 0.14.2
+              value: 0.15.0
             - name: OPERATOR_IMAGE_VERSION
-              value: 1.18.1
+              value: 1.19.0
             - name: OPERATOR_LOG_LEVEL
               value: '2'
             - name: TRUSTED_CA_CONFIGMAP_NAME

--- a/assets/optional/cert-manager/rbac/role.yaml
+++ b/assets/optional/cert-manager/rbac/role.yaml
@@ -226,6 +226,8 @@ rules:
   resources:
   - certmanagers/finalizers
   - istiocsrs/finalizers
+  - trustmanagers/finalizers
+  - bundles/finalizers
   verbs:
   - update
 - apiGroups:
@@ -233,6 +235,8 @@ rules:
   resources:
   - certmanagers/status
   - istiocsrs/status
+  - trustmanagers/status
+  - bundles/status
   verbs:
   - get
   - patch
@@ -241,6 +245,20 @@ rules:
   - operator.openshift.io
   resources:
   - istiocsrs
+  - trustmanagers
+  - bundles
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - trust.cert-manager.io
+  resources:
+  - bundles
+  - bundles/finalizers
+  - bundles/status
   verbs:
   - get
   - list

--- a/assets/optional/cert-manager/release-cert-manager-x86_64.json
+++ b/assets/optional/cert-manager/release-cert-manager-x86_64.json
@@ -1,13 +1,13 @@
 {
   "release": {
-    "base": "1.18.1"
+    "base": "1.19.0"
   },
   "images": {
-    "cert-manager-operator": "registry.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:57a1aea49d7cc275b37b8f52d602a3a9d1601ec6a21a3268dd4903566cb2e335",
-    "cert-manager-istiocsr": "registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:41df7aabbce42599bad7fdc721cd12aa6e12d17e1c0658fb3294a1f68483d656",
-    "cert-manager-acmesolver": "registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:155383c4664ea3ed18d0f079be720ad68a5de044448a744d7579af7ff0fc7e0a",
-    "cert-manager-webhook": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:09c857f0c20721d6b447f5f567182befc1ca6157128225849117a5c830feab23",
-    "cert-manager-ca-injector": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:09c857f0c20721d6b447f5f567182befc1ca6157128225849117a5c830feab23",
-    "cert-manager-controller": "registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:09c857f0c20721d6b447f5f567182befc1ca6157128225849117a5c830feab23"
+    "cert-manager-operator": "registry.stage.redhat.io/cert-manager/cert-manager-operator-rhel9@sha256:484342520dc3babe0ff4a9360edc98816556f2bd1b9981ec3d5dbab09a7536a9",
+    "cert-manager-istiocsr": "registry.stage.redhat.io/cert-manager/cert-manager-istio-csr-rhel9@sha256:c94278e1c409be1a8617e94bb29eb85b602760daf554f1b3120ef3cee04b3f4f",
+    "cert-manager-acmesolver": "registry.stage.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9@sha256:06738b00d823d39672f97ca7364f2b9c7c3a988e2268741298783b1398784cf5",
+    "cert-manager-webhook": "registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c",
+    "cert-manager-ca-injector": "registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c",
+    "cert-manager-controller": "registry.stage.redhat.io/cert-manager/jetstack-cert-manager-rhel9@sha256:e6c851778fdb826bfe2536b236ad99c373e9d1e9eaf4c543208bf4597682c06c"
   }
 }

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -563,6 +563,7 @@ install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshi
 install -p -m644 assets/optional/cert-manager/crd/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/crd
 install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/crd/bases
 install -p -m644 assets/optional/cert-manager/crd/bases/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/crd/bases
+install -p -m644 assets/optional/cert-manager/crd/bases/*.yml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/crd/bases
 install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/crd/patches
 install -p -m644 assets/optional/cert-manager/crd/patches/*.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/crd/patches
 install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/rbac

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -236,6 +236,7 @@ func RunMicroshift(cfg *config.Config) error {
 	util.Must(m.AddService(controllers.NewClusterID(cfg)))
 	util.Must(m.AddService(controllers.NewTelemetryManager(cfg)))
 	util.Must(m.AddService(controllers.NewHostsWatcherManager(cfg)))
+	util.Must(m.AddService(controllers.NewTrustedCABundleManager(cfg)))
 	util.Must(m.AddService(gdp.NewGenericDevicePlugin(cfg)))
 
 	// Storing and clearing the env, so other components don't send the READY=1 until MicroShift is fully ready

--- a/pkg/controllers/trusted-ca-bundle-manager.go
+++ b/pkg/controllers/trusted-ca-bundle-manager.go
@@ -1,0 +1,168 @@
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/openshift/microshift/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+const (
+	trustedCABundlePath  = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+	trustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
+	trustedCABundleKey   = "ca-bundle.crt"
+	resyncInterval       = 30 * time.Second
+)
+
+type TrustedCABundleManager struct {
+	kubeconfig string
+}
+
+func NewTrustedCABundleManager(cfg *config.Config) *TrustedCABundleManager {
+	return &TrustedCABundleManager{
+		kubeconfig: cfg.KubeConfigPath(config.KubeAdmin),
+	}
+}
+
+func (s *TrustedCABundleManager) Name() string { return "trusted-ca-bundle-manager" }
+func (s *TrustedCABundleManager) Dependencies() []string {
+	return []string{"kube-apiserver", "infrastructure-services-manager"}
+}
+
+func (s *TrustedCABundleManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
+	defer close(stopped)
+
+	restCfg, err := clientcmd.BuildConfigFromFlags("", s.kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to build kubeconfig: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	if err := s.syncTrustedCABundle(ctx, client); err != nil {
+		klog.Warningf("%s failed initial trusted CA bundle sync: %v", s.Name(), err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create file watcher: %w", err)
+	}
+	defer func() {
+		if cerr := watcher.Close(); cerr != nil {
+			klog.Errorf("%s failed to close file watcher: %v", s.Name(), cerr)
+		}
+	}()
+
+	for _, path := range []string{trustedCABundlePath, filepath.Dir(trustedCABundlePath)} {
+		if err := watcher.Add(path); err != nil {
+			klog.Warningf("%s failed to watch %s: %v", s.Name(), path, err)
+		}
+	}
+
+	close(ready)
+	klog.Infof("%s is ready, watching %s", s.Name(), trustedCABundlePath)
+
+	lastHash, _ := s.getFileHash()
+	resyncTicker := time.NewTicker(resyncInterval)
+	defer resyncTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-resyncTicker.C:
+			if err := s.syncTrustedCABundle(ctx, client); err != nil {
+				klog.V(4).Infof("%s periodic sync: %v", s.Name(), err)
+			}
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return fmt.Errorf("watcher channel closed")
+			}
+			if event.Name != trustedCABundlePath {
+				continue
+			}
+			if event.Op&fsnotify.Write == 0 && event.Op&fsnotify.Create == 0 {
+				continue
+			}
+			currentHash, err := s.getFileHash()
+			if err != nil {
+				klog.Warningf("%s failed to hash CA bundle: %v", s.Name(), err)
+				continue
+			}
+			if currentHash == lastHash {
+				continue
+			}
+			klog.Infof("%s detected CA bundle change, syncing", s.Name())
+			if err := s.syncTrustedCABundle(ctx, client); err != nil {
+				klog.Errorf("%s failed to sync CA bundle: %v", s.Name(), err)
+				continue
+			}
+			lastHash = currentHash
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return fmt.Errorf("watcher error channel closed")
+			}
+			klog.Errorf("%s watcher error: %v", s.Name(), err)
+		}
+	}
+}
+
+func (s *TrustedCABundleManager) syncTrustedCABundle(ctx context.Context, client kubernetes.Interface) error {
+	caBundle, err := os.ReadFile(trustedCABundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", trustedCABundlePath, err)
+	}
+	if len(caBundle) == 0 {
+		return fmt.Errorf("%s is empty", trustedCABundlePath)
+	}
+
+	configMaps, err := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{
+		LabelSelector: trustedCABundleLabel + "=true",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list ConfigMaps with label %s: %w", trustedCABundleLabel, err)
+	}
+
+	caBundleStr := string(caBundle)
+	for i := range configMaps.Items {
+		cm := &configMaps.Items[i]
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		if cm.Data[trustedCABundleKey] == caBundleStr {
+			klog.V(4).Infof("%s ConfigMap %s/%s already has current CA bundle", s.Name(), cm.Namespace, cm.Name)
+			continue
+		}
+		cm.Data[trustedCABundleKey] = caBundleStr
+		if _, err := client.CoreV1().ConfigMaps(cm.Namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+			klog.Errorf("%s failed to update ConfigMap %s/%s: %v", s.Name(), cm.Namespace, cm.Name, err)
+			continue
+		}
+		klog.Infof("%s injected trusted CA bundle into ConfigMap %s/%s", s.Name(), cm.Namespace, cm.Name)
+	}
+
+	return nil
+}
+
+func (s *TrustedCABundleManager) getFileHash() (string, error) {
+	content, err := os.ReadFile(trustedCABundlePath)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(content)
+	return fmt.Sprintf("%x", hash), nil
+}

--- a/scripts/auto-rebase/assets_cert_manager.yaml
+++ b/scripts/auto-rebase/assets_cert_manager.yaml
@@ -25,6 +25,8 @@ assets:
       - file: operator.openshift.io_certmanagers.yaml
       - file: operator.openshift.io_istiocsrs.yaml
       - file: orders.acme.cert-manager.io-crd.yaml
+      - file: customresourcedefinition_bundles.trust.cert-manager.io.yml
+      - file: operator.openshift.io_trustmanagers.yaml
   - dir: optional/cert-manager/crd/patches/
     src: cert-manager-operator/config/crd/patches/
     files:


### PR DESCRIPTION
Introduces trust-manager as a new operand to the cert-manager operator, enabling management of trust bundles across the cluster.

When a `TrustManager` CR is created, the trust-manager operand will be deployed in the cert-manager namespace, enabling users to create and distribute trust bundles across the cluster using `Bundle` resources.

This PR depends on https://github.com/openshift/cert-manager-operator/pull/379

##  testing
1.  start MicroShift instance with a cert-manager rpm installed from this PR.
2.  build cert-manager-operator image locally from  [cert-manager-operator-379](https://github.com/openshift/cert-manager-operator/pull/379)
  ```shell
       PR_NUMBER=379
       git clone https://github.com/openshift/cert-manager-operator.git
       cd cert-manager-operator/
       git fetch origin refs/pull/${PR_NUMBER}/head:trust-manager
       git checkout trust-manager
  
       # build the operator locally as `openshift.io/cert-manager-operator:latest`
       make image-build
   ``` 
3.  patch the deployment with the local image
     ```bash
	oc -n cert-manager-operator patch deployment/cert-manager-operator-controller-manager \
	--type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image","value": "openshift.io/cert-manager-operator:latest"},{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Never"}]'
	```

 4. create trust-manager CR:
     ```shell
        oc apply -f https://raw.githubusercontent.com/openshift/cert-manager-operator/refs/heads/master/config/samples/tech-preview/operator.openshift.io_v1alpha1_trustmanager.yaml
     ```


## open-question
- how do we handle `UNSUPPORTED_ADDON_FEATURES` flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bundle and TrustManager CRDs for managing trust bundles and operator configuration.
  * Added a trusted CA bundle manager service to sync cluster ConfigMaps from the system CA bundle.

* **Updates**
  * DNS solver gains protocol selection (TCP/UDP); HTTP solver pod templates support resource requests/limits.
  * Bumped cert-manager components to v1.19.x, added trust-manager, updated image pins and deployment env vars.
  * Extended RBAC for new resources and refined CRD list/merge behavior and issuer documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->