### PR TITLE
[release-4.17] USHIFT-7042: Enable EUS repos for RHEL 9.4 bootc test images

### DIFF
--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source-ostree-parent.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source-ostree-parent.containerfile
@@ -12,6 +12,16 @@ RUN ln -sr /run/secrets/etc-pki-entitlement /etc/pki/entitlement-host && \
     ln -sr /run/secrets/rhsm /etc/rhsm-host && \
     mkdir -p /var/opt
 
+# Lock the OS release version and enable EUS repositories to prevent
+# the installation of packages belonging to a newer OS release
+# hadolint ignore=SC1091
+RUN source /etc/os-release && \
+    echo "${VERSION_ID}" > /etc/dnf/vars/releasever && \
+    dnf config-manager --set-disabled '*' && \
+    dnf config-manager --set-enabled \
+        "rhel-9-for-$(uname -m)-baseos-eus-rpms" \
+        "rhel-9-for-$(uname -m)-appstream-eus-rpms"
+
 # Copy the repository configuration script
 COPY --chmod=755 ./bootc-images/microshift_repo_config.sh ${REPO_CONFIG_SCRIPT}
 

--- a/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
+++ b/test/image-blueprints/layer5-bootc/group1/rhel94-bootc-source.containerfile
@@ -5,6 +5,16 @@ ARG REPO_CONFIG_SCRIPT=/tmp/microshift_repo_config.sh
 ARG USHIFT_RPM_REPO_NAME=microshift-local
 ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
 
+# Lock the OS release version and enable EUS repositories to prevent
+# the installation of packages belonging to a newer OS release
+# hadolint ignore=SC1091
+RUN source /etc/os-release && \
+    echo "${VERSION_ID}" > /etc/dnf/vars/releasever && \
+    dnf config-manager --set-disabled '*' && \
+    dnf config-manager --set-enabled \
+        "rhel-9-for-$(uname -m)-baseos-eus-rpms" \
+        "rhel-9-for-$(uname -m)-appstream-eus-rpms"
+
 # Copy the repository configuration script
 COPY --chmod=755 ./bootc-images/microshift_repo_config.sh ${REPO_CONFIG_SCRIPT}
 


### PR DESCRIPTION
The rhel-bootc:9.4 base image ships with repos pointing to RHEL 9 latest content instead of RHEL 9.4 EUS. This causes dnf to install greenboot-rs (0.16.x) from RHEL 9.8 instead of bash greenboot (0.15.x) from 9.4 EUS. Greenboot-rs sets RefuseManualStartStop=yes on the greenboot-healthcheck.service unit, breaking both the test framework's Restart Greenboot keyword and the rollback/reboot mechanism.

Lock releasever and enable EUS repositories before installing packages, matching the pattern used on release-4.20+ via rpm-repo-config.sh.