### PR TITLE
NO-JIRA: Fix flaky observability and telemetry test teardown

### DIFF
--- a/test/suites/optional/observability.robot
+++ b/test/suites/optional/observability.robot
@@ -46,12 +46,14 @@ Kube Metrics Are Exported
 Journald Logs Are Exported
     [Documentation]    The opentelemetry-collector should be able to export journald logs.
 
-    Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {service_name="journald"}
+    Wait Until Keyword Succeeds    10x    5s
+    ...    Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {service_name="journald"}
 
 Kube Events Logs Are Exported
     [Documentation]    The opentelemetry-collector should be able to export Kubernetes events.
 
-    Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {service_name="kube_events"}
+    Wait Until Keyword Succeeds    10x    5s
+    ...    Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {service_name="kube_events"}
 
 Logs Should Not Contain Receiver Errors
     [Documentation]    Internal receiver errors are not treated as fatal. Typically these are due to a misconfiguration

--- a/test/suites/telemetry/telemetry.robot
+++ b/test/suites/telemetry/telemetry.robot
@@ -6,6 +6,7 @@ Resource            ../../resources/microshift-host.resource
 Resource            ../../resources/microshift-config.resource
 Resource            ../../resources/microshift-process.resource
 Resource            ../../resources/observability.resource
+Resource            ../../resources/ostree-health.resource
 Library             ../../resources/journalctl.py
 Library             ../../resources/prometheus.py
 Library             ../../resources/ProxyLibrary.py
@@ -110,6 +111,7 @@ Setup
 
 Teardown
     [Documentation]    Test suite teardown
+    Wait For MicroShift Healthcheck Success
     Logout MicroShift Host
     Remove Kubeconfig
 


### PR DESCRIPTION
## Summary
- Add retry logic to Loki queries in observability tests to handle race condition between OTEL collector restart and data ingestion
- Add healthcheck to telemetry suite teardown to prevent `vg-manager` CrashLoopBackOff from accumulating across rapid MicroShift restarts

## Test plan
- [x] `el98-lrel@optional` observability Loki tests pass consistently
- [x] `el98-lrel@storage-telemetry` storage reboot test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)