### PR TITLE
USHIFT-6531: switch devenv to use RHEL 9.8 OS image

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -157,7 +157,7 @@ Most of the following variables are defined in `vars/all.yml`. `rhel_target_vers
 | `enable_gpu` | Install NVIDIA GPU drivers and container toolkit for GPU workloads | `false` |
 | `deploy_gpu_test` | Deploy a test GPU workload to validate GPU functionality | `true` |
 | `run_workloads` | Run kube-burner performance workloads | `false` |
-| `rhel_target_version` | Pin RHEL to a specific version during upgrades (e.g., "9.6") | `undefined` |
+| `rhel_target_version` | Pin RHEL to a specific version during upgrades (e.g., "9.8") | `undefined` |
 
 ### Inventory Configuration
 

--- a/ansible/roles/create-vm/defaults/main.yml
+++ b/ansible/roles/create-vm/defaults/main.yml
@@ -3,7 +3,7 @@
 
 vm_name: microshift-dev
 vm_disk_dir: /var/lib/libvirt/images
-iso_file: /var/lib/libvirt/images/rhel-9.4-x86_64-dvd.iso
+iso_file: /var/lib/libvirt/images/rhel-9.8-x86_64-dvd.iso
 num_cpu: 4
 ram_size: 8
 disk_size: 60

--- a/docs/contributor/devenv_cloud.md
+++ b/docs/contributor/devenv_cloud.md
@@ -143,7 +143,7 @@ Run the following command to create a new virtual machine using **nested** virtu
 
 ```bash
 VMNAME=microshift-bench
-ISO="/var/lib/libvirt/images/rhel-9.2-$(uname -m)-dvd.iso"
+ISO="/var/lib/libvirt/images/rhel-9.8-$(uname -m)-dvd.iso"
 
 export NCPUS=2
 export RAMSIZE=2

--- a/docs/contributor/devenv_setup.md
+++ b/docs/contributor/devenv_setup.md
@@ -4,7 +4,7 @@ in a virtual machine.
 
 ## Create Development Virtual Machine
 Start by downloading one of the DVD ISO images for the `x86_64` or `aarch64` architecture:
-* RHEL 9.4 from https://developers.redhat.com/products/rhel/download
+* RHEL 9.8 from https://developers.redhat.com/products/rhel/download
 * CentOS 9 Stream from https://www.centos.org/download
 
 ### Creating VM

--- a/scripts/aws/manage_aws_stack.sh
+++ b/scripts/aws/manage_aws_stack.sh
@@ -178,7 +178,7 @@ Arguments:
                             the latest build will be selected.
 
     [--os <os>]:            (create/ami only) specific version of RHEL, 
-                            e.g. 'rhel-9.3'. Defaults to rhel-9.4.
+                            e.g. 'rhel-9.3'. Defaults to rhel-9.8.
 
     [--arch <arch>]:        (ami only) Filter AMIs based on arch. Must be 
                             one of: x86_64, arm64. Lists all when not set.
@@ -199,7 +199,7 @@ inst_type=""
 region=""
 pub_key="${HOME}/.ssh/id_rsa.pub"
 ami=""
-os="rhel-9.4"
+os="rhel-9.8"
 arch=""
 
 while [ $# -gt 0 ]; do

--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -56,7 +56,7 @@ function get_base_isofile {
             echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
         9)
-            echo "rhel-9.4-$(uname -m)-dvd.iso"
+            echo "rhel-9.8-$(uname -m)-dvd.iso"
             ;;
         9.*)
             echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"


### PR DESCRIPTION
## Summary
- Update all devenv defaults, docs, and scripts that still referenced older RHEL versions (9.2, 9.4, 9.6) to target RHEL 9.8 for the 4.22 release
- Covers VM ISO defaults (`manage-vm.sh`, `create-vm` role), AWS hypervisor default (`manage_aws_stack.sh`), and contributor documentation

## Test plan
- [ ] Verify `manage-vm.sh create -v 9` uses RHEL 9.8 ISO
- [ ] Verify `manage_aws_stack.sh create` defaults to `rhel-9.8`
- [ ] Review updated docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RHEL version references in setup guides and README from versions 9.2, 9.4, and 9.6 to 9.8.

* **Chores**
  * Updated default RHEL ISO version from 9.4 to 9.8 across Ansible configuration and VM management scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->