### PR TITLE
Cert Rotation Test: Drop TZ=UTC to use local timezone / Force UTC on all VMs?

### DIFF
--- a/test/kickstart-templates/includes/post-system.cfg
+++ b/test/kickstart-templates/includes/post-system.cfg
@@ -2,6 +2,8 @@
 useradd -m -p \$5\$XDVQ6DxT8S5YWLV7\$8f2om5JfjK56v9ofUkUAwZXTxJl3Sqnc9yPnza4xoJ0 redhat
 echo -e 'redhat\tALL=(ALL)\tNOPASSWD: ALL' > /etc/sudoers.d/microshift
 
+ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+
 # Make the KUBECONFIG from MicroShift directly available for the root user
 if [ ! -d /root ]; then
     # Workaround for bootc container init.

--- a/test/suites/standard2/validate-certificate-rotation.robot
+++ b/test/suites/standard2/validate-certificate-rotation.robot
@@ -99,7 +99,7 @@ Change System Date To
     [Arguments]    ${future_date}
     ${ushift_pid}=    MicroShift Process ID
     Systemctl    stop    chronyd
-    Command Should Work    TZ=UTC timedatectl set-time "${future_date}"
+    Command Should Work    timedatectl set-time "${future_date}"
     Sleep    5s
     Wait Until MicroShift Process ID Changes    ${ushift_pid}
     All Certificates Should Be Valid For Current Time
@@ -110,7 +110,7 @@ Compute Date After Days
     [Documentation]    return system date after number of days elapsed from midnight tomorrow
     [Arguments]    ${number_of_days}    ${date_format}
     # Certificates are aligned to expire at midnight of the next day + validity
-    ${future_date}=    Command Should Work    TZ=UTC date "+${date_format}" -d "tomorrow + ${number_of_days} day"
+    ${future_date}=    Command Should Work    date "+${date_format}" -d "tomorrow + ${number_of_days} day"
     RETURN    ${future_date}
 
 Certs Should Expire On


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated certificate rotation validation tests with refined date/time handling to improve rotation and expiry checks.
* **Chores**
  * Post-install system configuration now ensures system local time is set to UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->