### PR TITLE
USHIFT-6978: remove initramfs FIPS module check from bootc validation

### DIFF
--- a/test/suites/fips/validate-fips.robot
+++ b/test/suites/fips/validate-fips.robot
@@ -132,12 +132,6 @@ Fips Should Be Enabled Bootc
     Should Be Equal As Integers    0    ${rc}
     Should Be Equal As Strings    ${stdout.strip()}    FIPS
 
-    # Verify initramfs FIPS module presence
-    ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    bash -c 'lsinitrd -m 2>/dev/null | grep -Fxq fips'
-    ...    sudo=False    return_rc=True    return_stdout=True    return_stderr=True
-    Should Be Equal As Integers    0    ${rc}
-
 Get Images From Release File
     [Documentation]    Obtains list of Images from Release.
     ${stdout}    ${stderr}    ${rc}=    Execute Command


### PR DESCRIPTION
## Summary
- Remove the `lsinitrd -m | grep fips` check from `Fips Should Be Enabled Bootc` in `validate-fips.robot`
- This check tests a RHEL packaging detail (whether `dracut-fips` is installed), not actual FIPS enablement
- The remaining two checks — `/proc/sys/crypto/fips_enabled` and `update-crypto-policies --show` — are sufficient to verify FIPS mode is active
- On RHEL 9, the `fips` dracut module lives in a separate `dracut-fips` package not present in bootc images; on RHEL 10+ it's in base `dracut`

## Test plan
- [x] Verify `el98-lrel@ai-model-serving-online-fips` scenario passes on RHEL 9 bootc
- [x] Verify FIPS test still passes on RHEL 10 bootc

Jira: https://issues.redhat.com/browse/USHIFT-6978