### PR TITLE
[release-4.22] fix: support RHEL 10 bootc images in published-images scenarios

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -307,6 +307,7 @@ sos_report_for_vm_offline() {
 
 get_lrel_release_image_url() {
     local -r brew_lrel_release_version="$1"
+    local -r rhel_version="${2:-9}"
     local image_url=""
 
     # Strip the rpm release suffix and convert tilde to dash.
@@ -327,7 +328,7 @@ get_lrel_release_image_url() {
 
     if [ -n "${mirror_path}" ]; then
         if ! image_url="$(curl -fsS --retry 3 \
-            "https://mirror.openshift.com/pub/openshift-v4/${UNAME_M}/microshift/${mirror_path}/${release_version}/el9/bootc-pullspec.txt")"; then
+            "https://mirror.openshift.com/pub/openshift-v4/${UNAME_M}/microshift/${mirror_path}/${release_version}/el${rhel_version}/bootc-pullspec.txt")"; then
             image_url=""
         fi
         echo "${image_url}"
@@ -343,7 +344,7 @@ get_lrel_release_image_url() {
     fi
 
     # Resolve the arch-specific digest from both registries
-    local -r image_path="openshift4/microshift-bootc-rhel9"
+    local -r image_path="openshift4/microshift-bootc-rhel${rhel_version}"
     local -r image_tag="v${release_version}"
     local -r prod_registry="registry.redhat.io"
     local -r stage_registry="registry.stage.redhat.io"

--- a/test/scenarios-bootc/el10/releases/el102-lrel@published-images-standard1.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@published-images-standard1.sh
@@ -7,7 +7,7 @@
 # shellcheck disable=SC2034  # used elsewhere
 IMAGE_SIGSTORE_ENABLED=true
 
-LATEST_RELEASE_IMAGE_URL="$(get_lrel_release_image_url "${BREW_LREL_RELEASE_VERSION}")"
+LATEST_RELEASE_IMAGE_URL="$(get_lrel_release_image_url "${BREW_LREL_RELEASE_VERSION}" 10)"
 
 scenario_create_vms() {
     exit_if_image_not_set "${LATEST_RELEASE_IMAGE_URL}"

--- a/test/scenarios-bootc/el10/releases/el102-lrel@published-images-standard2.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@published-images-standard2.sh
@@ -7,7 +7,7 @@
 # shellcheck disable=SC2034  # used elsewhere
 IMAGE_SIGSTORE_ENABLED=true
 
-LATEST_RELEASE_IMAGE_URL="$(get_lrel_release_image_url "${BREW_LREL_RELEASE_VERSION}")"
+LATEST_RELEASE_IMAGE_URL="$(get_lrel_release_image_url "${BREW_LREL_RELEASE_VERSION}" 10)"
 
 scenario_create_vms() {
     exit_if_image_not_set "${LATEST_RELEASE_IMAGE_URL}"


### PR DESCRIPTION
## Summary
- Add `rhel_version` parameter to `get_lrel_release_image_url()` so el10 scenarios resolve `microshift-bootc-rhel10` instead of `rhel9`
- Enable `el102-lrel@published-images-standard1` scenario (remove `.disabled` suffix)

4.22.1 is the first release with RHEL 10 bootc images. Without this fix, the el10 published-images scenarios pull the wrong (rhel9) image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)