### PR TITLE
USHIFT-6868: Increase greenboot timeout for release scenarios

### DIFF
--- a/test/scenarios-bootc/el10/releases/el102-lrel@ai-model-serving-online.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@ai-model-serving-online.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 # Currently, RHOAI is only available for x86_64

--- a/test/scenarios-bootc/el10/releases/el102-lrel@configuration.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@configuration.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@dual-stack.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@dual-stack.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@fips.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@fips.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-fips"
 
 check_platform() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@ginkgo-tests.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@ginkgo-tests.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@ipv6.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@ipv6.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Redefine network-related settings to use the dedicated IPv6 network bridge
 # shellcheck disable=SC2034  # used elsewhere
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_IPV6_NETWORK}")"

--- a/test/scenarios-bootc/el10/releases/el102-lrel@iso-standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@iso-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@iso-standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@iso-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@multi-config-standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@multi-config-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Multi-config scenario: Combines multiple configurations to validate no conflicts
 # - Low-latency (tuned)
 # - TLSv1.3

--- a/test/scenarios-bootc/el10/releases/el102-lrel@multi-config-standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@multi-config-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Multi-config scenario: Combines multiple configurations to validate no conflicts
 # - Low-latency (tuned)
 # - TLSv1.3

--- a/test/scenarios-bootc/el10/releases/el102-lrel@multi-nic.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@multi-nic.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@nightly-brew-standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@nightly-brew-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-nightly-with-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@nightly-brew-standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@nightly-brew-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-nightly-with-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@optional.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@optional.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el10/releases/el102-lrel@osconfig-router.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@osconfig-router.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@published-images-standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@published-images-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Enable container signature verification for published MicroShift images.
 # These are ec / rc / zstream, thus guaranteed to be signed.
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el10/releases/el102-lrel@storage-telemetry.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@storage-telemetry.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@tlsv13-standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@tlsv13-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@tlsv13-standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@tlsv13-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel102-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@lvms.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@lvms.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@lvms.sh
+++ b/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el96-lrel@published-images-standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el96-lrel@published-images-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Enable container signature verification for published MicroShift images.
 # These are ec / rc / zstream, thus guaranteed to be signed.
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el9/releases/el96-lrel@published-images-standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el96-lrel@published-images-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Enable container signature verification for published MicroShift images.
 # These are ec / rc / zstream, thus guaranteed to be signed.
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@lvms.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@lvms.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios-bootc/el9/releases/el98-lrel@ai-model-serving-online.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@ai-model-serving-online.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 # Currently, RHOAI is only available for x86_64

--- a/test/scenarios-bootc/el9/releases/el98-lrel@configuration.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@configuration.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@dual-stack.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@dual-stack.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@fips.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@fips.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-fips"
 
 check_platform() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@ginkgo-tests.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@ginkgo-tests.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@ipv6.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@ipv6.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Redefine network-related settings to use the dedicated IPv6 network bridge
 # shellcheck disable=SC2034  # used elsewhere
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_IPV6_NETWORK}")"

--- a/test/scenarios-bootc/el9/releases/el98-lrel@iso-standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@iso-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@iso-standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@iso-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@multi-config-standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@multi-config-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Multi-config scenario: Combines multiple configurations to validate no conflicts
 # - Low-latency (tuned)
 # - TLSv1.3

--- a/test/scenarios-bootc/el9/releases/el98-lrel@multi-config-standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@multi-config-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Multi-config scenario: Combines multiple configurations to validate no conflicts
 # - Low-latency (tuned)
 # - TLSv1.3

--- a/test/scenarios-bootc/el9/releases/el98-lrel@multi-nic.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@multi-nic.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@nightly-brew-standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@nightly-brew-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-nightly-with-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@nightly-brew-standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@nightly-brew-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-nightly-with-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@optional.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@optional.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el9/releases/el98-lrel@osconfig-router.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@osconfig-router.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@storage-telemetry.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@storage-telemetry.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@tlsv13-standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@tlsv13-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-lrel@tlsv13-standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@tlsv13-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-bootc-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el96-yminus1@el98-lrel@lvms.sh
+++ b/test/scenarios/releases/el96-yminus1@el98-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios/releases/el96-yminus1@el98-lrel@standard1.sh
+++ b/test/scenarios/releases/el96-yminus1@el98-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios/releases/el96-yminus1@el98-lrel@standard2.sh
+++ b/test/scenarios/releases/el96-yminus1@el98-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios/releases/el96-yminus2@el98-lrel@lvms.sh
+++ b/test/scenarios/releases/el96-yminus2@el98-lrel@lvms.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios/releases/el96-yminus2@el98-lrel@standard1.sh
+++ b/test/scenarios/releases/el96-yminus2@el98-lrel@standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios/releases/el96-yminus2@el98-lrel@standard2.sh
+++ b/test/scenarios/releases/el96-yminus2@el98-lrel@standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # NOTE: Unlike most suites, these tests rely on being run IN ORDER to
 # ensure MicroShift is upgraded before running standard suite tests
 export TEST_RANDOMIZATION=none

--- a/test/scenarios/releases/el98-lrel@backups.sh
+++ b/test/scenarios/releases/el98-lrel@backups.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@configuration.sh
+++ b/test/scenarios/releases/el98-lrel@configuration.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@dual-stack.sh
+++ b/test/scenarios/releases/el98-lrel@dual-stack.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@ginkgo-multi-config.sh
+++ b/test/scenarios/releases/el98-lrel@ginkgo-multi-config.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Multi-config scenario: Combines multiple configurations to validate no conflicts
 # - Low-latency (tuned)
 # - TLSv1.3

--- a/test/scenarios/releases/el98-lrel@ginkgo-tests.sh
+++ b/test/scenarios/releases/el98-lrel@ginkgo-tests.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@ipv6.sh
+++ b/test/scenarios/releases/el98-lrel@ipv6.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Redefine network-related settings to use the dedicated IPv6 network bridge
 # shellcheck disable=SC2034  # used elsewhere
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_IPV6_NETWORK}")"

--- a/test/scenarios/releases/el98-lrel@iso-standard1.sh
+++ b/test/scenarios/releases/el98-lrel@iso-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@iso-standard2.sh
+++ b/test/scenarios/releases/el98-lrel@iso-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@multi-nic.sh
+++ b/test/scenarios/releases/el98-lrel@multi-nic.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@optional.sh
+++ b/test/scenarios/releases/el98-lrel@optional.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios/releases/el98-lrel@osconfig.sh
+++ b/test/scenarios/releases/el98-lrel@osconfig.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@router.sh
+++ b/test/scenarios/releases/el98-lrel@router.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@storage.sh
+++ b/test/scenarios/releases/el98-lrel@storage.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@tlsv13-standard1.sh
+++ b/test/scenarios/releases/el98-lrel@tlsv13-standard1.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {

--- a/test/scenarios/releases/el98-lrel@tlsv13-standard2.sh
+++ b/test/scenarios/releases/el98-lrel@tlsv13-standard2.sh
@@ -2,6 +2,10 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
+# Increase greenboot timeout for release scenarios (optional operators need more time)
+# shellcheck disable=SC2034  # used elsewhere
+export GREENBOOT_TIMEOUT=1200
+
 start_image="rhel98-brew-lrel-optional"
 
 scenario_create_vms() {


### PR DESCRIPTION
## Summary
- Set `export GREENBOOT_TIMEOUT=1200` in all release scenario files (bootc and non-bootc)
- Release scenarios use images with all optional operators (OLM, cert-manager, gateway-api, SR-IOV, LVMS) that need more time to pull images and start
- The default `GREENBOOT_TIMEOUT=600` (10 min) is insufficient for the full optional stack, especially on ARM
- Presubmit scenarios already set `GREENBOOT_TIMEOUT=1200` explicitly but release scenarios were missed
- Excludes low-latency scenarios which have `SKIP_GREENBOOT=true`

## Test plan
- [x] Monitor next runs of periodic bootc release jobs (ARM and x86)
- [x] Verify release scenarios with optional images pass greenboot healthcheck

Jira: https://issues.redhat.com/browse/USHIFT-6868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced release test reliability by increasing the greenboot timeout to 1200 seconds across all release validation scenarios. This configuration change allocates more time for system boot verification during testing phases, reducing timeout-related failures and improving overall release quality across various platform configurations and upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->