### PR TITLE
wip

### DIFF
--- a/test/kickstart-templates/includes/main-prologue.cfg
+++ b/test/kickstart-templates/includes/main-prologue.cfg
@@ -4,6 +4,20 @@ timezone UTC
 text
 reboot
 
+# Disable bootupd in anaconda so it uses the legacy GRUB installation path.
+# A recent RHEL 9.8 compose added bootupd to the ostree sysroot, causing
+# "bootupctl backend install --auto" to fail with "No update metadata for
+# component BIOS found" in QEMU/KVM VMs. Making have_bootupd() return False
+# causes both the storage module (installs GRUB to MBR/ESP) and the rpm-ostree
+# module (configures grub.cfg) to use their standard non-bootupd code paths.
+%pre --log=/dev/console
+UTIL_FILE=$(find /usr/lib*/python3*/site-packages/pyanaconda/modules/payloads/payload/rpm_ostree -name util.py 2>/dev/null | head -1)
+if [ -n "${UTIL_FILE}" ] && grep -q 'def have_bootupd' "${UTIL_FILE}"; then
+    sed -i '/def have_bootupd/a\    return False' "${UTIL_FILE}"
+    find "$(dirname "${UTIL_FILE}")" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+fi
+%end
+
 # Partition the disk with hardware-specific boot and swap partitions, adding an
 # LVM volume that contains a system root partition of the specified size.
 # The remainder of the volume will be used by the CSI driver for storing data.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the kickstart installation template prologue to run a pre-install step that disables bootupd during Anaconda installs, ensuring bootupd-dependent behavior is avoided and any cached Python artifacts are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->