### PR TITLE
NO-ISSUE: fix Go download flake with --fail and --retry

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -283,7 +283,7 @@ function install_build_deps() {
         echo "Installing go ${GO_VER}..."
         # This is installed into different location (/usr/local/bin/go) from dnf installed Go (/usr/bin/go) so it doesn't conflict
         # /usr/local/bin is before /usr/bin in $PATH so newer one is picked up
-        curl -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.linux-${GO_ARCH}.tar.gz"
+        curl --fail --retry 3 --retry-delay 5 -L -o "go${GO_VER}.linux-${GO_ARCH}.tar.gz" "https://go.dev/dl/go${GO_VER}.linux-${GO_ARCH}.tar.gz"
         sudo rm -rf "/usr/local/go${GO_VER}"
         sudo mkdir -p "/usr/local/go${GO_VER}"
         sudo tar -C "/usr/local/go${GO_VER}" -xzf "go${GO_VER}.linux-${GO_ARCH}.tar.gz" --strip-components 1


### PR DESCRIPTION
## Summary
- Adds `--fail` and `--retry 3 --retry-delay 5` flags to the `curl` command that downloads the Go toolchain in `configure-vm.sh`
- Fixes flaky CI failures caused by transient network issues where `curl` received the 302 redirect from `go.dev` (323 bytes of HTML) but failed to follow through to `dl.google.com`, silently saving the redirect page as the tarball
- Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_microshift/6883/pull-ci-openshift-microshift-main-e2e-aws-tests-arm/2066817145680957440

## Test plan
- [ ] CI jobs that install Go via `configure-vm.sh` pass normally
- [ ] Transient network failures during Go download are retried automatically
- [ ] HTTP errors (e.g., 404) cause an immediate failure instead of silently saving error pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)