### PR TITLE
USHIFT-6984: Check Brew RPM availability in scenarios

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -581,6 +581,15 @@ exit_if_image_not_found() {
     fi
 }
 
+# Exit the script if Brew RPMs are not found.
+exit_if_brew_rpms_not_found() {
+    if [[ -z "${BREW_LREL_RELEASE_VERSION}" ]]; then
+        echo "Brew RPM release version is not set - VM can't be created"
+        record_junit "BREW_LREL_RELEASE_VERSION is not set" "brew_rpms_not_found" "SKIPPED"
+        exit 0
+    fi
+}
+
 # Exit the script if the latest release image is not set.
 exit_if_image_not_set() {
     local -r release_image_url="${1}"

--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -583,7 +583,7 @@ exit_if_image_not_found() {
 
 # Exit the script if Brew RPMs are not found.
 exit_if_brew_rpms_not_found() {
-    if [[ -z "${BREW_LREL_RELEASE_VERSION}" ]]; then
+    if [[ -z "${BREW_LREL_RELEASE_VERSION:-}" ]]; then
         echo "Brew RPM release version is not set - VM can't be created"
         record_junit "BREW_LREL_RELEASE_VERSION is not set" "brew_rpms_not_found" "SKIPPED"
         exit 0

--- a/test/scenarios/releases/el98-zprel@el98-lrel@rpm-upgrade.sh.disabled
+++ b/test/scenarios/releases/el98-zprel@el98-lrel@rpm-upgrade.sh.disabled
@@ -15,6 +15,7 @@ export TEST_RANDOMIZATION=none
 
 scenario_create_vms() {
     exit_if_zprel_not_exist
+    exit_if_brew_rpms_not_found
 
     prepare_kickstart host1 kickstart-liveimg.ks.template ""
     launch_vm --boot_blueprint rhel-9.8
@@ -32,12 +33,14 @@ scenario_create_vms() {
 
 scenario_remove_vms() {
     exit_if_zprel_not_exist
+    exit_if_brew_rpms_not_found
 
     remove_vm host1
 }
 
 scenario_run_tests() {
     exit_if_zprel_not_exist
+    exit_if_brew_rpms_not_found
 
     # Enable the rhocp repo for the current minor version to install previous Z-stream version
     run_command_on_vm host1 "sudo subscription-manager repos --enable fast-datapath-for-rhel-9-\$(uname -m)-rpms"

--- a/test/scenarios/releases/el98@rpm-standard1.sh
+++ b/test/scenarios/releases/el98@rpm-standard1.sh
@@ -44,6 +44,8 @@ EOF
 }
 
 scenario_create_vms() {
+    exit_if_brew_rpms_not_found
+
     prepare_kickstart host1 kickstart-liveimg.ks.template ""
     launch_vm rhel-9.8
     # Open the firewall ports. Other scenarios get this behavior by
@@ -59,10 +61,14 @@ scenario_create_vms() {
 }
 
 scenario_remove_vms() {
+    exit_if_brew_rpms_not_found
+
     remove_vm host1
 }
 
 scenario_run_tests() {
+    exit_if_brew_rpms_not_found
+
     local -r reponame=$(basename "${BREW_REPO}")
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
 

--- a/test/scenarios/releases/el98@rpm-standard2.sh
+++ b/test/scenarios/releases/el98@rpm-standard2.sh
@@ -44,6 +44,8 @@ EOF
 }
 
 scenario_create_vms() {
+    exit_if_brew_rpms_not_found
+
     prepare_kickstart host1 kickstart-liveimg.ks.template ""
     launch_vm rhel-9.8
 
@@ -60,10 +62,14 @@ scenario_create_vms() {
 }
 
 scenario_remove_vms() {
+    exit_if_brew_rpms_not_found
+
     remove_vm host1
 }
 
 scenario_run_tests() {
+    exit_if_brew_rpms_not_found
+
     local -r reponame=$(basename "${BREW_REPO}")
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
 

--- a/test/scenarios/releases/el98@rpm-upgrade.sh
+++ b/test/scenarios/releases/el98@rpm-upgrade.sh
@@ -72,6 +72,8 @@ EOF
 }
 
 scenario_create_vms() {
+    exit_if_brew_rpms_not_found
+
     prepare_kickstart host1 kickstart-liveimg.ks.template ""
     launch_vm rhel-9.8
 
@@ -88,10 +90,14 @@ scenario_create_vms() {
 }
 
 scenario_remove_vms() {
+    exit_if_brew_rpms_not_found
+
     remove_vm host1
 }
 
 scenario_run_tests() {
+    exit_if_brew_rpms_not_found
+
     local -r reponame=$(basename "${BREW_REPO}")
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
 


### PR DESCRIPTION
Replaces https://github.com/openshift/microshift/pull/6707.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added pre-checks to ensure required build artifacts are available before VM creation, removal, or test execution.
  * Scenarios now skip early with a recorded skipped result and graceful exit when dependencies are missing.
  * Made VM lifecycle handling consistent across create, remove, and test phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->