### PR TITLE
PERFSCALE-2104: Enable and apply fieldalignment linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,6 +73,27 @@ linters:
           - errcheck
           - goconst
           - gosec
+      # fieldalignment is useful for runtime structs, but test fixtures are
+      # usually clearer in table-driven test order.
+      - path: '_test\.go'
+        text: 'fieldalignment:'
+        linters:
+          - govet
+      # Preserve Kubernetes API type conventions.
+      - path: 'pkg/apis/microshift/v1alpha1/types\.go'
+        text: 'fieldalignment:'
+        linters:
+          - govet
+      # Preserve user-facing configuration field order.
+      - path: 'pkg/config/.*\.go'
+        text: 'fieldalignment:'
+        linters:
+          - govet
+      # Preserve OVSDB model field order.
+      - path: 'pkg/controllers/c2cc/nbdb\.go'
+        text: 'fieldalignment:'
+        linters:
+          - govet
       - path: 'pkg/cmd/init\.go'
         text: 'calculated cyclomatic complexity for function initKubeconfigs is'
       - path: 'pkg/config/config\.go'
@@ -120,6 +141,9 @@ linters:
   settings:
     cyclop:
       max-complexity: 20
+    govet:
+      enable:
+        - fieldalignment
     funcorder:
       struct-method: false
     inamedparam:

--- a/pkg/admin/prerun/version.go
+++ b/pkg/admin/prerun/version.go
@@ -22,6 +22,7 @@ var (
 	errDataVersionDoesNotExist = errors.New("version file for MicroShift data does not exist")
 )
 
+//nolint:govet // fieldalignment: preserve persisted version metadata JSON field order.
 type versionFile struct {
 	Version      versionMetadata `json:"version"`
 	DeploymentID string          `json:"deployment_id,omitempty"`
@@ -117,8 +118,8 @@ func WriteVersionMetadata() error {
 }
 
 type versions struct {
-	exec versionMetadata
 	data *versionMetadata
+	exec versionMetadata
 }
 
 // getVersions obtains and returns versions of executable and data dir.

--- a/pkg/controllers/c2cc/controller.go
+++ b/pkg/controllers/c2cc/controller.go
@@ -21,18 +21,17 @@ const (
 var healthcheckCRD = []string{"crd/microshift.io_remoteclusters.yaml"}
 
 type C2CCRouteManager struct {
-	cfg        *config.Config
-	nodeName   string
-	kubeconfig string
-
 	kubeClient       kubernetes.Interface
 	microshiftClient microshiftclient.MicroshiftV1alpha1Interface
+	cfg              *config.Config
 	ovn              *ovnRouteManager
 	annotation       *annotationManager
 	nftMgr           *nftablesManager
 	routes           *linuxRouteManager
 	svcRoutes        *serviceRouteManager
 	healthcheck      *healthcheckCRManager
+	nodeName         string
+	kubeconfig       string
 }
 
 func NewC2CCRouteManager(cfg *config.Config) *C2CCRouteManager {
@@ -215,6 +214,7 @@ func (c *C2CCRouteManager) initForCleanup(ctx context.Context) func() {
 }
 
 func (c *C2CCRouteManager) fullReconcile(ctx context.Context) {
+	//nolint:govet // fieldalignment: keep positional composite literal order.
 	subsystems := []struct {
 		name string
 		fn   func(context.Context) error
@@ -236,6 +236,7 @@ func (c *C2CCRouteManager) fullReconcile(ctx context.Context) {
 func (c *C2CCRouteManager) cleanupAll(ctx context.Context) {
 	klog.V(2).Infof("Cleaning up any leftover C2CC state")
 
+	//nolint:govet // fieldalignment: keep positional composite literal order.
 	type cleanable struct {
 		name string
 		fn   func(context.Context) error

--- a/pkg/controllers/c2cc/nbdb.go
+++ b/pkg/controllers/c2cc/nbdb.go
@@ -69,7 +69,8 @@ func waitForOVNSocket(ctx context.Context) error {
 	}
 }
 
-func connectOVNNB(ctx context.Context) (client.Client, error) { //nolint:ireturn
+//nolint:ireturn // libovsdb exposes client.Client as the public connection interface.
+func connectOVNNB(ctx context.Context) (client.Client, error) {
 	if err := waitForOVNSocket(ctx); err != nil {
 		return nil, fmt.Errorf("failed to wait for OVN NB socket: %w", err)
 	}

--- a/pkg/controllers/c2cc/routes.go
+++ b/pkg/controllers/c2cc/routes.go
@@ -18,6 +18,7 @@ const (
 	c2ccRulePriority = 100
 )
 
+//nolint:govet // fieldalignment: keep the embedded route-table fields first.
 type linuxRouteManager struct {
 	policyRouteTable
 

--- a/pkg/controllers/c2cc/service_routes.go
+++ b/pkg/controllers/c2cc/service_routes.go
@@ -19,6 +19,7 @@ const (
 	mgmtPortInterface   = "ovn-k8s-mp0"
 )
 
+//nolint:govet // fieldalignment: keep the embedded route-table fields first.
 type serviceRouteManager struct {
 	policyRouteTable
 

--- a/pkg/controllers/cluster-policy-controller.go
+++ b/pkg/controllers/cluster-policy-controller.go
@@ -31,10 +31,9 @@ import (
 )
 
 type ClusterPolicyController struct {
+	configErr  error
 	run        func(context.Context) error
 	kubeconfig string
-
-	configErr error
 }
 
 func NewClusterPolicyController(cfg *config.Config) *ClusterPolicyController {

--- a/pkg/controllers/filewatcher.go
+++ b/pkg/controllers/filewatcher.go
@@ -18,17 +18,17 @@ import (
 )
 
 type fileWatcherConfig struct {
-	serviceName        string
-	dependencies       []string
-	file               string
+	labels             map[string]string
+	annotations        map[string]string
 	kubeconfig         string
-	enabled            bool
+	serviceName        string
 	configMapNamespace string
 	configMapName      string
 	configMapDataKey   string
-	labels             map[string]string
-	annotations        map[string]string
+	file               string
+	dependencies       []string
 	eventMask          fsnotify.Op
+	enabled            bool
 	reAddOnCreate      bool
 	mergeAnnotations   bool
 	deleteOnDisable    bool

--- a/pkg/controllers/kube-apiserver.go
+++ b/pkg/controllers/kube-apiserver.go
@@ -75,13 +75,12 @@ func init() {
 }
 
 type KubeAPIServer struct {
-	kasConfigBytes []byte
-	verbosity      int
-	configuration  *config.Config
-
+	configuration    *config.Config
 	masterURL        string
 	servingCAPath    string
 	advertiseAddress string
+	kasConfigBytes   []byte
+	verbosity        int
 }
 
 func NewKubeAPIServer(cfg *config.Config) *KubeAPIServer {

--- a/pkg/controllers/kube-controller-manager.go
+++ b/pkg/controllers/kube-controller-manager.go
@@ -44,11 +44,10 @@ const (
 )
 
 type KubeControllerManager struct {
-	args    []string
-	applyFn func() error
-
 	// TODO: report configuration errors immediately
 	configureErr error
+	applyFn      func() error
+	args         []string
 }
 
 func NewKubeControllerManager(ctx context.Context, cfg *config.Config) *KubeControllerManager {

--- a/pkg/controllers/openshift-route-controller-manager.go
+++ b/pkg/controllers/openshift-route-controller-manager.go
@@ -39,11 +39,10 @@ import (
 )
 
 type OCPRouteControllerManager struct {
+	configErr     error
 	run           func(context.Context) error
 	kubeconfig    string
 	kubeadmconfig string
-
-	configErr error
 }
 
 const (

--- a/pkg/loadbalancerservice/controller.go
+++ b/pkg/loadbalancerservice/controller.go
@@ -28,16 +28,16 @@ const (
 )
 
 type LoadbalancerServiceController struct {
-	IPAddresses []string
-	NICNames    []string
-	NodeIP      string
-	KubeConfig  string
-	Ipv4        bool
-	Ipv6        bool
-	client      *kubernetes.Clientset
 	indexer     cache.Indexer
 	queue       workqueue.TypedRateLimitingInterface[string]
 	informer    cache.SharedIndexInformer
+	client      *kubernetes.Clientset
+	NodeIP      string
+	KubeConfig  string
+	IPAddresses []string
+	NICNames    []string
+	Ipv4        bool
+	Ipv6        bool
 }
 
 var _ servicemanager.Service = &LoadbalancerServiceController{}

--- a/pkg/mdns/controller.go
+++ b/pkg/mdns/controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
+//nolint:govet // fieldalignment: keep the embedded mutex first.
 type MicroShiftmDNSController struct {
 	sync.Mutex
 

--- a/pkg/mdns/server/resolver.go
+++ b/pkg/mdns/server/resolver.go
@@ -24,6 +24,7 @@ import (
 
 const defaultTTL = 120
 
+//nolint:govet // fieldalignment: keep the embedded mutex first.
 type Resolver struct {
 	sync.Mutex
 

--- a/pkg/mdns/server/server.go
+++ b/pkg/mdns/server/server.go
@@ -31,10 +31,10 @@ const (
 )
 
 type Server struct {
-	iface     *net.Interface
 	responder Responder
-	listeners []*net.UDPConn
+	iface     *net.Interface
 	stopCh    chan struct{}
+	listeners []*net.UDPConn
 }
 
 type Responder interface {

--- a/pkg/servicemanager/manager.go
+++ b/pkg/servicemanager/manager.go
@@ -13,14 +13,12 @@ import (
 )
 
 type ServiceManager struct {
-	name string
-	deps []string
-
-	services   []Service
 	serviceMap map[string]Service
 	startRec   *startuprecorder.StartupRecorder
-
-	errChan chan error
+	errChan    chan error
+	name       string
+	deps       []string
+	services   []Service
 }
 
 func NewServiceManager(startRec *startuprecorder.StartupRecorder) *ServiceManager {

--- a/pkg/servicemanager/service.go
+++ b/pkg/servicemanager/service.go
@@ -8,10 +8,9 @@ import (
 type RunFunc func(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error
 
 type GenericService struct {
+	run  RunFunc
 	name string
 	deps []string
-
-	run RunFunc
 }
 
 func NewGenericService(name string, dependencies []string, run RunFunc) *GenericService {

--- a/pkg/servicemanager/startuprecorder/startuprecorder.go
+++ b/pkg/servicemanager/startuprecorder/startuprecorder.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
+//nolint:govet // fieldalignment: preserve startup service JSON field order.
 type ServiceData struct {
 	Name         string        `json:"name"`
 	Dependencies []string      `json:"dependencies"`
@@ -24,16 +25,17 @@ type MicroshiftData struct {
 	TimeToReady   time.Duration `json:"timeToReady"`
 }
 
+//nolint:govet // fieldalignment: preserve startup JSON top-level field order.
 type StartupData struct {
 	Services   []ServiceData  `json:"services"`
 	Microshift MicroshiftData `json:"microshift"`
 }
 
 type StartupRecorder struct {
-	Data StartupData
+	allLogged chan struct{}
+	Data      StartupData
 
 	ServiceCount int
-	allLogged    chan struct{}
 	m            sync.Mutex
 }
 

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -69,14 +69,14 @@ type MetricLabel struct {
 }
 
 type TelemetryClient struct {
+	// For proxy configuration.
+	transport http.RoundTripper
 	endpoint  string
 	clusterId string
 	// next two attributes are required to compute the cpu usage based
 	// on the cpu seconds we get from kubelet.
 	previousCPUSeconds   float64
 	previousCPUtimestamp int64
-	// For proxy configuration.
-	transport http.RoundTripper
 }
 
 func NewTelemetryClient(endpoint, clusterId, proxy string) *TelemetryClient {

--- a/pkg/util/all_err_group.go
+++ b/pkg/util/all_err_group.go
@@ -10,11 +10,10 @@ import (
 // AllErrGroup is a helper to wait for all goroutines and get all errors that occurred.
 // It's based on sync.WaitGroup (which doesn't capture any errors) and errgroup.Group (which only captures the first error).
 type AllErrGroup struct {
-	wg   sync.WaitGroup
-	mu   sync.Mutex
-	errs []error
-
+	errs   []error
+	wg     sync.WaitGroup
 	amount int
+	mu     sync.Mutex
 }
 
 func (g *AllErrGroup) Go(f func() error) {

--- a/pkg/util/cryptomaterial/certchains/chainsbuilder.go
+++ b/pkg/util/cryptomaterial/certchains/chainsbuilder.go
@@ -12,11 +12,10 @@ type CertificateChainsBuilder interface {
 }
 
 type certificateChains struct {
-	signers []CertificateSignerBuilder
-
 	// fileBundles maps fileName -> signers, where fileName is the filename of a CA bundle
 	// where PEM certificates should be stored
 	fileBundles map[string][][]string
+	signers     []CertificateSignerBuilder
 }
 
 func NewCertificateChains(signers ...CertificateSignerBuilder) CertificateChainsBuilder {

--- a/pkg/util/cryptomaterial/certchains/signerbuilder.go
+++ b/pkg/util/cryptomaterial/certchains/signerbuilder.go
@@ -29,18 +29,16 @@ type CertificateSignerBuilder interface {
 }
 
 type certificateSigner struct {
-	signerName     string
-	signerDir      string
-	signerValidity time.Duration
-
 	// signerConfig should only be used in case this is a sub-ca signer
 	// It should be populated during CertificateSigner.SignSubCA()
 	signerConfig       *crypto.CA
+	signerName         string
+	signerDir          string
 	subCAs             []CertificateSignerBuilder
 	certificatesToSign []CSRInfo
-
 	// locations of bundles where this signer appears
-	caBundlePaths []string
+	caBundlePaths  []string
+	signerValidity time.Duration
 }
 
 // NewCertificateSigner returns a builder object for a certificate chain for the given signer

--- a/pkg/util/cryptomaterial/certchains/signers.go
+++ b/pkg/util/cryptomaterial/certchains/signers.go
@@ -24,6 +24,7 @@ type CSRMeta struct {
 	Validity time.Duration
 }
 
+//nolint:govet // fieldalignment: keep the embedded CSR metadata first.
 type ClientCertificateSigningRequestInfo struct {
 	CSRMeta
 
@@ -50,15 +51,13 @@ type PeerCertificateSigningRequestInfo struct {
 func (i *PeerCertificateSigningRequestInfo) GetMeta() CSRMeta { return i.CSRMeta }
 
 type CertificateSigner struct {
-	signerName     string
-	signerConfig   *crypto.CA
-	signerDir      string
-	signerValidity time.Duration
-
+	signerConfig       *crypto.CA
 	subCAs             map[string]*CertificateSigner
 	signedCertificates map[string]*signedCertificateInfo
-
-	caBundlePaths sets.Set[string]
+	caBundlePaths      sets.Set[string]
+	signerName         string
+	signerDir          string
+	signerValidity     time.Duration
 }
 
 type signedCertificateInfo struct {


### PR DESCRIPTION
Enables the govet fieldalignment analyzer through the existing make verify-golangci path and applies the current baseline cleanup.

What changed:
- Enabled govet.fieldalignment in .golangci.yaml.
- Reordered internal/runtime structs that had no serialization, positional literal, reflection, unsafe, or binary-layout dependency.
- Kept field order for API, config, persisted JSON, startup JSON, OVSDB model, generated, and test/table-fixture shapes.
- Used narrow per-struct //nolint comments where source order is intentional and a file-level exclusion would hide future findings.

Why:
fieldalignment can reduce struct padding and pointer scan ranges, but it is a blunt analyzer. The useful CI value is catching future inefficient layouts in high-cardinality structs, not mechanically rewriting every struct in the tree. This PR fixes the safe internal cases and scopes exclusions so reviewers still get signal for new runtime structs.

Impact:
The structs changed here are mostly startup-time singletons or low-cardinality runtime objects, so direct memory/GC savings are expected to be small. The main benefit is the ongoing guardrail during review.

Verification:
- make verify-golangci
- go test ./pkg/admin/prerun ./pkg/servicemanager/startuprecorder ./pkg/servicemanager ./pkg/controllers/c2cc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized struct field alignment across the codebase for improved memory efficiency and performance.
  * Enhanced code quality tooling configuration to enforce stricter linting standards across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->