### PR TITLE
USHIFT-7315: Use faster disk for VirtualMachine type in aws stack

### DIFF
--- a/scripts/aws/cf-gen.yaml
+++ b/scripts/aws/cf-gen.yaml
@@ -12,8 +12,8 @@ Mappings:
    VirtualMachine:
      PrimaryVolumeSize: "200"
      SecondaryVolumeSize: "200"
-     Throughput: 125
-     Iops: 3000
+     Throughput: 750
+     Iops: 6000
 Parameters:
   EC2Type:
     Default: 'VirtualMachine'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased virtual machine storage performance by raising disk throughput and IOPS limits, which may improve responsiveness for storage-heavy workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->