### PR TITLE
USHIFT-7168: Bump Go to 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ GO_TEST_PACKAGES=./cmd/... ./pkg/...
 export CGO_ENABLED ?= 1
 
 # Specify OCP build tools image tag when building rpm with podman
-RPM_BUILDER_IMAGE_TAG := rhel-9-golang-1.25-openshift-4.22
+RPM_BUILDER_IMAGE_TAG := rhel-9-golang-1.26-openshift-5.0
 
 all: generate-config microshift etcd
 

--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -43,7 +43,7 @@ fi
 # It's before rebase.py because we want this to be part of the rebase PR.
 # Go version in go.mods are updated in rebase.sh.
 go_version=$(go version 2>/dev/null | awk '{print $3}' | tr -d '[a-z]')
-sed -i "s/^GO_VER=.*/GO_VER=${go_version}/" ./scripts/devenv-builder/configure-vm.sh
+sed -i "s/GO_VER=.*/GO_VER=${go_version}/" ./scripts/devenv-builder/configure-vm.sh
 go_version_xy="$(echo "${go_version}" | cut -f1-2 -d.)"
 sed -i "s/^%global golang_version .*/%global golang_version ${go_version_xy}/" ./packaging/rpm/microshift.spec
 

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -278,7 +278,7 @@ function install_build_deps() {
     # run only if booted with systemd
     [[ -d /run/systemd/system ]] &&  sudo systemctl enable --now cockpit.socket
 
-    GO_VER=1.24.4
+    GO_VER=1.26.3
     GO_ARCH=$([ "$(uname -m)" == "x86_64" ] && echo "amd64" || echo "arm64")
     GO_INSTALL_DIR="/usr/local/go${GO_VER}"
     if [ ! -d "${GO_INSTALL_DIR}" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RPM build tooling to use Go 1.26 (previously 1.25) with OpenShift 5.0 compatibility
  * Updated development environment to use Go 1.26.3 (previously 1.24.4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->