### PR TITLE
USHIFT-6950: Ansible: Update host defaults for MicroShift 4.22

### DIFF
--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -9,7 +9,7 @@ go_arch: arm64
 go_files:
   - go
   - gofmt
-go_version: 1.24.4
+go_version: 1.25.0
 go_install_dir: /usr/local/go{{ go_version }}
 
 install_packages:
@@ -29,6 +29,6 @@ install_packages:
   - tar
   - vnstat
 
-default_vg_name: microshift
+default_vg_name: rhel_microshift
 vg_name: "{{ default_vg_name }}"
 lvm_disk: /dev/xvdb

--- a/ansible/vars/microshift_versions.yml
+++ b/ansible/vars/microshift_versions.yml
@@ -24,3 +24,6 @@ microshift_versions:
   "4.21":
     expected_pods: 6
     all_pods: 9
+  "4.22":
+    expected_pods: 6
+    all_pods: 9


### PR DESCRIPTION
Adds the 4.22 pod-readiness entry, bumps the bundled Go toolchain to 1.25 as required by MicroShift 4.22, and switches the default LVM volume group to `rhel_microshift` to match the VG created by standard RHEL installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Go toolchain upgraded to version 1.25.0.
  * LVM volume group naming convention updated.

* **New Features**
  * Added support for MicroShift version 4.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->