### PR TITLE
USHIFT-6887: Fix microshift-baseline tuned profile on RHEL 10

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -182,7 +182,11 @@ osbuilder blueprints or bootc containerfiles.
 Summary: Baseline configuration for running low latency workload on MicroShift
 BuildArch: noarch
 Requires: microshift = %{version}
+%if 0%{?rhel} >= 10
+Requires: tuned
+%else
 Requires: tuned-profiles-cpu-partitioning
+%endif
 Requires: python3-pyyaml
 
 %description low-latency
@@ -439,7 +443,11 @@ install -p -m644 packaging/tuned/microshift-cleanup-kubelet.service %{buildroot}
 
 # low-latency
 install -d -m755 %{buildroot}/%{_prefix}/lib/tuned/microshift-baseline
+%if 0%{?rhel} >= 10
+install -p -m644 packaging/tuned/profile/tuned.conf.rhel10 %{buildroot}/%{_prefix}/lib/tuned/microshift-baseline/tuned.conf
+%else
 install -p -m644 packaging/tuned/profile/tuned.conf %{buildroot}/%{_prefix}/lib/tuned/microshift-baseline/tuned.conf
+%endif
 install -p -m755 packaging/tuned/profile/script.sh %{buildroot}/%{_prefix}/lib/tuned/microshift-baseline/script.sh
 install -d -m755 %{buildroot}%{_sysconfdir}/tuned
 install -p -m644 packaging/tuned/profile/variables.conf %{buildroot}%{_sysconfdir}/tuned/microshift-baseline-variables.conf

--- a/packaging/tuned/profile/tuned.conf.rhel10
+++ b/packaging/tuned/profile/tuned.conf.rhel10
@@ -1,0 +1,30 @@
+[main]
+summary=Optimized for running low latency workloads on MicroShift
+# On RHEL 10, the cpu-partitioning profile from tuned-profiles-cpu-partitioning
+# is not recognized by TuneD. Use latency-performance as the parent and inline
+# the necessary cpu-partitioning settings directly.
+include=latency-performance
+
+[variables]
+include=/etc/tuned/microshift-baseline-variables.conf
+isolated_cores_expanded=${f:cpulist_unpack:${isolated_cores}}
+offline_cpu_set_expanded=${f:cpulist_unpack:${offline_cpu_set}}
+
+[bootloader]
+cmdline_cpu_part=+nohz=on nohz_full=${isolated_cores} rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${f:cpulist2hex_invert:${isolated_cores}}
+cmdline_microshift_hp=+hugepagesz=${hugepages_size} hugepages=${hugepages}
+cmdline_microshift_extra=+${additional_args}
+
+[sysctl]
+kernel.hung_task_timeout_secs = 600
+kernel.nmi_watchdog = 0
+vm.stat_interval = 10
+kernel.timer_migration = 0
+kernel.sched_rt_runtime_us=-1
+
+[scheduler]
+isolated_cores=${isolated_cores}
+
+[script]
+priority=5
+script=${i:PROFILE_DIR}/script.sh


### PR DESCRIPTION
## Summary
- Create a RHEL 10-specific `tuned.conf.rhel10` that uses `include=latency-performance` instead of `include=cpu-partitioning`, with the cpu-partitioning settings inlined (nohz, nohz_full, rcu_nocbs, tuned.non_isolcpus, scheduler isolated_cores, sysctl entries)
- Add RPM spec conditionals (`%if 0%{?rhel} >= 10`) to install the correct variant and adjust the `Requires:` dependency
- RHEL 9 is completely unchanged — same `tuned.conf`, same `tuned-profiles-cpu-partitioning` dependency

### Root cause
On RHEL 10, `tuned-adm profile microshift-baseline` fails with _"Requested profile 'microshift-baseline' doesn't exist"_ because the TuneD daemon cannot resolve the `cpu-partitioning` parent profile from `tuned-profiles-cpu-partitioning`. The `microshift-tuned` service exits with status 1, preventing the required reboot.

### Files changed
- `packaging/tuned/profile/tuned.conf.rhel10` (new) — self-contained profile using `latency-performance` parent
- `packaging/rpm/microshift.spec` — conditional `Requires:` and conditional install

## Test plan
- [ ] Verify `el102-lrel@low-latency` scenario passes on ARM RHEL 10 (tuned profile activates, reboot occurs)
- [ ] Verify `el102-lrel@multi-config-standard1` scenario passes
- [ ] Verify `el102-lrel@multi-config-standard2` scenario passes
- [ ] Verify RHEL 9 low-latency scenarios are unaffected (no changes to RHEL 9 path)
- [ ] Verify kernel args match expectations: `nohz=on nohz_full=<cores> rcu_nocbs=<cores> tuned.non_isolcpus=<hex>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RHEL 10–specific low-latency tuning profile for optimized performance on RHEL 10 systems.

* **Chores**
  * Updated packaging configuration to automatically select appropriate dependencies and tuning profiles based on RHEL version, ensuring proper low-latency support across RHEL versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->