### PR TITLE
USHIFT-6831: cert-manager Trust manager featuregate and test

### DIFF
--- a/assets/optional/cert-manager/manager/kustomization.yaml
+++ b/assets/optional/cert-manager/manager/kustomization.yaml
@@ -58,6 +58,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: cert-manager-images
+      fieldPath: data.cert-manager-trust-manager
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=cert-manager-operator].env.[name=RELATED_IMAGE_CERT_MANAGER_TRUST_MANAGER].value
+  - source:
+      kind: ConfigMap
+      name: cert-manager-images
       fieldPath: data.controller
     targets:
       - select:

--- a/assets/optional/cert-manager/manager/kustomization.yaml
+++ b/assets/optional/cert-manager/manager/kustomization.yaml
@@ -4,6 +4,24 @@ resources:
   - manager.yaml
   - images.yaml
 
+patches:
+  - target:
+      kind: Deployment
+      name: controller-manager
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: controller-manager
+      spec:
+        template:
+          spec:
+            containers:
+            - name: cert-manager-operator
+              env:
+              - name: UNSUPPORTED_ADDON_FEATURES
+                value: TrustManager=true
+
 replacements:
   - source:
       kind: ConfigMap

--- a/test/assets/cert-manager/ca-certificate.yaml.template
+++ b/test/assets/cert-manager/ca-certificate.yaml.template
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ca-certificate
+  namespace: ${TRUST_MANAGER_NS}
+spec:
+  isCA: true
+  commonName: test-ca.example.com
+  secretName: ca-certificate-secret
+  issuerRef:
+    name: ${ISSUER_NAME}
+    kind: ClusterIssuer

--- a/test/assets/cert-manager/certificate.yaml.template
+++ b/test/assets/cert-manager/certificate.yaml.template
@@ -1,0 +1,15 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${CERT_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  secretName: ${SECRET_NAME}
+  issuerRef:
+    name: ${ISSUER_NAME}
+    kind: ClusterIssuer
+  commonName: ${CERT_COMMON_NAME}
+  dnsNames:
+  - ${CERT_DNS_NAME}
+  - www.${CERT_DNS_NAME}

--- a/test/assets/cert-manager/cluster-issuer.yaml.template
+++ b/test/assets/cert-manager/cluster-issuer.yaml.template
@@ -1,0 +1,7 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${ISSUER_NAME}
+spec:
+  selfSigned: {}

--- a/test/assets/cert-manager/http01-certificate.yaml.template
+++ b/test/assets/cert-manager/http01-certificate.yaml.template
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${HTTP01_CERT_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  commonName: ${DNS_NAME}
+  dnsNames:
+  - ${DNS_NAME}
+  duration: 1h
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ${HTTP01_ISSUER_NAME}
+  renewBefore: 58m
+  secretName: ${HTTP01_SECRET_NAME}
+  usages:
+  - server auth

--- a/test/assets/cert-manager/http01-issuer.yaml.template
+++ b/test/assets/cert-manager/http01-issuer.yaml.template
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ${HTTP01_ISSUER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  acme:
+    server: "https://pebble.${NAMESPACE}.svc.cluster.local:14000/dir"
+    skipTLSVerify: true
+    privateKeySecretRef:
+      name: acme-account-key
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: openshift-ingress

--- a/test/assets/cert-manager/ingress-rbac.yaml.template
+++ b/test/assets/cert-manager/ingress-rbac.yaml.template
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader
+  namespace: ${NAMESPACE}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["${SECRET_NAME}"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ingress-secret-reader
+  namespace: ${NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-reader
+subjects:
+- kind: ServiceAccount
+  name: router
+  namespace: openshift-ingress

--- a/test/assets/cert-manager/ingress-route.yaml.template
+++ b/test/assets/cert-manager/ingress-route.yaml.template
@@ -1,0 +1,16 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ${ROUTE_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  port:
+    targetPort: 8080
+  tls:
+    externalCertificate:
+      name: ${SECRET_NAME}
+    termination: edge
+  to:
+    kind: Service
+    name: hello-microshift

--- a/test/assets/cert-manager/trust-bundle-secret.yaml.template
+++ b/test/assets/cert-manager/trust-bundle-secret.yaml.template
@@ -1,0 +1,16 @@
+---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ${TRUST_MANAGER_BUNDLE_NAME}
+spec:
+  sources:
+    - secret:
+        name: ca-certificate-secret
+        key: tls.crt
+  target:
+    configMap:
+      key: ca-bundle.crt
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ${NAMESPACE}

--- a/test/assets/cert-manager/trust-bundle-source-secret.yaml.template
+++ b/test/assets/cert-manager/trust-bundle-source-secret.yaml.template
@@ -1,0 +1,16 @@
+---
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ${TRUST_MANAGER_BUNDLE_NAME}
+spec:
+  sources:
+    - secret:
+        name: ca-source-secret
+        key: tls.crt
+  target:
+    configMap:
+      key: ca-bundle.crt
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ${NAMESPACE}

--- a/test/assets/cert-manager/trust-manager-cr.yaml
+++ b/test/assets/cert-manager/trust-manager-cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: TrustManager
+metadata:
+  name: cluster
+spec:
+  trustManagerConfig: {}

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -149,3 +149,10 @@ Remove Files
         ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
         Should Be Equal As Integers    ${rc}    0
     END
+
+Generate File From Template
+    [Documentation]    Generate file from template
+    [Arguments]    ${template_file}    ${out_file}
+    ${template}=    OperatingSystem.Get File    ${template_file}
+    ${message}=    Replace Variables    ${template}
+    OperatingSystem.Create File    ${out_file}    ${message}

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -23,36 +23,35 @@ Test Tags           cert-manager    certificates    tls
 
 
 *** Variables ***
-${CERT_NAME}                        test-certificate
-${SECRET_NAME}                      test-cert-secret
-${ISSUER_NAME}                      test-issuer
-${CERT_COMMON_NAME}                 example.com
-${CERT_DNS_NAME}                    example.com
-${ROUTE_NAME}                       hello-app
-${CERT_ISSUER_YAML}                 SEPARATOR=\n
-...                                 ---
-...                                 apiVersion: cert-manager.io/v1
-...                                 kind: ClusterIssuer
-...                                 metadata:
-...                                 \ \ name: ${ISSUER_NAME}
-...                                 spec:
-...                                 \ \ selfSigned: {}
+${CERT_NAME}                    test-certificate
+${SECRET_NAME}                  test-cert-secret
+${ISSUER_NAME}                  test-issuer
+${CERT_COMMON_NAME}             example.com
+${CERT_DNS_NAME}                example.com
+${ROUTE_NAME}                   hello-app
+${CERT_ISSUER_YAML}             SEPARATOR=\n
+...                             ---
+...                             apiVersion: cert-manager.io/v1
+...                             kind: ClusterIssuer
+...                             metadata:
+...                             \ \ name: ${ISSUER_NAME}
+...                             spec:
+...                             \ \ selfSigned: {}
 
-${HTTP01_ISSUER_NAME}               letsencrypt-http01
-${HTTP01_CERT_NAME}                 cert-from-${HTTP01_ISSUER_NAME}
-${HTTP01_SECRET_NAME}               ${HTTP01_CERT_NAME}
-${PEBBLE_DEPLOYMENT_FILE}           ./assets/cert-manager/pebble-server.yaml
-${HOSTSFILE_ENABLED}                SEPARATOR=\n
-...                                 ---
-...                                 dns:
-...                                 \ \ hosts:
-...                                 \ \ \ \ status: Enabled
+${HTTP01_ISSUER_NAME}           letsencrypt-http01
+${HTTP01_CERT_NAME}             cert-from-${HTTP01_ISSUER_NAME}
+${HTTP01_SECRET_NAME}           ${HTTP01_CERT_NAME}
+${PEBBLE_DEPLOYMENT_FILE}       ./assets/cert-manager/pebble-server.yaml
+${HOSTSFILE_ENABLED}            SEPARATOR=\n
+...                             ---
+...                             dns:
+...                             \ \ hosts:
+...                             \ \ \ \ status: Enabled
 
-${TRUST_MANAGER_BUNDLE_NAME}        test-trust-bundle
-${TRUST_MANAGER_OPERATOR_NS}        cert-manager-operator
-${TRUST_MANAGER_NS}                 cert-manager
-${TRUST_MANAGER_DEPLOYMENT}         cert-manager-operator-controller-manager
-${TRUST_MANAGER_MANIFESTS_DIR}      /etc/microshift/manifests.d/trust-manager
+${TRUST_MANAGER_BUNDLE_NAME}    test-trust-bundle
+${TRUST_MANAGER_OPERATOR_NS}    cert-manager-operator
+${TRUST_MANAGER_NS}             cert-manager
+${TRUST_MANAGER_DEPLOYMENT}     cert-manager-operator-controller-manager
 
 
 *** Test Cases ***
@@ -506,21 +505,25 @@ Cleanup DNS For Test
     Restart MicroShift
 
 Enable Trust Manager
-    [Documentation]    Deploy trust-manager by creating a TrustManager CR via manifests.d
-    ...    and restarting MicroShift. The UNSUPPORTED_ADDON_FEATURES=TrustManager=true
-    ...    feature gate is already set in the system cert-manager kustomization.
-    Create Trust Manager CR Manifests
-    Restart MicroShift
+    [Documentation]    Deploy trust-manager by applying the TrustManager CR directly.
+    ...    The UNSUPPORTED_ADDON_FEATURES=TrustManager=true feature gate is already
+    ...    set in the system cert-manager kustomization.
+    ${tm_cr}=    CATENATE    SEPARATOR=\n
+    ...    apiVersion: operator.openshift.io/v1alpha1
+    ...    kind: TrustManager
+    ...    metadata:
+    ...    \ \ name: cluster
+    ...    spec:
+    ...    \ \ trustManagerConfig: {}
+    Apply Trust Manager YAML    ${tm_cr}
     Wait Until Keyword Succeeds    30x    10s
     ...    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
 
 Disable Trust Manager
-    [Documentation]    Remove the TrustManager CR manifests.d and restart MicroShift.
+    [Documentation]    Remove the TrustManager CR and wait for cleanup.
     Run With Kubeconfig    oc delete trustmanager cluster --ignore-not-found
     Run With Kubeconfig    oc delete bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
     Run With Kubeconfig    oc delete deployment trust-manager -n ${TRUST_MANAGER_NS} --ignore-not-found
-    Remove Trust Manager CR Manifests
-    Restart MicroShift
     Wait Until Keyword Succeeds    12x    10s
     ...    Trust Manager Pod Should Not Exist
 
@@ -529,35 +532,7 @@ Trust Manager Pod Should Not Exist
     ${output}=    Run With Kubeconfig
     ...    oc get pods -n ${TRUST_MANAGER_NS} -l app.kubernetes.io/name\=cert-manager-trust-manager --no-headers
     ...    allow_fail=True
-    Should Be Empty    ${output}    msg=trust-manager pod still exists
-
-Create Trust Manager CR Manifests
-    [Documentation]    Create the manifests.d kustomization with the TrustManager CR
-    ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    mkdir -p ${TRUST_MANAGER_MANIFESTS_DIR}
-    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
-    Should Be Equal As Integers    ${rc}    0
-    ${kustomization}=    CATENATE    SEPARATOR=\n
-    ...    apiVersion: kustomize.config.k8s.io/v1beta1
-    ...    kind: Kustomization
-    ...    resources:
-    ...    \ \ - trust-manager-cr.yaml
-    Upload String To File    ${kustomization}    ${TRUST_MANAGER_MANIFESTS_DIR}/kustomization.yaml
-    ${tm_cr}=    CATENATE    SEPARATOR=\n
-    ...    apiVersion: operator.openshift.io/v1alpha1
-    ...    kind: TrustManager
-    ...    metadata:
-    ...    \ \ name: cluster
-    ...    spec:
-    ...    \ \ trustManagerConfig: {}
-    Upload String To File    ${tm_cr}    ${TRUST_MANAGER_MANIFESTS_DIR}/trust-manager-cr.yaml
-
-Remove Trust Manager CR Manifests
-    [Documentation]    Remove the trust-manager manifests.d directory
-    ${stdout}    ${stderr}    ${rc}=    Execute Command
-    ...    rm -rf ${TRUST_MANAGER_MANIFESTS_DIR}
-    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
-    Should Be Equal As Integers    ${rc}    0
+    Should Not Contain    ${output}    trust-manager    msg=trust-manager pod still exists
 
 Create CA Secret For Trust Manager
     [Documentation]    Generate a self-signed CA cert locally and create a secret in the trust namespace

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -23,30 +23,36 @@ Test Tags           cert-manager    certificates    tls
 
 
 *** Variables ***
-${CERT_NAME}                    test-certificate
-${SECRET_NAME}                  test-cert-secret
-${ISSUER_NAME}                  test-issuer
-${CERT_COMMON_NAME}             example.com
-${CERT_DNS_NAME}                example.com
-${ROUTE_NAME}                   hello-app
-${CERT_ISSUER_YAML}             SEPARATOR=\n
-...                             ---
-...                             apiVersion: cert-manager.io/v1
-...                             kind: ClusterIssuer
-...                             metadata:
-...                             \ \ name: ${ISSUER_NAME}
-...                             spec:
-...                             \ \ selfSigned: {}
+${CERT_NAME}                        test-certificate
+${SECRET_NAME}                      test-cert-secret
+${ISSUER_NAME}                      test-issuer
+${CERT_COMMON_NAME}                 example.com
+${CERT_DNS_NAME}                    example.com
+${ROUTE_NAME}                       hello-app
+${CERT_ISSUER_YAML}                 SEPARATOR=\n
+...                                 ---
+...                                 apiVersion: cert-manager.io/v1
+...                                 kind: ClusterIssuer
+...                                 metadata:
+...                                 \ \ name: ${ISSUER_NAME}
+...                                 spec:
+...                                 \ \ selfSigned: {}
 
-${HTTP01_ISSUER_NAME}           letsencrypt-http01
-${HTTP01_CERT_NAME}             cert-from-${HTTP01_ISSUER_NAME}
-${HTTP01_SECRET_NAME}           ${HTTP01_CERT_NAME}
-${PEBBLE_DEPLOYMENT_FILE}       ./assets/cert-manager/pebble-server.yaml
-${HOSTSFILE_ENABLED}            SEPARATOR=\n
-...                             ---
-...                             dns:
-...                             \ \ hosts:
-...                             \ \ \ \ status: Enabled
+${HTTP01_ISSUER_NAME}               letsencrypt-http01
+${HTTP01_CERT_NAME}                 cert-from-${HTTP01_ISSUER_NAME}
+${HTTP01_SECRET_NAME}               ${HTTP01_CERT_NAME}
+${PEBBLE_DEPLOYMENT_FILE}           ./assets/cert-manager/pebble-server.yaml
+${HOSTSFILE_ENABLED}                SEPARATOR=\n
+...                                 ---
+...                                 dns:
+...                                 \ \ hosts:
+...                                 \ \ \ \ status: Enabled
+
+${TRUST_MANAGER_BUNDLE_NAME}        test-trust-bundle
+${TRUST_MANAGER_OPERATOR_NS}        cert-manager-operator
+${TRUST_MANAGER_NS}                 cert-manager
+${TRUST_MANAGER_DEPLOYMENT}         cert-manager-operator-controller-manager
+${TRUST_MANAGER_MANIFESTS_DIR}      /etc/microshift/manifests.d/trust-manager
 
 
 *** Test Cases ***
@@ -94,6 +100,72 @@ Test Cert manager with local acme server
     [Teardown]    Run Keywords
     ...    Cleanup HTTP01 Resources
     ...    AND    Cleanup DNS For Test    ${dns_name}
+
+Trust Manager Deployment
+    [Documentation]    Verify trust-manager can be enabled and deploys successfully
+    [Tags]    trust-manager
+    [Setup]    Enable Trust Manager
+    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
+    ${status}=    Oc Get JsonPath    trustmanager    ${EMPTY}    cluster
+    ...    .status.conditions[?(@.type=="Ready")].status
+    Should Be Equal    ${status}    True    msg=TrustManager CR is not ready
+    [Teardown]    Disable Trust Manager
+
+Trust Manager Bundle Creates ConfigMap
+    [Documentation]    Verify trust-manager Bundle CR syncs a CA cert into a ConfigMap
+    [Tags]    trust-manager
+    [Setup]    Enable Trust Manager
+
+    Create CA Secret For Trust Manager
+    ${bundle_yaml}=    Create Trust Bundle From Source Secret YAML
+    Apply Trust Manager YAML    ${bundle_yaml}
+    Oc Wait    bundle ${TRUST_MANAGER_BUNDLE_NAME}
+    ...    --for=jsonpath='{.status.conditions[0].reason}'=Synced --timeout=${DEFAULT_WAIT_TIMEOUT}
+
+    ${cm_data}=    Oc Get JsonPath
+    ...    configmap
+    ...    ${NAMESPACE}
+    ...    ${TRUST_MANAGER_BUNDLE_NAME}
+    ...    .data.ca-bundle\\.crt
+    Should Contain    ${cm_data}    BEGIN CERTIFICATE    msg=ConfigMap does not contain CA certificate data
+
+    [Teardown]    Run Keywords
+    ...    Cleanup Trust Bundle
+    ...    AND    Run With Kubeconfig    oc delete secret ca-source-secret -n ${TRUST_MANAGER_NS} --ignore-not-found
+    ...    AND    Disable Trust Manager
+
+Trust Manager Bundle With Cert Manager CA
+    [Documentation]    Verify trust-manager Bundle can use a cert-manager CA secret as a source
+    [Tags]    trust-manager
+    [Setup]    Enable Trust Manager
+
+    ${issuer_yaml}=    Create Cert Issuer YAML
+    Apply Trust Manager YAML    ${issuer_yaml}
+    Oc Wait    -n ${NAMESPACE} clusterissuer ${ISSUER_NAME}
+    ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
+
+    ${ca_cert_yaml}=    Create CA Certificate YAML
+    Apply Trust Manager YAML    ${ca_cert_yaml}
+    Oc Wait    -n ${TRUST_MANAGER_NS} certificate ca-certificate
+    ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
+
+    ${bundle_yaml}=    Create Trust Bundle From Secret YAML
+    Apply Trust Manager YAML    ${bundle_yaml}
+    Oc Wait    bundle ${TRUST_MANAGER_BUNDLE_NAME}
+    ...    --for=jsonpath='{.status.conditions[0].reason}'=Synced --timeout=${DEFAULT_WAIT_TIMEOUT}
+
+    ${cm_data}=    Oc Get JsonPath
+    ...    configmap
+    ...    ${NAMESPACE}
+    ...    ${TRUST_MANAGER_BUNDLE_NAME}
+    ...    .data.ca-bundle\\.crt
+    Should Contain    ${cm_data}    BEGIN CERTIFICATE    msg=ConfigMap does not contain CA certificate data
+
+    [Teardown]    Run Keywords
+    ...    Cleanup Trust Bundle
+    ...    AND    Oc Delete    certificate/ca-certificate -n ${TRUST_MANAGER_NS}
+    ...    AND    Remove ClusterIssuer
+    ...    AND    Disable Trust Manager
 
 
 *** Keywords ***
@@ -432,3 +504,143 @@ Cleanup DNS For Test
     Remove Entry From Hosts    ${dns_name}
     Remove Drop In MicroShift Config    20-dns
     Restart MicroShift
+
+Enable Trust Manager
+    [Documentation]    Deploy trust-manager by creating a TrustManager CR via manifests.d
+    ...    and restarting MicroShift. The UNSUPPORTED_ADDON_FEATURES=TrustManager=true
+    ...    feature gate is already set in the system cert-manager kustomization.
+    Create Trust Manager CR Manifests
+    Restart MicroShift
+    Wait Until Keyword Succeeds    30x    10s
+    ...    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
+
+Disable Trust Manager
+    [Documentation]    Remove the TrustManager CR manifests.d and restart MicroShift.
+    Run With Kubeconfig    oc delete trustmanager cluster --ignore-not-found
+    Run With Kubeconfig    oc delete bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
+    Run With Kubeconfig    oc delete deployment trust-manager -n ${TRUST_MANAGER_NS} --ignore-not-found
+    Remove Trust Manager CR Manifests
+    Restart MicroShift
+    Wait Until Keyword Succeeds    12x    10s
+    ...    Trust Manager Pod Should Not Exist
+
+Trust Manager Pod Should Not Exist
+    [Documentation]    Verify trust-manager pod no longer exists in cert-manager namespace
+    ${output}=    Run With Kubeconfig
+    ...    oc get pods -n ${TRUST_MANAGER_NS} -l app.kubernetes.io/name\=cert-manager-trust-manager --no-headers
+    ...    allow_fail=True
+    Should Be Empty    ${output}    msg=trust-manager pod still exists
+
+Create Trust Manager CR Manifests
+    [Documentation]    Create the manifests.d kustomization with the TrustManager CR
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    mkdir -p ${TRUST_MANAGER_MANIFESTS_DIR}
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Should Be Equal As Integers    ${rc}    0
+    ${kustomization}=    CATENATE    SEPARATOR=\n
+    ...    apiVersion: kustomize.config.k8s.io/v1beta1
+    ...    kind: Kustomization
+    ...    resources:
+    ...    \ \ - trust-manager-cr.yaml
+    Upload String To File    ${kustomization}    ${TRUST_MANAGER_MANIFESTS_DIR}/kustomization.yaml
+    ${tm_cr}=    CATENATE    SEPARATOR=\n
+    ...    apiVersion: operator.openshift.io/v1alpha1
+    ...    kind: TrustManager
+    ...    metadata:
+    ...    \ \ name: cluster
+    ...    spec:
+    ...    \ \ trustManagerConfig: {}
+    Upload String To File    ${tm_cr}    ${TRUST_MANAGER_MANIFESTS_DIR}/trust-manager-cr.yaml
+
+Remove Trust Manager CR Manifests
+    [Documentation]    Remove the trust-manager manifests.d directory
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    rm -rf ${TRUST_MANAGER_MANIFESTS_DIR}
+    ...    sudo=True    return_rc=True    return_stdout=True    return_stderr=True
+    Should Be Equal As Integers    ${rc}    0
+
+Create CA Secret For Trust Manager
+    [Documentation]    Generate a self-signed CA cert locally and create a secret in the trust namespace
+    ${cert_file}=    Create Random Temp File
+    ${result}=    Process.Run Process
+    ...    openssl    req    -x509    -newkey    ec    -pkeyopt    ec_paramgen_curve:prime256v1
+    ...    -nodes    -keyout    /dev/null    -out    ${cert_file}    -days    365
+    ...    -subj    /CN\=test-ca.example.com
+    ...    stderr=STDOUT
+    Should Be Equal As Integers    ${result.rc}    0
+    Run With Kubeconfig
+    ...    oc create secret generic ca-source-secret -n ${TRUST_MANAGER_NS} --from-file=tls.crt=${cert_file}
+    Remove File    ${cert_file}
+
+Create Trust Bundle From Source Secret YAML
+    [Documentation]    Creates a Bundle CR YAML sourced from a manually created secret in the trust namespace
+    ${yaml}=    CATENATE    SEPARATOR=\n
+    ...    ---
+    ...    apiVersion: trust.cert-manager.io/v1alpha1
+    ...    kind: Bundle
+    ...    metadata:
+    ...    \ \ name: ${TRUST_MANAGER_BUNDLE_NAME}
+    ...    spec:
+    ...    \ \ sources:
+    ...    \ \ \ \ - secret:
+    ...    \ \ \ \ \ \ \ \ name: ca-source-secret
+    ...    \ \ \ \ \ \ \ \ key: tls.crt
+    ...    \ \ target:
+    ...    \ \ \ \ configMap:
+    ...    \ \ \ \ \ \ key: ca-bundle.crt
+    ...    \ \ \ \ namespaceSelector:
+    ...    \ \ \ \ \ \ matchLabels:
+    ...    \ \ \ \ \ \ \ \ kubernetes.io/metadata.name: ${NAMESPACE}
+    RETURN    ${yaml}
+
+Create CA Certificate YAML
+    [Documentation]    Creates a cert-manager CA Certificate in the trust namespace
+    ${yaml}=    CATENATE    SEPARATOR=\n
+    ...    ---
+    ...    apiVersion: cert-manager.io/v1
+    ...    kind: Certificate
+    ...    metadata:
+    ...    \ \ name: ca-certificate
+    ...    \ \ namespace: ${TRUST_MANAGER_NS}
+    ...    spec:
+    ...    \ \ isCA: true
+    ...    \ \ commonName: test-ca.example.com
+    ...    \ \ secretName: ca-certificate-secret
+    ...    \ \ issuerRef:
+    ...    \ \ \ \ name: ${ISSUER_NAME}
+    ...    \ \ \ \ kind: ClusterIssuer
+    RETURN    ${yaml}
+
+Create Trust Bundle From Secret YAML
+    [Documentation]    Creates a Bundle CR YAML sourced from a cert-manager CA secret in the trust namespace
+    ${yaml}=    CATENATE    SEPARATOR=\n
+    ...    ---
+    ...    apiVersion: trust.cert-manager.io/v1alpha1
+    ...    kind: Bundle
+    ...    metadata:
+    ...    \ \ name: ${TRUST_MANAGER_BUNDLE_NAME}
+    ...    spec:
+    ...    \ \ sources:
+    ...    \ \ \ \ - secret:
+    ...    \ \ \ \ \ \ \ \ name: ca-certificate-secret
+    ...    \ \ \ \ \ \ \ \ key: tls.crt
+    ...    \ \ target:
+    ...    \ \ \ \ configMap:
+    ...    \ \ \ \ \ \ key: ca-bundle.crt
+    ...    \ \ \ \ namespaceSelector:
+    ...    \ \ \ \ \ \ matchLabels:
+    ...    \ \ \ \ \ \ \ \ kubernetes.io/metadata.name: ${NAMESPACE}
+    RETURN    ${yaml}
+
+Apply Trust Manager YAML
+    [Documentation]    Apply YAML manifest, allowing both created and configured/unchanged results
+    [Arguments]    ${yaml_content}
+    ${temp_file}=    Create Random Temp File    ${yaml_content}
+    ${result}=    Oc Apply    -f ${temp_file}
+    Remove File    ${temp_file}
+    Log    Applied manifest: ${result}
+
+Cleanup Trust Bundle
+    [Documentation]    Remove the test trust-manager Bundle CR and its target ConfigMap
+    Run With Kubeconfig    oc delete bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
+    Run With Kubeconfig    oc delete configmap ${TRUST_MANAGER_BUNDLE_NAME} -n ${NAMESPACE} --ignore-not-found

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -513,19 +513,11 @@ Enable Trust Manager
     ...    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
 
 Disable Trust Manager
-    [Documentation]    Remove the TrustManager CR and let the operator clean up the deployment.
-    ...    Do not delete the deployment directly — the operator would recreate it
-    ...    because the TrustManager feature gate is always enabled.
+    [Documentation]    Remove the TrustManager CR and leftover Bundle.
+    ...    The operator keeps the trust-manager deployment running while the
+    ...    TrustManager feature gate is enabled, so we do not assert pod absence.
     Oc Delete    trustmanager cluster --ignore-not-found
     Oc Delete    bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
-    Wait Until Keyword Succeeds    30x    10s
-    ...    Trust Manager Pod Should Not Exist
-
-Trust Manager Pod Should Not Exist
-    [Documentation]    Verify trust-manager pod no longer exists in cert-manager namespace
-    ${output}=    Run With Kubeconfig
-    ...    oc get pods -n ${TRUST_MANAGER_NS} -l app.kubernetes.io/name\=cert-manager-trust-manager --no-headers
-    Should Be Empty    ${output}    msg=trust-manager pod still exists
 
 Create CA Secret For Trust Manager
     [Documentation]    Generate a self-signed CA cert locally and create a secret in the trust namespace

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -513,11 +513,12 @@ Enable Trust Manager
     ...    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
 
 Disable Trust Manager
-    [Documentation]    Remove the TrustManager CR and wait for cleanup.
+    [Documentation]    Remove the TrustManager CR and let the operator clean up the deployment.
+    ...    Do not delete the deployment directly — the operator would recreate it
+    ...    because the TrustManager feature gate is always enabled.
     Oc Delete    trustmanager cluster --ignore-not-found
     Oc Delete    bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
-    Oc Delete    deployment trust-manager -n ${TRUST_MANAGER_NS} --ignore-not-found
-    Wait Until Keyword Succeeds    12x    10s
+    Wait Until Keyword Succeeds    30x    10s
     ...    Trust Manager Pod Should Not Exist
 
 Trust Manager Pod Should Not Exist

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -51,7 +51,7 @@ ${HOSTSFILE_ENABLED}            SEPARATOR=\n
 ${TRUST_MANAGER_BUNDLE_NAME}    test-trust-bundle
 ${TRUST_MANAGER_OPERATOR_NS}    cert-manager-operator
 ${TRUST_MANAGER_NS}             cert-manager
-${TRUST_MANAGER_DEPLOYMENT}     cert-manager-operator-controller-manager
+${TRUST_MANAGER_CR_FILE}        ./assets/cert-manager/trust-manager-cr.yaml
 
 
 *** Test Cases ***
@@ -119,7 +119,7 @@ Trust Manager Bundle Creates ConfigMap
     ${bundle_yaml}=    Create Trust Bundle From Source Secret YAML
     Apply Trust Manager YAML    ${bundle_yaml}
     Oc Wait    bundle ${TRUST_MANAGER_BUNDLE_NAME}
-    ...    --for=jsonpath='{.status.conditions[0].reason}'=Synced --timeout=${DEFAULT_WAIT_TIMEOUT}
+    ...    --for=jsonpath='{.status.conditions[?(@.type=="Synced")].status}'=True --timeout=${DEFAULT_WAIT_TIMEOUT}
 
     ${cm_data}=    Oc Get JsonPath
     ...    configmap
@@ -130,7 +130,7 @@ Trust Manager Bundle Creates ConfigMap
 
     [Teardown]    Run Keywords
     ...    Cleanup Trust Bundle
-    ...    AND    Run With Kubeconfig    oc delete secret ca-source-secret -n ${TRUST_MANAGER_NS} --ignore-not-found
+    ...    AND    Oc Delete    secret ca-source-secret -n ${TRUST_MANAGER_NS} --ignore-not-found
     ...    AND    Disable Trust Manager
 
 Trust Manager Bundle With Cert Manager CA
@@ -151,7 +151,7 @@ Trust Manager Bundle With Cert Manager CA
     ${bundle_yaml}=    Create Trust Bundle From Secret YAML
     Apply Trust Manager YAML    ${bundle_yaml}
     Oc Wait    bundle ${TRUST_MANAGER_BUNDLE_NAME}
-    ...    --for=jsonpath='{.status.conditions[0].reason}'=Synced --timeout=${DEFAULT_WAIT_TIMEOUT}
+    ...    --for=jsonpath='{.status.conditions[?(@.type=="Synced")].status}'=True --timeout=${DEFAULT_WAIT_TIMEOUT}
 
     ${cm_data}=    Oc Get JsonPath
     ...    configmap
@@ -508,22 +508,15 @@ Enable Trust Manager
     [Documentation]    Deploy trust-manager by applying the TrustManager CR directly.
     ...    The UNSUPPORTED_ADDON_FEATURES=TrustManager=true feature gate is already
     ...    set in the system cert-manager kustomization.
-    ${tm_cr}=    CATENATE    SEPARATOR=\n
-    ...    apiVersion: operator.openshift.io/v1alpha1
-    ...    kind: TrustManager
-    ...    metadata:
-    ...    \ \ name: cluster
-    ...    spec:
-    ...    \ \ trustManagerConfig: {}
-    Apply Trust Manager YAML    ${tm_cr}
+    Oc Apply    -f ${TRUST_MANAGER_CR_FILE}
     Wait Until Keyword Succeeds    30x    10s
     ...    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
 
 Disable Trust Manager
     [Documentation]    Remove the TrustManager CR and wait for cleanup.
-    Run With Kubeconfig    oc delete trustmanager cluster --ignore-not-found
-    Run With Kubeconfig    oc delete bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
-    Run With Kubeconfig    oc delete deployment trust-manager -n ${TRUST_MANAGER_NS} --ignore-not-found
+    Oc Delete    trustmanager cluster --ignore-not-found
+    Oc Delete    bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
+    Oc Delete    deployment trust-manager -n ${TRUST_MANAGER_NS} --ignore-not-found
     Wait Until Keyword Succeeds    12x    10s
     ...    Trust Manager Pod Should Not Exist
 
@@ -531,8 +524,7 @@ Trust Manager Pod Should Not Exist
     [Documentation]    Verify trust-manager pod no longer exists in cert-manager namespace
     ${output}=    Run With Kubeconfig
     ...    oc get pods -n ${TRUST_MANAGER_NS} -l app.kubernetes.io/name\=cert-manager-trust-manager --no-headers
-    ...    allow_fail=True
-    Should Not Contain    ${output}    trust-manager    msg=trust-manager pod still exists
+    Should Be Empty    ${output}    msg=trust-manager pod still exists
 
 Create CA Secret For Trust Manager
     [Documentation]    Generate a self-signed CA cert locally and create a secret in the trust namespace
@@ -611,11 +603,14 @@ Apply Trust Manager YAML
     [Documentation]    Apply YAML manifest, allowing both created and configured/unchanged results
     [Arguments]    ${yaml_content}
     ${temp_file}=    Create Random Temp File    ${yaml_content}
-    ${result}=    Oc Apply    -f ${temp_file}
-    Remove File    ${temp_file}
-    Log    Applied manifest: ${result}
+    TRY
+        ${result}=    Oc Apply    -f ${temp_file}
+        Log    Applied manifest: ${result}
+    FINALLY
+        Remove File    ${temp_file}
+    END
 
 Cleanup Trust Bundle
     [Documentation]    Remove the test trust-manager Bundle CR and its target ConfigMap
-    Run With Kubeconfig    oc delete bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
-    Run With Kubeconfig    oc delete configmap ${TRUST_MANAGER_BUNDLE_NAME} -n ${NAMESPACE} --ignore-not-found
+    Oc Delete    bundle ${TRUST_MANAGER_BUNDLE_NAME} --ignore-not-found
+    Oc Delete    configmap ${TRUST_MANAGER_BUNDLE_NAME} -n ${NAMESPACE} --ignore-not-found

--- a/test/suites/optional/cert-manager.robot
+++ b/test/suites/optional/cert-manager.robot
@@ -23,35 +23,35 @@ Test Tags           cert-manager    certificates    tls
 
 
 *** Variables ***
-${CERT_NAME}                    test-certificate
-${SECRET_NAME}                  test-cert-secret
-${ISSUER_NAME}                  test-issuer
-${CERT_COMMON_NAME}             example.com
-${CERT_DNS_NAME}                example.com
-${ROUTE_NAME}                   hello-app
-${CERT_ISSUER_YAML}             SEPARATOR=\n
-...                             ---
-...                             apiVersion: cert-manager.io/v1
-...                             kind: ClusterIssuer
-...                             metadata:
-...                             \ \ name: ${ISSUER_NAME}
-...                             spec:
-...                             \ \ selfSigned: {}
+${CERT_NAME}                        test-certificate
+${SECRET_NAME}                      test-cert-secret
+${ISSUER_NAME}                      test-issuer
+${CERT_COMMON_NAME}                 example.com
+${CERT_DNS_NAME}                    example.com
+${ROUTE_NAME}                       hello-app
+${CLUSTER_ISSUER_TMPL}              ./assets/cert-manager/cluster-issuer.yaml.template
+${CERTIFICATE_TMPL}                 ./assets/cert-manager/certificate.yaml.template
+${INGRESS_RBAC_TMPL}                ./assets/cert-manager/ingress-rbac.yaml.template
+${INGRESS_ROUTE_TMPL}               ./assets/cert-manager/ingress-route.yaml.template
+${HTTP01_ISSUER_TMPL}               ./assets/cert-manager/http01-issuer.yaml.template
+${HTTP01_CERTIFICATE_TMPL}          ./assets/cert-manager/http01-certificate.yaml.template
+${TRUST_BUNDLE_SRC_SECRET_TMPL}     ./assets/cert-manager/trust-bundle-source-secret.yaml.template
+${CA_CERTIFICATE_TMPL}              ./assets/cert-manager/ca-certificate.yaml.template
+${TRUST_BUNDLE_SECRET_TMPL}         ./assets/cert-manager/trust-bundle-secret.yaml.template
 
-${HTTP01_ISSUER_NAME}           letsencrypt-http01
-${HTTP01_CERT_NAME}             cert-from-${HTTP01_ISSUER_NAME}
-${HTTP01_SECRET_NAME}           ${HTTP01_CERT_NAME}
-${PEBBLE_DEPLOYMENT_FILE}       ./assets/cert-manager/pebble-server.yaml
-${HOSTSFILE_ENABLED}            SEPARATOR=\n
-...                             ---
-...                             dns:
-...                             \ \ hosts:
-...                             \ \ \ \ status: Enabled
+${HTTP01_ISSUER_NAME}               letsencrypt-http01
+${HTTP01_CERT_NAME}                 cert-from-${HTTP01_ISSUER_NAME}
+${HTTP01_SECRET_NAME}               ${HTTP01_CERT_NAME}
+${PEBBLE_DEPLOYMENT_FILE}           ./assets/cert-manager/pebble-server.yaml
+${HOSTSFILE_ENABLED}                SEPARATOR=\n
+...                                 ---
+...                                 dns:
+...                                 \ \ hosts:
+...                                 \ \ \ \ status: Enabled
 
-${TRUST_MANAGER_BUNDLE_NAME}    test-trust-bundle
-${TRUST_MANAGER_OPERATOR_NS}    cert-manager-operator
-${TRUST_MANAGER_NS}             cert-manager
-${TRUST_MANAGER_CR_FILE}        ./assets/cert-manager/trust-manager-cr.yaml
+${TRUST_MANAGER_BUNDLE_NAME}        test-trust-bundle
+${TRUST_MANAGER_NS}                 cert-manager
+${TRUST_MANAGER_CR_FILE}            ./assets/cert-manager/trust-manager-cr.yaml
 
 
 *** Test Cases ***
@@ -59,19 +59,15 @@ Create Ingress route with Custom certificate
     [Documentation]    Create route with a custom certificate
     [Setup]    Run Keywords
     Verify Cert Manager Kustomization Success
-    ${cert_issuer_yaml}=    Create Cert Issuer YAML
-    Apply YAML Manifest    ${cert_issuer_yaml}
+    Apply Template    ${CLUSTER_ISSUER_TMPL}
     Oc Wait    -n ${NAMESPACE} clusterissuer ${ISSUER_NAME}
     ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
-    ${cert_yaml}=    Create Certificate YAML For Test
-    Apply YAML Manifest    ${cert_yaml}
+    Apply Template    ${CERTIFICATE_TMPL}
     Oc Wait    -n ${NAMESPACE} certificate ${CERT_NAME}
     ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
-    ${rbac_yaml}=    Create Ingress RBAC YAML
-    Apply YAML Manifest    ${rbac_yaml}
+    Apply Template    ${INGRESS_RBAC_TMPL}
     Deploy Hello MicroShift
-    ${route_yaml}=    Create Ingress Route YAML
-    Apply YAML Manifest    ${route_yaml}
+    Apply Template    ${INGRESS_ROUTE_TMPL}
     Oc Wait    -n ${NAMESPACE} route ${ROUTE_NAME}
     ...    --for=jsonpath='.status.ingress' --timeout=${DEFAULT_WAIT_TIMEOUT}
     [Teardown]    Run Keywords
@@ -82,32 +78,29 @@ Test Cert manager with local acme server
     [Tags]    http01    acme
     [Setup]    Setup Pebble Server    ${NAMESPACE}
 
-    ${dns_name}=    Generate Random HostName
-    Setup DNS For Test    ${USHIFT_HOST}    ${dns_name}
+    ${DNS_NAME}=    Generate Random HostName
+    VAR    ${DNS_NAME}=    ${DNS_NAME}    scope=TEST
+    Setup DNS For Test    ${USHIFT_HOST}    ${DNS_NAME}
     Oc Get JsonPath    ingressclass    ${EMPTY}    openshift-ingress    .metadata.name
-    ${http01_issuer_yaml}=    Create HTTP01 Issuer YAML
-    Apply YAML Manifest    ${http01_issuer_yaml}
+    Apply Template    ${HTTP01_ISSUER_TMPL}
     Oc Wait    -n ${NAMESPACE} issuer ${HTTP01_ISSUER_NAME}
     ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
 
-    ${cert_yaml}=    Create Certificate YAML    ${dns_name}
-    Apply YAML Manifest    ${cert_yaml}
+    Apply Template    ${HTTP01_CERTIFICATE_TMPL}
     Oc Wait    -n ${NAMESPACE} certificate ${HTTP01_CERT_NAME}    --for="condition=Ready" --timeout=300s
 
     Verify Certificate    ${HTTP01_CERT_NAME}    ${NAMESPACE}
 
     [Teardown]    Run Keywords
     ...    Cleanup HTTP01 Resources
-    ...    AND    Cleanup DNS For Test    ${dns_name}
+    ...    AND    Cleanup DNS For Test    ${DNS_NAME}
 
 Trust Manager Deployment
     [Documentation]    Verify trust-manager can be enabled and deploys successfully
     [Tags]    trust-manager
     [Setup]    Enable Trust Manager
-    Labeled Pod Should Be Ready    app.kubernetes.io/name=cert-manager-trust-manager    ns=${TRUST_MANAGER_NS}
-    ${status}=    Oc Get JsonPath    trustmanager    ${EMPTY}    cluster
-    ...    .status.conditions[?(@.type=="Ready")].status
-    Should Be Equal    ${status}    True    msg=TrustManager CR is not ready
+    Wait Until Keyword Succeeds    30x    10s
+    ...    TrustManager CR Should Be Ready
     [Teardown]    Disable Trust Manager
 
 Trust Manager Bundle Creates ConfigMap
@@ -116,8 +109,7 @@ Trust Manager Bundle Creates ConfigMap
     [Setup]    Enable Trust Manager
 
     Create CA Secret For Trust Manager
-    ${bundle_yaml}=    Create Trust Bundle From Source Secret YAML
-    Apply Trust Manager YAML    ${bundle_yaml}
+    Apply Template    ${TRUST_BUNDLE_SRC_SECRET_TMPL}
     Oc Wait    bundle ${TRUST_MANAGER_BUNDLE_NAME}
     ...    --for=jsonpath='{.status.conditions[?(@.type=="Synced")].status}'=True --timeout=${DEFAULT_WAIT_TIMEOUT}
 
@@ -138,18 +130,15 @@ Trust Manager Bundle With Cert Manager CA
     [Tags]    trust-manager
     [Setup]    Enable Trust Manager
 
-    ${issuer_yaml}=    Create Cert Issuer YAML
-    Apply Trust Manager YAML    ${issuer_yaml}
+    Apply Template    ${CLUSTER_ISSUER_TMPL}
     Oc Wait    -n ${NAMESPACE} clusterissuer ${ISSUER_NAME}
     ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
 
-    ${ca_cert_yaml}=    Create CA Certificate YAML
-    Apply Trust Manager YAML    ${ca_cert_yaml}
+    Apply Template    ${CA_CERTIFICATE_TMPL}
     Oc Wait    -n ${TRUST_MANAGER_NS} certificate ca-certificate
     ...    --for="condition=Ready" --timeout=${DEFAULT_WAIT_TIMEOUT}
 
-    ${bundle_yaml}=    Create Trust Bundle From Secret YAML
-    Apply Trust Manager YAML    ${bundle_yaml}
+    Apply Template    ${TRUST_BUNDLE_SECRET_TMPL}
     Oc Wait    bundle ${TRUST_MANAGER_BUNDLE_NAME}
     ...    --for=jsonpath='{.status.conditions[?(@.type=="Synced")].status}'=True --timeout=${DEFAULT_WAIT_TIMEOUT}
 
@@ -162,7 +151,7 @@ Trust Manager Bundle With Cert Manager CA
 
     [Teardown]    Run Keywords
     ...    Cleanup Trust Bundle
-    ...    AND    Oc Delete    certificate/ca-certificate -n ${TRUST_MANAGER_NS}
+    ...    AND    Oc Delete    certificate/ca-certificate -n ${TRUST_MANAGER_NS} --ignore-not-found
     ...    AND    Remove ClusterIssuer
     ...    AND    Disable Trust Manager
 
@@ -188,16 +177,18 @@ Deploy Hello MicroShift
 
 Remove ClusterIssuer
     [Documentation]    Remove the cluster issuer
-    Oc Delete    clusterissuer/${ISSUER_NAME}
+    Oc Delete    clusterissuer/${ISSUER_NAME} --ignore-not-found
 
-Apply YAML Manifest
-    [Documentation]    Apply YAML manifest to the cluster
-    [Arguments]    ${yaml_content}
-    ${temp_file}=    Create Random Temp File    ${yaml_content}
-    ${result}=    Oc Apply    -f ${temp_file}
-    Remove File    ${temp_file}
-    Should Contain    ${result}    created    msg=Failed to apply YAML manifest
-    Log    Applied manifest: ${result}
+Apply Template
+    [Documentation]    Generate YAML from template and apply to cluster
+    [Arguments]    ${template_file}
+    ${tmp}=    Create Random Temp File
+    Generate File From Template    ${template_file}    ${tmp}
+    TRY
+        Oc Apply    -f ${tmp}
+    FINALLY
+        Remove File    ${tmp}
+    END
 
 Generate Random HostName
     [Documentation]    Generate Random Hostname
@@ -222,135 +213,6 @@ Check Pebble Deployment Ready
     [Arguments]    ${namespace}
     ${result}=    Oc Get JsonPath    deployment    ${namespace}    pebble    .status.readyReplicas
     Should Be Equal    ${result}    1    msg=Pebble deployment not ready yet
-
-Create Cert Issuer YAML
-    [Documentation]    Creates cluster issuer YAML
-    ${cert_issuer_yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: cert-manager.io/v1
-    ...    kind: ClusterIssuer
-    ...    metadata:
-    ...    \ \ name: ${ISSUER_NAME}
-    ...    spec:
-    ...    \ \ selfSigned: {}
-    RETURN    ${cert_issuer_yaml}
-
-Create Certificate YAML For Test
-    [Documentation]    Creates certificate YAML for basic test
-    ${cert_yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: cert-manager.io/v1
-    ...    kind: Certificate
-    ...    metadata:
-    ...    \ \ name: ${CERT_NAME}
-    ...    \ \ namespace: ${NAMESPACE}
-    ...    spec:
-    ...    \ \ secretName: ${SECRET_NAME}
-    ...    \ \ issuerRef:
-    ...    \ \ \ \ name: ${ISSUER_NAME}
-    ...    \ \ \ \ kind: ClusterIssuer
-    ...    \ \ commonName: ${CERT_COMMON_NAME}
-    ...    \ \ dnsNames:
-    ...    \ \ - ${CERT_DNS_NAME}
-    ...    \ \ - www.${CERT_DNS_NAME}
-    RETURN    ${cert_yaml}
-
-Create Ingress RBAC YAML
-    [Documentation]    Creates RBAC YAML for ingress
-    ${rbac_yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: rbac.authorization.k8s.io/v1
-    ...    kind: Role
-    ...    metadata:
-    ...    \ \ name: secret-reader
-    ...    \ \ namespace: ${NAMESPACE}
-    ...    rules:
-    ...    - apiGroups: [""]
-    ...    \ \ resources: ["secrets"]
-    ...    \ \ resourceNames: ["${SECRET_NAME}"]
-    ...    \ \ verbs: ["get", "list", "watch"]
-    ...    ---
-    ...    apiVersion: rbac.authorization.k8s.io/v1
-    ...    kind: RoleBinding
-    ...    metadata:
-    ...    \ \ name: ingress-secret-reader
-    ...    \ \ namespace: ${NAMESPACE}
-    ...    roleRef:
-    ...    \ \ apiGroup: rbac.authorization.k8s.io
-    ...    \ \ kind: Role
-    ...    \ \ name: secret-reader
-    ...    subjects:
-    ...    - kind: ServiceAccount
-    ...    \ \ name: router
-    ...    \ \ namespace: openshift-ingress
-    RETURN    ${rbac_yaml}
-
-Create Ingress Route YAML
-    [Documentation]    Creates route YAML for ingress
-    ${route_yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: route.openshift.io/v1
-    ...    kind: Route
-    ...    metadata:
-    ...    \ \ name: ${ROUTE_NAME}
-    ...    \ \ namespace: ${NAMESPACE}
-    ...    spec:
-    ...    \ \ port:
-    ...    \ \ \ \ targetPort: 8080
-    ...    \ \ tls:
-    ...    \ \ \ \ externalCertificate:
-    ...    \ \ \ \ \ \ name: ${SECRET_NAME}
-    ...    \ \ \ \ termination: edge
-    ...    \ \ to:
-    ...    \ \ \ \ kind: Service
-    ...    \ \ \ \ name: hello-microshift
-    RETURN    ${route_yaml}
-
-Create HTTP01 Issuer YAML
-    [Documentation]    Creates HTTP01 issuer YAML
-    ${http01_issuer_yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: cert-manager.io/v1
-    ...    kind: Issuer
-    ...    metadata:
-    ...    \ \ name: ${HTTP01_ISSUER_NAME}
-    ...    \ \ namespace: ${NAMESPACE}
-    ...    spec:
-    ...    \ \ acme:
-    ...    \ \ \ \ server: "https://pebble.${NAMESPACE}.svc.cluster.local:14000/dir"
-    ...    \ \ \ \ skipTLSVerify: true
-    ...    \ \ \ \ privateKeySecretRef:
-    ...    \ \ \ \ \ \ name: acme-account-key
-    ...    \ \ \ \ solvers:
-    ...    \ \ \ \ - http01:
-    ...    \ \ \ \ \ \ \ \ ingress:
-    ...    \ \ \ \ \ \ \ \ \ \ ingressClassName: openshift-ingress
-    RETURN    ${http01_issuer_yaml}
-
-Create Certificate YAML
-    [Documentation]    Creates certificate YAML with the specified DNS name
-    [Arguments]    ${dns_name}
-    ${cert_yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: cert-manager.io/v1
-    ...    kind: Certificate
-    ...    metadata:
-    ...    \ \ name: ${HTTP01_CERT_NAME}
-    ...    \ \ namespace: ${NAMESPACE}
-    ...    spec:
-    ...    \ \ commonName: ${dns_name}
-    ...    \ \ dnsNames:
-    ...    \ \ - ${dns_name}
-    ...    \ \ duration: 1h
-    ...    \ \ issuerRef:
-    ...    \ \ \ \ group: cert-manager.io
-    ...    \ \ \ \ kind: Issuer
-    ...    \ \ \ \ name: ${HTTP01_ISSUER_NAME}
-    ...    \ \ renewBefore: 58m
-    ...    \ \ secretName: ${HTTP01_SECRET_NAME}
-    ...    \ \ usages:
-    ...    \ \ - server auth
-    RETURN    ${cert_yaml}
 
 Verify Certificate
     [Documentation]    Verifies the issued certificate content (same logic as Go tests)
@@ -405,10 +267,10 @@ Verify Certificate Common Name
 
 Cleanup HTTP01 Resources
     [Documentation]    Cleanup HTTP01 test resources
-    Oc Delete    certificate/${HTTP01_CERT_NAME} -n ${NAMESPACE}
-    Oc Delete    issuer/${HTTP01_ISSUER_NAME} -n ${NAMESPACE}
-    Oc Delete    deployment/pebble -n ${NAMESPACE}
-    Oc Delete    service/pebble -n ${NAMESPACE}
+    Oc Delete    certificate/${HTTP01_CERT_NAME} -n ${NAMESPACE} --ignore-not-found
+    Oc Delete    issuer/${HTTP01_ISSUER_NAME} -n ${NAMESPACE} --ignore-not-found
+    Oc Delete    deployment/pebble -n ${NAMESPACE} --ignore-not-found
+    Oc Delete    service/pebble -n ${NAMESPACE} --ignore-not-found
 
 Configure DNS For Domain
     [Documentation]    Configure DNS configmap in openshift-dns namespace and restart DNS pod
@@ -528,80 +390,14 @@ Create CA Secret For Trust Manager
     ...    -subj    /CN\=test-ca.example.com
     ...    stderr=STDOUT
     Should Be Equal As Integers    ${result.rc}    0
-    Run With Kubeconfig
-    ...    oc create secret generic ca-source-secret -n ${TRUST_MANAGER_NS} --from-file=tls.crt=${cert_file}
+    Oc Create    secret generic ca-source-secret -n ${TRUST_MANAGER_NS} --from-file=tls.crt=${cert_file}
     Remove File    ${cert_file}
 
-Create Trust Bundle From Source Secret YAML
-    [Documentation]    Creates a Bundle CR YAML sourced from a manually created secret in the trust namespace
-    ${yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: trust.cert-manager.io/v1alpha1
-    ...    kind: Bundle
-    ...    metadata:
-    ...    \ \ name: ${TRUST_MANAGER_BUNDLE_NAME}
-    ...    spec:
-    ...    \ \ sources:
-    ...    \ \ \ \ - secret:
-    ...    \ \ \ \ \ \ \ \ name: ca-source-secret
-    ...    \ \ \ \ \ \ \ \ key: tls.crt
-    ...    \ \ target:
-    ...    \ \ \ \ configMap:
-    ...    \ \ \ \ \ \ key: ca-bundle.crt
-    ...    \ \ \ \ namespaceSelector:
-    ...    \ \ \ \ \ \ matchLabels:
-    ...    \ \ \ \ \ \ \ \ kubernetes.io/metadata.name: ${NAMESPACE}
-    RETURN    ${yaml}
-
-Create CA Certificate YAML
-    [Documentation]    Creates a cert-manager CA Certificate in the trust namespace
-    ${yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: cert-manager.io/v1
-    ...    kind: Certificate
-    ...    metadata:
-    ...    \ \ name: ca-certificate
-    ...    \ \ namespace: ${TRUST_MANAGER_NS}
-    ...    spec:
-    ...    \ \ isCA: true
-    ...    \ \ commonName: test-ca.example.com
-    ...    \ \ secretName: ca-certificate-secret
-    ...    \ \ issuerRef:
-    ...    \ \ \ \ name: ${ISSUER_NAME}
-    ...    \ \ \ \ kind: ClusterIssuer
-    RETURN    ${yaml}
-
-Create Trust Bundle From Secret YAML
-    [Documentation]    Creates a Bundle CR YAML sourced from a cert-manager CA secret in the trust namespace
-    ${yaml}=    CATENATE    SEPARATOR=\n
-    ...    ---
-    ...    apiVersion: trust.cert-manager.io/v1alpha1
-    ...    kind: Bundle
-    ...    metadata:
-    ...    \ \ name: ${TRUST_MANAGER_BUNDLE_NAME}
-    ...    spec:
-    ...    \ \ sources:
-    ...    \ \ \ \ - secret:
-    ...    \ \ \ \ \ \ \ \ name: ca-certificate-secret
-    ...    \ \ \ \ \ \ \ \ key: tls.crt
-    ...    \ \ target:
-    ...    \ \ \ \ configMap:
-    ...    \ \ \ \ \ \ key: ca-bundle.crt
-    ...    \ \ \ \ namespaceSelector:
-    ...    \ \ \ \ \ \ matchLabels:
-    ...    \ \ \ \ \ \ \ \ kubernetes.io/metadata.name: ${NAMESPACE}
-    RETURN    ${yaml}
-
-Apply Trust Manager YAML
-    [Documentation]    Apply YAML manifest, allowing both created and configured/unchanged results
-    [Arguments]    ${yaml_content}
-    ${temp_file}=    Create Random Temp File    ${yaml_content}
-    TRY
-        ${result}=    Oc Apply    -f ${temp_file}
-        Log    Applied manifest: ${result}
-    FINALLY
-        Remove File    ${temp_file}
-    END
+TrustManager CR Should Be Ready
+    [Documentation]    Check TrustManager CR has Ready=True status condition
+    ${status}=    Oc Get JsonPath    trustmanager    ${EMPTY}    cluster
+    ...    .status.conditions[?(@.type=="Ready")].status
+    Should Be Equal    ${status}    True    msg=TrustManager CR is not ready
 
 Cleanup Trust Bundle
     [Documentation]    Remove the test trust-manager Bundle CR and its target ConfigMap

--- a/test/suites/optional/gateway-api.robot
+++ b/test/suites/optional/gateway-api.robot
@@ -5,6 +5,7 @@ Resource            ../../resources/microshift-network.resource
 Resource            ../../resources/microshift-process.resource
 Resource            ../../resources/optional-config.resource
 Resource            ../../resources/oc.resource
+Resource            ../../resources/common.resource
 
 Suite Setup         Setup
 Suite Teardown      Teardown
@@ -141,10 +142,3 @@ Verify Gateway Service Has External IP
     ...    oc get svc test-gateway-openshift-gateway-api -n ${namespace} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
     Should Not Be Empty    ${result}    Gateway service does not have an external IP assigned
     RETURN    ${result}
-
-Generate File From Template
-    [Documentation]    Generate file from template
-    [Arguments]    ${template_file}    ${out_file}
-    ${template}    OperatingSystem.Get File    ${template_file}
-    ${message}    Replace Variables    ${template}
-    OperatingSystem.Append To File    ${out_file}    ${message}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional TrustManager support for cert-manager: operator enables TrustManager and surfaces the trust-manager image for use.
  * Default TrustManager custom resource added to enable cluster trust-bundle management.

* **Tests**
  * End-to-end tests covering TrustManager deployment readiness, bundle → ConfigMap synchronization, CA source handling (self-signed and cert-manager-issued), and lifecycle operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->