### PR TITLE
[release-4.22] USHIFT-7169: Add RHEL 10.2 RPM standard release test scenario

### DIFF
--- a/test/image-blueprints-bootc/el10/layer1-base/group2/rhel102-installer.image-installer
+++ b/test/image-blueprints-bootc/el10/layer1-base/group2/rhel102-installer.image-installer
@@ -1,4 +1,2 @@
 
-# TODO: Replace this by a RHEL 10.2 image when its RPM repositories are released.
-# rhel-10.2
-rhel-10.1
+rhel-10.2

--- a/test/scenarios-bootc/el10/releases/el102@rpm-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102@rpm-standard.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# The RPM-based image used to create the VM for this test does not
+# include MicroShift or greenboot, so tell the framework not to wait
+# for greenboot to finish when creating the VM.
+export SKIP_GREENBOOT=true
+
+# NOTE: Unlike most suites, these tests rely on being run IN ORDER to
+# ensure the host is in a good state at the start of each test. We
+# could have separated them and run them as separate scenarios, but
+# did not want to spend the resources on a new VM.
+export TEST_RANDOMIZATION=none
+
+# Add extra timeout because it run both standard1 and standard2 suites.
+export TEST_EXECUTION_TIMEOUT=60m
+
+# On RHEL 10, rhocp and fast-datapath repos are not available via
+# subscription-manager. Create repo files pointing to the RHEL 9 CDN
+# using entitlement certificates as a workaround.
+configure_cdn_repo() {
+    local -r repo_id=$1
+    local -r repo_name=$2
+    local -r baseurl=$3
+
+    local -r cert=$(run_command_on_vm host1 "ls /etc/pki/entitlement/[0-9]*.pem | grep -v '\-key.pem' | head -n1")
+    local -r key=$(run_command_on_vm host1 "ls /etc/pki/entitlement/[0-9]*-key.pem | head -n1")
+    local -r tmp_file=$(mktemp)
+
+    tee "${tmp_file}" >/dev/null <<EOF
+[${repo_id}]
+name=${repo_name}
+baseurl=${baseurl}
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify=1
+sslcacert=/etc/rhsm/ca/redhat-uep.pem
+sslclientcert=${cert}
+sslclientkey=${key}
+EOF
+    copy_file_to_vm host1 "${tmp_file}" "${tmp_file}"
+    run_command_on_vm host1 "sudo cp ${tmp_file} /etc/yum.repos.d/${repo_id}.repo"
+    rm -f "${tmp_file}"
+}
+
+configure_rhocp_repo() {
+    local -r rhocp=$1
+    local -r version=$2
+    local -r arch=${3:-$(uname -m)}
+
+    # The repository may be empty if the beta mirror is not up yet
+    if [[ -z "${rhocp}" ]] ; then
+        return
+    fi
+
+    if [[ "${rhocp}" =~ ^[0-9]{1,2}$ ]]; then
+        configure_cdn_repo \
+            "rhocp-4.${rhocp}" \
+            "Red Hat OpenShift 4.${rhocp} for RHEL 9" \
+            "https://cdn.redhat.com/content/dist/layered/rhel9/${arch}/rhocp/4.${rhocp}/os"
+    elif [[ "${rhocp}" =~ ^http ]]; then
+        local -r ocp_repo_name="rhocp-4.${version}-for-rhel-9-mirrorbeta-rpms"
+        local -r tmp_file=$(mktemp)
+
+        tee "${tmp_file}" >/dev/null <<EOF
+[${ocp_repo_name}]
+name=Beta rhocp RPMs for RHEL 9
+baseurl=${rhocp}
+enabled=1
+gpgcheck=0
+skip_if_unavailable=0
+EOF
+        copy_file_to_vm host1 "${tmp_file}" "${tmp_file}"
+        run_command_on_vm host1 "sudo cp ${tmp_file} /etc/yum.repos.d/${ocp_repo_name}.repo"
+        rm -f "${tmp_file}"
+    fi
+}
+
+scenario_create_vms() {
+    exit_if_brew_rpms_not_found
+
+    prepare_kickstart host1 kickstart-liveimg.ks.template ""
+    launch_vm rhel102-installer
+
+    # Open the firewall ports. Other scenarios get this behavior by
+    # embedding settings in the blueprint, but there is no blueprint
+    # for this scenario. We need do this step before running the RF
+    # suite so that suite can assume it can reach all of the same
+    # ports as for any other test.
+    configure_vm_firewall host1
+
+    # Register the host with subscription manager so we can install
+    # dependencies.
+    subscription_manager_register host1
+}
+
+scenario_remove_vms() {
+    exit_if_brew_rpms_not_found
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_brew_rpms_not_found
+
+    local -r reponame=$(basename "${BREW_REPO}")
+    local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
+    local -r arch=$(uname -m)
+
+    # Enable the rhocp and dependency repositories.
+    #
+    # Note that rhocp or beta dependencies repository may not yet exist
+    # for the current version. Then, just use whatever we can get for
+    # the previous minor version.
+    configure_rhocp_repo "${RHOCP_MINOR_Y}"       "${MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y_BETA}"  "${MINOR_VERSION}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 10.2"
+    configure_cdn_repo \
+        "fast-datapath" \
+        "Red Hat Fast Datapath for RHEL 9" \
+        "https://cdn.redhat.com/content/dist/layered/rhel9/${arch}/fast-datapath/os"
+
+    run_tests host1 \
+        --exitonfailure \
+        --variable "SOURCE_REPO_URL:${repo_url}" \
+        --variable "TARGET_VERSION:${BREW_LREL_RELEASE_VERSION}" \
+        --variable "EXPECTED_OS_VERSION:10.2" \
+        suites/rpm/install.robot \
+        suites/standard1/ \
+        suites/standard2/ \
+        suites/rpm/remove.robot
+}


### PR DESCRIPTION
## Summary

Backport of #6873 to release-4.22.

Add `el102@rpm-standard.sh` under `test/scenarios-bootc/el10/releases/`
for testing MicroShift RPM lifecycle on a bare RHEL 10.2 VM.

Adapted `configure_rhocp_repo` to the release-4.22 2-arg interface
(hardcoded major version 4) since `MAJOR_VERSION` is not available
on this branch.

## Test plan

- [ ] `e2e-aws-tests-bootc-release-el10` passes
- [ ] `e2e-aws-tests-bootc-release-arm-el10` passes

JIRA: https://issues.redhat.com/browse/USHIFT-7169