### PR TITLE
USHIFT-6985: Add retry to Root CA ConfigMap signer verification

### DIFF
--- a/test/suites/standard2/validate-service-account-ca-bundle.robot
+++ b/test/suites/standard2/validate-service-account-ca-bundle.robot
@@ -30,6 +30,7 @@ Root CA ConfigMap Contains All Signers
 
 *** Keywords ***
 Verify Root CA ConfigMap Has All Signers
+    [Documentation]    Fetch the kube-root-ca.crt ConfigMap and verify it contains all expected signers.
     ${configmap}=    Oc Get    configmap    ${NAMESPACE}    ${ROOT_CA_CONFIGMAP_NAME}
     VAR    ${ca_bundle}=    ${configmap.data['ca.crt']}
     Should Not Be Empty    ${ca_bundle}
@@ -37,6 +38,7 @@ Verify Root CA ConfigMap Has All Signers
     Should Contain    ${subjects}    kube-apiserver-localhost-signer
     Should Contain    ${subjects}    kube-apiserver-service-network-signer
     Should Contain    ${subjects}    kube-apiserver-external-signer
+
 Get Certificate Subjects From Bundle
     [Documentation]    Extract all certificate subjects from a PEM-encoded CA bundle string.
     ...    For CA certificates, the Subject field contains the signer name.

--- a/test/suites/standard2/validate-service-account-ca-bundle.robot
+++ b/test/suites/standard2/validate-service-account-ca-bundle.robot
@@ -24,17 +24,19 @@ Root CA ConfigMap Contains All Signers
     [Documentation]    Verify that the kube-root-ca.crt ConfigMap contains certificates
     ...    from all required signers: kube-apiserver-localhost-signer,
     ...    kube-apiserver-service-network-signer, and kube-apiserver-external-signer
+    Wait Until Keyword Succeeds    60s    5s
+    ...    Verify Root CA ConfigMap Has All Signers
+
+
+*** Keywords ***
+Verify Root CA ConfigMap Has All Signers
     ${configmap}=    Oc Get    configmap    ${NAMESPACE}    ${ROOT_CA_CONFIGMAP_NAME}
     VAR    ${ca_bundle}=    ${configmap.data['ca.crt']}
     Should Not Be Empty    ${ca_bundle}
-
     ${subjects}=    Get Certificate Subjects From Bundle    ${ca_bundle}
     Should Contain    ${subjects}    kube-apiserver-localhost-signer
     Should Contain    ${subjects}    kube-apiserver-service-network-signer
     Should Contain    ${subjects}    kube-apiserver-external-signer
-
-
-*** Keywords ***
 Get Certificate Subjects From Bundle
     [Documentation]    Extract all certificate subjects from a PEM-encoded CA bundle string.
     ...    For CA certificates, the Subject field contains the signer name.


### PR DESCRIPTION
## Summary
- The `Root CA ConfigMap Contains All Signers` test fails intermittently on ARM (aarch64) in ISO image scenarios (`el98-lrel@iso-standard2`) because the `kube-root-ca.crt` ConfigMap is not fully populated by the time the test runs.
- Wraps the entire verification (ConfigMap fetch + openssl subject extraction + signer assertions) in `Wait Until Keyword Succeeds` with a 60s timeout and 5s retry interval.
- The test passes consistently on x86_64 and on ARM in non-ISO scenarios; only the ISO installation path on ARM exhibits this timing issue.

## Evidence
- Failing job: [periodic-ci-openshift-microshift-release-4.22-periodics-e2e-aws-tests-bootc-release-arm-periodic-el9/2061644145188933632](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-microshift-release-4.22-periodics-e2e-aws-tests-bootc-release-arm-periodic-el9/2061644145188933632)
- Failed in `el98-lrel@iso-standard2` (22.8s, error: `1 != 0`) while passing in 5 other scenarios (~0.25s each)

## Test plan
- [ ] Verify the test passes on ARM ISO scenarios with the retry
- [ ] Confirm no regression on x86_64 standard2 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Root CA ConfigMap validation test with retry logic to improve reliability in verifying certificate signer identities.
  * Refactored CA bundle verification logic into a dedicated test keyword for improved test organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->