### PR TITLE
USHIFT-6984: Skip RPM scenario tests when no brew RPMs are available

### DIFF
--- a/test/scenarios/releases/el98@rpm-standard1.sh
+++ b/test/scenarios/releases/el98@rpm-standard1.sh
@@ -63,6 +63,11 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
+    if [[ -z "${BREW_LREL_RELEASE_VERSION}" ]]; then
+        echo "WARNING: No brew RPMs available for ${MAJOR_VERSION}.${MINOR_VERSION}, skipping RPM tests"
+        return 0
+    fi
+
     local -r reponame=$(basename "${BREW_REPO}")
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
 

--- a/test/scenarios/releases/el98@rpm-standard2.sh
+++ b/test/scenarios/releases/el98@rpm-standard2.sh
@@ -64,6 +64,11 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
+    if [[ -z "${BREW_LREL_RELEASE_VERSION}" ]]; then
+        echo "WARNING: No brew RPMs available for ${MAJOR_VERSION}.${MINOR_VERSION}, skipping RPM tests"
+        return 0
+    fi
+
     local -r reponame=$(basename "${BREW_REPO}")
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
 

--- a/test/scenarios/releases/el98@rpm-upgrade.sh
+++ b/test/scenarios/releases/el98@rpm-upgrade.sh
@@ -92,6 +92,11 @@ scenario_remove_vms() {
 }
 
 scenario_run_tests() {
+    if [[ -z "${BREW_LREL_RELEASE_VERSION}" ]]; then
+        echo "WARNING: No brew RPMs available for ${MAJOR_VERSION}.${MINOR_VERSION}, skipping RPM tests"
+        return 0
+    fi
+
     local -r reponame=$(basename "${BREW_REPO}")
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
 


### PR DESCRIPTION
## Summary
- Skip RPM-based test scenarios (rpm-standard1, rpm-standard2, rpm-upgrade) gracefully when `BREW_LREL_RELEASE_VERSION` is empty
- Fixes 56 test failures on release-5.0 periodic CI jobs (amd64 + arm64) caused by passing empty `TARGET_VERSION` to Robot Framework

## Root Cause
MicroShift 5.0 has no brew RPMs yet. The version resolution chain (`build_rpms.sh` → `manage_brew_rpms.sh` → `common_versions.sh`) correctly resolves this to empty — brew RPMs are optional by design (see `build_rpms.sh` lines 111-113). The scenario scripts were the only link that didn't handle the empty result, blindly passing it to Robot Framework where `Should Not Be Empty ${TARGET_VERSION}` fails and cascades to all tests.

## Changes
Each RPM scenario's `scenario_run_tests()` now checks `BREW_LREL_RELEASE_VERSION` at the top and returns 0 with a warning if empty. No other changes needed — the upstream chain already does the authoritative "does this exist" check.

## Test plan
- [ ] Verify release-5.0 periodic CI jobs no longer fail on RPM scenarios
- [ ] Verify RPM scenarios still run correctly on releases with brew RPMs available (e.g. 4.22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * RPM test scenarios now gracefully skip when release version information is unavailable, with informative warnings instead of failing. This prevents false test failures during incomplete configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->