### PR TITLE
USHIFT-6774: Leave VM ready after tuned suite

### DIFF
--- a/test/suites/tuned/microshift-tuned.robot
+++ b/test/suites/tuned/microshift-tuned.robot
@@ -83,6 +83,8 @@ Teardown
     Command Should Work    mv /etc/microshift/tuned.yaml.bak /etc/microshift/tuned.yaml
     Enable MicroShift
     Restart MicroShift-Tuned Expecting Reboot
+    # Let's leave VM in a state ready to pick up by next suite
+    Wait For MicroShift Healthcheck Success
     Logout MicroShift Host
 
 Restart MicroShift-Tuned Expecting Reboot


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite reliability by adding a post-restart system health verification step to ensure proper recovery before completing teardown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->