### PR TITLE
USHIFT-7186: Propagate cache download error

### DIFF
--- a/test/bin/ci_phase_iso_build.sh
+++ b/test/bin/ci_phase_iso_build.sh
@@ -46,7 +46,7 @@ download_build_cache() {
     if ./bin/manage_build_cache.sh verify -b "${SCENARIO_BUILD_BRANCH}" -t "${cache_last}" ; then
         # Download the cached images
         ./bin/manage_build_cache.sh download -b "${SCENARIO_BUILD_BRANCH}" -t "${cache_last}"
-        return 0
+        return $?
     fi
     return 1
 }


### PR DESCRIPTION
bash's `if` disables the `set -e`, so if the `manage_build_cache.sh download` fails, the error is ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build cache handling to properly report download status, ensuring build failures are correctly communicated instead of being masked as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->