### PR TITLE
USHIFT-6996: fix CI test: Wait for MicroShift healthcheck before reading kubeconfig in Workload-Partitioning suite

### DIFF
--- a/test/suites/tuned/workload-partitioning.robot
+++ b/test/suites/tuned/workload-partitioning.robot
@@ -258,6 +258,10 @@ Cleanup And Create NS
     VAR    ${NAMESPACE}=    ${ns}    scope=SUITE
 
 Setup Suite And Wait For Healthcheck
-    [Documentation]    Run setup suit and wait for healthcheck to succeed
-    Setup Suite
+    [Documentation]    Wait for MicroShift to be healthy before setting up kubeconfig.
+    ...    After the preceding Tuned suite triggers a reboot in its teardown,
+    ...    MicroShift may not have fully started when this suite begins.
+    Check Required Env Variables
+    Login MicroShift Host
     Wait For MicroShift Healthcheck Success
+    Setup Kubeconfig


### PR DESCRIPTION
## Summary

Fix for the following CI bugs:
- [USHIFT-6996](https://issues.redhat.com/browse/USHIFT-6996)

*Auto-generated by [/microshift-ci:fix-test-bugs](https://github.com/openshift-eng/edge-tooling)* :robot:

## Rationale

The Workload-Partitioning suite setup called Setup Suite (which reads the kubeconfig file from /var/lib/microshift/) before waiting for MicroShift healthcheck. After the preceding Tuned suite triggers a reboot in its teardown, MicroShift may not have fully started when the Workload-Partitioning suite begins, causing the kubeconfig file to not yet exist. The fix reorders the setup to: login SSH, wait for MicroShift healthcheck (ensuring the service is fully running and kubeconfig is written), then read the kubeconfig.

## Changed files

- `test/suites/tuned/workload-partitioning.robot `

## Verification

- [ ] CI passes
- [ ] Changes are limited to test/scripts/docs
- [ ] Fix addresses the shared root cause described in the JIRA bugs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup with enhanced health checks and initialization verification to ensure system readiness before test execution, addressing scenarios where prior operations may leave the system in a transitional state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->