### PR TITLE
USHIFT-6812: Optimize bootc image building for upgrade tests

### DIFF
--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -137,8 +137,7 @@ run_bootc_image_build() {
 
             if [[ "${os}" == "el10" ]]; then
                 # Build el9 images for upgrade tests
-                $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/el9/layer1-base
-                $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/el9/layer2-presubmit
+                $(dry_run) bash -x ./bin/build_bootc_images.sh -l ./image-blueprints-bootc/el10/layer5-upgrade
             fi
 
             if [[ "${CI_JOB_NAME}" =~ .*periodic.* ]]; then

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel96-bootc.image-bootc
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel96-bootc.image-bootc
@@ -1,0 +1,1 @@
+../../../el9/layer1-base/group2/rhel96-bootc.image-bootc

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel96-test-agent.containerfile
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel96-test-agent.containerfile
@@ -1,0 +1,1 @@
+../../../el9/layer1-base/group1/rhel96-test-agent.containerfile

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel98-bootc.image-bootc
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel98-bootc.image-bootc
@@ -1,0 +1,1 @@
+../../../el9/layer1-base/group2/rhel98-bootc.image-bootc

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel98-test-agent.containerfile
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group1/rhel98-test-agent.containerfile
@@ -1,0 +1,1 @@
+../../../el9/layer1-base/group1/rhel98-test-agent.containerfile

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group2/rhel96-bootc-prel.containerfile
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group2/rhel96-bootc-prel.containerfile
@@ -1,0 +1,1 @@
+../../../el9/layer1-base/group2/rhel96-bootc-prel.containerfile

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group2/rhel96-bootc-yminus2.containerfile
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group2/rhel96-bootc-yminus2.containerfile
@@ -1,0 +1,1 @@
+../../../el9/layer1-base/group2/rhel96-bootc-yminus2.containerfile

--- a/test/image-blueprints-bootc/el10/layer5-upgrade/group2/rhel98-bootc-source.containerfile
+++ b/test/image-blueprints-bootc/el10/layer5-upgrade/group2/rhel98-bootc-source.containerfile
@@ -1,0 +1,1 @@
+../../../el9/layer2-presubmit/group1/rhel98-bootc-source.containerfile


### PR DESCRIPTION
Contains changes from [this PR](https://github.com/openshift/microshift/pull/6489), should be merged after. 

This PR introduces a new el10 bootc image layer called `layer5-upgrade`, which contains symbolic links to el9 images required for upgrade scenarios. This allows us to not build all el9 images in el10 jobs, but only the required ones, thus saving time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CI upgrade test sequence to use new test blueprint layer configuration.
  * Added test blueprint reference files for RHEL 10 upgrade testing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->