### PR TITLE
NO-ISSUE: C2CC IPSec test: tcpdump robustness

### DIFF
--- a/test/resources/ipsec.resource
+++ b/test/resources/ipsec.resource
@@ -71,7 +71,7 @@ Start Tcpdump For ESP On Cluster
     VAR    ${pcap_file}=    /tmp/esp-capture-${alias}.pcap
     Disruptive Command On Cluster    ${alias}    rm -f ${pcap_file}
     Command On Cluster    ${alias}
-    ...    nohup timeout ${timeout} tcpdump -i ${iface} -w ${pcap_file} esp &>/dev/null &
+    ...    nohup timeout ${timeout} tcpdump -U -i ${iface} -w ${pcap_file} esp &>/dev/null &
     Sleep    2s    reason=Wait for tcpdump to initialize packet capture
     RETURN    ${pcap_file}
 

--- a/test/resources/ipsec.resource
+++ b/test/resources/ipsec.resource
@@ -66,19 +66,24 @@ Verify XFRM Counters Incremented
 
 Start Tcpdump For ESP On Cluster
     [Documentation]    Start tcpdump in the background capturing ESP packets.
-    ...    Returns the pcap file path. Uses timeout to auto-exit.
-    [Arguments]    ${alias}    ${iface}=enp1s0    ${timeout}=15
+    ...    Returns the pcap file path.
+    [Arguments]    ${alias}    ${iface}=enp1s0
     VAR    ${pcap_file}=    /tmp/esp-capture-${alias}.pcap
     Disruptive Command On Cluster    ${alias}    rm -f ${pcap_file}
-    Command On Cluster    ${alias}
-    ...    nohup timeout ${timeout} tcpdump -U -i ${iface} -w ${pcap_file} esp &>/dev/null &
+    ${conn_id}=    Get From Dictionary    ${C2CC_SSH_IDS}    ${alias}
+    SSHLibrary.Switch Connection    ${conn_id}
+    SSHLibrary.Start Command    tcpdump -U -i ${iface} -w ${pcap_file} esp 2>/dev/null    sudo=True
     Sleep    2s    reason=Wait for tcpdump to initialize packet capture
     RETURN    ${pcap_file}
 
 Wait For Tcpdump And Verify ESP
-    [Documentation]    Wait briefly for traffic to be captured, then verify ESP packets in pcap.
+    [Documentation]    Stop tcpdump, then verify ESP packets in pcap.
     [Arguments]    ${alias}    ${pcap_file}
-    Sleep    5s    reason=Wait for ESP packets to be captured
+    Sleep    3s    reason=Wait for ESP packets to be captured
+    Disruptive Command On Cluster    ${alias}    pkill -INT tcpdump
+    ${conn_id}=    Get From Dictionary    ${C2CC_SSH_IDS}    ${alias}
+    SSHLibrary.Switch Connection    ${conn_id}
+    SSHLibrary.Read Command Output
     ${stdout}=    Command On Cluster    ${alias}
     ...    tcpdump -r ${pcap_file} 2>/dev/null | head -5
     Should Contain    ${stdout}    ESP

--- a/test/resources/ipsec.resource
+++ b/test/resources/ipsec.resource
@@ -80,7 +80,7 @@ Wait For Tcpdump And Verify ESP
     [Documentation]    Stop tcpdump, then verify ESP packets in pcap.
     [Arguments]    ${alias}    ${pcap_file}
     Sleep    3s    reason=Wait for ESP packets to be captured
-    Disruptive Command On Cluster    ${alias}    pkill -INT tcpdump
+    Disruptive Command On Cluster    ${alias}    pkill -INT -f "tcpdump.*${pcap_file}"
     ${conn_id}=    Get From Dictionary    ${C2CC_SSH_IDS}    ${alias}
     SSHLibrary.Switch Connection    ${conn_id}
     ${stdout}    ${stderr}=    SSHLibrary.Read Command Output    return_stderr=True

--- a/test/resources/ipsec.resource
+++ b/test/resources/ipsec.resource
@@ -72,7 +72,7 @@ Start Tcpdump For ESP On Cluster
     Disruptive Command On Cluster    ${alias}    rm -f ${pcap_file}
     ${conn_id}=    Get From Dictionary    ${C2CC_SSH_IDS}    ${alias}
     SSHLibrary.Switch Connection    ${conn_id}
-    SSHLibrary.Start Command    tcpdump -U -i ${iface} -w ${pcap_file} esp 2>/dev/null    sudo=True
+    SSHLibrary.Start Command    tcpdump -U -i ${iface} -w ${pcap_file} esp    sudo=True
     Sleep    2s    reason=Wait for tcpdump to initialize packet capture
     RETURN    ${pcap_file}
 
@@ -83,7 +83,9 @@ Wait For Tcpdump And Verify ESP
     Disruptive Command On Cluster    ${alias}    pkill -INT tcpdump
     ${conn_id}=    Get From Dictionary    ${C2CC_SSH_IDS}    ${alias}
     SSHLibrary.Switch Connection    ${conn_id}
-    SSHLibrary.Read Command Output
+    ${stdout}    ${stderr}=    SSHLibrary.Read Command Output    return_stderr=True
+    Log    tcpdump stdout: ${stdout}    level=DEBUG
+    Log    tcpdump stderr: ${stderr}    level=DEBUG
     ${stdout}=    Command On Cluster    ${alias}
     ...    tcpdump -r ${pcap_file} 2>/dev/null | head -5
     Should Contain    ${stdout}    ESP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved IPSec ESP packet capture and verification for cluster tests: per-cluster capture management over SSH, simplified startup/teardown with a shorter initialization wait and a graceful interrupt to end captures, and capture output (stdout/stderr) is now collected and logged before verification to reduce flakiness and improve retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->