### PR TITLE
NO-ISSUE: configure-vm.sh: Wait for firewall & install gettext

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -271,7 +271,7 @@ function install_build_deps() {
     if ${DNF_UPDATE}; then
         "${DNF_RETRY}" "update" "--nobest"
     fi
-    "${DNF_RETRY}" "install" "gcc git golang cockpit make jq selinux-policy-devel rpm-build jq bash-completion avahi-tools createrepo"
+    "${DNF_RETRY}" "install" "gcc git golang cockpit make jq selinux-policy-devel rpm-build jq bash-completion avahi-tools createrepo gettext"
 
     # run only if booted with systemd
     [[ -d /run/systemd/system ]] &&  sudo systemctl enable --now cockpit.socket

--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -347,6 +347,10 @@ function build_and_install_microshift_rpms() {
 function configure_firewall() {
     "${DNF_RETRY}" "install" "firewalld"
     sudo systemctl enable firewalld --now
+    for _ in $(seq 30) ; do
+        sudo firewall-cmd --state &>/dev/null && break
+        sleep 1
+    done
     sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
     sudo firewall-cmd --permanent --zone=trusted --add-source=169.254.169.1
     sudo firewall-cmd --permanent --zone=trusted --add-source=fd01::/48


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall setup reliability by waiting briefly for the firewall service to become ready before applying configuration changes.
  * Reduced the chance of setup failures caused by running firewall commands too early.
* **Chores**
  * Added an additional build dependency required during virtual machine build setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->