### PR TITLE
USHIFT-7128: Ansible: refresh node setup automation

### DIFF
--- a/ansible/roles/common/tasks/nodename.yml
+++ b/ansible/roles/common/tasks/nodename.yml
@@ -11,7 +11,7 @@
 #
 # become: yes — these files may be root-readable only; failed_when: false on
 # the slurps would otherwise silently mask permission errors and fall back
-# to ansible_hostname even when an override is configured.
+# to ansible_facts.hostname even when an override is configured.
 
 - name: Resolve kubernetes nodename
   become: yes
@@ -56,5 +56,5 @@
 - name: Set kubernetes_nodename fact
   ansible.builtin.set_fact:
     kubernetes_nodename: "{{ ((_microshift_hostname_override | length > 0)
-                              | ternary(_microshift_hostname_override, ansible_hostname))
+                              | ternary(_microshift_hostname_override, ansible_facts.hostname))
                               | lower }}"

--- a/ansible/roles/install-logging-exporters/defaults/main.yml
+++ b/ansible/roles/install-logging-exporters/defaults/main.yml
@@ -1,4 +1,4 @@
-process_exporter_url: https://github.com/ncabatoff/process-exporter/releases/download/v0.7.10/process-exporter_0.7.10_linux_amd64.rpm
+process_exporter_url: https://github.com/ncabatoff/process-exporter/releases/download/v0.8.7/process-exporter_0.8.7_linux_amd64.rpm
 
 prometheus_services:
   - process-exporter

--- a/ansible/roles/install-logging/tasks/main.yml
+++ b/ansible/roles/install-logging/tasks/main.yml
@@ -35,6 +35,7 @@
     state: restarted
     enabled: true
   loop: "{{ logging_services }}"
+  when: item != 'grafana-server' or (grafana_setup | bool)
 
 - name: Configure Grafana dashboards and datasources
   when: grafana_setup | bool
@@ -49,7 +50,7 @@
 
     - name: Create prometheus datasource in grafana
       ansible.builtin.uri:
-        url: http://{{ grafana_host_address | default(ansible_default_ipv4.address) }}:{{ grafana_port }}/api/datasources
+        url: http://{{ grafana_host_address | default(ansible_facts.default_ipv4.address) }}:{{ grafana_port }}/api/datasources
         url_username: "{{ grafana_username }}"
         url_password: "{{ grafana_password }}"
         status_code: [200, 409]
@@ -64,7 +65,7 @@
 
     - name: Create microshift perf dashboard in grafana
       ansible.builtin.uri:
-        url: http://{{ grafana_host_address | default(ansible_default_ipv4.address) }}:{{ grafana_port }}/api/dashboards/db
+        url: http://{{ grafana_host_address | default(ansible_facts.default_ipv4.address) }}:{{ grafana_port }}/api/dashboards/db
         url_username: "{{ grafana_username }}"
         url_password: "{{ grafana_password }}"
         force_basic_auth: true

--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -3,13 +3,13 @@
 
 crio_metrics_conf: 01-crio-metrics.conf
 crio_metrics_path: "/etc/crio/crio.conf.d/{{ crio_metrics_conf }}"
-etcd_dir: "{{ ansible_env.HOME }}/etcd"
+etcd_dir: "{{ ansible_facts.env.HOME }}/etcd"
 etcd_repo: https://github.com/openshift/etcd.git
 
-microshift_dir: "{{ ansible_env.HOME }}/microshift"
+microshift_dir: "{{ ansible_facts.env.HOME }}/microshift"
 microshift_repo: https://github.com/openshift/microshift.git
 microshift_rpms: []
-microshift_version: 4.17.1
+microshift_version: 4.22.0
 
 du_dirs:
   - /

--- a/ansible/roles/manage-repos/defaults/main.yml
+++ b/ansible/roles/manage-repos/defaults/main.yml
@@ -12,9 +12,11 @@ repo_list:
     repo_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_facts.architecture }}/dependencies/rpms/{{ ocp_version }}-el9-beta/"
 
 rhel_beta: ''
-rhel_repos:
+rhel_base_repos:
   - rhel-{{ ansible_facts.distribution_major_version }}-for-{{ ansible_facts.architecture }}-baseos-{{ rhel_beta }}rpms
   - rhel-{{ ansible_facts.distribution_major_version }}-for-{{ ansible_facts.architecture }}-appstream-{{ rhel_beta }}rpms
   - codeready-builder-{{ rhel_beta }}for-rhel-{{ ansible_facts.distribution_major_version }}-{{ ansible_facts.architecture }}-rpms
   - fast-datapath-{{ rhel_beta }}for-rhel-{{ ansible_facts.distribution_major_version }}-{{ ansible_facts.architecture }}-rpms
+rhel_ocp_repos:
   - rhocp-{{ ocp_version }}-for-rhel-{{ ansible_facts.distribution_major_version }}-{{ ansible_facts.architecture }}-rpms
+rhel_repos: "{{ rhel_base_repos + rhel_ocp_repos }}"

--- a/ansible/roles/manage-repos/tasks/create-mirrors.yaml
+++ b/ansible/roles/manage-repos/tasks/create-mirrors.yaml
@@ -12,3 +12,15 @@
         src: ocpbeta.repo.j2
         dest: "/etc/yum.repos.d/{{ item.repo_name }}.repo"
         mode: '0644'
+      register: microshift_mirror_repo
+
+    - name: Clean stale metadata for updated pre-release repo
+      ansible.builtin.command:
+        argv:
+          - dnf
+          - clean
+          - metadata
+          - "--disablerepo=*"
+          - "--enablerepo={{ item.repo_name }}"
+      changed_when: true
+      when: microshift_mirror_repo.changed

--- a/ansible/roles/manage-repos/tasks/main.yml
+++ b/ansible/roles/manage-repos/tasks/main.yml
@@ -41,22 +41,27 @@
     ansible.builtin.set_fact:
       microshift_prerelease: "{{ 'rc' in microshift_version or 'ec' in microshift_version or 'latest' in microshift_version }}"
 
+  - name: Enable required RHEL package repos for microshift
+    community.general.rhsm_repository:
+      name: "{{ rhel_base_repos }}"
+
   - name: Create microshift prerelease mirrors
-    include_tasks: roles/manage-repos/tasks/create-mirrors.yaml
+    include_tasks: create-mirrors.yaml
     loop: "{{ repo_list }}"
     when:
       - microshift_prerelease | bool
       - not (build_microshift | bool)
 
-  - name: Enable required repos for microshift
+  - name: Enable OpenShift repo for released microshift
     community.general.rhsm_repository:
-      name: "{{ rhel_repos }}"
+      name: "{{ rhel_ocp_repos }}"
     when:
       - not (microshift_prerelease | bool)
 
   - name: Install EPEL repo
     ansible.builtin.dnf:
       name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
+      disablerepo: "*"
       disable_gpg_check: true
       state: present
   when: ansible_facts.distribution == "RedHat"

--- a/ansible/roles/nvidia-gpu-test/tasks/main.yml
+++ b/ansible/roles/nvidia-gpu-test/tasks/main.yml
@@ -137,7 +137,7 @@
     - name: Save host nvidia-smi output to file
       ansible.builtin.copy:
         content: "{{ host_nvidia_smi.stdout }}"
-        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/host-nvidia-smi-{{ ansible_date_time.epoch }}.log"
+        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/host-nvidia-smi-{{ ansible_facts.date_time.epoch }}.log"
         mode: '0644'
       delegate_to: localhost
       become: no
@@ -145,7 +145,7 @@
     - name: Save pod nvidia-smi output to file
       ansible.builtin.copy:
         content: "{{ pod_nvidia_smi_logs.stdout }}"
-        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/pod-nvidia-smi-{{ ansible_date_time.epoch }}.log"
+        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/pod-nvidia-smi-{{ ansible_facts.date_time.epoch }}.log"
         mode: '0644'
       delegate_to: localhost
       become: no
@@ -153,7 +153,7 @@
     - name: Save cuda-vector-add output to file
       ansible.builtin.copy:
         content: "{{ cuda_vector_add_logs.stdout }}"
-        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/cuda-vector-add-{{ ansible_date_time.epoch }}.log"
+        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/cuda-vector-add-{{ ansible_facts.date_time.epoch }}.log"
         mode: '0644'
       delegate_to: localhost
       become: no
@@ -161,7 +161,7 @@
     - name: Save test summary to file
       ansible.builtin.copy:
         content: |
-          GPU Test Summary - {{ ansible_date_time.iso8601 }}
+          GPU Test Summary - {{ ansible_facts.date_time.iso8601 }}
           ========================================
           Host: {{ hostvars[groups['microshift'][0]]['ansible_host'] }}
           Host GPUs Detected: {{ gpu_count.stdout | trim }}
@@ -170,7 +170,7 @@
           nvidia-smi Status: {{ 'PASSED' if pod_nvidia_smi_logs.rc == 0 else 'FAILED' }}
           cuda-vector-add Status: {{ 'PASSED' if 'Test PASSED' in cuda_vector_add_logs.stdout else 'FAILED' }}
           CUDA Test Result: {{ 'Success' if 'Test PASSED' in cuda_vector_add_logs.stdout else 'Failed' }}
-        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/test-summary-{{ ansible_date_time.epoch }}.log"
+        dest: "{{ gpu_test_logs_dir | default('./gpu-test-logs') }}/test-summary-{{ ansible_facts.date_time.epoch }}.log"
         mode: '0644'
       delegate_to: localhost
       become: no

--- a/ansible/roles/setup-microshift-host/defaults/main.yml
+++ b/ansible/roles/setup-microshift-host/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # setup-microshift-host default vars
 
-# Pin RHEL to a specific version during upgrades (e.g., "9.6")
+# Pin RHEL to a specific version during upgrades (e.g., "9.8")
 # Leave undefined to upgrade to the latest available version
-# rhel_target_version: "9.6"
+rhel_target_version: "9.8"
 
 go_arch: arm64
 go_files:

--- a/ansible/vars/all.yml
+++ b/ansible/vars/all.yml
@@ -6,18 +6,19 @@ prometheus_logging: "{{ prometheus_logging_arg | default('true')  }}"
 results_base_dir: "{{ playbook_dir }}/results"
 
 # RHEL subscription and repository management
-manage_subscription: false
+manage_subscription: true
 rhel_username:
 rhel_password:
 rhel_pool_id:
-manage_repos: false
+manage_repos: true
 
 # MicroShift installation options
-setup_microshift_host: false
-install_microshift: "{{ install_microshift_arg | default('false') }}"
+setup_microshift_host: true
+install_microshift: "{{ install_microshift_arg | default('true') }}"
 build_etcd_binary: false
 build_microshift: false
-microshift_version: "4.20"
+microshift_version: "4.22"
+rhel_target_version: "9.8"
 
 # Service account
 sa_token_file: sa-token


### PR DESCRIPTION
Routine maintenance of the node-setup Ansible to keep it current with recent MicroShift and RHEL releases and to clear deprecated fact usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription and repository management now enabled by default for streamlined setup.

* **Chores**
  * Updated MicroShift to version 4.22 and process exporter to version 0.8.7.
  * Set RHEL target version to 9.8.
  * Refactored repository configuration and service restart conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->