### PR TITLE
USHIFT-6794: Config for Cluster 2 Cluster Communication

### DIFF
--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -2,6 +2,7 @@
   "type": "object",
   "required": [
     "apiServer",
+    "c2cc",
     "debugging",
     "dns",
     "etcd",
@@ -173,6 +174,47 @@
                 "VersionTLS12",
                 "VersionTLS13"
               ]
+            }
+          }
+        }
+      }
+    },
+    "c2cc": {
+      "type": "object",
+      "properties": {
+        "remoteClusters": {
+          "description": "List of remote clusters to establish connectivity with.\nC2CC is disabled when this list is empty.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "clusterNetwork",
+              "nextHop",
+              "serviceNetwork"
+            ],
+            "properties": {
+              "clusterNetwork": {
+                "description": "Pod CIDRs of the remote cluster. Must not overlap with local cluster or other remotes.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "domain": {
+                "description": "DNS domain suffix for the remote cluster (e.g., \"cluster-b.remote\").\nServices are reachable as \u003csvc\u003e.\u003cns\u003e.svc.\u003cdomain\u003e.\nOptional — if empty, no DNS forwarding is configured for this remote.",
+                "type": "string"
+              },
+              "nextHop": {
+                "description": "IP address of the remote cluster's node, used as next-hop for routing.",
+                "type": "string"
+              },
+              "serviceNetwork": {
+                "description": "Service CIDRs of the remote cluster. Must not overlap with local cluster or other remotes.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/cmd/generate-config/config/config-openapi-spec.json
+++ b/cmd/generate-config/config/config-openapi-spec.json
@@ -2,7 +2,7 @@
   "type": "object",
   "required": [
     "apiServer",
-    "c2cc",
+    "clusterToCluster",
     "debugging",
     "dns",
     "etcd",
@@ -179,7 +179,7 @@
         }
       }
     },
-    "c2cc": {
+    "clusterToCluster": {
       "type": "object",
       "properties": {
         "remoteClusters": {

--- a/docs/user/howto_config.md
+++ b/docs/user/howto_config.md
@@ -30,6 +30,12 @@ apiServer:
     tls:
         cipherSuites: []
         minVersion: ""
+c2cc:
+    remoteClusters:
+        - clusterNetwork: []
+          domain: ""
+          nextHop: ""
+          serviceNetwork: []
 debugging:
     logLevel: ""
 dns:
@@ -182,6 +188,12 @@ apiServer:
     tls:
         cipherSuites: []
         minVersion: VersionTLS12
+c2cc:
+    remoteClusters:
+        - clusterNetwork: []
+          domain: ""
+          nextHop: ""
+          serviceNetwork: []
 debugging:
     logLevel: Normal
 dns:

--- a/docs/user/howto_config.md
+++ b/docs/user/howto_config.md
@@ -30,7 +30,7 @@ apiServer:
     tls:
         cipherSuites: []
         minVersion: ""
-c2cc:
+clusterToCluster:
     remoteClusters:
         - clusterNetwork: []
           domain: ""
@@ -188,7 +188,7 @@ apiServer:
     tls:
         cipherSuites: []
         minVersion: VersionTLS12
-c2cc:
+clusterToCluster:
     remoteClusters:
         - clusterNetwork: []
           domain: ""

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -41,7 +41,7 @@ apiServer:
         # to serve from the API server. Allowed values: VersionTLS12, VersionTLS13.
         # Defaults to VersionTLS12.
         minVersion: VersionTLS12
-c2cc:
+clusterToCluster:
     # List of remote clusters to establish connectivity with.
     # C2CC is disabled when this list is empty.
     remoteClusters:

--- a/packaging/microshift/config.yaml
+++ b/packaging/microshift/config.yaml
@@ -41,6 +41,20 @@ apiServer:
         # to serve from the API server. Allowed values: VersionTLS12, VersionTLS13.
         # Defaults to VersionTLS12.
         minVersion: VersionTLS12
+c2cc:
+    # List of remote clusters to establish connectivity with.
+    # C2CC is disabled when this list is empty.
+    remoteClusters:
+        - # Pod CIDRs of the remote cluster. Must not overlap with local cluster or other remotes.
+          clusterNetwork: []
+          # DNS domain suffix for the remote cluster (e.g., "cluster-b.remote").
+          # Services are reachable as <svc>.<ns>.svc.<domain>.
+          # Optional — if empty, no DNS forwarding is configured for this remote.
+          domain: ""
+          # IP address of the remote cluster's node, used as next-hop for routing.
+          nextHop: ""
+          # Service CIDRs of the remote cluster. Must not overlap with local cluster or other remotes.
+          serviceNetwork: []
 debugging:
     # Valid values are: "Normal", "Debug", "Trace", "TraceAll".
     # Defaults to "Normal".

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -15,6 +15,9 @@ type C2CC struct {
 	// List of remote clusters to establish connectivity with.
 	// C2CC is disabled when this list is empty.
 	RemoteClusters []RemoteCluster `json:"remoteClusters,omitempty"`
+
+	// Populated during validation with parsed network objects.
+	Resolved []ResolvedRemoteCluster `json:"-"`
 }
 
 type RemoteCluster struct {
@@ -28,6 +31,18 @@ type RemoteCluster struct {
 	// Services are reachable as <svc>.<ns>.svc.<domain>.
 	// Optional — if empty, no DNS forwarding is configured for this remote.
 	Domain string `json:"domain,omitempty"`
+}
+
+type ResolvedRemoteCluster struct {
+	NextHop        net.IP
+	ClusterNetwork []*net.IPNet
+	ServiceNetwork []*net.IPNet
+	Domain         string
+}
+
+type labeledCIDR struct {
+	net *net.IPNet
+	str string
 }
 
 func (c *C2CC) IsEnabled() bool {
@@ -68,9 +83,74 @@ func defaultGetHostIPs() ([]net.IP, error) {
 	return ips, nil
 }
 
+func (c *C2CC) parseRemoteClusters() ([]ResolvedRemoteCluster, []error) {
+	resolved := make([]ResolvedRemoteCluster, len(c.RemoteClusters))
+	var errs []error
+
+	for i := range c.RemoteClusters {
+		rc := &c.RemoteClusters[i]
+		label := fmt.Sprintf("remoteClusters[%d]", i)
+
+		ip := net.ParseIP(rc.NextHop)
+		if ip == nil {
+			errs = append(errs, fmt.Errorf("%s.nextHop %q is not a valid IP address", label, rc.NextHop))
+		}
+		resolved[i].NextHop = ip
+
+		if len(rc.ClusterNetwork) == 0 {
+			errs = append(errs, fmt.Errorf("%s.clusterNetwork must not be empty", label))
+		}
+		if len(rc.ServiceNetwork) == 0 {
+			errs = append(errs, fmt.Errorf("%s.serviceNetwork must not be empty", label))
+		}
+
+		for j, cidr := range rc.ClusterNetwork {
+			if ipNet := parseAndValidateCIDR(cidr, fmt.Sprintf("%s.clusterNetwork[%d]", label, j), &errs); ipNet != nil {
+				resolved[i].ClusterNetwork = append(resolved[i].ClusterNetwork, ipNet)
+			}
+		}
+		for j, cidr := range rc.ServiceNetwork {
+			if ipNet := parseAndValidateCIDR(cidr, fmt.Sprintf("%s.serviceNetwork[%d]", label, j), &errs); ipNet != nil {
+				resolved[i].ServiceNetwork = append(resolved[i].ServiceNetwork, ipNet)
+			}
+		}
+
+		resolved[i].Domain = rc.Domain
+	}
+
+	return resolved, errs
+}
+
+func parseAndValidateCIDR(cidr, field string, errs *[]error) *net.IPNet {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		*errs = append(*errs, fmt.Errorf("%s %q is not a valid CIDR: %w", field, cidr, err))
+		return nil
+	}
+
+	ones, _ := ipNet.Mask.Size()
+	if ipNet.IP.To4() != nil {
+		if ones < 8 {
+			*errs = append(*errs, fmt.Errorf("%s %q has mask /%d shorter than minimum /8", field, cidr, ones))
+			return nil
+		}
+	} else {
+		if ones < 32 {
+			*errs = append(*errs, fmt.Errorf("%s %q has mask /%d shorter than minimum /32", field, cidr, ones))
+			return nil
+		}
+	}
+	return ipNet
+}
+
 func (c *C2CC) validate(cfg *Config) error {
 	if cfg.Network.CNIPlugin != CniPluginUnset && cfg.Network.CNIPlugin != CniPluginOVNK {
 		return fmt.Errorf("c2cc requires OVN-Kubernetes CNI (network.cniPlugin must be \"\" or \"ovnk\", got %q)", cfg.Network.CNIPlugin)
+	}
+
+	resolved, parseErrs := c.parseRemoteClusters()
+	if len(parseErrs) > 0 {
+		return errors.Join(parseErrs...)
 	}
 
 	hostIPs, err := getHostIPs()
@@ -99,46 +179,40 @@ func (c *C2CC) validate(cfg *Config) error {
 	seenNextHops := make(map[string]int, len(c.RemoteClusters))
 	seenRemoteDomains := make(map[string]int, len(c.RemoteClusters))
 
-	// Overlap check: start with local CIDRs, then accumulate each remote's CIDRs.
-	seenCIDRs := make([]string, 0, len(cfg.Network.ClusterNetwork)+len(cfg.Network.ServiceNetwork)+len(c.RemoteClusters)*4)
-	seenCIDRs = append(seenCIDRs, cfg.Network.ClusterNetwork...)
-	seenCIDRs = append(seenCIDRs, cfg.Network.ServiceNetwork...)
+	seenCIDRs := make([]labeledCIDR, 0, len(cfg.Network.ClusterNetwork)+len(cfg.Network.ServiceNetwork)+len(c.RemoteClusters)*4)
+	for _, s := range cfg.Network.ClusterNetwork {
+		if _, ipNet, err := net.ParseCIDR(s); err == nil {
+			seenCIDRs = append(seenCIDRs, labeledCIDR{net: ipNet, str: s})
+		}
+	}
+	for _, s := range cfg.Network.ServiceNetwork {
+		if _, ipNet, err := net.ParseCIDR(s); err == nil {
+			seenCIDRs = append(seenCIDRs, labeledCIDR{net: ipNet, str: s})
+		}
+	}
 
 	for i := range c.RemoteClusters {
 		rc := &c.RemoteClusters[i]
+		res := &resolved[i]
 		label := fmt.Sprintf("remoteClusters[%d]", i)
 
-		ip := net.ParseIP(rc.NextHop)
-		if ip == nil {
-			errs = append(errs, fmt.Errorf("%s.nextHop %q is not a valid IP address", label, rc.NextHop))
+		normalizedNextHop := res.NextHop.String()
+		if res.NextHop.Equal(nodeIP) || (nodeIPv6 != nil && res.NextHop.Equal(nodeIPv6)) {
+			errs = append(errs, fmt.Errorf("%s.nextHop %q must not equal the local node IP (routing loop)", label, normalizedNextHop))
+		}
+		if prev, ok := seenNextHops[normalizedNextHop]; ok {
+			errs = append(errs, fmt.Errorf("%s.nextHop %q duplicates remoteClusters[%d]", label, normalizedNextHop, prev))
 		} else {
-			normalizedNextHop := ip.String()
-			if ip.Equal(nodeIP) || (nodeIPv6 != nil && ip.Equal(nodeIPv6)) {
-				errs = append(errs, fmt.Errorf("%s.nextHop %q must not equal the local node IP (routing loop)", label, normalizedNextHop))
-			}
-			if prev, ok := seenNextHops[normalizedNextHop]; ok {
-				errs = append(errs, fmt.Errorf("%s.nextHop %q duplicates remoteClusters[%d]", label, normalizedNextHop, prev))
-			} else {
-				seenNextHops[normalizedNextHop] = i
-			}
+			seenNextHops[normalizedNextHop] = i
 		}
 
-		if len(rc.ClusterNetwork) == 0 {
-			errs = append(errs, fmt.Errorf("%s.clusterNetwork must not be empty", label))
+		for j, cidrNet := range res.ClusterNetwork {
+			errs = append(errs, checkCIDRConflicts(cidrNet, rc.ClusterNetwork[j], label, seenCIDRs, hostIPs)...)
+			seenCIDRs = append(seenCIDRs, labeledCIDR{net: cidrNet, str: rc.ClusterNetwork[j]})
 		}
-		if len(rc.ServiceNetwork) == 0 {
-			errs = append(errs, fmt.Errorf("%s.serviceNetwork must not be empty", label))
-		}
-
-		for j, cidr := range rc.ClusterNetwork {
-			errs = append(errs, validateRemoteCIDR(cidr, fmt.Sprintf("%s.clusterNetwork[%d]", label, j)))
-			errs = append(errs, checkCIDRConflicts(cidr, label, seenCIDRs, hostIPs)...)
-			seenCIDRs = append(seenCIDRs, cidr)
-		}
-		for j, cidr := range rc.ServiceNetwork {
-			errs = append(errs, validateRemoteCIDR(cidr, fmt.Sprintf("%s.serviceNetwork[%d]", label, j)))
-			errs = append(errs, checkCIDRConflicts(cidr, label, seenCIDRs, hostIPs)...)
-			seenCIDRs = append(seenCIDRs, cidr)
+		for j, cidrNet := range res.ServiceNetwork {
+			errs = append(errs, checkCIDRConflicts(cidrNet, rc.ServiceNetwork[j], label, seenCIDRs, hostIPs)...)
+			seenCIDRs = append(seenCIDRs, labeledCIDR{net: cidrNet, str: rc.ServiceNetwork[j]})
 		}
 
 		if rc.Domain != "" {
@@ -152,44 +226,29 @@ func (c *C2CC) validate(cfg *Config) error {
 			}
 		}
 
-		errs = append(errs, validateIPFamilyConsistency(rc.ClusterNetwork, label+".clusterNetwork")...)
-		errs = append(errs, validateIPFamilyConsistency(rc.ServiceNetwork, label+".serviceNetwork")...)
-		errs = append(errs, validateNetworkShape(rc.ClusterNetwork, rc.ServiceNetwork, label)...)
-		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, rc.ClusterNetwork, label)...)
-		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, rc.ServiceNetwork, label)...)
+		errs = append(errs, validateIPFamilyConsistencyNets(res.ClusterNetwork, label+".clusterNetwork")...)
+		errs = append(errs, validateIPFamilyConsistencyNets(res.ServiceNetwork, label+".serviceNetwork")...)
+		errs = append(errs, validateNetworkShapeNets(res.ClusterNetwork, res.ServiceNetwork, label)...)
+		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, res.ClusterNetwork, label)...)
+		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, res.ServiceNetwork, label)...)
 	}
 
-	return errors.Join(errs...)
-}
-
-func validateRemoteCIDR(cidr, field string) error {
-	_, ipNet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return fmt.Errorf("%s %q is not a valid CIDR: %w", field, cidr, err)
+	if err := errors.Join(errs...); err != nil {
+		return err
 	}
 
-	ones, _ := ipNet.Mask.Size()
-	if ipNet.IP.To4() != nil {
-		if ones < 8 {
-			return fmt.Errorf("%s %q has mask /%d shorter than minimum /8", field, cidr, ones)
-		}
-	} else {
-		if ones < 32 {
-			return fmt.Errorf("%s %q has mask /%d shorter than minimum /32", field, cidr, ones)
-		}
-	}
+	c.Resolved = resolved
 	return nil
 }
 
-func validateIPFamilyConsistency(cidrs []string, field string) []error {
+func validateIPFamilyConsistencyNets(cidrs []*net.IPNet, field string) []error {
 	var v4, v6 int
 	for _, c := range cidrs {
-		switch netutils.IPFamilyOfCIDRString(c) {
+		switch netutils.IPFamilyOfCIDR(c) {
 		case netutils.IPv4:
 			v4++
 		case netutils.IPv6:
 			v6++
-		case netutils.IPFamilyUnknown:
 		}
 	}
 	var errs []error
@@ -202,15 +261,15 @@ func validateIPFamilyConsistency(cidrs []string, field string) []error {
 	return errs
 }
 
-func validateNetworkShape(clusterNetwork, serviceNetwork []string, label string) []error {
+func validateNetworkShapeNets(clusterNetwork, serviceNetwork []*net.IPNet, label string) []error {
 	if len(clusterNetwork) != len(serviceNetwork) {
 		return []error{fmt.Errorf("%s: clusterNetwork and serviceNetwork have different cardinality (%d vs %d)",
 			label, len(clusterNetwork), len(serviceNetwork))}
 	}
 	var errs []error
 	for i := 0; i < len(clusterNetwork); i++ {
-		cFamily := netutils.IPFamilyOfCIDRString(clusterNetwork[i])
-		sFamily := netutils.IPFamilyOfCIDRString(serviceNetwork[i])
+		cFamily := netutils.IPFamilyOfCIDR(clusterNetwork[i])
+		sFamily := netutils.IPFamilyOfCIDR(serviceNetwork[i])
 		if cFamily != netutils.IPFamilyUnknown && sFamily != netutils.IPFamilyUnknown && cFamily != sFamily {
 			errs = append(errs, fmt.Errorf("%s: clusterNetwork[%d] and serviceNetwork[%d] have mismatched IP families", label, i, i))
 		}
@@ -218,10 +277,10 @@ func validateNetworkShape(clusterNetwork, serviceNetwork []string, label string)
 	return errs
 }
 
-func validateRemoteIPFamilyCompatibility(localV4, localV6 bool, remoteCIDRs []string, label string) []error {
+func validateRemoteIPFamilyCompatibility(localV4, localV6 bool, remoteCIDRs []*net.IPNet, label string) []error {
 	var errs []error
 	for _, c := range remoteCIDRs {
-		family := netutils.IPFamilyOfCIDRString(c)
+		family := netutils.IPFamilyOfCIDR(c)
 		if family == netutils.IPv4 && !localV4 {
 			errs = append(errs, fmt.Errorf("%s: %q is IPv4 but local cluster has no IPv4 network", label, c))
 		}
@@ -232,28 +291,21 @@ func validateRemoteIPFamilyCompatibility(localV4, localV6 bool, remoteCIDRs []st
 	return errs
 }
 
-func checkCIDRConflicts(cidr, label string, seenCIDRs []string, hostIPs []net.IP) []error {
+func checkCIDRConflicts(cidr *net.IPNet, cidrStr, label string, seenCIDRs []labeledCIDR, hostIPs []net.IP) []error {
 	var errs []error
 	for _, existing := range seenCIDRs {
-		if cidrsOverlap(cidr, existing) {
-			errs = append(errs, fmt.Errorf("%s: CIDR %q overlaps with %q", label, cidr, existing))
+		if cidrsOverlap(cidr, existing.net) {
+			errs = append(errs, fmt.Errorf("%s: CIDR %q overlaps with %q", label, cidrStr, existing.str))
 		}
 	}
-	if _, ipNet, err := net.ParseCIDR(cidr); err == nil {
-		for _, hostIP := range hostIPs {
-			if ipNet.Contains(hostIP) {
-				errs = append(errs, fmt.Errorf("remote CIDR %q contains host interface IP %s — this would disrupt management traffic", cidr, hostIP))
-			}
+	for _, hostIP := range hostIPs {
+		if cidr.Contains(hostIP) {
+			errs = append(errs, fmt.Errorf("remote CIDR %q contains host interface IP %s — this would disrupt management traffic", cidrStr, hostIP))
 		}
 	}
 	return errs
 }
 
-func cidrsOverlap(a, b string) bool {
-	_, netA, errA := net.ParseCIDR(a)
-	_, netB, errB := net.ParseCIDR(b)
-	if errA != nil || errB != nil {
-		return false
-	}
-	return netA.Contains(netB.IP) || netB.Contains(netA.IP)
+func cidrsOverlap(a, b *net.IPNet) bool {
+	return a.Contains(b.IP) || b.Contains(a.IP)
 }

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -192,45 +192,9 @@ func (c *C2CC) validate(cfg *Config) error {
 	}
 
 	for i := range c.RemoteClusters {
-		rc := &c.RemoteClusters[i]
-		res := &resolved[i]
-		label := fmt.Sprintf("remoteClusters[%d]", i)
-
-		normalizedNextHop := res.NextHop.String()
-		if res.NextHop.Equal(nodeIP) || (nodeIPv6 != nil && res.NextHop.Equal(nodeIPv6)) {
-			errs = append(errs, fmt.Errorf("%s.nextHop %q must not equal the local node IP (routing loop)", label, normalizedNextHop))
-		}
-		if prev, ok := seenNextHops[normalizedNextHop]; ok {
-			errs = append(errs, fmt.Errorf("%s.nextHop %q duplicates remoteClusters[%d]", label, normalizedNextHop, prev))
-		} else {
-			seenNextHops[normalizedNextHop] = i
-		}
-
-		for j, cidrNet := range res.ClusterNetwork {
-			errs = append(errs, checkCIDRConflicts(cidrNet, rc.ClusterNetwork[j], label, seenCIDRs, hostIPs)...)
-			seenCIDRs = append(seenCIDRs, labeledCIDR{net: cidrNet, str: rc.ClusterNetwork[j]})
-		}
-		for j, cidrNet := range res.ServiceNetwork {
-			errs = append(errs, checkCIDRConflicts(cidrNet, rc.ServiceNetwork[j], label, seenCIDRs, hostIPs)...)
-			seenCIDRs = append(seenCIDRs, labeledCIDR{net: cidrNet, str: rc.ServiceNetwork[j]})
-		}
-
-		if rc.Domain != "" {
-			if domainErrs := validation.IsDNS1123Subdomain(rc.Domain); len(domainErrs) > 0 {
-				errs = append(errs, fmt.Errorf("%s.domain %q is not a valid DNS name: %s", label, rc.Domain, strings.Join(domainErrs, ", ")))
-			}
-			if prev, ok := seenRemoteDomains[rc.Domain]; ok {
-				errs = append(errs, fmt.Errorf("%s.domain %q duplicates remoteClusters[%d]", label, rc.Domain, prev))
-			} else {
-				seenRemoteDomains[rc.Domain] = i
-			}
-		}
-
-		errs = append(errs, validateIPFamilyConsistencyNets(res.ClusterNetwork, label+".clusterNetwork")...)
-		errs = append(errs, validateIPFamilyConsistencyNets(res.ServiceNetwork, label+".serviceNetwork")...)
-		errs = append(errs, validateNetworkShapeNets(res.ClusterNetwork, res.ServiceNetwork, label)...)
-		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, res.ClusterNetwork, label)...)
-		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, res.ServiceNetwork, label)...)
+		errs = append(errs, validateRemoteCluster(i, &c.RemoteClusters[i], &resolved[i],
+			nodeIP, nodeIPv6, localV4, localV6, hostIPs,
+			seenNextHops, seenRemoteDomains, &seenCIDRs)...)
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -241,17 +205,66 @@ func (c *C2CC) validate(cfg *Config) error {
 	return nil
 }
 
+func validateRemoteCluster(
+	i int, rc *RemoteCluster, res *ResolvedRemoteCluster,
+	nodeIP, nodeIPv6 net.IP, localV4, localV6 bool, hostIPs []net.IP,
+	seenNextHops map[string]int, seenRemoteDomains map[string]int, seenCIDRs *[]labeledCIDR,
+) []error {
+	label := fmt.Sprintf("remoteClusters[%d]", i)
+	var errs []error
+
+	normalizedNextHop := res.NextHop.String()
+	if res.NextHop.Equal(nodeIP) || (nodeIPv6 != nil && res.NextHop.Equal(nodeIPv6)) {
+		errs = append(errs, fmt.Errorf("%s.nextHop %q must not equal the local node IP (routing loop)", label, normalizedNextHop))
+	}
+	if prev, ok := seenNextHops[normalizedNextHop]; ok {
+		errs = append(errs, fmt.Errorf("%s.nextHop %q duplicates remoteClusters[%d]", label, normalizedNextHop, prev))
+	} else {
+		seenNextHops[normalizedNextHop] = i
+	}
+
+	for j, cidrNet := range res.ClusterNetwork {
+		errs = append(errs, checkCIDRConflicts(cidrNet, rc.ClusterNetwork[j], label, *seenCIDRs, hostIPs)...)
+		*seenCIDRs = append(*seenCIDRs, labeledCIDR{net: cidrNet, str: rc.ClusterNetwork[j]})
+	}
+	for j, cidrNet := range res.ServiceNetwork {
+		errs = append(errs, checkCIDRConflicts(cidrNet, rc.ServiceNetwork[j], label, *seenCIDRs, hostIPs)...)
+		*seenCIDRs = append(*seenCIDRs, labeledCIDR{net: cidrNet, str: rc.ServiceNetwork[j]})
+	}
+
+	if rc.Domain != "" {
+		if domainErrs := validation.IsDNS1123Subdomain(rc.Domain); len(domainErrs) > 0 {
+			errs = append(errs, fmt.Errorf("%s.domain %q is not a valid DNS name: %s", label, rc.Domain, strings.Join(domainErrs, ", ")))
+		}
+		if prev, ok := seenRemoteDomains[rc.Domain]; ok {
+			errs = append(errs, fmt.Errorf("%s.domain %q duplicates remoteClusters[%d]", label, rc.Domain, prev))
+		} else {
+			seenRemoteDomains[rc.Domain] = i
+		}
+	}
+
+	errs = append(errs, validateIPFamilyConsistencyNets(res.ClusterNetwork, label+".clusterNetwork")...)
+	errs = append(errs, validateIPFamilyConsistencyNets(res.ServiceNetwork, label+".serviceNetwork")...)
+	errs = append(errs, validateNetworkShapeNets(res.ClusterNetwork, res.ServiceNetwork, label)...)
+	errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, res.ClusterNetwork, label)...)
+	errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, res.ServiceNetwork, label)...)
+
+	return errs
+}
+
 func validateIPFamilyConsistencyNets(cidrs []*net.IPNet, field string) []error {
 	var v4, v6 int
+	var errs []error
 	for _, c := range cidrs {
 		switch netutils.IPFamilyOfCIDR(c) {
 		case netutils.IPv4:
 			v4++
 		case netutils.IPv6:
 			v6++
+		case netutils.IPFamilyUnknown:
+			errs = append(errs, fmt.Errorf("%s has unrecognized IP family: %v", field, c))
 		}
 	}
-	var errs []error
 	if v4 > 1 {
 		errs = append(errs, fmt.Errorf("%s has multiple IPv4 entries (max 1)", field))
 	}

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -1,5 +1,16 @@
 package config
 
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/validation"
+	netutils "k8s.io/utils/net"
+)
+
 type C2CC struct {
 	// List of remote clusters to establish connectivity with.
 	// C2CC is disabled when this list is empty.
@@ -21,4 +32,189 @@ type RemoteCluster struct {
 
 func (c *C2CC) IsEnabled() bool {
 	return len(c.RemoteClusters) > 0
+}
+
+var getHostIPs = defaultGetHostIPs
+
+func defaultGetHostIPs() ([]net.IP, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("listing network interfaces: %w", err)
+	}
+	var ips []net.IP
+	for _, link := range links {
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ips = append(ips, addr.IP)
+		}
+	}
+	return ips, nil
+}
+
+func (c *C2CC) validate(cfg *Config) error {
+	if cfg.Network.CNIPlugin != CniPluginUnset && cfg.Network.CNIPlugin != CniPluginOVNK {
+		return fmt.Errorf("c2cc requires OVN-Kubernetes CNI (network.cniPlugin must be \"\" or \"ovnk\", got %q)", cfg.Network.CNIPlugin)
+	}
+
+	hostIPs, err := getHostIPs()
+	if err != nil {
+		return fmt.Errorf("failed to get host IPs: %w", err)
+	}
+
+	nodeIP := net.ParseIP(cfg.Node.NodeIP)
+	if nodeIP == nil {
+		return fmt.Errorf("failed to parse cfg.Node.NodeIP (%q)", cfg.Node.NodeIP)
+	}
+
+	localV4 := cfg.IsIPv4()
+	localV6 := cfg.IsIPv6()
+
+	var errs []error
+
+	seenNextHops := make(map[string]int, len(c.RemoteClusters))
+	seenRemoteDomains := make(map[string]int, len(c.RemoteClusters))
+
+	// Overlap check: start with local CIDRs, then accumulate each remote's CIDRs.
+	seenCIDRs := make([]string, 0, len(cfg.Network.ClusterNetwork)+len(cfg.Network.ServiceNetwork)+len(c.RemoteClusters)*4)
+	seenCIDRs = append(seenCIDRs, cfg.Network.ClusterNetwork...)
+	seenCIDRs = append(seenCIDRs, cfg.Network.ServiceNetwork...)
+
+	for i := range c.RemoteClusters {
+		rc := &c.RemoteClusters[i]
+		label := fmt.Sprintf("remoteClusters[%d]", i)
+
+		ip := net.ParseIP(rc.NextHop)
+		if ip == nil {
+			errs = append(errs, fmt.Errorf("%s.nextHop %q is not a valid IP address", label, rc.NextHop))
+		} else {
+			normalizedNextHop := ip.String()
+			if ip.Equal(nodeIP) {
+				errs = append(errs, fmt.Errorf("%s.nextHop %q must not equal the local node IP (routing loop)", label, normalizedNextHop))
+			}
+			if prev, ok := seenNextHops[normalizedNextHop]; ok {
+				errs = append(errs, fmt.Errorf("%s.nextHop %q duplicates remoteClusters[%d]", label, normalizedNextHop, prev))
+			} else {
+				seenNextHops[normalizedNextHop] = i
+			}
+		}
+
+		if len(rc.ClusterNetwork) == 0 {
+			errs = append(errs, fmt.Errorf("%s.clusterNetwork must not be empty", label))
+		}
+		if len(rc.ServiceNetwork) == 0 {
+			errs = append(errs, fmt.Errorf("%s.serviceNetwork must not be empty", label))
+		}
+
+		for j, cidr := range rc.ClusterNetwork {
+			errs = append(errs, validateRemoteCIDR(cidr, fmt.Sprintf("%s.clusterNetwork[%d]", label, j)))
+			errs = append(errs, checkCIDRConflicts(cidr, label, seenCIDRs, hostIPs)...)
+			seenCIDRs = append(seenCIDRs, cidr)
+		}
+		for j, cidr := range rc.ServiceNetwork {
+			errs = append(errs, validateRemoteCIDR(cidr, fmt.Sprintf("%s.serviceNetwork[%d]", label, j)))
+			errs = append(errs, checkCIDRConflicts(cidr, label, seenCIDRs, hostIPs)...)
+			seenCIDRs = append(seenCIDRs, cidr)
+		}
+
+		if rc.Domain != "" {
+			if domainErrs := validation.IsDNS1123Subdomain(rc.Domain); len(domainErrs) > 0 {
+				errs = append(errs, fmt.Errorf("%s.domain %q is not a valid DNS name: %s", label, rc.Domain, strings.Join(domainErrs, ", ")))
+			}
+			if prev, ok := seenRemoteDomains[rc.Domain]; ok {
+				errs = append(errs, fmt.Errorf("%s.domain %q duplicates remoteClusters[%d]", label, rc.Domain, prev))
+			} else {
+				seenRemoteDomains[rc.Domain] = i
+			}
+		}
+
+		errs = append(errs, validateIPFamilyConsistency(rc.ClusterNetwork, label+".clusterNetwork")...)
+		errs = append(errs, validateIPFamilyConsistency(rc.ServiceNetwork, label+".serviceNetwork")...)
+		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, rc.ClusterNetwork, label)...)
+		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, rc.ServiceNetwork, label)...)
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateRemoteCIDR(cidr, field string) error {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("%s %q is not a valid CIDR: %w", field, cidr, err)
+	}
+
+	ones, _ := ipNet.Mask.Size()
+	if ipNet.IP.To4() != nil {
+		if ones < 8 {
+			return fmt.Errorf("%s %q has mask /%d shorter than minimum /8", field, cidr, ones)
+		}
+	} else {
+		if ones < 32 {
+			return fmt.Errorf("%s %q has mask /%d shorter than minimum /32", field, cidr, ones)
+		}
+	}
+	return nil
+}
+
+func validateIPFamilyConsistency(cidrs []string, field string) []error {
+	var v4, v6 int
+	for _, c := range cidrs {
+		switch netutils.IPFamilyOfCIDRString(c) {
+		case netutils.IPv4:
+			v4++
+		case netutils.IPv6:
+			v6++
+		case netutils.IPFamilyUnknown:
+		}
+	}
+	var errs []error
+	if v4 > 1 {
+		errs = append(errs, fmt.Errorf("%s has multiple IPv4 entries (max 1)", field))
+	}
+	if v6 > 1 {
+		errs = append(errs, fmt.Errorf("%s has multiple IPv6 entries (max 1)", field))
+	}
+	return errs
+}
+
+func validateRemoteIPFamilyCompatibility(localV4, localV6 bool, remoteCIDRs []string, label string) []error {
+	var errs []error
+	for _, c := range remoteCIDRs {
+		family := netutils.IPFamilyOfCIDRString(c)
+		if family == netutils.IPv4 && !localV4 {
+			errs = append(errs, fmt.Errorf("%s: %q is IPv4 but local cluster has no IPv4 network", label, c))
+		}
+		if family == netutils.IPv6 && !localV6 {
+			errs = append(errs, fmt.Errorf("%s: %q is IPv6 but local cluster has no IPv6 network", label, c))
+		}
+	}
+	return errs
+}
+
+func checkCIDRConflicts(cidr, label string, seenCIDRs []string, hostIPs []net.IP) []error {
+	var errs []error
+	for _, existing := range seenCIDRs {
+		if cidrsOverlap(cidr, existing) {
+			errs = append(errs, fmt.Errorf("%s: CIDR %q overlaps with %q", label, cidr, existing))
+		}
+	}
+	if _, ipNet, err := net.ParseCIDR(cidr); err == nil {
+		for _, hostIP := range hostIPs {
+			if ipNet.Contains(hostIP) {
+				errs = append(errs, fmt.Errorf("remote CIDR %q contains host interface IP %s — this would disrupt management traffic", cidr, hostIP))
+			}
+		}
+	}
+	return errs
+}
+
+func cidrsOverlap(a, b string) bool {
+	_, netA, errA := net.ParseCIDR(a)
+	_, netB, errB := net.ParseCIDR(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return netA.Contains(netB.IP) || netB.Contains(netA.IP)
 }

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -83,6 +83,14 @@ func (c *C2CC) validate(cfg *Config) error {
 		return fmt.Errorf("failed to parse cfg.Node.NodeIP (%q)", cfg.Node.NodeIP)
 	}
 
+	var nodeIPv6 net.IP
+	if cfg.Node.NodeIPV6 != "" {
+		nodeIPv6 = net.ParseIP(cfg.Node.NodeIPV6)
+		if nodeIPv6 == nil {
+			return fmt.Errorf("failed to parse cfg.Node.NodeIPV6 (%q)", cfg.Node.NodeIPV6)
+		}
+	}
+
 	localV4 := cfg.IsIPv4()
 	localV6 := cfg.IsIPv6()
 
@@ -105,7 +113,7 @@ func (c *C2CC) validate(cfg *Config) error {
 			errs = append(errs, fmt.Errorf("%s.nextHop %q is not a valid IP address", label, rc.NextHop))
 		} else {
 			normalizedNextHop := ip.String()
-			if ip.Equal(nodeIP) {
+			if ip.Equal(nodeIP) || (nodeIPv6 != nil && ip.Equal(nodeIPv6)) {
 				errs = append(errs, fmt.Errorf("%s.nextHop %q must not equal the local node IP (routing loop)", label, normalizedNextHop))
 			}
 			if prev, ok := seenNextHops[normalizedNextHop]; ok {

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -1,0 +1,24 @@
+package config
+
+type C2CC struct {
+	// List of remote clusters to establish connectivity with.
+	// C2CC is disabled when this list is empty.
+	RemoteClusters []RemoteCluster `json:"remoteClusters,omitempty"`
+}
+
+type RemoteCluster struct {
+	// IP address of the remote cluster's node, used as next-hop for routing.
+	NextHop string `json:"nextHop"`
+	// Pod CIDRs of the remote cluster. Must not overlap with local cluster or other remotes.
+	ClusterNetwork []string `json:"clusterNetwork"`
+	// Service CIDRs of the remote cluster. Must not overlap with local cluster or other remotes.
+	ServiceNetwork []string `json:"serviceNetwork"`
+	// DNS domain suffix for the remote cluster (e.g., "cluster-b.remote").
+	// Services are reachable as <svc>.<ns>.svc.<domain>.
+	// Optional — if empty, no DNS forwarding is configured for this remote.
+	Domain string `json:"domain,omitempty"`
+}
+
+func (c *C2CC) IsEnabled() bool {
+	return len(c.RemoteClusters) > 0
+}

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -34,6 +34,20 @@ func (c *C2CC) IsEnabled() bool {
 	return len(c.RemoteClusters) > 0
 }
 
+func (rc *RemoteCluster) isEmpty() bool {
+	return rc.NextHop == "" && len(rc.ClusterNetwork) == 0 && len(rc.ServiceNetwork) == 0 && rc.Domain == ""
+}
+
+func (c *C2CC) stripEmptyRemoteClusters() {
+	filtered := c.RemoteClusters[:0]
+	for i := range c.RemoteClusters {
+		if !c.RemoteClusters[i].isEmpty() {
+			filtered = append(filtered, c.RemoteClusters[i])
+		}
+	}
+	c.RemoteClusters = filtered
+}
+
 var getHostIPs = defaultGetHostIPs
 
 func defaultGetHostIPs() ([]net.IP, error) {

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -145,7 +145,7 @@ func parseAndValidateCIDR(cidr, field string, errs *[]error) *net.IPNet {
 
 func (c *C2CC) validate(cfg *Config) error {
 	if cfg.Network.CNIPlugin != CniPluginUnset && cfg.Network.CNIPlugin != CniPluginOVNK {
-		return fmt.Errorf("c2cc requires OVN-Kubernetes CNI (network.cniPlugin must be \"\" or \"ovnk\", got %q)", cfg.Network.CNIPlugin)
+		return fmt.Errorf("cluster to cluster requires OVN-Kubernetes CNI (network.cniPlugin must be \"\" or \"ovnk\", got %q)", cfg.Network.CNIPlugin)
 	}
 
 	resolved, parseErrs := c.parseRemoteClusters()

--- a/pkg/config/c2cc.go
+++ b/pkg/config/c2cc.go
@@ -59,7 +59,7 @@ func defaultGetHostIPs() ([]net.IP, error) {
 	for _, link := range links {
 		addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("listing addresses for interface %q: %w", link.Attrs().Name, err)
 		}
 		for _, addr := range addrs {
 			ips = append(ips, addr.IP)
@@ -146,6 +146,7 @@ func (c *C2CC) validate(cfg *Config) error {
 
 		errs = append(errs, validateIPFamilyConsistency(rc.ClusterNetwork, label+".clusterNetwork")...)
 		errs = append(errs, validateIPFamilyConsistency(rc.ServiceNetwork, label+".serviceNetwork")...)
+		errs = append(errs, validateNetworkShape(rc.ClusterNetwork, rc.ServiceNetwork, label)...)
 		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, rc.ClusterNetwork, label)...)
 		errs = append(errs, validateRemoteIPFamilyCompatibility(localV4, localV6, rc.ServiceNetwork, label)...)
 	}
@@ -189,6 +190,22 @@ func validateIPFamilyConsistency(cidrs []string, field string) []error {
 	}
 	if v6 > 1 {
 		errs = append(errs, fmt.Errorf("%s has multiple IPv6 entries (max 1)", field))
+	}
+	return errs
+}
+
+func validateNetworkShape(clusterNetwork, serviceNetwork []string, label string) []error {
+	if len(clusterNetwork) != len(serviceNetwork) {
+		return []error{fmt.Errorf("%s: clusterNetwork and serviceNetwork have different cardinality (%d vs %d)",
+			label, len(clusterNetwork), len(serviceNetwork))}
+	}
+	var errs []error
+	for i := 0; i < len(clusterNetwork); i++ {
+		cFamily := netutils.IPFamilyOfCIDRString(clusterNetwork[i])
+		sFamily := netutils.IPFamilyOfCIDRString(serviceNetwork[i])
+		if cFamily != netutils.IPFamilyUnknown && sFamily != netutils.IPFamilyUnknown && cFamily != sFamily {
+			errs = append(errs, fmt.Errorf("%s: clusterNetwork[%d] and serviceNetwork[%d] have mismatched IP families", label, i, i))
+		}
 	}
 	return errs
 }

--- a/pkg/config/c2cc_test.go
+++ b/pkg/config/c2cc_test.go
@@ -450,6 +450,30 @@ func TestC2CC_Validate(t *testing.T) {
 				}},
 			}),
 		},
+		{
+			name: "clusterNetwork and serviceNetwork cardinality mismatch",
+			cfg: mkDualStackC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16", "fd03::/48"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "different cardinality",
+		},
+		{
+			name: "clusterNetwork and serviceNetwork IP family mismatch at same index",
+			cfg: mkDualStackC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16", "fd03::/48"},
+					ServiceNetwork: []string{"fd04::/112", "10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "mismatched IP families",
+		},
 	}
 
 	for _, tt := range ttests {

--- a/pkg/config/c2cc_test.go
+++ b/pkg/config/c2cc_test.go
@@ -328,8 +328,8 @@ func TestC2CC_Validate(t *testing.T) {
 			cfg: mkC2CCConfig(C2CC{
 				RemoteClusters: []RemoteCluster{{
 					NextHop:        "10.100.0.2",
-                     ClusterNetwork: []string{"fd03::/48", "fd05::/48"},
-                     ServiceNetwork: []string{"fd04::/112"},
+					ClusterNetwork: []string{"fd03::/48", "fd05::/48"},
+					ServiceNetwork: []string{"fd04::/112"},
 				}},
 			}),
 			expectErr: true,
@@ -439,6 +439,18 @@ func TestC2CC_Validate(t *testing.T) {
 			}),
 			expectErr: true,
 			errMsg:    "domain \"cluster-b.remote\" duplicates remoteClusters[0]",
+		},
+		{
+			name: "NextHop equals local NodeIPV6 in dual-stack",
+			cfg: mkDualStackC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "fd00::1",
+					ClusterNetwork: []string{"fd03::/48"},
+					ServiceNetwork: []string{"fd04::/112"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "routing loop",
 		},
 		{
 			name: "single-stack IPv4 remote with dual-stack local",

--- a/pkg/config/c2cc_test.go
+++ b/pkg/config/c2cc_test.go
@@ -1,0 +1,477 @@
+package config
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestC2CC_IsEnabled(t *testing.T) {
+	t.Run("empty remote clusters", func(t *testing.T) {
+		c := C2CC{}
+		assert.False(t, c.IsEnabled())
+	})
+
+	t.Run("with remote clusters", func(t *testing.T) {
+		c := C2CC{
+			RemoteClusters: []RemoteCluster{{
+				NextHop:        "10.100.0.2",
+				ClusterNetwork: []string{"10.45.0.0/16"},
+				ServiceNetwork: []string{"10.46.0.0/16"},
+			}},
+		}
+		assert.True(t, c.IsEnabled())
+	})
+}
+
+func mkC2CCConfig(c2cc C2CC) *Config {
+	return &Config{
+		Network: Network{
+			CNIPlugin:      CniPluginOVNK,
+			ClusterNetwork: []string{"10.42.0.0/16"},
+			ServiceNetwork: []string{"10.43.0.0/16"},
+		},
+		Node: Node{
+			NodeIP: "10.100.0.1",
+		},
+		C2CC: c2cc,
+	}
+}
+
+func mkDualStackC2CCConfig(c2cc C2CC) *Config {
+	return &Config{
+		Network: Network{
+			CNIPlugin:      CniPluginOVNK,
+			ClusterNetwork: []string{"10.42.0.0/16", "fd01::/48"},
+			ServiceNetwork: []string{"10.43.0.0/16", "fd02::/112"},
+		},
+		Node: Node{
+			NodeIP:   "10.100.0.1",
+			NodeIPV6: "fd00::1",
+		},
+		C2CC: c2cc,
+	}
+}
+
+func mkIPv6OnlyC2CCConfig(c2cc C2CC) *Config {
+	return &Config{
+		Network: Network{
+			CNIPlugin:      CniPluginOVNK,
+			ClusterNetwork: []string{"fd01::/48"},
+			ServiceNetwork: []string{"fd02::/112"},
+		},
+		Node: Node{
+			NodeIP: "fd00::1",
+		},
+		C2CC: c2cc,
+	}
+}
+
+func stubHostIPs(t *testing.T, ips []net.IP) {
+	t.Helper()
+	orig := getHostIPs
+	getHostIPs = func() ([]net.IP, error) { return ips, nil }
+	t.Cleanup(func() { getHostIPs = orig })
+}
+
+func TestC2CC_Validate(t *testing.T) {
+	ttests := []struct {
+		name      string
+		cfg       *Config
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "valid single remote IPv4",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+		},
+		{
+			name: "valid multiple remotes",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{
+					{
+						NextHop:        "10.100.0.2",
+						ClusterNetwork: []string{"10.45.0.0/16"},
+						ServiceNetwork: []string{"10.46.0.0/16"},
+					},
+					{
+						NextHop:        "10.100.0.3",
+						ClusterNetwork: []string{"10.55.0.0/16"},
+						ServiceNetwork: []string{"10.56.0.0/16"},
+					},
+				},
+			}),
+		},
+		{
+			name: "valid dual-stack remote with dual-stack local",
+			cfg: mkDualStackC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16", "fd03::/48"},
+					ServiceNetwork: []string{"10.46.0.0/16", "fd04::/112"},
+				}},
+			}),
+		},
+		{
+			name: "invalid NextHop",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "not-an-ip",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "not a valid IP",
+		},
+		{
+			name: "invalid CIDR format",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"not-a-cidr"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "not a valid CIDR",
+		},
+		{
+			name: "local cluster network overlap",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.42.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "overlaps with",
+		},
+		{
+			name: "local service network overlap",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.43.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "overlaps with",
+		},
+		{
+			name: "same remote clusterNetwork overlaps own serviceNetwork",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.45.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "overlaps with",
+		},
+		{
+			name: "remote A cluster overlaps remote B service",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{
+					{
+						NextHop:        "10.100.0.2",
+						ClusterNetwork: []string{"10.45.0.0/16"},
+						ServiceNetwork: []string{"10.46.0.0/16"},
+					},
+					{
+						NextHop:        "10.100.0.3",
+						ClusterNetwork: []string{"10.55.0.0/16"},
+						ServiceNetwork: []string{"10.45.0.0/16"},
+					},
+				},
+			}),
+			expectErr: true,
+			errMsg:    "overlaps with",
+		},
+		{
+			name: "duplicate NextHop across remotes",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{
+					{
+						NextHop:        "10.100.0.2",
+						ClusterNetwork: []string{"10.45.0.0/16"},
+						ServiceNetwork: []string{"10.46.0.0/16"},
+					},
+					{
+						NextHop:        "10.100.0.2",
+						ClusterNetwork: []string{"10.55.0.0/16"},
+						ServiceNetwork: []string{"10.56.0.0/16"},
+					},
+				},
+			}),
+			expectErr: true,
+			errMsg:    "duplicates remoteClusters[0]",
+		},
+		{
+			name: "NextHop equals local node IP",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.1",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "routing loop",
+		},
+		{
+			name: "CIDR mask too short IPv4",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.0.0.0/4"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "shorter than minimum /8",
+		},
+		{
+			name: "CIDR mask too short IPv6",
+			cfg: mkDualStackC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16", "fd00::/16"},
+					ServiceNetwork: []string{"10.46.0.0/16", "fd04::/112"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "shorter than minimum /32",
+		},
+		{
+			name: "OVN-K disabled",
+			cfg: func() *Config {
+				cfg := mkC2CCConfig(C2CC{
+					RemoteClusters: []RemoteCluster{{
+						NextHop:        "10.100.0.2",
+						ClusterNetwork: []string{"10.45.0.0/16"},
+						ServiceNetwork: []string{"10.46.0.0/16"},
+					}},
+				})
+				cfg.Network.CNIPlugin = CniPluginNone
+				return cfg
+			}(),
+			expectErr: true,
+			errMsg:    "requires OVN-Kubernetes",
+		},
+		{
+			name: "remote CIDR contains host interface IP",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.100.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "contains host interface IP",
+		},
+		{
+			name: "multiple IPv4 entries in clusterNetwork",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16", "10.47.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "multiple IPv4 entries",
+		},
+		{
+			name: "multiple IPv6 entries in clusterNetwork",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+                     ClusterNetwork: []string{"fd03::/48", "fd05::/48"},
+                     ServiceNetwork: []string{"fd04::/112"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "multiple IPv6 entries",
+		},
+		{
+			name: "IPv6 remote with IPv4-only local",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "fd00::2",
+					ClusterNetwork: []string{"fd03::/48"},
+					ServiceNetwork: []string{"fd04::/112"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "is IPv6 but local cluster has no IPv6 network",
+		},
+		{
+			name: "IPv4 remote with IPv6-only local",
+			cfg: mkIPv6OnlyC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "is IPv4 but local cluster has no IPv4 network",
+		},
+		{
+			name: "NextHop equals local node IP non-canonical form",
+			cfg: mkIPv6OnlyC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "fd00:0:0:0:0:0:0:1",
+					ClusterNetwork: []string{"fd03::/48"},
+					ServiceNetwork: []string{"fd04::/112"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "routing loop",
+		},
+		{
+			name: "empty clusterNetwork",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "clusterNetwork must not be empty",
+		},
+		{
+			name: "empty serviceNetwork",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{},
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "serviceNetwork must not be empty",
+		},
+		{
+			name: "invalid domain",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+					Domain:         "not a valid domain!",
+				}},
+			}),
+			expectErr: true,
+			errMsg:    "is not a valid DNS name",
+		},
+		{
+			name: "valid domain",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+					Domain:         "cluster-b.remote",
+				}},
+			}),
+		},
+		{
+			name: "duplicate domain across remotes",
+			cfg: mkC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{
+					{
+						NextHop:        "10.100.0.2",
+						ClusterNetwork: []string{"10.45.0.0/16"},
+						ServiceNetwork: []string{"10.46.0.0/16"},
+						Domain:         "cluster-b.remote",
+					},
+					{
+						NextHop:        "10.100.0.3",
+						ClusterNetwork: []string{"10.55.0.0/16"},
+						ServiceNetwork: []string{"10.56.0.0/16"},
+						Domain:         "cluster-b.remote",
+					},
+				},
+			}),
+			expectErr: true,
+			errMsg:    "domain \"cluster-b.remote\" duplicates remoteClusters[0]",
+		},
+		{
+			name: "single-stack IPv4 remote with dual-stack local",
+			cfg: mkDualStackC2CCConfig(C2CC{
+				RemoteClusters: []RemoteCluster{{
+					NextHop:        "10.100.0.2",
+					ClusterNetwork: []string{"10.45.0.0/16"},
+					ServiceNetwork: []string{"10.46.0.0/16"},
+				}},
+			}),
+		},
+	}
+
+	for _, tt := range ttests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubHostIPs(t, []net.IP{net.ParseIP("10.100.0.1")})
+
+			err := tt.cfg.C2CC.validate(tt.cfg)
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestC2CC_ValidateDualStack(t *testing.T) {
+	stubHostIPs(t, nil)
+
+	t.Run("valid IPv6-only remote with IPv6-only local", func(t *testing.T) {
+		cfg := mkIPv6OnlyC2CCConfig(C2CC{
+			RemoteClusters: []RemoteCluster{{
+				NextHop:        "fd00::2",
+				ClusterNetwork: []string{"fd03::/48"},
+				ServiceNetwork: []string{"fd04::/112"},
+			}},
+		})
+		assert.NoError(t, cfg.C2CC.validate(cfg))
+	})
+
+	t.Run("dual-stack remote with dual-stack local", func(t *testing.T) {
+		cfg := mkDualStackC2CCConfig(C2CC{
+			RemoteClusters: []RemoteCluster{{
+				NextHop:        "10.100.0.2",
+				ClusterNetwork: []string{"10.45.0.0/16", "fd03::/48"},
+				ServiceNetwork: []string{"10.46.0.0/16", "fd04::/112"},
+			}},
+		})
+		assert.NoError(t, cfg.C2CC.validate(cfg))
+	})
+
+	t.Run("single-stack IPv6 remote with dual-stack local", func(t *testing.T) {
+		cfg := mkDualStackC2CCConfig(C2CC{
+			RemoteClusters: []RemoteCluster{{
+				NextHop:        "fd00::2",
+				ClusterNetwork: []string{"fd03::/48"},
+				ServiceNetwork: []string{"fd04::/112"},
+			}},
+		})
+		assert.NoError(t, cfg.C2CC.validate(cfg))
+	})
+}

--- a/pkg/config/c2cc_test.go
+++ b/pkg/config/c2cc_test.go
@@ -25,6 +25,36 @@ func TestC2CC_IsEnabled(t *testing.T) {
 	})
 }
 
+func TestC2CC_StripEmptyRemoteClusters(t *testing.T) {
+	t.Run("strips zero-value entries", func(t *testing.T) {
+		c := C2CC{
+			RemoteClusters: []RemoteCluster{{}},
+		}
+		c.stripEmptyRemoteClusters()
+		assert.Empty(t, c.RemoteClusters)
+		assert.False(t, c.IsEnabled())
+	})
+
+	t.Run("keeps non-empty entries", func(t *testing.T) {
+		c := C2CC{
+			RemoteClusters: []RemoteCluster{
+				{},
+				{NextHop: "10.0.0.1", ClusterNetwork: []string{"10.45.0.0/16"}, ServiceNetwork: []string{"10.46.0.0/16"}},
+				{},
+			},
+		}
+		c.stripEmptyRemoteClusters()
+		assert.Len(t, c.RemoteClusters, 1)
+		assert.Equal(t, "10.0.0.1", c.RemoteClusters[0].NextHop)
+	})
+
+	t.Run("no-op on empty list", func(t *testing.T) {
+		c := C2CC{}
+		c.stripEmptyRemoteClusters()
+		assert.Empty(t, c.RemoteClusters)
+	})
+}
+
 func mkC2CCConfig(c2cc C2CC) *Config {
 	return &Config{
 		Network: Network{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,7 +62,7 @@ type Config struct {
 
 	GenericDevicePlugin GenericDevicePlugin `json:"genericDevicePlugin"`
 
-	C2CC C2CC `json:"c2cc"`
+	C2CC C2CC `json:"clusterToCluster"`
 
 	// Internal-only fields
 	userSettings *Config `json:"-"` // the values read from the config file
@@ -701,7 +701,7 @@ func (c *Config) validate() error {
 	}
 	if c.C2CC.IsEnabled() {
 		if err := c.C2CC.validate(c); err != nil {
-			return fmt.Errorf("error validating c2cc: %w", err)
+			return fmt.Errorf("error validating clusterToCluster: %w", err)
 		}
 	}
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -697,6 +697,11 @@ func (c *Config) validate() error {
 	if err := c.Network.Multus.Validate(); err != nil {
 		return fmt.Errorf("error validating multus configuration: %v", err)
 	}
+	if c.C2CC.IsEnabled() {
+		if err := c.C2CC.validate(c); err != nil {
+			return fmt.Errorf("error validating c2cc: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -544,6 +544,8 @@ func (c *Config) updateComputedValues() error {
 		c.Telemetry = Telemetry{Status: StatusDisabled}
 	}
 
+	c.C2CC.stripEmptyRemoteClusters()
+
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,8 @@ type Config struct {
 
 	GenericDevicePlugin GenericDevicePlugin `json:"genericDevicePlugin"`
 
+	C2CC C2CC `json:"c2cc"`
+
 	// Internal-only fields
 	userSettings *Config `json:"-"` // the values read from the config file
 
@@ -197,6 +199,7 @@ func (c *Config) fillDefaults() error {
 	c.GenericDevicePlugin = genericDevicePluginDefaults()
 	c.Telemetry = telemetryDefaults()
 	c.DNS = dnsDefaults()
+	c.C2CC = C2CC{}
 	return nil
 }
 
@@ -450,6 +453,10 @@ func (c *Config) incorporateUserSettings(u *Config) {
 	}
 	if len(u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled) > 0 {
 		c.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled = u.ApiServer.FeatureGates.SpecialHandlingSupportExceptionRequired.Disabled
+	}
+
+	if u.C2CC.RemoteClusters != nil {
+		c.C2CC = u.C2CC
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote-cluster connectivity config: define remote cluster/service CIDRs, next-hop routes, and optional DNS domains; feature enables when remotes are provided and validates conflicts, routing loops, host-interface overlap, and IP-family compatibility.

* **Tests**
  * Added comprehensive validation and enablement tests covering parsing, overlap detection, uniqueness, mask/cardinality rules, host-interface checks, and DNS validation.

* **Documentation**
  * Added user config examples showing the new c2cc section.

* **Chores**
  * Updated configuration schema and packaging defaults to include c2cc.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->