### PR TITLE
USHIFT-7339: Wait for LV cleanup in pvc-resize teardown

### DIFF
--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -161,6 +161,21 @@ Named VolumeSnapshot Should Be Deleted
     [Arguments]    ${name}    ${ns}=${NAMESPACE}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
     Oc Wait    -n ${ns} volumesnapshot/${name}    --for=Delete --timeout=${timeout}
 
+No Topolvm LogicalVolumes Should Exist
+    [Documentation]    Wait until all topolvm LogicalVolumes are deleted.
+    ...    ${timeout}    Period of time to wait for all LogicalVolumes to be removed.
+    [Arguments]    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
+    Wait Until Keyword Succeeds    ${timeout}    5s
+    ...    Verify No LogicalVolumes Exist
+
+Verify No LogicalVolumes Exist
+    [Documentation]    Assert that no topolvm LogicalVolumes currently exist.
+    ${output}    ${rc}=    Run With Kubeconfig
+    ...    oc get logicalvolumes.topolvm.io -o name --no-headers
+    ...    allow_fail=${TRUE}
+    ...    return_rc=${TRUE}
+    Should Be Empty    ${output}
+
 Oc Create
     [Documentation]    Run 'oc create' on a specific resource in the current test namespace
     ...    Returns the combined STDOUT/STDERR output of the command.

--- a/test/suites/storage/pvc-resize.robot
+++ b/test/suites/storage/pvc-resize.robot
@@ -37,3 +37,4 @@ Test Case Teardown
     [Documentation]    Clean up test suite resources
     Oc Delete    -f ${SOURCE_POD} -n ${NAMESPACE}
     Remove Namespace    ${NAMESPACE}
+    No Topolvm LogicalVolumes Should Exist

--- a/test/suites/storage/reboot.robot
+++ b/test/suites/storage/reboot.robot
@@ -37,3 +37,4 @@ Test Case Teardown
     [Documentation]    Clean up test suite resources
     Oc Delete    -f ${SOURCE_POD} -n ${NAMESPACE}
     Remove Namespace    ${NAMESPACE}
+    No Topolvm LogicalVolumes Should Exist

--- a/test/suites/storage/snapshot.robot
+++ b/test/suites/storage/snapshot.robot
@@ -112,6 +112,7 @@ Test Case Teardown
     Named PVC Should Be Deleted    test-claim-thin
     Named PVC Should Be Deleted    snapshot-restore
     Remove Namespace    ${NAMESPACE}
+    No Topolvm LogicalVolumes Should Exist
 
 Write To Volume
     [Documentation]    Write some simple text to the data volume


### PR DESCRIPTION
The Snapshot suite setup fails intermittently with "Volume group has insufficient free space" when the preceding Pvc-Resize test leaves a topolvm LogicalVolume not yet finalized. Add a wait in pvc-resize teardown to ensure all LogicalVolumes are removed before the next suite runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened storage test teardown cleanup by verifying that no TopoLVM LogicalVolumes remain after pod and namespace removal, using a retry-based check until timeout.
  * Applied the same post-teardown “no TopoLVM LogicalVolumes” validation to reboot and snapshot test flows for consistent cleanup across runs.
* **Tests**
  * Added an additional readiness check for `LVMVolumeGroupNodeStatus` during snapshot suite setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->