### PR TITLE
USHIFT-6948: Verify local host name in standard suite

### DIFF
--- a/test/suites/standard1/hostname.robot
+++ b/test/suites/standard1/hostname.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       Tests verifying hostname resolution
+Documentation       Tests verifying hostname
 
 Resource            ../../resources/microshift-process.resource
 Resource            ../../resources/microshift-host.resource
@@ -18,8 +18,18 @@ ${OLD_HOSTNAME}     ${EMPTY}
 
 
 *** Test Cases ***
-Verify local name resolution
-    [Documentation]    Verify correct name resolution through mDNS
+Verify Local Host Name
+    [Documentation]    Verify correct host name setting
+
+    ${hostname}=    Command Should Work    hostname
+    # Host name sanity test includes:
+    # - It should not be a localhost
+    # - It should contain the suite name as this is how the testing framework names VMs
+    Should Not Contain    ${hostname}    local
+    Should Contain    ${hostname}    standard
+
+Verify Local Host Name Resolution
+    [Documentation]    Verify correct host name resolution through mDNS
     [Setup]    Configure New Hostname
 
     Named Deployment Should Be Available    router-default    timeout=${DEFAULT_WAIT_TIMEOUT}    ns=openshift-ingress


### PR DESCRIPTION
Verify that anaconda correctly sets the host name during kickstart installation.

This PR adds a new test case to the `standard1` suite that checks:
- The hostname is not "localhost" or any variant containing "local"
- The hostname contains the expected suite name (e.g., "standard"), confirming that the testing framework's VM naming convention was applied by anaconda during kickstart

The existing "Verify local name resolution" test is renamed to "Verify Local Host Name Resolution" for clarity.

Jira: https://redhat.atlassian.net/browse/USHIFT-6948