### PR TITLE
USHIFT-6949: Remove external cAdvisor exporter from Ansible

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,7 +6,7 @@ number of points in time as well as performance data for each of the two starts.
 
 ## Prerequisites
 
-We are using [Prometheus](https://prometheus.io/), [process-exporter](https://github.com/ncabatoff/process-exporter) and [cAdvisor](https://github.com/google/cadvisor) to capture a wide array of performance tool data.
+We are using [Prometheus](https://prometheus.io/) and [process-exporter](https://github.com/ncabatoff/process-exporter) to capture a wide array of performance tool data.
 
 It is necessary to have two hosts configured for running the benchmarks:
 * Ansible control node used to start the automation scripts

--- a/ansible/roles/configure-firewall/defaults/main.yml
+++ b/ansible/roles/configure-firewall/defaults/main.yml
@@ -14,7 +14,6 @@ firewall_ports:
   - 5353/udp
   - 6443/tcp
   - 8080/tcp
-  - 8082/tcp
   - 9091/tcp
   - 9100/tcp
   - 9256/tcp

--- a/ansible/roles/install-logging-exporters/defaults/main.yml
+++ b/ansible/roles/install-logging-exporters/defaults/main.yml
@@ -1,7 +1,3 @@
-cadvisor_external: false
-cadvisor_url: https://github.com/google/cadvisor/releases/download/v0.47.2/cadvisor-v0.47.2-linux-amd64
-cadvisor_checksum: sha256:30602f675e9bcd39b0d4cd4bd9e83c0849dd4bb3a60a0544b9f2a6451a3facfe
-
 process_exporter_url: https://github.com/ncabatoff/process-exporter/releases/download/v0.7.10/process-exporter_0.7.10_linux_amd64.rpm
 
 prometheus_services:

--- a/ansible/roles/install-logging-exporters/tasks/main.yml
+++ b/ansible/roles/install-logging-exporters/tasks/main.yml
@@ -10,29 +10,6 @@
     disable_gpg_check: true
     state: present
 
-- name: external cadvisor steps
-  block:
-    - name: download cadvisor
-      ansible.builtin.get_url:
-        url: "{{ cadvisor_url }}"
-        dest: /usr/bin/cadvisor
-        checksum: "{{ cadvisor_checksum }}"
-        mode: '0755'
-
-    - name: install systemd unit for cadvisor
-      ansible.builtin.template:
-        src: cadvisor.service.j2
-        dest: /usr/lib/systemd/system/cadvisor.service
-        backup: true
-
-    - name: start and enable cadvisor service
-      ansible.builtin.systemd:
-        name: cadvisor
-        daemon_reload: yes
-        state: started
-        enabled: yes
-  when: cadvisor_external | bool
-
 - name: start and enable prometheus exporter services
   ansible.builtin.systemd:
     name: "{{ item }}"

--- a/ansible/roles/install-logging-exporters/templates/cadvisor.service.j2
+++ b/ansible/roles/install-logging-exporters/templates/cadvisor.service.j2
@@ -1,8 +1,0 @@
-[Unit]
-Description=cAdvisor
-
-[Service]
-ExecStart=/usr/bin/cadvisor -port=8082
-
-[Install]
-WantedBy=multi-user.target

--- a/ansible/roles/install-logging/templates/prometheus.yml.j2
+++ b/ansible/roles/install-logging/templates/prometheus.yml.j2
@@ -39,17 +39,9 @@ scrape_configs:
         - {{ host }}:9256
 {% endfor %}
 
-  - job_name: cadvisor
-    static_configs:
-      - targets:
-{% for host in groups['microshift'] %}
-        - {{ host }}:8082
-{% endfor %}
-
   - job_name: crio
     static_configs:
       - targets:
 {% for host in groups['microshift'] %}
         - {{ host }}:9537
 {% endfor %}
-

--- a/ansible/roles/microshift-start/tasks/main.yml
+++ b/ansible/roles/microshift-start/tasks/main.yml
@@ -79,11 +79,6 @@
   environment:
     PBENCH_TOOL_DATA_SINK: localhost:8081
 
-- name: check for cadvisor
-  ansible.builtin.command: which cadvisor
-  register: cadvisor_check
-  ignore_errors: true
-
 - name: record network measurement start epoch
   ansible.builtin.command: date +%s
   register: network_start_epoch


### PR DESCRIPTION
Container metrics are now collected from the kubelet's `/metrics/cadvisor` endpoint, so the standalone cAdvisor exporter is no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites documentation to reflect changes to monitoring tools used for capturing system performance metrics.

* **Chores**
  * Removed a monitoring component from infrastructure setup.
  * Removed associated firewall port access rules.
  * Removed related monitoring metrics configuration.
  * Removed component service definitions and installation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->