### PR TITLE
USHIFT-6401, USHIFT-6788: Add fail-fast RBAC bootstrap hook deadlock detection

### DIFF
--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -62,6 +62,10 @@ const (
 	rbacHookDeadlockTimeout = 15
 	// rbacHookCheckInterval is how often to check the RBAC hook status
 	rbacHookCheckInterval = 2
+	// rbacHookMaxWaitDuration is the absolute maximum time to wait for the RBAC hook
+	// regardless of etcd health state changes. This prevents flapping from extending
+	// detection indefinitely.
+	rbacHookMaxWaitDuration = 30 * time.Second
 )
 
 var (
@@ -456,10 +460,18 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 	case <-time.After(5 * time.Second):
 	}
 
+	// Track wall-clock deadline to prevent flapping from extending detection indefinitely
+	startTime := time.Now()
 	checkCount := 0
 	maxChecks := (rbacHookDeadlockTimeout - 5) / rbacHookCheckInterval // Account for initial delay
 
 	for checkCount < maxChecks {
+		// Check absolute deadline first - this cannot be reset by etcd state changes
+		if time.Since(startTime) >= rbacHookMaxWaitDuration {
+			klog.Errorf("RBAC bootstrap hook exceeded maximum wait duration of %v", rbacHookMaxWaitDuration)
+			break
+		}
+
 		select {
 		case <-ctx.Done():
 			return
@@ -486,18 +498,20 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 		}
 
 		if etcdHealthy {
-			klog.Warningf("RBAC bootstrap hook not ready (check %d/%d), but etcd is healthy - potential deadlock",
-				checkCount, maxChecks)
+			klog.Warningf("RBAC bootstrap hook not ready (check %d/%d, elapsed %v), but etcd is healthy - potential deadlock",
+				checkCount, maxChecks, time.Since(startTime).Round(time.Second))
 		} else {
 			// etcd not healthy - not a deadlock, just waiting for etcd
 			klog.V(4).Infof("RBAC hook waiting, etcd not yet healthy (check %d/%d)", checkCount, maxChecks)
 			// Reset counter since this isn't a deadlock condition
+			// Note: wall-clock deadline (startTime) is NOT reset - flapping cannot extend indefinitely
 			checkCount = 0
 		}
 	}
 
 	// Reached max checks with etcd healthy but hook not completing - deadlock detected
-	klog.Error("RBAC bootstrap hook deadlock confirmed: etcd healthy but hook not completing")
+	klog.Errorf("RBAC bootstrap hook deadlock confirmed after %v: etcd healthy but hook not completing",
+		time.Since(startTime).Round(time.Second))
 	close(deadlockDetected)
 }
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -55,6 +56,12 @@ import (
 
 const (
 	kubeAPIStartupTimeout = 60
+	// rbacHookDeadlockTimeout is the time to wait for the RBAC bootstrap hook
+	// before declaring a deadlock. This is shorter than kubeAPIStartupTimeout
+	// to allow for faster recovery.
+	rbacHookDeadlockTimeout = 15
+	// rbacHookCheckInterval is how often to check the RBAC hook status
+	rbacHookCheckInterval = 2
 )
 
 var (
@@ -348,7 +355,13 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 		return err
 	}
 
-	// run readiness check
+	// Channel to signal RBAC hook deadlock detection
+	rbacDeadlockDetected := make(chan struct{})
+
+	// Run RBAC hook deadlock detector
+	go s.detectRBACHookDeadlock(ctx, restClient, rbacDeadlockDetected)
+
+	// Run standard readiness check
 	go func() {
 		err := wait.PollUntilContextTimeout(ctx, time.Second, kubeAPIStartupTimeout*time.Second, true, func(ctx context.Context) (bool, error) {
 			var status int
@@ -420,7 +433,127 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 		return err
 	case perr := <-panicChannel:
 		panic(perr)
+	case <-rbacDeadlockDetected:
+		klog.Error("RBAC bootstrap hook deadlock detected - restarting microshift-etcd.scope to recover")
+		if err := restartMicroshiftEtcdScope(); err != nil {
+			klog.Errorf("Failed to restart microshift-etcd.scope: %v", err)
+		}
+		return fmt.Errorf("RBAC bootstrap hook deadlock detected after %d seconds", rbacHookDeadlockTimeout)
 	}
+}
+
+// detectRBACHookDeadlock monitors the RBAC bootstrap hook status and detects deadlock conditions.
+// A deadlock is detected when:
+// 1. The RBAC hook is not completing (stuck in "not finished" state)
+// 2. etcd is healthy and responsive
+// This indicates the circular dependency where the hook waits for API server
+// while API server waits for the hook.
+func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient rest.Interface, deadlockDetected chan<- struct{}) {
+	// Wait a few seconds before starting detection to allow normal startup
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(5 * time.Second):
+	}
+
+	checkCount := 0
+	maxChecks := (rbacHookDeadlockTimeout - 5) / rbacHookCheckInterval // Account for initial delay
+
+	for checkCount < maxChecks {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(rbacHookCheckInterval * time.Second):
+		}
+
+		checkCount++
+
+		// Check RBAC hook status
+		var status int
+		err := restClient.Get().AbsPath("/readyz/poststarthook/rbac/bootstrap-roles").Do(ctx).StatusCode(&status).Error()
+
+		// If hook is ready, no deadlock
+		if err == nil && status == 200 {
+			klog.V(4).Info("RBAC bootstrap hook completed successfully")
+			return
+		}
+
+		// Hook not ready - check if etcd is healthy
+		etcdHealthy, etcdErr := isEtcdHealthy(ctx)
+		if etcdErr != nil {
+			klog.V(4).Infof("Could not check etcd health: %v", etcdErr)
+			continue
+		}
+
+		if etcdHealthy {
+			klog.Warningf("RBAC bootstrap hook not ready (check %d/%d), but etcd is healthy - potential deadlock",
+				checkCount, maxChecks)
+		} else {
+			// etcd not healthy - not a deadlock, just waiting for etcd
+			klog.V(4).Infof("RBAC hook waiting, etcd not yet healthy (check %d/%d)", checkCount, maxChecks)
+			// Reset counter since this isn't a deadlock condition
+			checkCount = 0
+		}
+	}
+
+	// Reached max checks with etcd healthy but hook not completing - deadlock detected
+	klog.Error("RBAC bootstrap hook deadlock confirmed: etcd healthy but hook not completing")
+	close(deadlockDetected)
+}
+
+// isEtcdHealthy checks if etcd is responsive by attempting to connect and get status.
+func isEtcdHealthy(ctx context.Context) (bool, error) {
+	certsDir := cryptomaterial.CertsDirectory(config.DataDir)
+	etcdAPIServerClientCertDir := cryptomaterial.EtcdAPIServerClientCertDir(certsDir)
+
+	tlsInfo := transport.TLSInfo{
+		CertFile:      cryptomaterial.ClientCertPath(etcdAPIServerClientCertDir),
+		KeyFile:       cryptomaterial.ClientKeyPath(etcdAPIServerClientCertDir),
+		TrustedCAFile: cryptomaterial.CACertPath(cryptomaterial.EtcdSignerDir(certsDir)),
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+	if err != nil {
+		return false, fmt.Errorf("failed to create TLS config: %w", err)
+	}
+
+	// Use a short timeout for health check
+	checkCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"https://localhost:2379"},
+		DialTimeout: 1 * time.Second,
+		TLS:         tlsConfig,
+		Context:     checkCtx,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to create etcd client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = client.Status(checkCtx, "localhost:2379")
+	if err != nil {
+		return false, nil // etcd not healthy, but not an error condition
+	}
+
+	return true, nil
+}
+
+// restartMicroshiftEtcdScope restarts the microshift-etcd.scope to recover from deadlock.
+// This forces a clean restart of etcd which can help break the circular dependency.
+func restartMicroshiftEtcdScope() error {
+	klog.Info("Stopping microshift-etcd.scope for recovery")
+
+	stopCmd := exec.Command("systemctl", "stop", "microshift-etcd.scope")
+	if out, err := stopCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stop microshift-etcd.scope: %w, output: %s", err, string(out))
+	}
+
+	// Wait briefly for cleanup
+	time.Sleep(1 * time.Second)
+
+	klog.Info("microshift-etcd.scope stopped - MicroShift will restart")
+	return nil
 }
 
 func discoverEtcdServers(ctx context.Context, kubeconfigPath string) ([]string, error) {

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -61,7 +61,8 @@ const (
 	// to allow for faster recovery.
 	rbacHookDeadlockTimeout = 15
 	// rbacHookCheckInterval is how often to check the RBAC hook status
-	rbacHookCheckInterval = 2
+	rbacHookPollDelayStart = 5 * time.Second
+	rbacHookCheckInterval  = 2
 	// rbacHookMaxWaitDuration is the absolute maximum time to wait for the RBAC hook
 	// regardless of etcd health state changes. This prevents flapping from extending
 	// detection indefinitely.
@@ -452,24 +453,38 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 // 2. etcd is healthy and responsive
 // This indicates the circular dependency where the hook waits for API server
 // while API server waits for the hook.
+//
+// Closed upstream Kubernetes issues:
+// https://github.com/kubernetes/kubernetes/issues/86715
+// https://github.com/kubernetes/kubernetes/issues/97119
 func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient rest.Interface, deadlockDetected chan<- struct{}) {
 	// Wait a few seconds before starting detection to allow normal startup
 	select {
 	case <-ctx.Done():
 		return
-	case <-time.After(5 * time.Second):
+	case <-time.After(rbacHookPollDelayStart):
 	}
 
+	checkCount := 0
+	maxChecks := int((rbacHookDeadlockTimeout - rbacHookPollDelayStart) / rbacHookCheckInterval) // Account for initial delay
 	// Track wall-clock deadline to prevent flapping from extending detection indefinitely
 	startTime := time.Now()
-	checkCount := 0
-	maxChecks := (rbacHookDeadlockTimeout - 5) / rbacHookCheckInterval // Account for initial delay
 
-	for checkCount < maxChecks {
+	for {
 		// Check absolute deadline first - this cannot be reset by etcd state changes
 		if time.Since(startTime) >= rbacHookMaxWaitDuration {
 			klog.Errorf("RBAC bootstrap hook exceeded maximum wait duration of %v", rbacHookMaxWaitDuration)
-			break
+			// Only trigger deadlock recovery if we've confirmed the predicate enough times
+			if checkCount >= maxChecks {
+				break // Fall through to close(deadlockDetected)
+			}
+			// Timeout but not confirmed deadlock - exit without triggering recovery
+			return
+		}
+
+		// Check if we've confirmed deadlock enough times
+		if checkCount >= maxChecks {
+			break // Fall through to close(deadlockDetected)
 		}
 
 		select {
@@ -478,11 +493,15 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 		case <-time.After(rbacHookCheckInterval * time.Second):
 		}
 
-		checkCount++
-
 		// Check RBAC hook status
+		probeCtx, cancel := context.WithTimeout(ctx, time.Second)
 		var status int
-		err := restClient.Get().AbsPath("/readyz/poststarthook/rbac/bootstrap-roles").Do(ctx).StatusCode(&status).Error()
+		err := restClient.Get().
+			AbsPath("/readyz/poststarthook/rbac/bootstrap-roles").
+			Do(probeCtx).
+			StatusCode(&status).
+			Error()
+		cancel()
 
 		// If hook is ready, no deadlock
 		if err == nil && status == 200 {
@@ -490,14 +509,23 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 			return
 		}
 
-		// Hook not ready - check if etcd is healthy
+		// If RBAC probe errored, skip this iteration (don't count toward deadlock)
+		if err != nil {
+			klog.V(4).Infof("RBAC probe error (not counting toward deadlock): %v", err)
+			continue
+		}
+
+		// Hook not ready (status != 200) - check if etcd is healthy
 		etcdHealthy, etcdErr := isEtcdHealthy(ctx)
 		if etcdErr != nil {
-			klog.V(4).Infof("Could not check etcd health: %v", etcdErr)
+			klog.V(4).Infof("Could not check etcd health (not counting toward deadlock): %v", etcdErr)
 			continue
 		}
 
 		if etcdHealthy {
+			// Only increment when BOTH conditions are met:
+			// RBAC probe returned not-ready AND etcd is healthy
+			checkCount++
 			klog.Warningf("RBAC bootstrap hook not ready (check %d/%d, elapsed %v), but etcd is healthy - potential deadlock",
 				checkCount, maxChecks, time.Since(startTime).Round(time.Second))
 		} else {
@@ -509,7 +537,7 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 		}
 	}
 
-	// Reached max checks with etcd healthy but hook not completing - deadlock detected
+	// Only reached when checkCount >= maxChecks (deadlock confirmed)
 	klog.Errorf("RBAC bootstrap hook deadlock confirmed after %v: etcd healthy but hook not completing",
 		time.Since(startTime).Round(time.Second))
 	close(deadlockDetected)
@@ -558,7 +586,11 @@ func isEtcdHealthy(ctx context.Context) (bool, error) {
 func restartMicroshiftEtcdScope() error {
 	klog.Info("Stopping microshift-etcd.scope for recovery")
 
-	stopCmd := exec.Command("systemctl", "stop", "microshift-etcd.scope")
+	// Set a timeout in case systemd or DBus stalls and the fail-fast recovery path hangs and Run never returns
+	cmdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stopCmd := exec.CommandContext(cmdCtx, "systemctl", "stop", "microshift-etcd.scope")
 	if out, err := stopCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to stop microshift-etcd.scope: %w, output: %s", err, string(out))
 	}

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -443,7 +443,7 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 		if err := restartMicroshiftEtcdScope(ctx); err != nil {
 			klog.Errorf("Failed to restart microshift-etcd.scope: %v", err)
 		}
-		return fmt.Errorf("RBAC bootstrap hook deadlock detected after %d seconds", rbacHookDeadlockTimeout)
+		return fmt.Errorf("RBAC bootstrap hook deadlock detected after %v", rbacHookDeadlockTimeout)
 	}
 }
 

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -55,14 +55,14 @@ import (
 )
 
 const (
-	kubeAPIStartupTimeout = 60
+	kubeAPIStartupTimeout = 60 * time.Second
 	// rbacHookDeadlockTimeout is the time to wait for the RBAC bootstrap hook
 	// before declaring a deadlock. This is shorter than kubeAPIStartupTimeout
 	// to allow for faster recovery.
-	rbacHookDeadlockTimeout = 15
+	rbacHookDeadlockTimeout = 15 * time.Second
 	// rbacHookCheckInterval is how often to check the RBAC hook status
 	rbacHookPollDelayStart = 5 * time.Second
-	rbacHookCheckInterval  = 2
+	rbacHookCheckInterval  = 2 * time.Second
 	// rbacHookMaxWaitDuration is the absolute maximum time to wait for the RBAC hook
 	// regardless of etcd health state changes. This prevents flapping from extending
 	// detection indefinitely.
@@ -368,7 +368,7 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 
 	// Run standard readiness check
 	go func() {
-		err := wait.PollUntilContextTimeout(ctx, time.Second, kubeAPIStartupTimeout*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, time.Second, kubeAPIStartupTimeout, true, func(ctx context.Context) (bool, error) {
 			var status int
 			if err := restClient.Get().AbsPath("/readyz").Do(ctx).StatusCode(&status).Error(); err != nil {
 				klog.Infof("%q not yet ready: %v", s.Name(), err)
@@ -440,7 +440,7 @@ func (s *KubeAPIServer) Run(ctx context.Context, ready chan<- struct{}, stopped 
 		panic(perr)
 	case <-rbacDeadlockDetected:
 		klog.Error("RBAC bootstrap hook deadlock detected - restarting microshift-etcd.scope to recover")
-		if err := restartMicroshiftEtcdScope(); err != nil {
+		if err := restartMicroshiftEtcdScope(ctx); err != nil {
 			klog.Errorf("Failed to restart microshift-etcd.scope: %v", err)
 		}
 		return fmt.Errorf("RBAC bootstrap hook deadlock detected after %d seconds", rbacHookDeadlockTimeout)
@@ -496,11 +496,11 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 		// Check RBAC hook status
 		probeCtx, cancel := context.WithTimeout(ctx, time.Second)
 		var status int
-		err := restClient.Get().
+		result := restClient.Get().
 			AbsPath("/readyz/poststarthook/rbac/bootstrap-roles").
 			Do(probeCtx).
-			StatusCode(&status).
-			Error()
+			StatusCode(&status)
+		err := result.Error()
 		cancel()
 
 		// If hook is ready, no deadlock
@@ -509,8 +509,8 @@ func (s *KubeAPIServer) detectRBACHookDeadlock(ctx context.Context, restClient r
 			return
 		}
 
-		// If RBAC probe errored, skip this iteration (don't count toward deadlock)
-		if err != nil {
+		// If no HTTP status was received, skip this iteration (transport/timeout).
+		if err != nil && status == 0 {
 			klog.V(4).Infof("RBAC probe error (not counting toward deadlock): %v", err)
 			continue
 		}
@@ -583,11 +583,11 @@ func isEtcdHealthy(ctx context.Context) (bool, error) {
 
 // restartMicroshiftEtcdScope restarts the microshift-etcd.scope to recover from deadlock.
 // This forces a clean restart of etcd which can help break the circular dependency.
-func restartMicroshiftEtcdScope() error {
+func restartMicroshiftEtcdScope(ctx context.Context) error {
 	klog.Info("Stopping microshift-etcd.scope for recovery")
 
 	// Set a timeout in case systemd or DBus stalls and the fail-fast recovery path hangs and Run never returns
-	cmdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	stopCmd := exec.CommandContext(cmdCtx, "systemctl", "stop", "microshift-etcd.scope")


### PR DESCRIPTION
## Summary

- Add parallel RBAC bootstrap hook deadlock detector to kube-apiserver
- Detect deadlock condition in ~15 seconds instead of waiting 60 seconds
- Restart microshift-etcd.scope to recover from deadlock
- **[USHIFT-6788](https://redhat.atlassian.net/browse/USHIFT-6788)**: Add wall-clock deadline (`rbacHookMaxWaitDuration = 30s`) to prevent etcd health flapping from extending detection indefinitely

## Problem

MicroShift enters a permanent crash loop after first restart due to the RBAC bootstrap hook deadlocking when etcd contains existing data. The `rbac/bootstrap-roles` PostStartHook uses `context.TODO()` for API calls with no timeout, causing a circular dependency where the hook waits for API server readiness while the API server waits for the hook to complete.

Related upstream issues: kubernetes/kubernetes#86715, kubernetes/kubernetes#97119

## Root Cause

In `vendor/k8s.io/kubernetes/pkg/registry/rbac/rest/storage_rbac.go`, the `ensureRBACPolicy` function calls:
```go
client.RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{})
```

The loopback client blocks because KAS isn't ready. KAS isn't ready because the hook hasn't completed. `context.TODO()` means no timeout, so it hangs forever. The outer `wait.Poll` has a 30s timeout, but it's ineffective because each poll iteration can hang indefinitely.

## Solution

Add a fail-fast deadlock detector that:
1. Monitors `/readyz/poststarthook/rbac/bootstrap-roles` specifically
2. Checks if etcd is healthy while the hook is stuck
3. If etcd is healthy but hook not completing for 15 seconds, declares deadlock
4. **Enforces absolute 30s wall-clock deadline** regardless of etcd state changes (prevents flapping from extending detection)
5. Restarts `microshift-etcd.scope` to force clean recovery

This approach was chosen because it requires no vendor patches that must be carried through rebases, and keeps all MicroShift-specific logic in MicroShift code rather than modifying upstream Kubernetes sources.

## Rejected Alternatives

### Patch the vendored hook

**Approach:** Replace `context.TODO()` with the hook's `context.Context` (from `PostStartHookContext`). Three-line change to `storage_rbac.go`.

**Why rejected:** Requires patching both `deps/` and `vendor/` copies of upstream Kubernetes code. This patch must be carried through every rebase, adding maintenance burden and risk of the fix being lost during upstream syncs.

### In-process KAS restart

**Approach:** Bypass `NewAPIServerCommand()` (which has a one-shot signal handler that panics on second call), replicate the RunE setup with pflag, call `kubeapiserver.Run()` directly in a retry loop.

**Why rejected:** Fragile across rebases — must track internal KAS initialization changes. The signal handler workaround is brittle and could break silently with upstream changes. High maintenance burden for marginal benefit over the simpler etcd restart approach.

## Test plan

- [ ] Start MicroShift fresh - verify normal startup
- [ ] Stop and restart MicroShift - verify no crash loop
- [ ] If deadlock occurs, verify detection in ~15 seconds
- [ ] Verify "RBAC bootstrap hook deadlock detected" log message on recovery
- [ ] Verify wall-clock deadline prevents indefinite flapping extension
- [ ] Verify `make verify-go` passes
- [ ] Verify `make test-unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)