### PR TITLE
USHIFT-6996: fix CI test: wait for microshift-tuned service instead of boot count

### DIFF
--- a/test/scenarios-bootc/el10/periodics/el102-src@low-latency.sh
+++ b/test/scenarios-bootc/el10/periodics/el102-src@low-latency.sh
@@ -23,20 +23,23 @@ scenario_remove_vms() {
 scenario_run_tests() {
     exit_if_image_not_found "${start_image}"
 
-    # Should not be run immediately after creating VM because of
-    # microshift-tuned rebooting the node to activate the profile.
+    # Wait for microshift-tuned to finish its initial setup, which may
+    # include reboots to activate the TuneD profile. Polling the service
+    # SubState is more robust than counting boots — other system events
+    # (SELinux relabeling, cloud-init) can also trigger reboots.
     local -r start_time=$(date +%s)
     while true; do
-        boot_num=$(run_command_on_vm host1 "sudo journalctl --list-boots --quiet | wc -l" || true)
-        boot_num="${boot_num%$'\r'*}"
-        if [[ "${boot_num}" -ge 2 ]]; then
+        tuned_state=$(run_command_on_vm host1 \
+            "sudo systemctl show -p SubState --value microshift-tuned.service" || true)
+        tuned_state="${tuned_state%$'\r'*}"
+        if [[ "${tuned_state}" == "dead" || "${tuned_state}" == "exited" || "${tuned_state}" == "failed" ]]; then
             break
         fi
-        if [ $(( $(date +%s) - start_time )) -gt 60 ]; then
-            echo "Timed out waiting for VM having 2 boots"
+        if [ $(( $(date +%s) - start_time )) -gt 300 ]; then
+            echo "Timed out waiting for microshift-tuned to settle (state: ${tuned_state})"
             exit 1
         fi
-        sleep 5
+        sleep 10
     done
 
     # --exitonfailure because tests within suites are meant to be ordered,

--- a/test/scenarios-bootc/el10/releases/el102-lrel@low-latency.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@low-latency.sh
@@ -23,20 +23,23 @@ scenario_remove_vms() {
 scenario_run_tests() {
     exit_if_image_not_found "${start_image}"
 
-    # Should not be run immediately after creating VM because of
-    # microshift-tuned rebooting the node to activate the profile.
+    # Wait for microshift-tuned to finish its initial setup, which may
+    # include reboots to activate the TuneD profile. Polling the service
+    # SubState is more robust than counting boots — other system events
+    # (SELinux relabeling, cloud-init) can also trigger reboots.
     local -r start_time=$(date +%s)
     while true; do
-        boot_num=$(run_command_on_vm host1 "sudo journalctl --list-boots --quiet | wc -l" || true)
-        boot_num="${boot_num%$'\r'*}"
-        if [[ "${boot_num}" -ge 2 ]]; then
+        tuned_state=$(run_command_on_vm host1 \
+            "sudo systemctl show -p SubState --value microshift-tuned.service" || true)
+        tuned_state="${tuned_state%$'\r'*}"
+        if [[ "${tuned_state}" == "dead" || "${tuned_state}" == "exited" || "${tuned_state}" == "failed" ]]; then
             break
         fi
-        if [ $(( $(date +%s) - start_time )) -gt 60 ]; then
-            echo "Timed out waiting for VM having 2 boots"
+        if [ $(( $(date +%s) - start_time )) -gt 300 ]; then
+            echo "Timed out waiting for microshift-tuned to settle (state: ${tuned_state})"
             exit 1
         fi
-        sleep 5
+        sleep 10
     done
 
     # --exitonfailure because tests within suites are meant to be ordered,

--- a/test/scenarios-bootc/el9/periodics/el98-src@low-latency.sh
+++ b/test/scenarios-bootc/el9/periodics/el98-src@low-latency.sh
@@ -23,20 +23,23 @@ scenario_remove_vms() {
 scenario_run_tests() {
     exit_if_image_not_found "${start_image}"
 
-    # Should not be run immediately after creating VM because of
-    # microshift-tuned rebooting the node to activate the profile.
+    # Wait for microshift-tuned to finish its initial setup, which may
+    # include reboots to activate the TuneD profile. Polling the service
+    # SubState is more robust than counting boots — other system events
+    # (SELinux relabeling, cloud-init) can also trigger reboots.
     local -r start_time=$(date +%s)
     while true; do
-        boot_num=$(run_command_on_vm host1 "sudo journalctl --list-boots --quiet | wc -l" || true)
-        boot_num="${boot_num%$'\r'*}"
-        if [[ "${boot_num}" -ge 2 ]]; then
+        tuned_state=$(run_command_on_vm host1 \
+            "sudo systemctl show -p SubState --value microshift-tuned.service" || true)
+        tuned_state="${tuned_state%$'\r'*}"
+        if [[ "${tuned_state}" == "dead" || "${tuned_state}" == "exited" || "${tuned_state}" == "failed" ]]; then
             break
         fi
-        if [ $(( $(date +%s) - start_time )) -gt 60 ]; then
-            echo "Timed out waiting for VM having 2 boots"
+        if [ $(( $(date +%s) - start_time )) -gt 300 ]; then
+            echo "Timed out waiting for microshift-tuned to settle (state: ${tuned_state})"
             exit 1
         fi
-        sleep 5
+        sleep 10
     done
 
     # --exitonfailure because tests within suites are meant to be ordered,

--- a/test/scenarios-bootc/el9/releases/el98-lrel@low-latency.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@low-latency.sh
@@ -23,20 +23,23 @@ scenario_remove_vms() {
 scenario_run_tests() {
     exit_if_image_not_found "${start_image}"
 
-    # Should not be run immediately after creating VM because of
-    # microshift-tuned rebooting the node to activate the profile.
+    # Wait for microshift-tuned to finish its initial setup, which may
+    # include reboots to activate the TuneD profile. Polling the service
+    # SubState is more robust than counting boots — other system events
+    # (SELinux relabeling, cloud-init) can also trigger reboots.
     local -r start_time=$(date +%s)
     while true; do
-        boot_num=$(run_command_on_vm host1 "sudo journalctl --list-boots --quiet | wc -l" || true)
-        boot_num="${boot_num%$'\r'*}"
-        if [[ "${boot_num}" -ge 2 ]]; then
+        tuned_state=$(run_command_on_vm host1 \
+            "sudo systemctl show -p SubState --value microshift-tuned.service" || true)
+        tuned_state="${tuned_state%$'\r'*}"
+        if [[ "${tuned_state}" == "dead" || "${tuned_state}" == "exited" || "${tuned_state}" == "failed" ]]; then
             break
         fi
-        if [ $(( $(date +%s) - start_time )) -gt 60 ]; then
-            echo "Timed out waiting for VM having 2 boots"
+        if [ $(( $(date +%s) - start_time )) -gt 300 ]; then
+            echo "Timed out waiting for microshift-tuned to settle (state: ${tuned_state})"
             exit 1
         fi
-        sleep 5
+        sleep 10
     done
 
     # --exitonfailure because tests within suites are meant to be ordered,


### PR DESCRIPTION
## Summary

Fix for [USHIFT-6996](https://issues.redhat.com/browse/USHIFT-6996).
*Auto-generated by [/microshift-ci:fix-test-bugs](https://github.com/openshift-eng/edge-tooling)* :robot:

## Rationale

The boot count check (>= 2) is unreliable because other system events (SELinux relabeling, cloud-init) can also cause reboots, making the count reach 2 before microshift-tuned has triggered its profile-activation reboot. Replacing with a direct poll of microshift-tuned.service SubState ensures we wait for the actual service to finish — whether that involves zero, one, or multiple reboots. Timeout increased from 60s to 300s to handle slow first boots.

## Changed files

- `test/scenarios-bootc/el10/periodics/el102-src@low-latency.sh `
- `test/scenarios-bootc/el10/releases/el102-lrel@low-latency.sh `
- `test/scenarios-bootc/el9/periodics/el98-src@low-latency.sh `
- `test/scenarios-bootc/el9/releases/el98-lrel@low-latency.sh `

## Verification

- [ ] CI passes
- [ ] Changes are limited to test/scripts/docs
- [ ] Fix addresses the root cause described in the JIRA bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test readiness synchronization across all bootc scenarios. Changed from boot-count-based waits to polling actual service states, with extended timeout from 60 to 300 seconds. Enhanced reliability and robustness of test initialization for low-latency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->