### PR TITLE
USHIFT-6528: Switch to RHEL 9.8 production registry for bootc images

### DIFF
--- a/test/scenarios-bootc/el9/releases/el98-lrel@published-images-standard1.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@published-images-standard1.sh
@@ -13,7 +13,7 @@ scenario_create_vms() {
     exit_if_image_not_set "${LATEST_RELEASE_IMAGE_URL}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${LATEST_RELEASE_IMAGE_URL}"
-    launch_vm rhel96-bootc
+    launch_vm rhel98-bootc
 
     # Open the firewall ports. Other scenarios get this behavior by embedding
     # settings in the blueprint, but we cannot open firewall ports in published
@@ -32,7 +32,7 @@ scenario_run_tests() {
     exit_if_image_not_set "${LATEST_RELEASE_IMAGE_URL}"
 
     run_tests host1 \
-        --variable "EXPECTED_OS_VERSION:9.6" \
+        --variable "EXPECTED_OS_VERSION:9.8" \
         --variable "IMAGE_SIGSTORE_ENABLED:True" \
         suites/standard1/
 }

--- a/test/scenarios-bootc/el9/releases/el98-lrel@published-images-standard2.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@published-images-standard2.sh
@@ -13,7 +13,7 @@ scenario_create_vms() {
     exit_if_image_not_set "${LATEST_RELEASE_IMAGE_URL}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${LATEST_RELEASE_IMAGE_URL}"
-    launch_vm rhel96-bootc
+    launch_vm rhel98-bootc
 
     # Open the firewall ports. Other scenarios get this behavior by embedding
     # settings in the blueprint, but we cannot open firewall ports in published


### PR DESCRIPTION
Update published-images test scenarios from RHEL 9.6 (EL96) to RHEL 9.8 (EL98).

**Changes:**
- Replace `el96-lrel@published-images-standard1.sh` with `el98-lrel@published-images-standard1.sh`
- Replace `el96-lrel@published-images-standard2.sh` with `el98-lrel@published-images-standard2.sh`
- Update VM name: `rhel96-bootc` → `rhel98-bootc`
- Update expected OS version: `9.6` → `9.8` (standard1 scenario)

Both scenarios maintain signature verification for published MicroShift images and follow the same testing pattern as their EL96 predecessors.

**Related PR:**
- release-4.22: https://github.com/openshift/microshift/pull/6775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test scenarios to support validation of RHEL 9.8 bootc container images
  * Enhanced test infrastructure with OS version verification for the latest RHEL 9.8 releases
  * Maintained all existing test logic for image resolution, firewall configuration, and signature validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->