### PR TITLE
USHIFT-7019: C2CC - Increase amount of interconnected VMs in from 2 to 3

### DIFF
--- a/test/resources/c2cc.resource
+++ b/test/resources/c2cc.resource
@@ -22,6 +22,13 @@ ${HOST2_IP}                 ${EMPTY}
 ${HOST2_SSH_PORT}           ${EMPTY}
 ${HOST2_API_PORT}           ${EMPTY}
 ${KUBECONFIG_B}             ${EMPTY}
+${CLUSTER_C_POD_CIDR}       ${EMPTY}
+${CLUSTER_C_SVC_CIDR}       ${EMPTY}
+${CLUSTER_C_DOMAIN}         ${EMPTY}
+${HOST3_IP}                 ${EMPTY}
+${HOST3_SSH_PORT}           ${EMPTY}
+${HOST3_API_PORT}           ${EMPTY}
+${KUBECONFIG_C}             ${EMPTY}
 &{C2CC_KUBECONFIGS}         &{EMPTY}
 &{C2CC_SSH_IDS}             &{EMPTY}
 @{C2CC_REMOTE_ALIASES}      @{EMPTY}

--- a/test/resources/c2cc.resource
+++ b/test/resources/c2cc.resource
@@ -256,9 +256,9 @@ Verify Corefile Does Not Contain C2CC Server Block
     Should Not Contain    ${stdout}    ${domain}:5353
 
 Deploy Test Workloads
-    [Documentation]    Create namespace and deploy hello-microshift + curl-pod on both clusters.
+    [Documentation]    Create namespace and deploy hello-microshift + curl-pod on all clusters.
     VAR    ${assets}=    ${EXECDIR}/assets/c2cc
-    FOR    ${alias}    IN    cluster-a    cluster-b
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         ${ns}=    Create Unique Namespace On Cluster    ${alias}
         Set To Dictionary    ${NAMESPACES}    ${alias}    ${ns}
         Oc On Cluster    ${alias}    oc apply -n ${ns} -f ${assets}/hello-microshift.yaml
@@ -268,17 +268,17 @@ Deploy Test Workloads
     Wait For Service Endpoints
 
 Wait For Test Pods
-    [Documentation]    Wait for all test pods to be Ready on both clusters.
-    FOR    ${alias}    IN    cluster-a    cluster-b
+    [Documentation]    Wait for all test pods to be Ready on all clusters.
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         Oc On Cluster
         ...    ${alias}
         ...    oc wait pod/hello-microshift pod/curl-pod -n ${NAMESPACES}[${alias}] --for=condition=Ready --timeout=120s
     END
 
 Wait For Service Endpoints
-    [Documentation]    Wait for hello-microshift service to have endpoints on both clusters.
+    [Documentation]    Wait for hello-microshift service to have endpoints on all clusters.
     ...    Ensures OVN-K has synced the EndpointSlice and programmed the OVN load balancer.
-    FOR    ${alias}    IN    cluster-a    cluster-b
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         Wait Until Keyword Succeeds    120s    5s
         ...    Service Endpoints Should Exist    ${alias}    ${NAMESPACES}[${alias}]
     END
@@ -291,7 +291,7 @@ Service Endpoints Should Exist
     Should Not Be Empty    ${stdout}
 
 Cleanup Test Workloads
-    [Documentation]    Delete test namespace on both clusters. Ignores errors.
-    FOR    ${alias}    IN    cluster-a    cluster-b
+    [Documentation]    Delete test namespace on all clusters. Ignores errors.
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         Oc On Cluster    ${alias}    oc delete namespace ${NAMESPACES}[${alias}] --timeout=60s
     END

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
@@ -37,7 +37,7 @@ configure_c2cc_host() {
     local host=$1 remote_ip=$2 remote_pod_cidr=$3 remote_svc_cidr=$4 remote_domain=$5
 
     run_command_on_vm "${host}" "sudo mkdir -p /etc/microshift/config.d"
-    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null << EOF
+    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc-${remote_domain}.yaml > /dev/null << EOF
 clusterToCluster:
   remoteClusters:
   - nextHop: ${remote_ip}

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
@@ -78,7 +78,7 @@ scenario_create_vms() {
     prepare_kickstart host2 kickstart-bootc.ks.template rhel102-bootc-source
     prepare_kickstart host3 kickstart-bootc.ks.template rhel102-bootc-source
 
-    # Inject host2's non-default CIDRs into its kickstart config so MicroShift
+    # Inject host2's and host3's non-default CIDRs into its kickstart config so MicroShift
     # boots with the correct network from the start (no cleanup-data needed).
     local -r host2_ks_dir="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/host2"
     cat >> "${host2_ks_dir}/post-microshift.cfg" <<EOF

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
@@ -13,10 +13,15 @@ CLUSTER_B_POD_CIDR="10.45.0.0/16"
 CLUSTER_B_SVC_CIDR="10.46.0.0/16"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
+# Cluster C (host3): non-overlapping CIDRs
+CLUSTER_C_POD_CIDR="10.47.0.0/16"
+CLUSTER_C_SVC_CIDR="10.48.0.0/16"
+CLUSTER_C_DOMAIN="cluster-c.remote"
+
 wait_for_greenboot_on_hosts() {
     local junit_label=$1
     local host
-    for host in host1 host2; do
+    for host in host1 host2 host3; do
         local host_ip full_host
         host_ip=$(get_vm_property "${host}" ip)
         full_host=$(full_vm_name "${host}")
@@ -54,11 +59,16 @@ EOF"
 configure_c2cc_hosts() {
     local -r host1_ip=$(get_vm_property host1 ip)
     local -r host2_ip=$(get_vm_property host2 ip)
+    local -r host3_ip=$(get_vm_property host3 ip)
 
     wait_for_greenboot_on_hosts "c2cc_pre_greenboot"
 
     configure_c2cc_host host1 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
+    configure_c2cc_host host1 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
     configure_c2cc_host host2 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
+    configure_c2cc_host host2 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
+    configure_c2cc_host host3 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
+    configure_c2cc_host host3 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
 
     wait_for_greenboot_on_hosts "c2cc_greenboot"
 }
@@ -66,6 +76,7 @@ configure_c2cc_hosts() {
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel102-bootc-source
     prepare_kickstart host2 kickstart-bootc.ks.template rhel102-bootc-source
+    prepare_kickstart host3 kickstart-bootc.ks.template rhel102-bootc-source
 
     # Inject host2's non-default CIDRs into its kickstart config so MicroShift
     # boots with the correct network from the start (no cleanup-data needed).
@@ -79,14 +90,26 @@ network:
   - ${CLUSTER_B_SVC_CIDR}
 IEOF
 EOF
+    local -r host3_ks_dir="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/host3"
+    cat >> "${host3_ks_dir}/post-microshift.cfg" <<EOF
+cat - >>/etc/microshift/config.yaml <<IEOF
+network:
+  clusterNetwork:
+  - ${CLUSTER_C_POD_CIDR}
+  serviceNetwork:
+  - ${CLUSTER_C_SVC_CIDR}
+IEOF
+EOF
 
     launch_vm rhel102-bootc --vmname host1
     launch_vm rhel102-bootc --vmname host2
+    launch_vm rhel102-bootc --vmname host3
 }
 
 scenario_remove_vms() {
     remove_vm host1
     remove_vm host2
+    remove_vm host3
 }
 
 scenario_run_tests() {
@@ -97,12 +120,19 @@ scenario_run_tests() {
     # Retrieve host2's kubeconfig
     local -r host2_ip=$(get_vm_property host2 ip)
     local -r kubeconfig_b="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-b"
+    
+    # Retrieve host3's kubeconfig
+    local -r host3_ip=$(get_vm_property host3 ip)
+    local -r kubeconfig_c="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-c"
 
-    # Wait for host2 to be fully ready (run_tests only waits for host1)
+    # Wait for host2 and host3 to be fully ready (run_tests only waits for host1)
     wait_for_microshift_to_be_ready host2
+    wait_for_microshift_to_be_ready host3
 
     run_command_on_vm host2 "sudo cp /var/lib/microshift/resources/kubeadmin/${host2_ip}/kubeconfig /tmp/kubeconfig-b && sudo chmod 644 /tmp/kubeconfig-b"
+    run_command_on_vm host3 "sudo cp /var/lib/microshift/resources/kubeadmin/${host3_ip}/kubeconfig /tmp/kubeconfig-c && sudo chmod 644 /tmp/kubeconfig-c"
     copy_file_from_vm host2 "/tmp/kubeconfig-b" "${kubeconfig_b}"
+    copy_file_from_vm host3 "/tmp/kubeconfig-c" "${kubeconfig_c}"
 
     run_tests host1 \
         --variable "CLUSTER_A_POD_CIDR:${CLUSTER_A_POD_CIDR}" \
@@ -112,5 +142,9 @@ scenario_run_tests() {
         --variable "CLUSTER_B_SVC_CIDR:${CLUSTER_B_SVC_CIDR}" \
         --variable "CLUSTER_B_DOMAIN:${CLUSTER_B_DOMAIN}" \
         --variable "KUBECONFIG_B:${kubeconfig_b}" \
+        --variable "CLUSTER_C_POD_CIDR:${CLUSTER_C_POD_CIDR}" \
+        --variable "CLUSTER_C_SVC_CIDR:${CLUSTER_C_SVC_CIDR}" \
+        --variable "CLUSTER_C_DOMAIN:${CLUSTER_C_DOMAIN}" \
+        --variable "KUBECONFIG_C:${kubeconfig_c}" \
         suites/c2cc/
 }

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
@@ -41,7 +41,8 @@ configure_c2cc_host() {
     run_command_on_vm "${host}" "sudo mkdir -p /etc/microshift/config.d"
 
     # Build the YAML config with all remote clusters
-    local yaml_content="clusterToCluster:\n  remoteClusters:"
+    local yaml_content
+    yaml_content="clusterToCluster:"$'\n'"  remoteClusters:"
     local firewall_cidrs=()
 
     while [ $# -gt 0 ]; do
@@ -51,17 +52,17 @@ configure_c2cc_host() {
         local remote_domain=$4
         shift 4
 
-        yaml_content+="\n  - nextHop: ${remote_ip}"
-        yaml_content+="\n    clusterNetwork:"
-        yaml_content+="\n    - ${remote_pod_cidr}"
-        yaml_content+="\n    serviceNetwork:"
-        yaml_content+="\n    - ${remote_svc_cidr}"
-        yaml_content+="\n    domain: ${remote_domain}"
+        yaml_content+=$'\n'"  - nextHop: ${remote_ip}"
+        yaml_content+=$'\n'"    clusterNetwork:"
+        yaml_content+=$'\n'"    - ${remote_pod_cidr}"
+        yaml_content+=$'\n'"    serviceNetwork:"
+        yaml_content+=$'\n'"    - ${remote_svc_cidr}"
+        yaml_content+=$'\n'"    domain: ${remote_domain}"
 
         firewall_cidrs+=("${remote_pod_cidr}" "${remote_svc_cidr}")
     done
 
-    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null << 'EOF'
+    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null <<EOF
 ${yaml_content}
 EOF"
 

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
@@ -14,8 +14,8 @@ CLUSTER_B_SVC_CIDR="10.46.0.0/16"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
 # Cluster C (host3): non-overlapping CIDRs
-CLUSTER_C_POD_CIDR="10.47.0.0/16"
-CLUSTER_C_SVC_CIDR="10.48.0.0/16"
+CLUSTER_C_POD_CIDR="10.48.0.0/16"
+CLUSTER_C_SVC_CIDR="10.49.0.0/16"
 CLUSTER_C_DOMAIN="cluster-c.remote"
 
 wait_for_greenboot_on_hosts() {

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc.sh
@@ -34,25 +34,42 @@ wait_for_greenboot_on_hosts() {
 }
 
 configure_c2cc_host() {
-    local host=$1 remote_ip=$2 remote_pod_cidr=$3 remote_svc_cidr=$4 remote_domain=$5
+    local host=$1
+    shift
+    # Remaining args are sets of 4: remote_ip remote_pod_cidr remote_svc_cidr remote_domain (repeat)
 
     run_command_on_vm "${host}" "sudo mkdir -p /etc/microshift/config.d"
-    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc-${remote_domain}.yaml > /dev/null << EOF
-clusterToCluster:
-  remoteClusters:
-  - nextHop: ${remote_ip}
-    clusterNetwork:
-    - ${remote_pod_cidr}
-    serviceNetwork:
-    - ${remote_svc_cidr}
-    domain: ${remote_domain}
+
+    # Build the YAML config with all remote clusters
+    local yaml_content="clusterToCluster:\n  remoteClusters:"
+    local firewall_cidrs=()
+
+    while [ $# -gt 0 ]; do
+        local remote_ip=$1
+        local remote_pod_cidr=$2
+        local remote_svc_cidr=$3
+        local remote_domain=$4
+        shift 4
+
+        yaml_content+="\n  - nextHop: ${remote_ip}"
+        yaml_content+="\n    clusterNetwork:"
+        yaml_content+="\n    - ${remote_pod_cidr}"
+        yaml_content+="\n    serviceNetwork:"
+        yaml_content+="\n    - ${remote_svc_cidr}"
+        yaml_content+="\n    domain: ${remote_domain}"
+
+        firewall_cidrs+=("${remote_pod_cidr}" "${remote_svc_cidr}")
+    done
+
+    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null << 'EOF'
+${yaml_content}
 EOF"
 
     configure_vm_firewall "${host}"
-    run_command_on_vm "${host}" "sudo firewall-cmd --permanent --zone=trusted --add-source=${remote_pod_cidr}"
-    run_command_on_vm "${host}" "sudo firewall-cmd --permanent --zone=trusted --add-source=${remote_svc_cidr}"
+    for cidr in "${firewall_cidrs[@]}"; do
+        run_command_on_vm "${host}" "sudo firewall-cmd --permanent --zone=trusted --add-source=${cidr}"
+    done
     run_command_on_vm "${host}" "sudo firewall-cmd --reload"
-
     run_command_on_vm "${host}" "sudo systemctl restart microshift"
 }
 
@@ -63,12 +80,17 @@ configure_c2cc_hosts() {
 
     wait_for_greenboot_on_hosts "c2cc_pre_greenboot"
 
-    configure_c2cc_host host1 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
-    configure_c2cc_host host1 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
-    configure_c2cc_host host2 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
-    configure_c2cc_host host2 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
-    configure_c2cc_host host3 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
-    configure_c2cc_host host3 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
+    configure_c2cc_host host1 \
+        "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}" \
+        "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
+
+    configure_c2cc_host host2 \
+        "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}" \
+        "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
+
+    configure_c2cc_host host3 \
+        "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}" \
+        "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
 
     wait_for_greenboot_on_hosts "c2cc_greenboot"
 }

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
@@ -41,7 +41,8 @@ configure_c2cc_host() {
     run_command_on_vm "${host}" "sudo mkdir -p /etc/microshift/config.d"
 
     # Build the YAML config with all remote clusters
-    local yaml_content="clusterToCluster:\n  remoteClusters:"
+    local yaml_content
+    yaml_content="clusterToCluster:"$'\n'"  remoteClusters:"
     local firewall_cidrs=()
 
     while [ $# -gt 0 ]; do
@@ -51,17 +52,17 @@ configure_c2cc_host() {
         local remote_domain=$4
         shift 4
 
-        yaml_content+="\n  - nextHop: ${remote_ip}"
-        yaml_content+="\n    clusterNetwork:"
-        yaml_content+="\n    - ${remote_pod_cidr}"
-        yaml_content+="\n    serviceNetwork:"
-        yaml_content+="\n    - ${remote_svc_cidr}"
-        yaml_content+="\n    domain: ${remote_domain}"
+        yaml_content+=$'\n'"  - nextHop: ${remote_ip}"
+        yaml_content+=$'\n'"    clusterNetwork:"
+        yaml_content+=$'\n'"    - ${remote_pod_cidr}"
+        yaml_content+=$'\n'"    serviceNetwork:"
+        yaml_content+=$'\n'"    - ${remote_svc_cidr}"
+        yaml_content+=$'\n'"    domain: ${remote_domain}"
 
         firewall_cidrs+=("${remote_pod_cidr}" "${remote_svc_cidr}")
     done
 
-    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null << 'EOF'
+    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null <<EOF
 ${yaml_content}
 EOF"
 

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
@@ -13,10 +13,15 @@ CLUSTER_B_POD_CIDR="10.45.0.0/16"
 CLUSTER_B_SVC_CIDR="10.46.0.0/16"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
+# Cluster C (host3): non-overlapping CIDRs
+CLUSTER_C_POD_CIDR="10.48.0.0/16"
+CLUSTER_C_SVC_CIDR="10.49.0.0/16"
+CLUSTER_C_DOMAIN="cluster-c.remote"
+
 wait_for_greenboot_on_hosts() {
     local junit_label=$1
     local host
-    for host in host1 host2; do
+    for host in host1 host2 host3; do
         local host_ip full_host
         host_ip=$(get_vm_property "${host}" ip)
         full_host=$(full_vm_name "${host}")
@@ -32,7 +37,7 @@ configure_c2cc_host() {
     local host=$1 remote_ip=$2 remote_pod_cidr=$3 remote_svc_cidr=$4 remote_domain=$5
 
     run_command_on_vm "${host}" "sudo mkdir -p /etc/microshift/config.d"
-    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null << EOF
+    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc-${remote_domain}.yaml > /dev/null << EOF
 clusterToCluster:
   remoteClusters:
   - nextHop: ${remote_ip}
@@ -54,11 +59,16 @@ EOF"
 configure_c2cc_hosts() {
     local -r host1_ip=$(get_vm_property host1 ip)
     local -r host2_ip=$(get_vm_property host2 ip)
+    local -r host3_ip=$(get_vm_property host3 ip)
 
     wait_for_greenboot_on_hosts "c2cc_pre_greenboot"
 
     configure_c2cc_host host1 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
+    configure_c2cc_host host1 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
     configure_c2cc_host host2 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
+    configure_c2cc_host host2 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
+    configure_c2cc_host host3 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
+    configure_c2cc_host host3 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
 
     wait_for_greenboot_on_hosts "c2cc_greenboot"
 }
@@ -66,8 +76,9 @@ configure_c2cc_hosts() {
 scenario_create_vms() {
     prepare_kickstart host1 kickstart-bootc.ks.template rhel98-bootc-source
     prepare_kickstart host2 kickstart-bootc.ks.template rhel98-bootc-source
+    prepare_kickstart host3 kickstart-bootc.ks.template rhel98-bootc-source
 
-    # Inject host2's non-default CIDRs into its kickstart config so MicroShift
+    # Inject host2's and host3's non-default CIDRs into its kickstart config so MicroShift
     # boots with the correct network from the start (no cleanup-data needed).
     local -r host2_ks_dir="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/host2"
     cat >> "${host2_ks_dir}/post-microshift.cfg" <<EOF
@@ -79,14 +90,26 @@ network:
   - ${CLUSTER_B_SVC_CIDR}
 IEOF
 EOF
+    local -r host3_ks_dir="${SCENARIO_INFO_DIR}/${SCENARIO}/vms/host3"
+    cat >> "${host3_ks_dir}/post-microshift.cfg" <<EOF
+cat - >>/etc/microshift/config.yaml <<IEOF
+network:
+  clusterNetwork:
+  - ${CLUSTER_C_POD_CIDR}
+  serviceNetwork:
+  - ${CLUSTER_C_SVC_CIDR}
+IEOF
+EOF
 
     launch_vm rhel98-bootc --vmname host1
     launch_vm rhel98-bootc --vmname host2
+    launch_vm rhel98-bootc --vmname host3
 }
 
 scenario_remove_vms() {
     remove_vm host1
     remove_vm host2
+    remove_vm host3
 }
 
 scenario_run_tests() {
@@ -97,12 +120,19 @@ scenario_run_tests() {
     # Retrieve host2's kubeconfig
     local -r host2_ip=$(get_vm_property host2 ip)
     local -r kubeconfig_b="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-b"
+    
+    # Retrieve host3's kubeconfig
+    local -r host3_ip=$(get_vm_property host3 ip)
+    local -r kubeconfig_c="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-c"
 
-    # Wait for host2 to be fully ready (run_tests only waits for host1)
+    # Wait for host2 and host3 to be fully ready (run_tests only waits for host1)
     wait_for_microshift_to_be_ready host2
+    wait_for_microshift_to_be_ready host3
 
     run_command_on_vm host2 "sudo cp /var/lib/microshift/resources/kubeadmin/${host2_ip}/kubeconfig /tmp/kubeconfig-b && sudo chmod 644 /tmp/kubeconfig-b"
+    run_command_on_vm host3 "sudo cp /var/lib/microshift/resources/kubeadmin/${host3_ip}/kubeconfig /tmp/kubeconfig-c && sudo chmod 644 /tmp/kubeconfig-c"
     copy_file_from_vm host2 "/tmp/kubeconfig-b" "${kubeconfig_b}"
+    copy_file_from_vm host3 "/tmp/kubeconfig-c" "${kubeconfig_c}"
 
     run_tests host1 \
         --variable "CLUSTER_A_POD_CIDR:${CLUSTER_A_POD_CIDR}" \
@@ -112,5 +142,9 @@ scenario_run_tests() {
         --variable "CLUSTER_B_SVC_CIDR:${CLUSTER_B_SVC_CIDR}" \
         --variable "CLUSTER_B_DOMAIN:${CLUSTER_B_DOMAIN}" \
         --variable "KUBECONFIG_B:${kubeconfig_b}" \
+        --variable "CLUSTER_C_POD_CIDR:${CLUSTER_C_POD_CIDR}" \
+        --variable "CLUSTER_C_SVC_CIDR:${CLUSTER_C_SVC_CIDR}" \
+        --variable "CLUSTER_C_DOMAIN:${CLUSTER_C_DOMAIN}" \
+        --variable "KUBECONFIG_C:${kubeconfig_c}" \
         suites/c2cc/
 }

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
@@ -34,25 +34,42 @@ wait_for_greenboot_on_hosts() {
 }
 
 configure_c2cc_host() {
-    local host=$1 remote_ip=$2 remote_pod_cidr=$3 remote_svc_cidr=$4 remote_domain=$5
+    local host=$1
+    shift
+    # Remaining args are sets of 4: remote_ip remote_pod_cidr remote_svc_cidr remote_domain (repeat)
 
     run_command_on_vm "${host}" "sudo mkdir -p /etc/microshift/config.d"
-    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc-${remote_domain}.yaml > /dev/null << EOF
-clusterToCluster:
-  remoteClusters:
-  - nextHop: ${remote_ip}
-    clusterNetwork:
-    - ${remote_pod_cidr}
-    serviceNetwork:
-    - ${remote_svc_cidr}
-    domain: ${remote_domain}
+
+    # Build the YAML config with all remote clusters
+    local yaml_content="clusterToCluster:\n  remoteClusters:"
+    local firewall_cidrs=()
+
+    while [ $# -gt 0 ]; do
+        local remote_ip=$1
+        local remote_pod_cidr=$2
+        local remote_svc_cidr=$3
+        local remote_domain=$4
+        shift 4
+
+        yaml_content+="\n  - nextHop: ${remote_ip}"
+        yaml_content+="\n    clusterNetwork:"
+        yaml_content+="\n    - ${remote_pod_cidr}"
+        yaml_content+="\n    serviceNetwork:"
+        yaml_content+="\n    - ${remote_svc_cidr}"
+        yaml_content+="\n    domain: ${remote_domain}"
+
+        firewall_cidrs+=("${remote_pod_cidr}" "${remote_svc_cidr}")
+    done
+
+    run_command_on_vm "${host}" "sudo tee /etc/microshift/config.d/50-c2cc.yaml > /dev/null << 'EOF'
+${yaml_content}
 EOF"
 
     configure_vm_firewall "${host}"
-    run_command_on_vm "${host}" "sudo firewall-cmd --permanent --zone=trusted --add-source=${remote_pod_cidr}"
-    run_command_on_vm "${host}" "sudo firewall-cmd --permanent --zone=trusted --add-source=${remote_svc_cidr}"
+    for cidr in "${firewall_cidrs[@]}"; do
+        run_command_on_vm "${host}" "sudo firewall-cmd --permanent --zone=trusted --add-source=${cidr}"
+    done
     run_command_on_vm "${host}" "sudo firewall-cmd --reload"
-
     run_command_on_vm "${host}" "sudo systemctl restart microshift"
 }
 
@@ -63,12 +80,17 @@ configure_c2cc_hosts() {
 
     wait_for_greenboot_on_hosts "c2cc_pre_greenboot"
 
-    configure_c2cc_host host1 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
-    configure_c2cc_host host1 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
-    configure_c2cc_host host2 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
-    configure_c2cc_host host2 "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
-    configure_c2cc_host host3 "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}"
-    configure_c2cc_host host3 "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
+    configure_c2cc_host host1 \
+        "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}" \
+        "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
+
+    configure_c2cc_host host2 \
+        "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}" \
+        "${host3_ip}" "${CLUSTER_C_POD_CIDR}" "${CLUSTER_C_SVC_CIDR}" "${CLUSTER_C_DOMAIN}"
+
+    configure_c2cc_host host3 \
+        "${host1_ip}" "${CLUSTER_A_POD_CIDR}" "${CLUSTER_A_SVC_CIDR}" "${CLUSTER_A_DOMAIN}" \
+        "${host2_ip}" "${CLUSTER_B_POD_CIDR}" "${CLUSTER_B_SVC_CIDR}" "${CLUSTER_B_DOMAIN}"
 
     wait_for_greenboot_on_hosts "c2cc_greenboot"
 }

--- a/test/suites/c2cc/cleanup.robot
+++ b/test/suites/c2cc/cleanup.robot
@@ -86,6 +86,7 @@ Setup
     Setup Kubeconfig
     Register Local Cluster    cluster-a
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
+    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
     Disable C2CC On Cluster    cluster-a
 
 Teardown

--- a/test/suites/c2cc/cleanup.robot
+++ b/test/suites/c2cc/cleanup.robot
@@ -24,14 +24,24 @@ ${C2CC_CONFIG_PATH}     /etc/microshift/config.d/50-c2cc.yaml
 No Linux Routes In Table 200 After Disable
     [Documentation]    Routes to remote CIDRs in table 200 should be gone.
     ${stdout}=    Command On Cluster    cluster-a    ip route show table 200
-    Should Not Contain    ${stdout}    ${CLUSTER_B_POD_CIDR}
-    Should Not Contain    ${stdout}    ${CLUSTER_B_SVC_CIDR}
+    FOR    ${cidr}    IN
+    ...    ${CLUSTER_B_POD_CIDR}
+    ...    ${CLUSTER_B_SVC_CIDR}
+    ...    ${CLUSTER_C_POD_CIDR}
+    ...    ${CLUSTER_C_SVC_CIDR}
+        Should Not Contain    ${stdout}    ${cidr}
+    END
 
 No IP Rules For Table 200 After Disable
     [Documentation]    IP rules directing to table 200 should be gone.
     ${stdout}=    Command On Cluster    cluster-a    ip rule show
-    Should Not Contain    ${stdout}    to ${CLUSTER_B_POD_CIDR} lookup 200
-    Should Not Contain    ${stdout}    to ${CLUSTER_B_SVC_CIDR} lookup 200
+    FOR    ${cidr}    IN
+    ...    ${CLUSTER_B_POD_CIDR}
+    ...    ${CLUSTER_B_SVC_CIDR}
+    ...    ${CLUSTER_C_POD_CIDR}
+    ...    ${CLUSTER_C_SVC_CIDR}
+        Should Not Contain    ${stdout}    to ${cidr} lookup 200
+    END
 
 No Service Routes In Table 201 After Disable
     [Documentation]    Service routes in table 201 should be gone.
@@ -41,8 +51,13 @@ No Service Routes In Table 201 After Disable
 No Service IP Rules After Disable
     [Documentation]    Service IP rules for table 201 should be gone.
     ${stdout}=    Command On Cluster    cluster-a    ip rule show
-    Should Not Contain    ${stdout}    from ${CLUSTER_B_POD_CIDR} to ${CLUSTER_A_SVC_CIDR} lookup 201
-    Should Not Contain    ${stdout}    from ${CLUSTER_B_SVC_CIDR} to ${CLUSTER_A_SVC_CIDR} lookup 201
+    FOR    ${cidr}    IN
+    ...    ${CLUSTER_B_POD_CIDR}
+    ...    ${CLUSTER_B_SVC_CIDR}
+    ...    ${CLUSTER_C_POD_CIDR}
+    ...    ${CLUSTER_C_SVC_CIDR}
+        Should Not Contain    ${stdout}    from ${cidr} to ${CLUSTER_A_SVC_CIDR} lookup 201
+    END
 
 No NFTables Bypass Rules After Disable
     [Documentation]    C2CC nftables masquerade bypass rules should be gone.

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -20,6 +20,7 @@ Test Tags           c2cc
 
 *** Test Cases ***
 Test Cross Cluster Connectivity
+    [Documentation]    Verify pods on all clusters can reach pods/services on all other clusters.
     [Template]    Test Connectivity Between Clusters
     cluster-a    cluster-b    pod
     cluster-a    cluster-b    service
@@ -114,11 +115,9 @@ Test Connectivity Between Clusters
     ELSE
         Fail    Invalid endpoint_type: ${endpoint_type}. Must be 'pod' or 'service'.
     END
-    
+
     ${stdout}=    Curl From Cluster    ${source}    ${ip_dest}    8080
     Should Contain    ${stdout}    Hello MicroShift
-
-    
 
 Deploy Test Workloads
     [Documentation]    Create namespace and deploy hello-microshift + curl-pod on both clusters.

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -15,7 +15,7 @@ Test Tags           c2cc
 
 
 *** Variables ***
-&{NAMESPACES}       cluster-a=${EMPTY}    cluster-b=${EMPTY}
+&{NAMESPACES}       cluster-a=${EMPTY}    cluster-b=${EMPTY}    cluster-c=${EMPTY}
 
 
 *** Test Cases ***
@@ -34,62 +34,27 @@ Test Cross Cluster Connectivity
     cluster-c    cluster-a    service
     cluster-c    cluster-b    pod
     cluster-c    cluster-b    service
-Pod To Pod From Cluster A To Cluster B
-    [Documentation]    Verify pod on Cluster A can reach pod IP on Cluster B.
-    ${pod_ip_b}=    Get Hello Pod IP    cluster-b
-    ${stdout}=    Curl From Cluster    cluster-a    ${pod_ip_b}    8080
-    Should Contain    ${stdout}    Hello from
 
-Pod To Pod From Cluster B To Cluster A
-    [Documentation]    Verify pod on Cluster B can reach pod IP on Cluster A.
-    ${pod_ip_a}=    Get Hello Pod IP    cluster-a
-    ${stdout}=    Curl From Cluster    cluster-b    ${pod_ip_a}    8080
-    Should Contain    ${stdout}    Hello from
-
-Pod To Service From Cluster A To Cluster B
-    [Documentation]    Verify pod on Cluster A can reach service ClusterIP on Cluster B.
-    ${svc_ip_b}=    Get Hello Service IP    cluster-b
-    ${stdout}=    Curl From Cluster    cluster-a    ${svc_ip_b}    8080
-    Should Contain    ${stdout}    Hello from
-
-Pod To Service From Cluster B To Cluster A
-    [Documentation]    Verify pod on Cluster B can reach service ClusterIP on Cluster A.
-    ${svc_ip_a}=    Get Hello Service IP    cluster-a
-    ${stdout}=    Curl From Cluster    cluster-b    ${svc_ip_a}    8080
-    Should Contain    ${stdout}    Hello from
-
-Source IP Preserved Pod To Pod From Cluster A To Cluster B
-    [Documentation]    Verify cross-cluster pod-to-pod traffic preserves the source pod IP (no SNAT).
-    ${curl_pod_ip}=    Get Curl Pod IP    cluster-a
-    ${pod_ip_b}=    Get Hello Pod IP    cluster-b
-    ${stdout}=    Curl From Cluster    cluster-a    ${pod_ip_b}    8080
-    Should Contain    ${stdout}    source: ${curl_pod_ip}
-
-Source IP Preserved Pod To Pod From Cluster B To Cluster A
-    [Documentation]    Verify cross-cluster pod-to-pod traffic preserves the source pod IP (no SNAT).
-    ${curl_pod_ip}=    Get Curl Pod IP    cluster-b
-    ${pod_ip_a}=    Get Hello Pod IP    cluster-a
-    ${stdout}=    Curl From Cluster    cluster-b    ${pod_ip_a}    8080
-    Should Contain    ${stdout}    source: ${curl_pod_ip}
-
-Source IP Preserved Pod To Service From Cluster A To Cluster B
-    [Documentation]    Verify cross-cluster pod-to-service traffic preserves the source pod IP (no SNAT).
-    ${curl_pod_ip}=    Get Curl Pod IP    cluster-a
-    ${svc_ip_b}=    Get Hello Service IP    cluster-b
-    ${stdout}=    Curl From Cluster    cluster-a    ${svc_ip_b}    8080
-    Should Contain    ${stdout}    source: ${curl_pod_ip}
-
-Source IP Preserved Pod To Service From Cluster B To Cluster A
-    [Documentation]    Verify cross-cluster pod-to-service traffic preserves the source pod IP (no SNAT).
-    ${curl_pod_ip}=    Get Curl Pod IP    cluster-b
-    ${svc_ip_a}=    Get Hello Service IP    cluster-a
-    ${stdout}=    Curl From Cluster    cluster-b    ${svc_ip_a}    8080
-    Should Contain    ${stdout}    source: ${curl_pod_ip}
+Test Cross Cluster Source IP Preservation
+    [Documentation]    Verify cross cluster traffic preserves source pod IP (no SNAT).
+    [Template]    Test Source IP Preserved Between Clusters
+    cluster-a    cluster-b    pod
+    cluster-a    cluster-b    service
+    cluster-a    cluster-c    pod
+    cluster-a    cluster-c    service
+    cluster-b    cluster-a    pod
+    cluster-b    cluster-a    service
+    cluster-b    cluster-c    pod
+    cluster-b    cluster-c    service
+    cluster-c    cluster-a    pod
+    cluster-c    cluster-a    service
+    cluster-c    cluster-b    pod
+    cluster-c    cluster-b    service
 
 
 *** Keywords ***
 Setup
-    [Documentation]    Set up clusters and deploy test workloads on both.
+    [Documentation]    Set up clusters and deploy test workloads on all.
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig
@@ -117,10 +82,25 @@ Test Connectivity Between Clusters
     END
 
     ${stdout}=    Curl From Cluster    ${source}    ${ip_dest}    8080
-    Should Contain    ${stdout}    Hello MicroShift
+    Should Contain    ${stdout}    Hello from
+
+Test Source IP Preserved Between Clusters
+    [Documentation]    Verify ${source} to ${destination} pod-to-${endpoint_type} traffic preserves the source pod IP (no SNAT).
+    [Arguments]    ${source}    ${destination}    ${endpoint_type}
+    ${curl_pod_ip}=    Get Curl Pod IP    ${source}
+    IF    '${endpoint_type}' == 'pod'
+        ${ip_dest}=    Get Hello Pod IP    ${destination}
+    ELSE IF    '${endpoint_type}' == 'service'
+        ${ip_dest}=    Get Hello Service IP    ${destination}
+    ELSE
+        Fail    Invalid endpoint_type: ${endpoint_type}. Must be 'pod' or 'service'.
+    END
+
+    ${stdout}=    Curl From Cluster    ${source}    ${ip_dest}    8080
+    Should Contain    ${stdout}    source: ${curl_pod_ip}
 
 Deploy Test Workloads
-    [Documentation]    Create namespace and deploy hello-microshift + curl-pod on both clusters.
+    [Documentation]    Create namespace and deploy hello-microshift + curl-pod on all clusters.
     VAR    ${assets}=    ${EXECDIR}/assets/c2cc
     FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         Oc On Cluster    ${alias}    oc create namespace ${NAMESPACE}
@@ -130,14 +110,14 @@ Deploy Test Workloads
     Wait For Test Pods
 
 Wait For Test Pods
-    [Documentation]    Wait for all test pods to be Ready on both clusters.
+    [Documentation]    Wait for all test pods to be Ready on all clusters.
     FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         Oc On Cluster    ${alias}
         ...    oc wait pod/hello-microshift pod/curl-pod -n ${NAMESPACE} --for=condition=Ready --timeout=120s
     END
 
 Cleanup Test Workloads
-    [Documentation]    Delete test namespace on both clusters. Ignores errors.
+    [Documentation]    Delete test namespace on all clusters. Ignores errors.
     FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
         Run Keyword And Ignore Error
         ...    Oc On Cluster    ${alias}    oc delete namespace ${NAMESPACE} --timeout=60s

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Cross-cluster connectivity tests for C2CC.
-...                 Deploys test workloads on both clusters and verifies pod-to-pod
+...                 Deploys test workloads on all clusters and verifies pod-to-pod
 ...                 and pod-to-service communication in both directions.
 
 Resource            ../../resources/microshift-process.resource
@@ -98,30 +98,6 @@ Test Source IP Preserved Between Clusters
 
     ${stdout}=    Curl From Cluster    ${source}    ${ip_dest}    8080
     Should Contain    ${stdout}    source: ${curl_pod_ip}
-
-Deploy Test Workloads
-    [Documentation]    Create namespace and deploy hello-microshift + curl-pod on all clusters.
-    VAR    ${assets}=    ${EXECDIR}/assets/c2cc
-    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
-        Oc On Cluster    ${alias}    oc create namespace ${NAMESPACE}
-        Oc On Cluster    ${alias}    oc apply -n ${NAMESPACE} -f ${assets}/hello-microshift.yaml
-        Oc On Cluster    ${alias}    oc apply -n ${NAMESPACE} -f ${assets}/curl-pod.yaml
-    END
-    Wait For Test Pods
-
-Wait For Test Pods
-    [Documentation]    Wait for all test pods to be Ready on all clusters.
-    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
-        Oc On Cluster    ${alias}
-        ...    oc wait pod/hello-microshift pod/curl-pod -n ${NAMESPACE} --for=condition=Ready --timeout=120s
-    END
-
-Cleanup Test Workloads
-    [Documentation]    Delete test namespace on all clusters. Ignores errors.
-    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
-        Run Keyword And Ignore Error
-        ...    Oc On Cluster    ${alias}    oc delete namespace ${NAMESPACE} --timeout=60s
-    END
 
 Get Hello Pod IP
     [Documentation]    Get the pod IP of hello-microshift on the given cluster.

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -19,6 +19,20 @@ Test Tags           c2cc
 
 
 *** Test Cases ***
+Test Cross Cluster Connectivity
+    [Template]    Test Connectivity Between Clusters
+    cluster-a    cluster-b    pod
+    cluster-a    cluster-b    service
+    cluster-a    cluster-c    pod
+    cluster-a    cluster-c    service
+    cluster-b    cluster-a    pod
+    cluster-b    cluster-a    service
+    cluster-b    cluster-c    pod
+    cluster-b    cluster-c    service
+    cluster-c    cluster-a    pod
+    cluster-c    cluster-a    service
+    cluster-c    cluster-b    pod
+    cluster-c    cluster-b    service
 Pod To Pod From Cluster A To Cluster B
     [Documentation]    Verify pod on Cluster A can reach pod IP on Cluster B.
     ${pod_ip_b}=    Get Hello Pod IP    cluster-b
@@ -80,6 +94,7 @@ Setup
     Setup Kubeconfig
     Register Local Cluster    cluster-a
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
+    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
     Deploy Test Workloads
 
 Teardown
@@ -88,6 +103,46 @@ Teardown
     Teardown All Remote Clusters
     Remove Kubeconfig
     Logout MicroShift Host
+
+Test Connectivity Between Clusters
+    [Documentation]    Verify pod on ${source} can reach ${endpoint_type} IP on ${destination}
+    [Arguments]    ${source}    ${destination}    ${endpoint_type}
+    IF    '${endpoint_type}' == 'pod'
+        ${ip_dest}=    Get Hello Pod IP    ${destination}
+    ELSE IF    '${endpoint_type}' == 'service'
+        ${ip_dest}=    Get Hello Service IP    ${destination}
+    ELSE
+        Fail    Invalid endpoint_type: ${endpoint_type}. Must be 'pod' or 'service'.
+    END
+    
+    ${stdout}=    Curl From Cluster    ${source}    ${ip_dest}    8080
+    Should Contain    ${stdout}    Hello MicroShift
+
+    
+
+Deploy Test Workloads
+    [Documentation]    Create namespace and deploy hello-microshift + curl-pod on both clusters.
+    VAR    ${assets}=    ${EXECDIR}/assets/c2cc
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
+        Oc On Cluster    ${alias}    oc create namespace ${NAMESPACE}
+        Oc On Cluster    ${alias}    oc apply -n ${NAMESPACE} -f ${assets}/hello-microshift.yaml
+        Oc On Cluster    ${alias}    oc apply -n ${NAMESPACE} -f ${assets}/curl-pod.yaml
+    END
+    Wait For Test Pods
+
+Wait For Test Pods
+    [Documentation]    Wait for all test pods to be Ready on both clusters.
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
+        Oc On Cluster    ${alias}
+        ...    oc wait pod/hello-microshift pod/curl-pod -n ${NAMESPACE} --for=condition=Ready --timeout=120s
+    END
+
+Cleanup Test Workloads
+    [Documentation]    Delete test namespace on both clusters. Ignores errors.
+    FOR    ${alias}    IN    cluster-a    cluster-b    cluster-c
+        Run Keyword And Ignore Error
+        ...    Oc On Cluster    ${alias}    oc delete namespace ${NAMESPACE} --timeout=60s
+    END
 
 Get Hello Pod IP
     [Documentation]    Get the pod IP of hello-microshift on the given cluster.

--- a/test/suites/c2cc/dns.robot
+++ b/test/suites/c2cc/dns.robot
@@ -17,7 +17,7 @@ Test Tags           c2cc
 
 *** Variables ***
 &{NAMESPACES}       cluster-a=${EMPTY}    cluster-b=${EMPTY}    cluster-c=${EMPTY}
-&{DOMAIN_MAP}    cluster-a=${CLUSTER_A_DOMAIN}    cluster-b=${CLUSTER_B_DOMAIN}    cluster-c=${CLUSTER_C_DOMAIN}
+&{DOMAIN_MAP}       cluster-a=${CLUSTER_A_DOMAIN}    cluster-b=${CLUSTER_B_DOMAIN}    cluster-c=${CLUSTER_C_DOMAIN}
 
 
 *** Test Cases ***

--- a/test/suites/c2cc/dns.robot
+++ b/test/suites/c2cc/dns.robot
@@ -16,49 +16,51 @@ Test Tags           c2cc
 
 
 *** Variables ***
-&{NAMESPACES}       cluster-a=${EMPTY}    cluster-b=${EMPTY}
+&{NAMESPACES}       cluster-a=${EMPTY}    cluster-b=${EMPTY}    cluster-c=${EMPTY}
+&{DOMAIN_MAP}    cluster-a=${CLUSTER_A_DOMAIN}    cluster-b=${CLUSTER_B_DOMAIN}    cluster-c=${CLUSTER_C_DOMAIN}
 
 
 *** Test Cases ***
-Corefile Contains C2CC Server Block On Cluster A
-    [Documentation]    Verify Cluster A's Corefile has a server block for Cluster B's domain.
-    Verify Corefile Contains C2CC Server Block    cluster-a    ${CLUSTER_B_DOMAIN}
+Test Corefile Contains C2CC Server Block
+    [Documentation]    Verify every cluster's Corefile has a server block for every other cluster domain.
+    [Template]    Verify Corefile Contains C2CC Server Block
+    cluster-a    ${CLUSTER_B_DOMAIN}
+    cluster-a    ${CLUSTER_C_DOMAIN}
+    cluster-b    ${CLUSTER_A_DOMAIN}
+    cluster-b    ${CLUSTER_C_DOMAIN}
+    cluster-c    ${CLUSTER_A_DOMAIN}
+    cluster-c    ${CLUSTER_B_DOMAIN}
 
-Corefile Contains C2CC Server Block On Cluster B
-    [Documentation]    Verify Cluster B's Corefile has a server block for Cluster A's domain.
-    Verify Corefile Contains C2CC Server Block    cluster-b    ${CLUSTER_A_DOMAIN}
+Test Resolve Remote Service DNS
+    [Documentation]    Verify pods can resolve a service on all clusters via DNS.
+    [Template]    DNS Resolve From Cluster
+    cluster-a    hello-microshift.${NAMESPACES}[cluster-b].svc.${DOMAIN_MAP}[cluster-b]
+    cluster-a    hello-microshift.${NAMESPACES}[cluster-c].svc.${DOMAIN_MAP}[cluster-c]
+    cluster-b    hello-microshift.${NAMESPACES}[cluster-a].svc.${DOMAIN_MAP}[cluster-a]
+    cluster-b    hello-microshift.${NAMESPACES}[cluster-c].svc.${DOMAIN_MAP}[cluster-c]
+    cluster-c    hello-microshift.${NAMESPACES}[cluster-a].svc.${DOMAIN_MAP}[cluster-a]
+    cluster-c    hello-microshift.${NAMESPACES}[cluster-b].svc.${DOMAIN_MAP}[cluster-b]
 
-Resolve Remote Service DNS From Cluster A
-    [Documentation]    Verify pod on Cluster A can resolve a service on Cluster B via DNS.
-    DNS Resolve From Cluster    cluster-a
-    ...    hello-microshift.${NAMESPACES}[cluster-b].svc.${CLUSTER_B_DOMAIN}
-
-Resolve Remote Service DNS From Cluster B
-    [Documentation]    Verify pod on Cluster B can resolve a service on Cluster A via DNS.
-    DNS Resolve From Cluster    cluster-b
-    ...    hello-microshift.${NAMESPACES}[cluster-a].svc.${CLUSTER_A_DOMAIN}
-
-Curl Remote Service Via DNS From Cluster A
-    [Documentation]    Verify pod on Cluster A can reach a service on Cluster B using the remote DNS name.
-    ${stdout}=    Curl DNS From Cluster    cluster-a
-    ...    hello-microshift.${NAMESPACES}[cluster-b].svc.${CLUSTER_B_DOMAIN}    8080
-    Should Contain    ${stdout}    Hello from
-
-Curl Remote Service Via DNS From Cluster B
-    [Documentation]    Verify pod on Cluster B can reach a service on Cluster A using the remote DNS name.
-    ${stdout}=    Curl DNS From Cluster    cluster-b
-    ...    hello-microshift.${NAMESPACES}[cluster-a].svc.${CLUSTER_A_DOMAIN}    8080
-    Should Contain    ${stdout}    Hello from
+Test Curl Remote Service Via DNS
+    [Documentation]    Verify pod on a cluster can reach a service on all clusters using the remote DNS name.
+    [Template]    Curl Remote Service Via DNS
+    cluster-a    cluster-b
+    cluster-a    cluster-c
+    cluster-b    cluster-a
+    cluster-b    cluster-c
+    cluster-c    cluster-a
+    cluster-c    cluster-b
 
 
 *** Keywords ***
 Setup
-    [Documentation]    Set up clusters and deploy test workloads on both.
+    [Documentation]    Set up clusters and deploy test workloads on all.
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig
     Register Local Cluster    cluster-a
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
+    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
     Deploy Test Workloads
 
 Teardown
@@ -67,6 +69,13 @@ Teardown
     Teardown All Remote Clusters
     Remove Kubeconfig
     Logout MicroShift Host
+
+Curl Remote Service Via DNS
+    [Documentation]    Verify pod on ${source} can reach a service on ${destination} using the remote DNS name.
+    [Arguments]    ${source}    ${destination}
+    ${stdout}=    Curl DNS From Cluster    ${source}
+    ...    hello-microshift.${NAMESPACES}[${destination}].svc.${DOMAIN_MAP}[${destination}]    8080
+    Should Contain    ${stdout}    Hello from
 
 DNS Resolve From Cluster
     [Documentation]    Resolve a DNS name from curl-pod on the given cluster. Retries for up to 60s.

--- a/test/suites/c2cc/infrastructure.robot
+++ b/test/suites/c2cc/infrastructure.robot
@@ -15,61 +15,65 @@ Test Tags           c2cc
 
 
 *** Test Cases ***
-Linux Routes Table 200 Exist On Cluster A
-    [Documentation]    Verify routes to remote CIDRs exist in policy routing table 200 on Cluster A.
-    Verify Routes In Table 200    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+Linux Routes Table 200 Exist
+    [Template]    Verify Routes In Table 200
+    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-c    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
-Linux Routes Table 200 Exist On Cluster B
-    [Documentation]    Verify routes to remote CIDRs exist in policy routing table 200 on Cluster B.
-    Verify Routes In Table 200    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+IP Rules For Remote CIDRs Exist
+    [Template]    Verify IP Rules For Table 200
+    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-c    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
-IP Rules For Remote CIDRs Exist On Cluster A
-    [Documentation]    Verify IP rules at priority 100 direct remote CIDRs to table 200 on Cluster A.
-    Verify IP Rules For Table 200    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+Service Routes Table 201 Exist
+    [Template]    Verify Routes In Table 201
+    cluster-a    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_B_SVC_CIDR}
+    cluster-c    ${CLUSTER_C_SVC_CIDR}
 
-IP Rules For Remote CIDRs Exist On Cluster B
-    [Documentation]    Verify IP rules at priority 100 direct remote CIDRs to table 200 on Cluster B.
-    Verify IP Rules For Table 200    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+Service IP Rules Exist
+    [Template]    Verify Service IP Rules
+    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-b    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-c    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}    ${CLUSTER_C_SVC_CIDR}
 
-Service Routes Table 201 Exist On Cluster A
-    [Documentation]    Verify service routes exist in table 201 on Cluster A.
-    Verify Routes In Table 201    cluster-a    ${CLUSTER_A_SVC_CIDR}
+NFTables Bypass Rules Exist
+    [Template]    Verify NFTables Bypass Rules
+    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-c    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
-Service Routes Table 201 Exist On Cluster B
-    [Documentation]    Verify service routes exist in table 201 on Cluster B.
-    Verify Routes In Table 201    cluster-b    ${CLUSTER_B_SVC_CIDR}
+OVN Static Routes Exist
+    [Template]    Verify OVN Static Routes
+    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-c    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
-Service IP Rules Exist On Cluster A
-    [Documentation]    Verify IP rules at priority 99 for service routing on Cluster A.
-    Verify Service IP Rules    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}    ${CLUSTER_A_SVC_CIDR}
-
-Service IP Rules Exist On Cluster B
-    [Documentation]    Verify IP rules at priority 99 for service routing on Cluster B.
-    Verify Service IP Rules    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}    ${CLUSTER_B_SVC_CIDR}
-
-NFTables Bypass Rules Exist On Cluster A
-    [Documentation]    Verify nftables masquerade bypass rules for remote CIDRs on Cluster A.
-    Verify NFTables Bypass Rules    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
-
-NFTables Bypass Rules Exist On Cluster B
-    [Documentation]    Verify nftables masquerade bypass rules for remote CIDRs on Cluster B.
-    Verify NFTables Bypass Rules    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
-
-OVN Static Routes Exist On Cluster A
-    [Documentation]    Verify OVN NB static routes tagged with microshift-c2cc on Cluster A.
-    Verify OVN Static Routes    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
-
-OVN Static Routes Exist On Cluster B
-    [Documentation]    Verify OVN NB static routes tagged with microshift-c2cc on Cluster B.
-    Verify OVN Static Routes    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
-
-Node Annotation Set On Cluster A
-    [Documentation]    Verify SNAT-exclude annotation contains remote CIDRs on Cluster A.
-    Verify Node SNAT Annotation    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
-
-Node Annotation Set On Cluster B
-    [Documentation]    Verify SNAT-exclude annotation contains remote CIDRs on Cluster B.
-    Verify Node SNAT Annotation    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+Node Annotation Set
+    [Template]    Verify Node SNAT Annotation
+    cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
+    cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-b    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-b    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
+    cluster-c    ${CLUSTER_A_POD_CIDR}    ${CLUSTER_A_SVC_CIDR}
+    cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
 
 *** Keywords ***
@@ -80,6 +84,7 @@ Setup
     Setup Kubeconfig
     Register Local Cluster    cluster-a
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
+    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.

--- a/test/suites/c2cc/infrastructure.robot
+++ b/test/suites/c2cc/infrastructure.robot
@@ -16,6 +16,7 @@ Test Tags           c2cc
 
 *** Test Cases ***
 Linux Routes Table 200 Exist
+    [Documentation]    Verify routes to remote CIDRs exist in policy routing table 200 between all clusters.
     [Template]    Verify Routes In Table 200
     cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
     cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
@@ -25,6 +26,7 @@ Linux Routes Table 200 Exist
     cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
 IP Rules For Remote CIDRs Exist
+    [Documentation]    Verify IP rules at priority 100 direct remote CIDRs to table 200 between all clusters.
     [Template]    Verify IP Rules For Table 200
     cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
     cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
@@ -34,12 +36,14 @@ IP Rules For Remote CIDRs Exist
     cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
 Service Routes Table 201 Exist
+    [Documentation]    Verify service routes exist in table 201 on all clusters.
     [Template]    Verify Routes In Table 201
     cluster-a    ${CLUSTER_A_SVC_CIDR}
     cluster-b    ${CLUSTER_B_SVC_CIDR}
     cluster-c    ${CLUSTER_C_SVC_CIDR}
 
 Service IP Rules Exist
+    [Documentation]    Verify IP rules at priority 99 for service routing on all clusters.
     [Template]    Verify Service IP Rules
     cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}    ${CLUSTER_A_SVC_CIDR}
     cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}    ${CLUSTER_A_SVC_CIDR}
@@ -49,6 +53,7 @@ Service IP Rules Exist
     cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}    ${CLUSTER_C_SVC_CIDR}
 
 NFTables Bypass Rules Exist
+    [Documentation]    Verify nftables masquerade bypass rules for remote CIDRs on all clusters.
     [Template]    Verify NFTables Bypass Rules
     cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
     cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
@@ -58,6 +63,7 @@ NFTables Bypass Rules Exist
     cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
 OVN Static Routes Exist
+    [Documentation]    Verify OVN NB static routes tagged with microshift-c2cc on all clusters.
     [Template]    Verify OVN Static Routes
     cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
     cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}
@@ -67,6 +73,7 @@ OVN Static Routes Exist
     cluster-c    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
 
 Node Annotation Set
+    [Documentation]    Verify SNAT-exclude annotation contains remote CIDRs on all clusters.
     [Template]    Verify Node SNAT Annotation
     cluster-a    ${CLUSTER_B_POD_CIDR}    ${CLUSTER_B_SVC_CIDR}
     cluster-a    ${CLUSTER_C_POD_CIDR}    ${CLUSTER_C_SVC_CIDR}

--- a/test/suites/c2cc/sanity.robot
+++ b/test/suites/c2cc/sanity.robot
@@ -51,6 +51,7 @@ Setup
     Setup Kubeconfig
     Register Local Cluster    cluster-a
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
+    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.

--- a/test/suites/c2cc/sanity.robot
+++ b/test/suites/c2cc/sanity.robot
@@ -14,37 +14,29 @@ Test Tags           c2cc
 
 
 *** Test Cases ***
-Cluster A Is Running
-    [Documentation]    Verify MicroShift on Cluster A is healthy.
-    Verify Cluster Is Running    cluster-a
+Cluster Is Running
+    [Template]    Verify Cluster Is Running
+    cluster-a
+    cluster-b
+    cluster-c
 
-Cluster B Is Running
-    [Documentation]    Verify MicroShift on Cluster B is healthy.
-    Verify Cluster Is Running    cluster-b
+All Pods On Cluster Are Ready
+    [Template]    Verify All Pods Are Ready
+    cluster-a
+    cluster-b
+    cluster-c
 
-All Pods On Cluster A Are Ready
-    [Documentation]    All pods on Cluster A reach Ready state.
-    Verify All Pods Are Ready    cluster-a
+Cluster Has Expected Node
+    [Template]    Verify Cluster Has Node
+    cluster-a
+    cluster-b
+    cluster-c
 
-All Pods On Cluster B Are Ready
-    [Documentation]    All pods on Cluster B reach Ready state.
-    Verify All Pods Are Ready    cluster-b
-
-Cluster A Has Expected Node
-    [Documentation]    Verify Cluster A has a node.
-    Verify Cluster Has Node    cluster-a
-
-Cluster B Has Expected Node
-    [Documentation]    Verify Cluster B has a node.
-    Verify Cluster Has Node    cluster-b
-
-C2CC Controller Is Running On Cluster A
-    [Documentation]    Verify c2cc-route-manager logged startup on Cluster A.
-    Verify C2CC Controller Is Running    cluster-a
-
-C2CC Controller Is Running On Cluster B
-    [Documentation]    Verify c2cc-route-manager logged startup on Cluster B.
-    Verify C2CC Controller Is Running    cluster-b
+C2CC Controller Is Running On Cluster
+    [Template]    Verify C2CC Controller Is Running
+    cluster-a
+    cluster-b
+    cluster-c
 
 
 *** Keywords ***

--- a/test/suites/c2cc/sanity.robot
+++ b/test/suites/c2cc/sanity.robot
@@ -15,24 +15,28 @@ Test Tags           c2cc
 
 *** Test Cases ***
 Cluster Is Running
+    [Documentation]    Verify all clusters are healthy.
     [Template]    Verify Cluster Is Running
     cluster-a
     cluster-b
     cluster-c
 
 All Pods On Cluster Are Ready
+    [Documentation]    Verify all pods reach Ready state on all clusters.
     [Template]    Verify All Pods Are Ready
     cluster-a
     cluster-b
     cluster-c
 
 Cluster Has Expected Node
+    [Documentation]    Verify all clusters have a node.
     [Template]    Verify Cluster Has Node
     cluster-a
     cluster-b
     cluster-c
 
 C2CC Controller Is Running On Cluster
+    [Documentation]    Verify c2cc-route-manager logged startup on all clusters.
     [Template]    Verify C2CC Controller Is Running
     cluster-a
     cluster-b


### PR DESCRIPTION
Increase amount of interconnected VMs in from 2 to 3 in C2CC RF tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Cluster C to all c2cc test suites and kubeconfig outputs.
  * Replaced many per-cluster cases with template-driven tests validating cross-cluster pod/service connectivity, sanity, and infrastructure across A/B/C.
  * Expanded cleanup and validation checks to include Cluster C CIDRs and extended readiness/connectivity waits to cover Cluster C.

* **Chores**
  * Updated test resources and provisioning/orchestration to prepare, configure, include, and remove the additional cluster and its network/kubeconfig settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->