### PR TITLE
USHIFT-7240: work around kernel 7.x SELinux execmem denial on EL10 bootc

### DIFF
--- a/packaging/selinux/microshift.te
+++ b/packaging/selinux/microshift.te
@@ -4,8 +4,14 @@ type microshift_t;
 domain_type(microshift_t);
 
 gen_require(`
-	type kubelet_t, var_lib_t, container_var_lib_t;
+	type kubelet_t, var_lib_t, container_var_lib_t, kernel_t;
 ')
+
+# Workaround for kernel 7.x composefs/overlayfs SELinux regression (USHIFT-7215).
+# CRI-O runs as kernel_t instead of container_runtime_t on composefs, which denies
+# execmem needed for text relocations. Upstream fix: kernel v7.1-rc1 commits
+# 880bd496ec72, 6af36aeb147a, 82544d36b172. Remove when backported to RHEL 10.2 kernel.
+allow kernel_t self:process execmem;
 
 # When microshift creates backup folders in /var/lib/microshift-backups, the correct labels are applied
 # Note: filetrans_pattern rules states;


### PR DESCRIPTION
## Summary

- CRI-O fails to start on RHEL 10.2 bootc VMs due to a kernel 7.x regression where SELinux `mprotect()` checks on composefs/overlayfs evaluate the backing file's context instead of the overlay file's context
- CRI-O runs as `kernel_t` instead of `container_runtime_t`, which denies the `execmem` permission needed for text relocations (CGO libgpgme binding)

### Root cause

Kernel 7.0 has a regression in LSM/overlayfs where `mprotect()` access checks evaluate the **backing file's** security context instead of the **overlay file's** context. On composefs (used by bootc), this prevents SELinux domain transitions — CRI-O stays as `kernel_t` instead of transitioning to `container_runtime_t`.

### Upstream fix

3-commit series by Paul Moore, landed in v7.1-rc1 (not yet backported to RHEL 10.2 kernel):
1. [`880bd496ec72`](https://github.com/torvalds/linux/commit/880bd496ec72a6dcb00cb70c430ef752ba242ae7) — fs: prepare for adding LSM blob to backing_file
2. [`6af36aeb147a`](https://github.com/torvalds/linux/commit/6af36aeb147a06dea47c49859cd6ca5659aeb987) — lsm: add backing_file LSM hooks
3. [`82544d36b172`](https://github.com/torvalds/linux/commit/82544d36b1729153c8aeb179e84750f0c085d3b1) — selinux: fix overlayfs mmap() and mprotect() access checks

Remove this workaround** once the upstream kernel fix is backported to the RHEL 10.2 kernel.

### References

- Jira: https://redhat.atlassian.net/browse/USHIFT-7240
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2477939
- FCOS tracker: https://github.com/coreos/fedora-coreos-tracker/issues/2148

## Test plan

- [ ] Verify EL10 bootc periodic CI jobs pass (e2e-aws-tests-bootc-nightly-el10)
- [ ] Verify CRI-O starts successfully on RHEL 10.2 bootc VMs with kernel 7.x
- [ ] Verify no regressions on EL9 bootc jobs (unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved kernel 7.x composefs and overlayfs compatibility issues by updating SELinux security policies to properly handle system process permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->