### PR TITLE
USHIFT-7257: Modify Get Kubeconfig to avoid leaking contents in RF logs

### DIFF
--- a/test/resources/kubeconfig.resource
+++ b/test/resources/kubeconfig.resource
@@ -16,12 +16,19 @@ ${API_PORT}     ${EMPTY}    # overridden by scenario.sh in CI
 
 *** Keywords ***
 Get Kubeconfig
-    [Documentation]    Get the kubeconfig file from the host argument and return contents
+    [Documentation]    Get the kubeconfig file from the host argument and return contents.
+    ...    Uses a temp file and SCP download to avoid logging the kubeconfig in RF logs.
     [Arguments]    ${host}
-    ${kubeconfig}    ${rc}=    Execute Command
-    ...    cat /var/lib/microshift/resources/kubeadmin/${host}/kubeconfig
-    ...    sudo=True    return_rc=True
-    Should Be Equal As Integers    ${rc}    0
+
+    ${remote_tmp}=    Command Should Work    mktemp
+    Command Should Work    cp --preserve /var/lib/microshift/resources/kubeadmin/${host}/kubeconfig ${remote_tmp}
+    Command Should Work    chown ${USHIFT_USER} ${remote_tmp}
+
+    ${local_tmp}=    Create Random Temp File
+    SSHLibrary.Get File    ${remote_tmp}    ${local_tmp}
+    Command Should Work    rm -f ${remote_tmp}
+    ${kubeconfig}=    OperatingSystem.Get File    ${local_tmp}
+    Remove File    ${local_tmp}
     Should Not Be Empty    ${kubeconfig}
     RETURN    ${kubeconfig}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kubeconfig retrieval reliability by transferring the remote kubeconfig content through a temporary file instead of relying on remote command output.
  * Preserved file permissions and ownership during the transfer to avoid access/permission issues.
  * Ensured temporary files are removed after completion, keeping behavior consistent and maintaining the existing validation for non-empty kubeconfig content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->