### PR TITLE
USHIFT-7343: Exclude tuned* RPMs from fast-datapath repository

### DIFF
--- a/test/package-sources-bootc/microshift-fast-datapath-rhel9.repo
+++ b/test/package-sources-bootc/microshift-fast-datapath-rhel9.repo
@@ -9,3 +9,7 @@ sslcacert = /etc/rhsm/ca/redhat-uep.pem
 sslclientkey = {{ .Env.SSL_CLIENT_KEY_FILE }}
 sslclientcert = {{ .Env.SSL_CLIENT_CERT_FILE }}
 skip_if_unavailable = 0
+# FDP ships tuned packages whose version can beat the OS-provided ones.
+# If el9 tuned profile RPM is installed on el10,
+# it won't work because of change in TuneD search paths.
+excludepkgs = tuned*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the fast-datapath repository settings to avoid installing `tuned` packages from that source.
  * This helps prevent conflicts with system-provided packages and keeps package behavior consistent across installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->