### PR TITLE
USHIFT-7033: RPM test suites: set release

### DIFF
--- a/test/scenarios-bootc/el10/presubmits/el102-src@rpm-install.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@rpm-install.sh
@@ -140,6 +140,7 @@ scenario_run_tests() {
     configure_rhocp_repo "${RHOCP_MINOR_Y1}"      "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
     configure_rhocp_repo "${RHOCP_MINOR_Y1_BETA}" "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
     configure_microshift_mirror "${PREVIOUS_RELEASE_REPO}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 10.2"
     configure_cdn_repo \
         "fast-datapath" \
         "Red Hat Fast Datapath for RHEL 9" \

--- a/test/scenarios-bootc/el9/presubmits/el98-src@rpm-install.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@rpm-install.sh
@@ -106,6 +106,7 @@ scenario_run_tests() {
     configure_rhocp_repo "${RHOCP_MINOR_Y1}"      "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
     configure_rhocp_repo "${RHOCP_MINOR_Y1_BETA}" "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
     configure_microshift_mirror "${PREVIOUS_RELEASE_REPO}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 9.8"
     run_command_on_vm host1 "sudo subscription-manager repos --enable fast-datapath-for-rhel-9-\$(uname -m)-rpms"
 
     run_tests host1 \

--- a/test/scenarios/presubmits/el98-src@rpm-install.sh.disabled
+++ b/test/scenarios/presubmits/el98-src@rpm-install.sh.disabled
@@ -106,6 +106,7 @@ scenario_run_tests() {
     configure_rhocp_repo "${RHOCP_MINOR_Y1}"      "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
     configure_rhocp_repo "${RHOCP_MINOR_Y1_BETA}" "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
     configure_microshift_mirror "${PREVIOUS_RELEASE_REPO}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 9.8"
     run_command_on_vm host1 "sudo subscription-manager repos --enable fast-datapath-for-rhel-9-\$(uname -m)-rpms"
 
     run_tests host1 \

--- a/test/scenarios/releases/el98@rpm-standard1.sh
+++ b/test/scenarios/releases/el98@rpm-standard1.sh
@@ -73,6 +73,7 @@ scenario_run_tests() {
     # the previous minor version.
     configure_rhocp_repo "${RHOCP_MINOR_Y}"       "${MAJOR_VERSION}" "${MINOR_VERSION}"
     configure_rhocp_repo "${RHOCP_MINOR_Y_BETA}"  "${MAJOR_VERSION}" "${MINOR_VERSION}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 9.8"
     run_command_on_vm host1 "sudo subscription-manager repos --enable fast-datapath-for-rhel-9-\$(uname -m)-rpms"
 
     run_tests host1 \

--- a/test/scenarios/releases/el98@rpm-standard2.sh
+++ b/test/scenarios/releases/el98@rpm-standard2.sh
@@ -74,6 +74,7 @@ scenario_run_tests() {
     # the previous minor version.
     configure_rhocp_repo "${RHOCP_MINOR_Y}"       "${MAJOR_VERSION}" "${MINOR_VERSION}"
     configure_rhocp_repo "${RHOCP_MINOR_Y_BETA}"  "${MAJOR_VERSION}" "${MINOR_VERSION}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 9.8"
     run_command_on_vm host1 "sudo subscription-manager repos --enable fast-datapath-for-rhel-9-\$(uname -m)-rpms"
 
     run_tests host1 \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to explicitly set target RHEL release versions (9.8 and 10.2) before executing RPM package management test suites across multiple test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->