### PR TITLE
USHIFT-7058: Build and use small OLM catalog

### DIFF
--- a/test/assets/olm/catalog-source.yaml
+++ b/test/assets/olm/catalog-source.yaml
@@ -1,13 +1,13 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: redhat-operators
+  name: hello-microshift-catalog
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.16
-  displayName: Red Hat Operators
-  publisher: Red Hat
+  image: quay.io/microshift/hello-microshift-catalog:latest
+  displayName: Hello MicroShift Catalog
+  publisher: MicroShift CI
   grpcPodConfig:
     securityContextConfig: restricted
   updateStrategy:

--- a/test/assets/olm/hello-microshift-operator/build-catalog.sh
+++ b/test/assets/olm/hello-microshift-operator/build-catalog.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Build a file-based catalog image for the hello-microshift operator.
+#
+# The catalog contains a single operator (hello-microshift-operator v0.1.0)
+# that deploys a minimal HTTP server using quay.io/microshift/busybox:1.36.
+#
+# Usage:
+#   ./build-catalog.sh                                    # build only
+#   ./build-catalog.sh --push                             # build and push
+#   ./build-catalog.sh --image quay.io/myrepo/catalog:v1  # custom image name
+
+set -euo pipefail
+
+SCRIPT_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+ROOT_DIR="$(realpath "${SCRIPT_DIR}/../../../..")"
+
+DEFAULT_IMAGE="quay.io/microshift/hello-microshift-catalog:latest"
+IMAGE="${DEFAULT_IMAGE}"
+PUSH=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)
+            IMAGE="$2"
+            shift 2
+            ;;
+        --push)
+            PUSH=true
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+OPM="${OPM:-}"
+if [[ -z "${OPM}" ]]; then
+    OPM="${ROOT_DIR}/_output/bin/opm"
+    if [[ ! -x "${OPM}" ]]; then
+        echo "opm not found at ${OPM}, fetching..."
+        DEST_DIR="${ROOT_DIR}/_output/bin" "${ROOT_DIR}/scripts/fetch_tools.sh" opm
+    fi
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+CATALOG_DIR="${WORK_DIR}/catalog/hello-microshift-operator"
+mkdir -p "${CATALOG_DIR}"
+
+echo "Rendering bundle from ${SCRIPT_DIR}..."
+"${OPM}" render "${SCRIPT_DIR}" -o json > "${CATALOG_DIR}/catalog.json"
+
+echo "Appending package and channel entries..."
+yq -o json -I 0 "${SCRIPT_DIR}/catalog-extra.yaml" >> "${CATALOG_DIR}/catalog.json"
+
+echo "Validating file-based catalog..."
+"${OPM}" validate "${WORK_DIR}/catalog/"
+
+cat > "${WORK_DIR}/catalog.Dockerfile" <<'DOCKERFILE'
+FROM quay.io/operator-framework/opm:latest
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+COPY catalog/hello-microshift-operator /configs/hello-microshift-operator
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+DOCKERFILE
+
+ARCHES=(amd64 arm64)
+
+echo "Creating manifest ${IMAGE}..."
+podman manifest rm "${IMAGE}" 2>/dev/null || true
+podman manifest create "${IMAGE}"
+
+for arch in "${ARCHES[@]}"; do
+    echo "Building linux/${arch}..."
+    podman build --platform "linux/${arch}" \
+        --manifest "${IMAGE}" \
+        -f "${WORK_DIR}/catalog.Dockerfile" "${WORK_DIR}"
+done
+
+if ${PUSH}; then
+    echo "Pushing ${IMAGE}..."
+    podman manifest push --all "${IMAGE}" "docker://${IMAGE}"
+fi
+
+echo "Done: ${IMAGE}"

--- a/test/assets/olm/hello-microshift-operator/build-catalog.sh
+++ b/test/assets/olm/hello-microshift-operator/build-catalog.sh
@@ -63,7 +63,7 @@ echo "Validating file-based catalog..."
 cat > "${WORK_DIR}/catalog.Dockerfile" <<'DOCKERFILE'
 FROM quay.io/operator-framework/opm:latest
 ENTRYPOINT ["/bin/opm"]
-CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache", "--cache-enforce-integrity=false"]
 COPY catalog/hello-microshift-operator /configs/hello-microshift-operator
 LABEL operators.operatorframework.io.index.configs.v1=/configs
 DOCKERFILE

--- a/test/assets/olm/hello-microshift-operator/build-catalog.sh
+++ b/test/assets/olm/hello-microshift-operator/build-catalog.sh
@@ -71,7 +71,7 @@ DOCKERFILE
 ARCHES=(amd64 arm64)
 
 echo "Creating manifest ${IMAGE}..."
-podman manifest rm "${IMAGE}" 2>/dev/null || true
+podman rmi -f "${IMAGE}" 2>/dev/null || true
 podman manifest create "${IMAGE}"
 
 for arch in "${ARCHES[@]}"; do

--- a/test/assets/olm/hello-microshift-operator/catalog-extra.yaml
+++ b/test/assets/olm/hello-microshift-operator/catalog-extra.yaml
@@ -1,0 +1,10 @@
+---
+schema: olm.package
+name: hello-microshift-operator
+defaultChannel: alpha
+---
+schema: olm.channel
+name: alpha
+package: hello-microshift-operator
+entries:
+  - name: hello-microshift-operator.v0.1.0

--- a/test/assets/olm/hello-microshift-operator/manifests/hello-microshift-operator.clusterserviceversion.yaml
+++ b/test/assets/olm/hello-microshift-operator/manifests/hello-microshift-operator.clusterserviceversion.yaml
@@ -1,0 +1,57 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: hello-microshift-operator.v0.1.0
+  namespace: placeholder
+  annotations:
+    categories: "Testing"
+spec:
+  displayName: Hello MicroShift Operator
+  description: A minimal test operator that deploys a simple HTTP server.
+  version: 0.1.0
+  maturity: alpha
+  replaces: ""
+  minKubeVersion: 1.25.0
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+        - name: hello-microshift
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: hello-microshift
+            template:
+              metadata:
+                labels:
+                  app: hello-microshift
+              spec:
+                terminationGracePeriodSeconds: 0
+                containers:
+                  - name: hello-microshift
+                    image: quay.io/microshift/busybox:1.36
+                    command: ["/bin/sh"]
+                    args:
+                      - "-c"
+                      - 'while true; do echo -ne "HTTP/1.0 200 OK\r\nContent-Length: 16\r\n\r\nHello MicroShift" | nc -l -p 8080 ; done'
+                    ports:
+                      - containerPort: 8080
+                        protocol: TCP
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      seccompProfile:
+                        type: RuntimeDefault

--- a/test/assets/olm/hello-microshift-operator/metadata/annotations.yaml
+++ b/test/assets/olm/hello-microshift-operator/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: hello-microshift-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha

--- a/test/assets/olm/subscription.yaml
+++ b/test/assets/olm/subscription.yaml
@@ -1,9 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: amq-broker
+  name: hello-microshift-operator
   namespace: openshift-operators
 spec:
-  name: amq-broker-rhel8
-  source: redhat-operators
+  channel: alpha
+  name: hello-microshift-operator
+  source: hello-microshift-catalog
   sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/test/suites/optional/olm.robot
+++ b/test/suites/optional/olm.robot
@@ -15,7 +15,7 @@ Suite Teardown      Teardown
 *** Variables ***
 ${CATALOG_SOURCE}           ./assets/olm/catalog-source.yaml
 ${SUBSCRIPTION}             ./assets/olm/subscription.yaml
-${SUBSCRIPTION_NAME}        amq-broker
+${SUBSCRIPTION_NAME}        hello-microshift-operator
 ${MARKETPLACE_NAMESPACE}    openshift-marketplace
 ${OPERATORS_NAMESPACE}      openshift-operators
 ${OLM_NAMESPACE}            openshift-operator-lifecycle-manager
@@ -39,8 +39,8 @@ ${ALL_SUB_NAME}             nginx-ok2-1399
 
 
 *** Test Cases ***
-Deploy AmqBroker From Red Hat Operators catalog
-    [Documentation]    Deploy AMQ Broker from Red Hat Operators catalog.
+Deploy Hello MicroShift Operator From Catalog
+    [Documentation]    Deploy hello-microshift operator from a self-contained catalog.
     [Setup]    Setup Test
 
     ${csv}=    Get CSV Name From Subscription    ${OPERATORS_NAMESPACE}    ${SUBSCRIPTION_NAME}
@@ -176,8 +176,8 @@ OLM Should Be Ready
     Named Deployment Should Be Available    olm-operator    openshift-operator-lifecycle-manager
 
 Download CatalogSource Image
-    [Documentation]    CatalogSource container image contains a few gigabytes of data.
-    ...    Preload it to avoid timeouts during the CatalogSource resource creation.
+    [Documentation]    Preload the CatalogSource container image to avoid
+    ...    timeouts during the CatalogSource resource creation.
     ${yaml_content}=    OperatingSystem.Get File    ${CATALOG_SOURCE}
     ${yaml_data}=    Yaml Parse    ${yaml_content}
     VAR    ${image}=    ${yaml_data.spec.image}
@@ -188,10 +188,10 @@ Download CatalogSource Image
     Should Be Equal As Integers    0    ${rc}
 
 Create CatalogSource
-    [Documentation]    Create CatalogSource resource with Red Hat Community Catalog Index.
+    [Documentation]    Create CatalogSource resource with the hello-microshift catalog.
     Oc Create    -f ${CATALOG_SOURCE}
     Wait Until Keyword Succeeds    10m    15s
-    ...    CatalogSource Should Be Ready    ${MARKETPLACE_NAMESPACE}    redhat-operators
+    ...    CatalogSource Should Be Ready    ${MARKETPLACE_NAMESPACE}    hello-microshift-catalog
 
 CatalogSource Should Be Ready
     [Documentation]    Checks if CatalogSource is ready.


### PR DESCRIPTION
redhat-operator-index is almost 5GiB in size which might have been causing flakiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated OLM test assets and Robot suite to target the hello-microshift operator catalog and subscription.
* **Chores**
  * Added a script to build and optionally push file-based OLM catalog images for testing.
* **New Features**
  * Added operator bundle metadata, CSV manifest, catalog entries, and subscription configurations to enable catalog-based operator testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->