### PR TITLE
USHIFT-6983: Drop optional components from tuned CI images

### DIFF
--- a/test/image-blueprints-bootc/el10/layer4-release/group2/rhel102-bootc-brew-lrel-tuned.containerfile
+++ b/test/image-blueprints-bootc/el10/layer4-release/group2/rhel102-bootc-brew-lrel-tuned.containerfile
@@ -1,6 +1,47 @@
 # {{- if env.Getenv "BREW_LREL_RELEASE_VERSION" "" -}}
 # Note: This comment makes templating add a new line before the code
-FROM localhost/rhel102-bootc-brew-lrel-optional:latest
+FROM localhost/rhel102-test-agent:latest
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-brew
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Install MicroShift with low-latency support and cleanup.
+# Optional components are excluded to reduce etcd pressure during startup
+# on CPU-constrained tuned VMs (TuneD isolates most CPUs from system services).
+# OpenSSL is added as a temporary workaround. Systemd-resolved will bump systemd to a newer
+# version that requires openssl 3.4 or higher, but package is kept at 3.2.2. By installing
+# it we force an upgrade so that everything works.
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved openssl \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_LREL_RELEASE_VERSION" }}" \
+        {{ end -}}
+        "microshift-low-latency-{{ env.Getenv "BREW_LREL_RELEASE_VERSION" }}" \
+        && \
+    systemctl enable microshift microshift-test-agent && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
 
 # Enable microshift-tuned service
 RUN systemctl enable microshift-tuned

--- a/test/image-blueprints-bootc/el9/layer4-release/group2/rhel98-bootc-brew-lrel-tuned.containerfile
+++ b/test/image-blueprints-bootc/el9/layer4-release/group2/rhel98-bootc-brew-lrel-tuned.containerfile
@@ -1,6 +1,44 @@
 # {{- if env.Getenv "BREW_LREL_RELEASE_VERSION" "" -}}
 # Note: This comment makes templating add a new line before the code
-FROM localhost/rhel98-bootc-brew-lrel-optional:latest
+FROM localhost/rhel98-test-agent:latest
+
+# Build arguments
+ARG USHIFT_RPM_REPO_NAME=microshift-brew
+ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
+
+# Copy the MicroShift repository contents
+COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
+
+# Copy repository configuration
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+    /etc/yum.repos.d/
+
+# Install MicroShift with low-latency support and cleanup.
+# Optional components are excluded to reduce etcd pressure during startup
+# on CPU-constrained tuned VMs (TuneD isolates most CPUs from system services).
+RUN dnf repoinfo --enabled && \
+    dnf install -y firewalld systemd-resolved \
+        {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_LREL_RELEASE_VERSION" }}" \
+        {{ end -}}
+        "microshift-low-latency-{{ env.Getenv "BREW_LREL_RELEASE_VERSION" }}" \
+        && \
+    systemctl enable microshift microshift-test-agent && \
+    rm -vf /etc/yum.repos.d/microshift-*.repo && \
+    rm -rvf $USHIFT_RPM_REPO_PATH && \
+    dnf clean all
+
+# Configure firewall
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48 && \
+    firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=5353/udp && \
+    firewall-offline-cmd --zone=public --add-port=6443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
 
 # Enable microshift-tuned service
 RUN systemctl enable microshift-tuned


### PR DESCRIPTION
The tuned containerfiles inherited from the optional base image, which installed OLM, Istio, cert-manager, SR-IOV, and other optional components. None of the 3 scenarios using this image test optionals, but those components generated 58% of the slow etcd requests during startup on CPU-constrained ARM64 VMs (TuneD isolates most CPUs, leaving only 2 for system services). This etcd pressure contributes to PodSecurity admission timeouts that crash MicroShift on restart.

Make the tuned containerfiles self-contained: inherit from test-agent, install only core MicroShift + microshift-low-latency, and configure firewall directly. This eliminates the optional component overhead without affecting any other image consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test container images to install MicroShift packages (including low-latency variant), enable MicroShift services, and include RPM repo handling for offline installs.
  * Added explicit offline firewall configuration opening required SSH/HTTP/HTTPS/DNS/Kubernetes API and NodePort ports.
  * CI now forces rebuilds of tuned bootc images for EL9/EL10 group2 to ensure these updates are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->