### PR TITLE
USHIFT-7230: Add commit signing to rebase script

### DIFF
--- a/scripts/auto-rebase/rebase.py
+++ b/scripts/auto-rebase/rebase.py
@@ -369,7 +369,7 @@ def main():
         g.is_local_branch_based_on_newer_base_branch_commit(base_branch, remote_branch.name, rebase_branch_name)
     )
     if rbranch_does_not_exists or rbranch_exists_and_needs_update:
-        g.push(rebase_branch_name)
+        g.push(rebase_branch_name, base_branch, gh.gh_repo)
 
     prow_job_url = try_create_prow_job_url()
     pr_title = create_pr_title(rebase_branch_name, rebase_result.success)

--- a/scripts/pyutils/gitutils.py
+++ b/scripts/pyutils/gitutils.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
+import base64
 import logging
 
-from git import PushInfo, Repo  # GitPython
+from git import Repo  # GitPython
+from github import GithubException, InputGitTreeElement
 
 BOT_REMOTE_NAME = "bot-creds"
 REMOTE_ORIGIN = "origin"
@@ -69,19 +71,62 @@ class GitUtils():
             return
         self.remote.remove(self.git_repo, BOT_REMOTE_NAME)
 
-    def push(self, branch_name):
+    def push(self, branch_name, base_branch, gh_repo):
+        """
+        Replays local commits onto GitHub via the API so they are marked Verified.
+        Commits created through the GitHub API are automatically signed by GitHub
+        when using a GitHub App token, unlike commits created with git push.
+        """
         if self.dry_run:
-            logging.info(f"[DRY RUN] git push --force {branch_name}")
+            logging.info(f"[DRY RUN] Creating verified commits via GitHub API for branch {branch_name}")
             return
 
-        push_result = self.remote.push(branch_name, force=True)
+        # Collect commits between base_branch and branch_name, oldest first
+        commits = list(reversed(list(
+            self.git_repo.iter_commits(f"{base_branch}..{branch_name}")
+        )))
 
-        if len(push_result) != 1:
-            raise Exception(f"Unexpected amount ({len(push_result)}) of items in push_result: {push_result}")
-        if push_result[0].flags & PushInfo.ERROR:
-            raise Exception(f"Pushing branch failed: {push_result[0].summary}")
-        if push_result[0].flags & PushInfo.FORCED_UPDATE:
-            logging.info(f"Branch '{branch_name}' existed and was updated (force push)")
+        if not commits:
+            logging.info(f"No commits to push for branch {branch_name}")
+            return
+
+        parent_sha = gh_repo.get_branch(base_branch).commit.sha
+
+        for local_commit in commits:
+            # diff from parent → this commit: a=parent state, b=commit state
+            diffs = (local_commit.parents[0].diff(local_commit)
+                     if local_commit.parents else local_commit.diff(None))
+
+            tree_elements = []
+            for diff in diffs:
+                if diff.deleted_file:
+                    # sha=None signals a deletion to the GitHub tree API
+                    tree_elements.append(InputGitTreeElement(
+                        path=diff.a_path, mode="100644", type="blob", sha=None))
+                else:
+                    content = diff.b_blob.data_stream.read()
+                    try:
+                        blob = gh_repo.create_git_blob(content.decode("utf-8"), "utf-8")
+                    except UnicodeDecodeError:
+                        blob = gh_repo.create_git_blob(
+                            base64.b64encode(content).decode("ascii"), "base64")
+                    mode = "100755" if diff.b_blob.mode == 0o100755 else "100644"
+                    tree_elements.append(InputGitTreeElement(
+                        path=diff.b_path, mode=mode, type="blob", sha=blob.sha))
+
+            parent_gh_commit = gh_repo.get_git_commit(parent_sha)
+            new_tree = gh_repo.create_git_tree(tree_elements, parent_gh_commit.tree)
+            new_commit = gh_repo.create_git_commit(local_commit.message, new_tree, [parent_gh_commit])
+            logging.info(f"Created verified commit {new_commit.sha[:8]}: {local_commit.summary}")
+            parent_sha = new_commit.sha
+
+        try:
+            ref = gh_repo.get_git_ref(f"heads/{branch_name}")
+            ref.edit(parent_sha, force=True)
+            logging.info(f"Updated branch '{branch_name}' to {parent_sha[:8]}")
+        except GithubException:
+            gh_repo.create_git_ref(f"refs/heads/{branch_name}", parent_sha)
+            logging.info(f"Created branch '{branch_name}' at {parent_sha[:8]}")
 
     def get_remote_branch(self, branch_name):
         """

--- a/scripts/pyutils/gitutils.py
+++ b/scripts/pyutils/gitutils.py
@@ -3,7 +3,7 @@
 import base64
 import logging
 
-from git import Repo  # GitPython
+from git import NULL_TREE, Repo  # GitPython
 from github import GithubException, InputGitTreeElement
 
 BOT_REMOTE_NAME = "bot-creds"
@@ -95,7 +95,7 @@ class GitUtils():
         for local_commit in commits:
             # diff from parent → this commit: a=parent state, b=commit state
             diffs = (local_commit.parents[0].diff(local_commit)
-                     if local_commit.parents else local_commit.diff(None))
+                     if local_commit.parents else local_commit.diff(NULL_TREE))
 
             tree_elements = []
             for diff in diffs:
@@ -110,7 +110,12 @@ class GitUtils():
                     except UnicodeDecodeError:
                         blob = gh_repo.create_git_blob(
                             base64.b64encode(content).decode("ascii"), "base64")
-                    mode = "100755" if diff.b_blob.mode == 0o100755 else "100644"
+                    if diff.b_blob.mode == 0o120000:
+                        mode = "120000"
+                    elif diff.b_blob.mode == 0o100755:
+                        mode = "100755"
+                    else:
+                        mode = "100644"
                     tree_elements.append(InputGitTreeElement(
                         path=diff.b_path, mode=mode, type="blob", sha=blob.sha))
 
@@ -124,7 +129,9 @@ class GitUtils():
             ref = gh_repo.get_git_ref(f"heads/{branch_name}")
             ref.edit(parent_sha, force=True)
             logging.info(f"Updated branch '{branch_name}' to {parent_sha[:8]}")
-        except GithubException:
+        except GithubException as e:
+            if e.status != 404:
+                raise
             gh_repo.create_git_ref(f"refs/heads/{branch_name}", parent_sha)
             logging.info(f"Created branch '{branch_name}' at {parent_sha[:8]}")
 

--- a/scripts/pyutils/gitutils.py
+++ b/scripts/pyutils/gitutils.py
@@ -104,6 +104,9 @@ class GitUtils():
                     tree_elements.append(InputGitTreeElement(
                         path=diff.a_path, mode="100644", type="blob", sha=None))
                 else:
+                    if diff.renamed_file:
+                        tree_elements.append(InputGitTreeElement(
+                            path=diff.a_path, mode="100644", type="blob", sha=None))
                     content = diff.b_blob.data_stream.read()
                     try:
                         blob = gh_repo.create_git_blob(content.decode("utf-8"), "utf-8")


### PR DESCRIPTION

An example for the verified label: https://github.com/openshift/microshift/pull/6881/commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced the rebase workflow to create verified commits on GitHub by utilizing the GitHub API for commit creation instead of local operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->