### PR TITLE
USHIFT-6859: Update generate_common_versions.py to take "X.Y" as argument for 5.0 handling

### DIFF
--- a/test/bin/common_versions_verify.sh
+++ b/test/bin/common_versions_verify.sh
@@ -13,9 +13,9 @@ if ! git diff --exit-code "${SCENARIO_BUILD_BRANCH}^1...HEAD" "${ROOTDIR}/test/b
     "${ROOTDIR}/scripts/pyutils/create-venv.sh"
 
     if [ "${SCENARIO_BUILD_BRANCH}" == "main" ]; then
-        y=$(awk -F'[ .]' '{print $4}' < "${ROOTDIR}/Makefile.version.x86_64.var")
+        y=$(awk -F'[ .]' '{print $3 "." $4}' < "${ROOTDIR}/Makefile.version.x86_64.var")
     else
-        y=$(echo "${SCENARIO_BUILD_BRANCH}" | awk -F'[-.]' '{ print $3 }')
+        y=$(echo "${SCENARIO_BUILD_BRANCH}" | awk -F'[-]' '{ print $2 }')
     fi
 
     "${ROOTDIR}/_output/pyutils/bin/python" \

--- a/test/bin/pyutils/generate_common_versions.py
+++ b/test/bin/pyutils/generate_common_versions.py
@@ -19,7 +19,7 @@ import ghutils   # noqa: E402
 ARCH = os.uname().machine
 
 # Version map defining the last minor version for each major version.
-# Used for cross-major Y-1/Y-2 calculations (e.g., 5.0's Y-1 is 4.18).
+# Used for cross-major Y-1/Y-2 calculations (e.g., 5.0's Y-1 is 4.22).
 VERSION_MAP = {
     4: {'last_minor': 22}
 }
@@ -393,9 +393,14 @@ def generate_common_versions(major_version, minor_version):
 
 
 def main():
+    def parse_major_minor(value: str):
+        parts = value.split(".")
+        if len(parts) != 2 or not all(p.isdigit() for p in parts):
+            raise argparse.ArgumentTypeError("version must be in 'X.Y' format")
+        return int(parts[0]), int(parts[1])
+
     parser = argparse.ArgumentParser(description="Generate common_versions.sh variables.")
-    parser.add_argument("--major", type=int, default=4, help="The major version number (default: 4).")
-    parser.add_argument("minor", type=int, help="The minor version number.")
+    parser.add_argument("version", type=str, help="The major.minor version number.")
     parser.add_argument("--update-file", default=False, action="store_true", help="Update test/bin/common_versions.sh file.")
     parser.add_argument("--create-pr", default=False, action="store_true",
                         help=("Commit the changes to a new branch, push it to the openshift/microshift, and create a pull request." +
@@ -403,7 +408,8 @@ def main():
     parser.add_argument("--dry-run", default=False, action="store_true", help="Dry run")
     args = parser.parse_args()
 
-    output = generate_common_versions(args.major, args.minor)
+    major, minor = parse_major_minor(args.version)
+    output = generate_common_versions(major, minor)
 
     if args.update_file or args.create_pr:
         logging.info("Updating test/bin/common_versions.sh file")
@@ -420,8 +426,8 @@ def main():
             exit(0)
 
         base_branch = g.git_repo.active_branch.name
-        if not base_branch.startswith(f"release-{args.major}"):
-            logging.error(f"Script is expected to be executed on branch starting with 'release-{args.major}', but it's {base_branch}")
+        if not base_branch.startswith(f"release-{args.version}"):
+            logging.error(f"Script is expected to be executed on branch starting with 'release-{args.version}', but it's {base_branch}")
             exit(1)
 
         gh = ghutils.GithubUtils(dry_run=args.dry_run)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI now accepts a single required version string in X.Y format instead of separate major/minor arguments.
  * Corrected a cross-major example so the prior-release minor for 5.0 is now 4.22.

* **Chore**
  * Updated how the verification/regeneration process derives the version string, which changes the expected regenerated version output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->