### PR TITLE
CI: add GPG keys to composer package sources

### DIFF
--- a/test/package-sources/fast-datapath-rhel9.toml
+++ b/test/package-sources/fast-datapath-rhel9.toml
@@ -4,5 +4,6 @@ type = "yum-baseurl"
 url = "https://cdn.redhat.com/content/dist/layered/rhel9/{{ .Env.UNAME_M }}/fast-datapath/os"
 check_gpg = true
 check_ssl = true
+gpgkeys = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"]
 system = false
 rhsm = true

--- a/test/package-sources/rhocp-y.toml
+++ b/test/package-sources/rhocp-y.toml
@@ -5,6 +5,7 @@ type = "yum-baseurl"
 url = "https://cdn.redhat.com/content/dist/layered/rhel9/{{ .Env.UNAME_M }}/rhocp/{{ .Env.RHOCP_MAJOR_Y }}.{{ .Env.RHOCP_MINOR_Y }}/os"
 check_gpg = true
 check_ssl = true
+gpgkeys = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"]
 system = false
 rhsm = true
 {{- else if env.Getenv "RHOCP_MINOR_Y_BETA" "" -}}

--- a/test/package-sources/rhocp-y1.toml
+++ b/test/package-sources/rhocp-y1.toml
@@ -5,6 +5,7 @@ type = "yum-baseurl"
 url = "https://cdn.redhat.com/content/dist/layered/rhel9/{{ .Env.UNAME_M }}/rhocp/{{ .Env.RHOCP_MAJOR_Y1 }}.{{ .Env.RHOCP_MINOR_Y1 }}/os"
 check_gpg = true
 check_ssl = true
+gpgkeys = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"]
 system = false
 rhsm = true
 {{- else if env.Getenv "RHOCP_MINOR_Y1_BETA" "" -}}

--- a/test/package-sources/rhocp-y2.toml
+++ b/test/package-sources/rhocp-y2.toml
@@ -5,6 +5,7 @@ type = "yum-baseurl"
 url = "https://cdn.redhat.com/content/dist/layered/rhel9/{{ .Env.UNAME_M }}/rhocp/{{ .Env.RHOCP_MAJOR_Y2 }}.{{ .Env.RHOCP_MINOR_Y2 }}/os"
 check_gpg = true
 check_ssl = true
+gpgkeys = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"]
 system = false
 rhsm = true
 {{- end -}}


### PR DESCRIPTION
## Summary

- osbuild-composer now strictly enforces that repos with `check_gpg=true` must have `gpgkeys` configured
- Four RHSM-based package source TOML files (`fast-datapath`, `rhocp-y`, `rhocp-y1`, `rhocp-y2`) were missing the `gpgkeys` field
- This causes intermittent `ManifestCreationFailed` errors during `composer-cli compose start-ostree` for edge-commit builds, blocking all ostree-based CI jobs

### Error

```
ERROR: ManifestCreationFailed: failed to serialize osbuild manifest: cannot serialize
pipeline "os": package "tuned" requires GPG check but repo "81e07..." has no GPG keys configured
```

Affected packages: `openvswitch-selinux-extra-policy` (fast-datapath), `cri-tools` (rhocp-y1), `tuned` (fast-datapath).

### Why intermittent

The error is non-deterministic because osbuild-composer's depsolver sometimes resolves packages from system repos (which have GPG keys in `/etc/osbuild-composer/repositories/`) vs the user-added sources (which didn't). Some blueprints succeed on retry, but `rhel-9.8-microshift-source-optionals` consistently fails all 3 attempts.

### Fix

Add `gpgkeys = ["file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"]` to all GA-path RHSM sources that have `check_gpg = true`. Beta sources already use `check_gpg = false` and are unaffected.

### Files changed

- `test/package-sources/fast-datapath-rhel9.toml`
- `test/package-sources/rhocp-y.toml`
- `test/package-sources/rhocp-y1.toml`
- `test/package-sources/rhocp-y2.toml`

## Test plan

- [ ] Verify `e2e-aws-tests` presubmit passes (ostree image builds succeed without GPG errors)
- [ ] Verify no regressions in bootc jobs (bootc images don't use these package sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GPG key verification configurations to package source definitions for enhanced security validation across multiple repository configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->