### PR TITLE
USHIFT-6849: Add C2CC IPv6 tests scenarios

### DIFF
--- a/test/resources/c2cc.resource
+++ b/test/resources/c2cc.resource
@@ -32,7 +32,8 @@ ${KUBECONFIG_C}             ${EMPTY}
 &{C2CC_KUBECONFIGS}         &{EMPTY}
 &{C2CC_SSH_IDS}             &{EMPTY}
 @{C2CC_REMOTE_ALIASES}      @{EMPTY}
-${IP_FAMILY}                ipv4
+${IP_FAMILY}                ${EMPTY}
+${IP_CMD}                   ${{'ip -6' if '${IP_FAMILY}' == 'ipv6' else 'ip -4'}}
 
 
 *** Keywords ***
@@ -136,31 +137,27 @@ Oc Apply On Cluster
 Verify Routes In Table 200
     [Documentation]    Check that routes for the given CIDRs exist in table 200.
     [Arguments]    ${alias}    ${remote_pod_cidr}    ${remote_svc_cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} route show table 200
+    ${stdout}=    Command On Cluster    ${alias}    ${IP_CMD} route show table 200
     Should Contain    ${stdout}    ${remote_pod_cidr}
     Should Contain    ${stdout}    ${remote_svc_cidr}
 
 Verify IP Rules For Table 200
     [Documentation]    Check that IP rules at priority 100 exist for the given CIDRs.
     [Arguments]    ${alias}    ${remote_pod_cidr}    ${remote_svc_cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} rule show
+    ${stdout}=    Command On Cluster    ${alias}    ${IP_CMD} rule show
     Should Contain    ${stdout}    to ${remote_pod_cidr} lookup 200
     Should Contain    ${stdout}    to ${remote_svc_cidr} lookup 200
 
 Verify Routes In Table 201
     [Documentation]    Check that service routes exist in table 201 for the local service CIDR.
     [Arguments]    ${alias}    ${local_svc_cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} route show table 201
+    ${stdout}=    Command On Cluster    ${alias}    ${IP_CMD} route show table 201
     Should Contain    ${stdout}    ${local_svc_cidr}
 
 Verify Service IP Rules
     [Documentation]    Check that IP rules at priority 99 exist for cross-cluster service routing.
     [Arguments]    ${alias}    ${remote_pod_cidr}    ${remote_svc_cidr}    ${local_svc_cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} rule show
+    ${stdout}=    Command On Cluster    ${alias}    ${IP_CMD} rule show
     Should Contain    ${stdout}    from ${remote_pod_cidr} to ${local_svc_cidr} lookup 201
     Should Contain    ${stdout}    from ${remote_svc_cidr} to ${local_svc_cidr} lookup 201
 

--- a/test/resources/c2cc.resource
+++ b/test/resources/c2cc.resource
@@ -32,6 +32,7 @@ ${KUBECONFIG_C}             ${EMPTY}
 &{C2CC_KUBECONFIGS}         &{EMPTY}
 &{C2CC_SSH_IDS}             &{EMPTY}
 @{C2CC_REMOTE_ALIASES}      @{EMPTY}
+${IP_FAMILY}                ipv4
 
 
 *** Keywords ***
@@ -135,27 +136,31 @@ Oc Apply On Cluster
 Verify Routes In Table 200
     [Documentation]    Check that routes for the given CIDRs exist in table 200.
     [Arguments]    ${alias}    ${remote_pod_cidr}    ${remote_svc_cidr}
-    ${stdout}=    Command On Cluster    ${alias}    ip route show table 200
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} route show table 200
     Should Contain    ${stdout}    ${remote_pod_cidr}
     Should Contain    ${stdout}    ${remote_svc_cidr}
 
 Verify IP Rules For Table 200
     [Documentation]    Check that IP rules at priority 100 exist for the given CIDRs.
     [Arguments]    ${alias}    ${remote_pod_cidr}    ${remote_svc_cidr}
-    ${stdout}=    Command On Cluster    ${alias}    ip rule show
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} rule show
     Should Contain    ${stdout}    to ${remote_pod_cidr} lookup 200
     Should Contain    ${stdout}    to ${remote_svc_cidr} lookup 200
 
 Verify Routes In Table 201
     [Documentation]    Check that service routes exist in table 201 for the local service CIDR.
     [Arguments]    ${alias}    ${local_svc_cidr}
-    ${stdout}=    Command On Cluster    ${alias}    ip route show table 201
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} route show table 201
     Should Contain    ${stdout}    ${local_svc_cidr}
 
 Verify Service IP Rules
     [Documentation]    Check that IP rules at priority 99 exist for cross-cluster service routing.
     [Arguments]    ${alias}    ${remote_pod_cidr}    ${remote_svc_cidr}    ${local_svc_cidr}
-    ${stdout}=    Command On Cluster    ${alias}    ip rule show
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    ${alias}    ${ip_cmd} rule show
     Should Contain    ${stdout}    from ${remote_pod_cidr} to ${local_svc_cidr} lookup 201
     Should Contain    ${stdout}    from ${remote_svc_cidr} to ${local_svc_cidr} lookup 201
 

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc-ipv6.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc-ipv6.sh
@@ -3,19 +3,31 @@
 # Sourced from scenario.sh and uses functions defined there.
 export TEST_RANDOMIZATION=none
 
-# Cluster A (host1): default MicroShift CIDRs
-CLUSTER_A_POD_CIDR="10.42.0.0/16"
-CLUSTER_A_SVC_CIDR="10.43.0.0/16"
+# Redefine network-related settings to use the dedicated IPv6 network bridge
+# shellcheck disable=SC2034  # used elsewhere
+VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_IPV6_NETWORK}")"
+# shellcheck disable=SC2034  # used elsewhere
+WEB_SERVER_URL="http://[${VM_BRIDGE_IP}]:${WEB_SERVER_PORT}"
+# Using `hostname` here instead of a raw ip because skopeo only allows either
+# ipv4 or fqdn's, but not ipv6. Since the registry is hosted on the ipv6
+# network gateway in the host, we need to use a combination of the hostname
+# plus /etc/hosts resolution (which is taken care of by kickstart).
+# shellcheck disable=SC2034  # used elsewhere
+MIRROR_REGISTRY_URL="$(hostname):${MIRROR_REGISTRY_PORT}/microshift"
+
+# Cluster A (host1): non-overlapping CIDRs
+CLUSTER_A_POD_CIDR="fd01::/48"
+CLUSTER_A_SVC_CIDR="fd02::/48"
 CLUSTER_A_DOMAIN="cluster-a.remote"
 
 # Cluster B (host2): non-overlapping CIDRs
-CLUSTER_B_POD_CIDR="10.45.0.0/16"
-CLUSTER_B_SVC_CIDR="10.46.0.0/16"
+CLUSTER_B_POD_CIDR="fd04::/48"
+CLUSTER_B_SVC_CIDR="fd05::/48"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
 # Cluster C (host3): non-overlapping CIDRs
-CLUSTER_C_POD_CIDR="10.48.0.0/16"
-CLUSTER_C_SVC_CIDR="10.49.0.0/16"
+CLUSTER_C_POD_CIDR="fd07::/48"
+CLUSTER_C_SVC_CIDR="fd08::/48"
 CLUSTER_C_DOMAIN="cluster-c.remote"
 
 wait_for_greenboot_on_hosts() {
@@ -97,9 +109,9 @@ configure_c2cc_hosts() {
 }
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel102-bootc-source
-    prepare_kickstart host2 kickstart-bootc.ks.template rhel102-bootc-source
-    prepare_kickstart host3 kickstart-bootc.ks.template rhel102-bootc-source
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel102-bootc-source false true
+    prepare_kickstart host2 kickstart-bootc.ks.template rhel102-bootc-source false true 
+    prepare_kickstart host3 kickstart-bootc.ks.template rhel102-bootc-source false true
 
     # Inject host2's and host3's non-default CIDRs into its kickstart config so MicroShift
     # boots with the correct network from the start (no cleanup-data needed).
@@ -124,9 +136,9 @@ network:
 IEOF
 EOF
 
-    launch_vm rhel102-bootc --vmname host1
-    launch_vm rhel102-bootc --vmname host2
-    launch_vm rhel102-bootc --vmname host3
+    launch_vm rhel102-bootc --vmname host1 --network "${VM_IPV6_NETWORK}"
+    launch_vm rhel102-bootc --vmname host2 --network "${VM_IPV6_NETWORK}"
+    launch_vm rhel102-bootc --vmname host3 --network "${VM_IPV6_NETWORK}"
 }
 
 scenario_remove_vms() {
@@ -169,6 +181,7 @@ scenario_run_tests() {
         --variable "CLUSTER_C_SVC_CIDR:${CLUSTER_C_SVC_CIDR}" \
         --variable "CLUSTER_C_DOMAIN:${CLUSTER_C_DOMAIN}" \
         --variable "KUBECONFIG_C:${kubeconfig_c}" \
-        --variable "FOREIGN_CIDR:192.0.2.0/24" \
+        --variable "FOREIGN_CIDR:2001:db8::/64" \
+        --variable "IP_FAMILY:ipv6" \
         suites/c2cc/
 }

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc-ipv6.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc-ipv6.sh
@@ -17,17 +17,17 @@ MIRROR_REGISTRY_URL="$(hostname):${MIRROR_REGISTRY_PORT}/microshift"
 
 # Cluster A (host1): non-overlapping CIDRs
 CLUSTER_A_POD_CIDR="fd01::/48"
-CLUSTER_A_SVC_CIDR="fd02::/48"
+CLUSTER_A_SVC_CIDR="fd02::/112"
 CLUSTER_A_DOMAIN="cluster-a.remote"
 
 # Cluster B (host2): non-overlapping CIDRs
 CLUSTER_B_POD_CIDR="fd04::/48"
-CLUSTER_B_SVC_CIDR="fd05::/48"
+CLUSTER_B_SVC_CIDR="fd05::/112"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
 # Cluster C (host3): non-overlapping CIDRs
 CLUSTER_C_POD_CIDR="fd07::/48"
-CLUSTER_C_SVC_CIDR="fd08::/48"
+CLUSTER_C_SVC_CIDR="fd08::/112"
 CLUSTER_C_DOMAIN="cluster-c.remote"
 
 wait_for_greenboot_on_hosts() {

--- a/test/scenarios-bootc/el10/presubmits/el102-src@c2cc-ipv6.sh
+++ b/test/scenarios-bootc/el10/presubmits/el102-src@c2cc-ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Sourced from scenario.sh and uses functions defined there.
-export TEST_RANDOMIZATION=none
+export TEST_RANDOMIZATION=suites
 
 # Redefine network-related settings to use the dedicated IPv6 network bridge
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc-ipv6.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc-ipv6.sh
@@ -17,17 +17,17 @@ MIRROR_REGISTRY_URL="$(hostname):${MIRROR_REGISTRY_PORT}/microshift"
 
 # Cluster A (host1): non-overlapping CIDRs
 CLUSTER_A_POD_CIDR="fd01::/48"
-CLUSTER_A_SVC_CIDR="fd02::/48"
+CLUSTER_A_SVC_CIDR="fd02::/112"
 CLUSTER_A_DOMAIN="cluster-a.remote"
 
 # Cluster B (host2): non-overlapping CIDRs
 CLUSTER_B_POD_CIDR="fd04::/48"
-CLUSTER_B_SVC_CIDR="fd05::/48"
+CLUSTER_B_SVC_CIDR="fd05::/112"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
 # Cluster C (host3): non-overlapping CIDRs
 CLUSTER_C_POD_CIDR="fd07::/48"
-CLUSTER_C_SVC_CIDR="fd08::/48"
+CLUSTER_C_SVC_CIDR="fd08::/112"
 CLUSTER_C_DOMAIN="cluster-c.remote"
 
 wait_for_greenboot_on_hosts() {

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc-ipv6.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc-ipv6.sh
@@ -3,19 +3,31 @@
 # Sourced from scenario.sh and uses functions defined there.
 export TEST_RANDOMIZATION=none
 
-# Cluster A (host1): default MicroShift CIDRs
-CLUSTER_A_POD_CIDR="10.42.0.0/16"
-CLUSTER_A_SVC_CIDR="10.43.0.0/16"
+# Redefine network-related settings to use the dedicated IPv6 network bridge
+# shellcheck disable=SC2034  # used elsewhere
+VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_IPV6_NETWORK}")"
+# shellcheck disable=SC2034  # used elsewhere
+WEB_SERVER_URL="http://[${VM_BRIDGE_IP}]:${WEB_SERVER_PORT}"
+# Using `hostname` here instead of a raw ip because skopeo only allows either
+# ipv4 or fqdn's, but not ipv6. Since the registry is hosted on the ipv6
+# network gateway in the host, we need to use a combination of the hostname
+# plus /etc/hosts resolution (which is taken care of by kickstart).
+# shellcheck disable=SC2034  # used elsewhere
+MIRROR_REGISTRY_URL="$(hostname):${MIRROR_REGISTRY_PORT}/microshift"
+
+# Cluster A (host1): non-overlapping CIDRs
+CLUSTER_A_POD_CIDR="fd01::/48"
+CLUSTER_A_SVC_CIDR="fd02::/48"
 CLUSTER_A_DOMAIN="cluster-a.remote"
 
 # Cluster B (host2): non-overlapping CIDRs
-CLUSTER_B_POD_CIDR="10.45.0.0/16"
-CLUSTER_B_SVC_CIDR="10.46.0.0/16"
+CLUSTER_B_POD_CIDR="fd04::/48"
+CLUSTER_B_SVC_CIDR="fd05::/48"
 CLUSTER_B_DOMAIN="cluster-b.remote"
 
 # Cluster C (host3): non-overlapping CIDRs
-CLUSTER_C_POD_CIDR="10.48.0.0/16"
-CLUSTER_C_SVC_CIDR="10.49.0.0/16"
+CLUSTER_C_POD_CIDR="fd07::/48"
+CLUSTER_C_SVC_CIDR="fd08::/48"
 CLUSTER_C_DOMAIN="cluster-c.remote"
 
 wait_for_greenboot_on_hosts() {
@@ -97,9 +109,9 @@ configure_c2cc_hosts() {
 }
 
 scenario_create_vms() {
-    prepare_kickstart host1 kickstart-bootc.ks.template rhel102-bootc-source
-    prepare_kickstart host2 kickstart-bootc.ks.template rhel102-bootc-source
-    prepare_kickstart host3 kickstart-bootc.ks.template rhel102-bootc-source
+    prepare_kickstart host1 kickstart-bootc.ks.template rhel98-bootc-source false true
+    prepare_kickstart host2 kickstart-bootc.ks.template rhel98-bootc-source false true 
+    prepare_kickstart host3 kickstart-bootc.ks.template rhel98-bootc-source false true
 
     # Inject host2's and host3's non-default CIDRs into its kickstart config so MicroShift
     # boots with the correct network from the start (no cleanup-data needed).
@@ -124,9 +136,9 @@ network:
 IEOF
 EOF
 
-    launch_vm rhel102-bootc --vmname host1
-    launch_vm rhel102-bootc --vmname host2
-    launch_vm rhel102-bootc --vmname host3
+    launch_vm rhel98-bootc --vmname host1 --network "${VM_IPV6_NETWORK}"
+    launch_vm rhel98-bootc --vmname host2 --network "${VM_IPV6_NETWORK}"
+    launch_vm rhel98-bootc --vmname host3 --network "${VM_IPV6_NETWORK}"
 }
 
 scenario_remove_vms() {
@@ -169,6 +181,7 @@ scenario_run_tests() {
         --variable "CLUSTER_C_SVC_CIDR:${CLUSTER_C_SVC_CIDR}" \
         --variable "CLUSTER_C_DOMAIN:${CLUSTER_C_DOMAIN}" \
         --variable "KUBECONFIG_C:${kubeconfig_c}" \
-        --variable "FOREIGN_CIDR:192.0.2.0/24" \
+        --variable "FOREIGN_CIDR:2001:db8::/64" \
+        --variable "IP_FAMILY:ipv6" \
         suites/c2cc/
 }

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc-ipv6.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc-ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Sourced from scenario.sh and uses functions defined there.
-export TEST_RANDOMIZATION=none
+export TEST_RANDOMIZATION=suites
 
 # Redefine network-related settings to use the dedicated IPv6 network bridge
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
+++ b/test/scenarios-bootc/el9/presubmits/el98-src@c2cc.sh
@@ -169,5 +169,6 @@ scenario_run_tests() {
         --variable "CLUSTER_C_SVC_CIDR:${CLUSTER_C_SVC_CIDR}" \
         --variable "CLUSTER_C_DOMAIN:${CLUSTER_C_DOMAIN}" \
         --variable "KUBECONFIG_C:${kubeconfig_c}" \
+        --variable "FOREIGN_CIDR:192.0.2.0/24" \
         suites/c2cc/
 }

--- a/test/suites/c2cc/cleanup.robot
+++ b/test/suites/c2cc/cleanup.robot
@@ -23,7 +23,8 @@ ${C2CC_CONFIG_PATH}     /etc/microshift/config.d/50-c2cc.yaml
 *** Test Cases ***
 No Linux Routes In Table 200 After Disable
     [Documentation]    Routes to remote CIDRs in table 200 should be gone.
-    ${stdout}=    Command On Cluster    cluster-a    ip route show table 200
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} route show table 200
     FOR    ${cidr}    IN
     ...    ${CLUSTER_B_POD_CIDR}
     ...    ${CLUSTER_B_SVC_CIDR}
@@ -34,7 +35,8 @@ No Linux Routes In Table 200 After Disable
 
 No IP Rules For Table 200 After Disable
     [Documentation]    IP rules directing to table 200 should be gone.
-    ${stdout}=    Command On Cluster    cluster-a    ip rule show
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} rule show
     FOR    ${cidr}    IN
     ...    ${CLUSTER_B_POD_CIDR}
     ...    ${CLUSTER_B_SVC_CIDR}
@@ -45,12 +47,14 @@ No IP Rules For Table 200 After Disable
 
 No Service Routes In Table 201 After Disable
     [Documentation]    Service routes in table 201 should be gone.
-    ${stdout}=    Command On Cluster    cluster-a    ip route show table 201
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} route show table 201
     Should Not Contain    ${stdout}    ${CLUSTER_A_SVC_CIDR}
 
 No Service IP Rules After Disable
     [Documentation]    Service IP rules for table 201 should be gone.
-    ${stdout}=    Command On Cluster    cluster-a    ip rule show
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} rule show
     FOR    ${cidr}    IN
     ...    ${CLUSTER_B_POD_CIDR}
     ...    ${CLUSTER_B_SVC_CIDR}

--- a/test/suites/c2cc/cleanup.robot
+++ b/test/suites/c2cc/cleanup.robot
@@ -23,8 +23,7 @@ ${C2CC_CONFIG_PATH}     /etc/microshift/config.d/50-c2cc.yaml
 *** Test Cases ***
 No Linux Routes In Table 200 After Disable
     [Documentation]    Routes to remote CIDRs in table 200 should be gone.
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} route show table 200
+    ${stdout}=    Command On Cluster    cluster-a    ${IP_CMD} route show table 200
     FOR    ${cidr}    IN
     ...    ${CLUSTER_B_POD_CIDR}
     ...    ${CLUSTER_B_SVC_CIDR}
@@ -35,8 +34,7 @@ No Linux Routes In Table 200 After Disable
 
 No IP Rules For Table 200 After Disable
     [Documentation]    IP rules directing to table 200 should be gone.
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} rule show
+    ${stdout}=    Command On Cluster    cluster-a    ${IP_CMD} rule show
     FOR    ${cidr}    IN
     ...    ${CLUSTER_B_POD_CIDR}
     ...    ${CLUSTER_B_SVC_CIDR}
@@ -47,14 +45,12 @@ No IP Rules For Table 200 After Disable
 
 No Service Routes In Table 201 After Disable
     [Documentation]    Service routes in table 201 should be gone.
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} route show table 201
+    ${stdout}=    Command On Cluster    cluster-a    ${IP_CMD} route show table 201
     Should Not Contain    ${stdout}    ${CLUSTER_A_SVC_CIDR}
 
 No Service IP Rules After Disable
     [Documentation]    Service IP rules for table 201 should be gone.
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    ${stdout}=    Command On Cluster    cluster-a    ${ip_cmd} rule show
+    ${stdout}=    Command On Cluster    cluster-a    ${IP_CMD} rule show
     FOR    ${cidr}    IN
     ...    ${CLUSTER_B_POD_CIDR}
     ...    ${CLUSTER_B_SVC_CIDR}

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -123,6 +123,7 @@ Get Curl Pod IP
 Curl From Cluster
     [Documentation]    Exec curl from curl-pod on the given cluster to the target IP and port.
     [Arguments]    ${alias}    ${ip}    ${port}
+    ${url}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    http://[${ip}]:${port}/cgi-bin/hello    http://${ip}:${port}/cgi-bin/hello
     ${stdout}=    Oc On Cluster    ${alias}
-    ...    oc exec curl-pod -n ${NAMESPACES}[${alias}] -- curl -sS --max-time 10 http://${ip}:${port}/cgi-bin/hello
+    ...    oc exec curl-pod -n ${NAMESPACES}[${alias}] -- curl -sS --max-time 10 ${url}
     RETURN    ${stdout}

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -123,7 +123,10 @@ Get Curl Pod IP
 Curl From Cluster
     [Documentation]    Exec curl from curl-pod on the given cluster to the target IP and port.
     [Arguments]    ${alias}    ${ip}    ${port}
-    ${url}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    http://[${ip}]:${port}/cgi-bin/hello    http://${ip}:${port}/cgi-bin/hello
+    ${url}=    Set Variable If
+    ...    '${IP_FAMILY}' == 'ipv6'
+    ...    http://[${ip}]:${port}/cgi-bin/hello
+    ...    http://${ip}:${port}/cgi-bin/hello
     ${stdout}=    Oc On Cluster    ${alias}
     ...    oc exec curl-pod -n ${NAMESPACES}[${alias}] -- curl -sS --max-time 10 ${url}
     RETURN    ${stdout}

--- a/test/suites/c2cc/reconciliation.robot
+++ b/test/suites/c2cc/reconciliation.robot
@@ -111,27 +111,23 @@ Get Node Name On Cluster
 Delete Route From Table 200 On Cluster
     [Documentation]    Delete a specific route from policy routing table 200.
     [Arguments]    ${alias}    ${cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    Disruptive Command On Cluster    ${alias}    ${ip_cmd} route del ${cidr} table 200
+    Disruptive Command On Cluster    ${alias}    ${IP_CMD} route del ${cidr} table 200
 
 Delete IP Rule For Table 200 On Cluster
     [Documentation]    Delete an IP rule directing traffic to table 200.
     [Arguments]    ${alias}    ${cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    Disruptive Command On Cluster    ${alias}    ${ip_cmd} rule del to ${cidr} lookup 200
+    Disruptive Command On Cluster    ${alias}    ${IP_CMD} rule del to ${cidr} lookup 200
 
 Delete Service Route From Table 201 On Cluster
     [Documentation]    Delete a service route from table 201.
     [Arguments]    ${alias}    ${cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
-    Disruptive Command On Cluster    ${alias}    ${ip_cmd} route del ${cidr} table 201
+    Disruptive Command On Cluster    ${alias}    ${IP_CMD} route del ${cidr} table 201
 
 Delete Service IP Rule On Cluster
     [Documentation]    Delete a service IP rule from table 201.
     [Arguments]    ${alias}    ${from_cidr}    ${to_cidr}
-    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
     Disruptive Command On Cluster    ${alias}
-    ...    ${ip_cmd} rule del from ${from_cidr} to ${to_cidr} lookup 201
+    ...    ${IP_CMD} rule del from ${from_cidr} to ${to_cidr} lookup 201
 
 Delete NFTables C2CC Rule On Cluster
     [Documentation]    Delete an nftables bypass rule by discovering its handle.

--- a/test/suites/c2cc/reconciliation.robot
+++ b/test/suites/c2cc/reconciliation.robot
@@ -17,7 +17,7 @@ Test Tags           c2cc
 *** Variables ***
 ${RECONCILE_TIMEOUT}    30s
 ${RECONCILE_RETRY}      5s
-${FOREIGN_CIDR}         192.0.2.0/24
+${FOREIGN_CIDR}         ${EMPTY}
 
 
 *** Test Cases ***
@@ -111,23 +111,27 @@ Get Node Name On Cluster
 Delete Route From Table 200 On Cluster
     [Documentation]    Delete a specific route from policy routing table 200.
     [Arguments]    ${alias}    ${cidr}
-    Disruptive Command On Cluster    ${alias}    ip route del ${cidr} table 200
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    Disruptive Command On Cluster    ${alias}    ${ip_cmd} route del ${cidr} table 200
 
 Delete IP Rule For Table 200 On Cluster
     [Documentation]    Delete an IP rule directing traffic to table 200.
     [Arguments]    ${alias}    ${cidr}
-    Disruptive Command On Cluster    ${alias}    ip rule del to ${cidr} lookup 200
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    Disruptive Command On Cluster    ${alias}    ${ip_cmd} rule del to ${cidr} lookup 200
 
 Delete Service Route From Table 201 On Cluster
     [Documentation]    Delete a service route from table 201.
     [Arguments]    ${alias}    ${cidr}
-    Disruptive Command On Cluster    ${alias}    ip route del ${cidr} table 201
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
+    Disruptive Command On Cluster    ${alias}    ${ip_cmd} route del ${cidr} table 201
 
 Delete Service IP Rule On Cluster
     [Documentation]    Delete a service IP rule from table 201.
     [Arguments]    ${alias}    ${from_cidr}    ${to_cidr}
+    ${ip_cmd}=    Set Variable If    '${IP_FAMILY}' == 'ipv6'    ip -6    ip -4
     Disruptive Command On Cluster    ${alias}
-    ...    ip rule del from ${from_cidr} to ${to_cidr} lookup 201
+    ...    ${ip_cmd} rule del from ${from_cidr} to ${to_cidr} lookup 201
 
 Delete NFTables C2CC Rule On Cluster
     [Documentation]    Delete an nftables bypass rule by discovering its handle.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made C2CC tests IP-family-aware via an ${IP_FAMILY} toggle (supports ipv6).
  * Verification and cleanup steps now run IP-family-aware networking commands.
  * FOREIGN_CIDR default is now empty and can be supplied per run.
  * New IPv6 multi-host presubmit scenarios for EL9/EL10 to provision VMs, collect kubeconfigs, and run C2CC suites.
  * Connectivity checks now use IPv6-safe URL formatting when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->