### PR TITLE
USHIFT-6971: patch imagePullPolicy before clock fast-forward in cert rotation test

### DIFF
--- a/test/suites/standard2/validate-certificate-rotation.robot
+++ b/test/suites/standard2/validate-certificate-rotation.robot
@@ -97,6 +97,7 @@ Restore System Date
 Change System Date To
     [Documentation]    Move the system to a future date.
     [Arguments]    ${future_date}
+    Patch ImagePullPolicy For Date Change
     ${ushift_pid}=    MicroShift Process ID
     Systemctl    stop    chronyd
     Command Should Work    TZ=UTC timedatectl set-time "${future_date}"
@@ -158,3 +159,29 @@ Get Cert Fingerprint
     ${fingerprint}=    Command Should Work
     ...    openssl x509 -noout -fingerprint -sha256 -in ${cert_file}
     RETURN    ${fingerprint}
+
+Patch ImagePullPolicy For Date Change
+    [Documentation]    Patch all deployments with imagePullPolicy: Always -> IfNotPresent.
+    ...    Prevents image pull failures when the system clock is fast-forwarded past CDN
+    ...    TLS certificate expiry dates.
+    VAR    ${jq_filter}=
+    ...    .items[] | .metadata.namespace as $ns | .metadata.name as $d | .spec.template.spec.containers | to_entries[] | select(.value.imagePullPolicy == "Always") | "\\($ns) \\($d) \\(.key)"
+    ${stdout}=    Run With Kubeconfig
+    ...    oc get deploy -A -o json | jq -r '${jq_filter}'
+    ...    allow_fail=True
+    IF    '${stdout.strip()}' == '${EMPTY}'    RETURN
+    @{lines}=    Split String    ${stdout}    \n
+    FOR    ${line}    IN    @{lines}
+        IF    '${line.strip()}' == '${EMPTY}'    CONTINUE
+        @{parts}=    Split String    ${line}
+        Patch Deploy ImagePullPolicy To IfNotPresent    ${parts}[0]    ${parts}[1]    ${parts}[2]
+    END
+
+Patch Deploy ImagePullPolicy To IfNotPresent
+    [Documentation]    Patch a single deployment's container imagePullPolicy to IfNotPresent.
+    [Arguments]    ${ns}    ${deploy}    ${idx}
+    Log    Patching ${ns}/${deploy} container[${idx}] imagePullPolicy to IfNotPresent
+    Run With Kubeconfig
+    ...    oc patch deploy -n ${ns} ${deploy} --type=json -p '[{"op":"replace","path":"/spec/template/spec/containers/${idx}/imagePullPolicy","value":"IfNotPresent"}]'
+    Run With Kubeconfig
+    ...    oc rollout status deploy/${deploy} -n ${ns} --timeout=120s

--- a/test/suites/standard2/validate-certificate-rotation.robot
+++ b/test/suites/standard2/validate-certificate-rotation.robot
@@ -174,6 +174,11 @@ Patch ImagePullPolicy For Date Change
     FOR    ${line}    IN    @{lines}
         IF    '${line.strip()}' == '${EMPTY}'    CONTINUE
         @{parts}=    Split String    ${line}
+        ${parts_len}=    Get Length    ${parts}
+        IF    ${parts_len} != 3
+            Log    WARNING: Unexpected line format: ${line}
+            CONTINUE
+        END
         Patch Deploy ImagePullPolicy To IfNotPresent    ${parts}[0]    ${parts}[1]    ${parts}[2]
     END
 


### PR DESCRIPTION
## Summary
- Deployments with `imagePullPolicy: Always` fail image pulls when the cert rotation test fast-forwards the clock ~150 days past CDN TLS cert expiry, causing `ImagePullBackOff` and greenboot timeout.
- Before stopping chronyd and advancing the clock, dynamically discover and patch all such deployments to `IfNotPresent`. Images are already cached from initial startup, so no pull is needed.
- No revert is required — the VM is ephemeral and CDN certs are valid again after `Restore System Date` runs.

## Test plan
- [x] `make verify-rf` passes clean (robocop check + format)
- [x] `Manual Rotation Of Etcd Signer Certs` — PASS (37.7s)
- [x] `Certificate Rotation` — PASS (98.8s)
- [x] Tested on local bootc VM (el98-src@standard-suite2 scenario, rhel98-bootc-source image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated certificate rotation test suite: added steps to change container image pull policies to IfNotPresent with per-container patching and rollout waits, and introduced new test keywords to orchestrate these actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->