### PR TITLE
[release-4.22] NO-ISSUE: Wait a little bit longer for existence of ConfigMap

### DIFF
--- a/test/suites/standard1/kustomize.robot
+++ b/test/suites/standard1/kustomize.robot
@@ -224,7 +224,7 @@ Write Manifests
 ConfigMap Path Should Match
     [Documentation]    Ensure the config map path value matches the manifest dir
     [Arguments]    ${namespace}    ${manifest_dir}
-    ${configmap}=    Wait Until Keyword Succeeds    20x    10s
+    ${configmap}=    Wait Until Keyword Succeeds    30x    10s
     ...    Oc Get    configmap    ${namespace}    ${CONFIGMAP_NAME}
     Should Be Equal    ${manifest_dir}    ${configmap.data.path}
 


### PR DESCRIPTION
We need to wait a little bit more because they manifests are applied in alphanumerical order, and the manifest we want to test might lose the lottery and end up at the very end.