### PR TITLE
OCPBUGS-59566: Add openshift-marketplace network policy

### DIFF
--- a/assets/optional/operator-lifecycle-manager/0000_50_olm_01-marketplace-networkpolicy.yaml
+++ b/assets/optional/operator-lifecycle-manager/0000_50_olm_01-marketplace-networkpolicy.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: openshift-marketplace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/assets/optional/operator-lifecycle-manager/kustomization.yaml
+++ b/assets/optional/operator-lifecycle-manager/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - 0000_50_olm_00-packageserver.pdb.yaml
   - 0000_50_olm_00-subscriptions.crd.yaml
   - 0000_50_olm_01-networkpolicies.yaml
+  - 0000_50_olm_01-marketplace-networkpolicy.yaml
   - 0000_50_olm_02-olm-operator.serviceaccount.yaml
   - 0000_50_olm_03-olmconfig.yaml
   - 0000_50_olm_03-services.yaml

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -252,7 +252,7 @@ assets:
       - file: 0000_50_olm_00-subscriptions.crd.yaml
       - file: 0000_50_olm_01-networkpolicies.yaml
       - file: 0000_50_olm_01-marketplace-networkpolicy.yaml
-        ignore: "MicroShift-specific NetworkPolicy for openshift-marketplace namespace"
+        git_restore: True
       - file: 0000_50_olm_02-olm-operator.serviceaccount.yaml
       - file: 0000_50_olm_03-olmconfig.yaml
       - file: 0000_50_olm_03-services.yaml

--- a/scripts/auto-rebase/assets.yaml
+++ b/scripts/auto-rebase/assets.yaml
@@ -251,6 +251,8 @@ assets:
       - file: 0000_50_olm_00-packageserver.pdb.yaml
       - file: 0000_50_olm_00-subscriptions.crd.yaml
       - file: 0000_50_olm_01-networkpolicies.yaml
+      - file: 0000_50_olm_01-marketplace-networkpolicy.yaml
+        ignore: "MicroShift-specific NetworkPolicy for openshift-marketplace namespace"
       - file: 0000_50_olm_02-olm-operator.serviceaccount.yaml
       - file: 0000_50_olm_03-olmconfig.yaml
       - file: 0000_50_olm_03-services.yaml

--- a/test/suites/optional/olm.robot
+++ b/test/suites/optional/olm.robot
@@ -128,6 +128,12 @@ OLM Network Policies Are Correctly Configured
     Verify NetworkPolicy Spec Field    olm-operator    ${OLM_NAMESPACE}    ingress    metrics
     Verify NetworkPolicy Spec Field    olm-operator    ${OLM_NAMESPACE}    egress    53
 
+    # default-deny-all: no ingress/egress rules, applies to all pods in marketplace namespace
+    Verify NetworkPolicy Has Empty Pod Selector    default-deny-all    ${MARKETPLACE_NAMESPACE}
+    Verify NetworkPolicy Policy Types    default-deny-all    ${MARKETPLACE_NAMESPACE}
+    Verify NetworkPolicy Spec Field    default-deny-all    ${MARKETPLACE_NAMESPACE}    ingress    ${EMPTY}
+    Verify NetworkPolicy Spec Field    default-deny-all    ${MARKETPLACE_NAMESPACE}    egress    ${EMPTY}
+
     # default-allow-all: both Ingress and Egress defined with no port restrictions in openshift-operators
     Verify NetworkPolicy Has Empty Pod Selector    default-allow-all    ${OPERATORS_NAMESPACE}
     Verify NetworkPolicy Policy Types    default-allow-all    ${OPERATORS_NAMESPACE}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a network security policy for the marketplace namespace that enforces a default-deny posture for all inbound and outbound traffic on selected pods.

* **Tests**
  * Added validation tests to confirm the marketplace network policy exists, applies to all pods, lists both ingress and egress, and contains no allow rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->