### PR TITLE
PERFSCALE-2110: Ansible: scope create-vm teardown to target VM

### DIFF
--- a/ansible/roles/create-vm/tasks/main.yml
+++ b/ansible/roles/create-vm/tasks/main.yml
@@ -6,21 +6,17 @@
     command: list_vms
   register: all_vms
 
-- name: find VMs that start with "microshift-*"
-  set_fact:
-    vm_match: "{{ all_vms.list_vms | join(' ') | regex_findall('microshift-\\S+', multiline=True, ignorecase=True) }}"
-
-- name: destroy microshift VM
+- name: destroy target VM if present
   community.libvirt.virt:
-    name: "{{ item }}"
+    name: "{{ vm_name }}"
     state: destroyed
-  loop: "{{ vm_match }}"
+  when: vm_name in (all_vms.list_vms | default([]))
 
-- name: undefine microshift VM
+- name: undefine target VM if present
   community.libvirt.virt:
-    name: "{{ item }}"
+    name: "{{ vm_name }}"
     command: undefine
-  loop: "{{ vm_match }}"
+  when: vm_name in (all_vms.list_vms | default([]))
 
 - name: find create-vm.sh
   ansible.builtin.find:


### PR DESCRIPTION
Avoid over-deletion when multiple microshift-* VMs exist on the same libvirt host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced VM management with improved safety checks during cleanup operations to ensure tasks execute only when required VMs are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->