### PR TITLE
USHIFT-6938: fix CI test: increase clock advance to exceed cert rotation threshold

### DIFF
--- a/test/suites/standard2/validate-certificate-rotation.robot
+++ b/test/suites/standard2/validate-certificate-rotation.robot
@@ -23,7 +23,7 @@ ${ETCD_APISERVER_CLIENT_CERT}       /var/lib/microshift/certs/etcd-signer/apiser
 ${OSSL_CMD}                         openssl x509 -noout -dates -in
 ${OSSL_DATE_FORMAT}                 %b %d %Y
 ${TIMEDATECTL_DATE_FORMAT}          %Y-%m-%d %H:%M:%S
-${FUTURE_DAYS}                      150
+${FUTURE_DAYS}                      400
 
 
 *** Test Cases ***


### PR DESCRIPTION
## Summary

Automated fix for [USHIFT-6938](https://issues.redhat.com/browse/USHIFT-6938).

## Changed files

test/suites/standard2/validate-certificate-rotation.robot

## Verification

- [ ] CI passes
- [ ] Changes are limited to test/scripts/docs
- [ ] Fix addresses the root cause described in the JIRA bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated certificate rotation test validation to cover extended certificate validity periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->