### PR TITLE
USHIFT-6835: cert-manager create ca-bundle configmap for trust-manager

### DIFF
--- a/assets/optional/cert-manager/manager/kustomization.yaml
+++ b/assets/optional/cert-manager/manager/kustomization.yaml
@@ -65,3 +65,9 @@ replacements:
           name: controller-manager
         fieldPaths:
           - spec.template.spec.containers.[name=cert-manager-operator].image
+configMapGenerator:
+  - name: trusted-ca-bundle
+    files:
+      - ca-bundle.crt=tls-ca-bundle.pem
+generatorOptions:
+  disableNameSuffixHash: true

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -587,6 +587,11 @@ install -d -m755 %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshi
 install -p -m644 assets/optional/cert-manager/manager/manager.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/manager
 install -p -m644 assets/optional/cert-manager/manager/kustomization.yaml %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/manager
 
+# cert-manager CA bundle update script and systemd drop-in
+install -p -m755 packaging/systemd/microshift-cert-manager-update-ca-bundle.sh %{buildroot}%{_bindir}/microshift-cert-manager-update-ca-bundle
+mkdir -p -m755 %{buildroot}%{_sysconfdir}/systemd/system/microshift.service.d
+install -p -m644 packaging/systemd/microshift-cert-manager-ca-bundle.conf %{buildroot}%{_sysconfdir}/systemd/system/microshift.service.d/microshift-cert-manager-ca-bundle.conf
+
 %ifarch %{arm} aarch64
 cat assets/optional/cert-manager/manager/images-aarch64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/manager/images.yaml
 %endif
@@ -798,6 +803,9 @@ fi
 %files cert-manager
 %dir %{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager
 %{_prefix}/lib/microshift/manifests.d/060-microshift-cert-manager/*
+%{_bindir}/microshift-cert-manager-update-ca-bundle
+%dir %{_sysconfdir}/systemd/system/microshift.service.d
+%{_sysconfdir}/systemd/system/microshift.service.d/microshift-cert-manager-ca-bundle.conf
 
 %files cert-manager-release-info
 %{_datadir}/microshift/release/release-cert-manager-{x86_64,aarch64}.json

--- a/packaging/systemd/microshift-cert-manager-ca-bundle.conf
+++ b/packaging/systemd/microshift-cert-manager-ca-bundle.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/microshift-cert-manager-update-ca-bundle

--- a/packaging/systemd/microshift-cert-manager-update-ca-bundle.sh
+++ b/packaging/systemd/microshift-cert-manager-update-ca-bundle.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copy the system CA bundle into the cert-manager manifests directory
+# so kustomize can use it to create the trusted-ca-bundle ConfigMap.
+#
+# This script runs as ExecStartPre before MicroShift starts.
+
+set -euo pipefail
+
+SRC="/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+DST="/usr/lib/microshift/manifests.d/060-microshift-cert-manager/manager/tls-ca-bundle.pem"
+
+# Only copy if the cert-manager manifests directory exists (package installed)
+if [ -d "$(dirname "${DST}")" ] && [ -f "${SRC}" ]; then
+    cp -f "${SRC}" "${DST}"
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cert-manager now automatically updates CA bundle configuration on service startup for improved certificate management.

* **Chores**
  * Enhanced CRD manifest installation to recognize additional certificate file formats.
  * Updated packaging and systemd configuration for better certificate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->