### PR TITLE
USHIFT-6711: Allow potential kernel upgrade in bootc images

### DIFF
--- a/test/image-blueprints-bootc/templates/build-serialsim.sh.template
+++ b/test/image-blueprints-bootc/templates/build-serialsim.sh.template
@@ -13,15 +13,9 @@ function get_kernel_ver() {
 # Set the current kernel version and architecture variables.
 get_kernel_ver
 
-source /etc/os-release
-if [[ "${ID}" == "rhel" ]] ; then
-    # On RHEL, always install the kernel-devel package for the current kernel version.
-    dnf install -y "kernel-devel-${KERNEL_VER}"
-else
-    # On CentOS, attempt to install the kernel-devel package for the current kernel
-    # version, falling back to kernel-devel-matched if the former is not available.
-    dnf install -y "kernel-devel-${KERNEL_VER}" || dnf install -y kernel-devel-matched
-fi
+# Attempt to install the kernel-devel package for the current kernel version,
+# falling back to kernel-devel-matched if the former is not available.
+dnf install -y "kernel-devel-${KERNEL_VER}" || dnf install -y kernel-devel-matched
 
 # Reset the current kernel version and architecture variables.
 get_kernel_ver


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel development package installation by standardizing the installation approach across all system environments. The build process now uses a consistent strategy that attempts to install the specific kernel version package first, followed by automatic fallback support when needed. This enhancement ensures more reliable dependency resolution and reduces potential build failures during the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->