### PR TITLE
USHIFT-7271: Treat all C2CC clusters as remote

### DIFF
--- a/test/bin/c2cc_common.sh
+++ b/test/bin/c2cc_common.sh
@@ -264,26 +264,32 @@ c2cc_run_tests() {
     host2_vm=$(full_vm_name host2) || return 1
     host3_vm=$(full_vm_name host3) || return 1
 
-    local host2_ip host3_ip
+    local host1_ip host2_ip host3_ip
+    host1_ip=$(get_host_ip host1) || return 1
     host2_ip=$(get_host_ip host2) || return 1
     host3_ip=$(get_host_ip host3) || return 1
-    readonly host2_ip host3_ip
+    readonly host1_ip host2_ip host3_ip
 
+    local -r kubeconfig_a="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-a"
     local -r kubeconfig_b="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-b"
     local -r kubeconfig_c="${SCENARIO_INFO_DIR}/${SCENARIO}/kubeconfig-c"
 
-    # Wait for host2 and host3 to be fully ready (run_tests only waits for host1)
+    # Wait for all hosts to be fully ready before fetching kubeconfigs
+    wait_for_microshift_to_be_ready host1
     wait_for_microshift_to_be_ready host2
     wait_for_microshift_to_be_ready host3
 
+    run_command_on_vm host1 "sudo cp /var/lib/microshift/resources/kubeadmin/${host1_ip}/kubeconfig /tmp/kubeconfig-a && sudo chmod 644 /tmp/kubeconfig-a"
     run_command_on_vm host2 "sudo cp /var/lib/microshift/resources/kubeadmin/${host2_ip}/kubeconfig /tmp/kubeconfig-b && sudo chmod 644 /tmp/kubeconfig-b"
     run_command_on_vm host3 "sudo cp /var/lib/microshift/resources/kubeadmin/${host3_ip}/kubeconfig /tmp/kubeconfig-c && sudo chmod 644 /tmp/kubeconfig-c"
+    copy_file_from_vm host1 "/tmp/kubeconfig-a" "${kubeconfig_a}"
     copy_file_from_vm host2 "/tmp/kubeconfig-b" "${kubeconfig_b}"
     copy_file_from_vm host3 "/tmp/kubeconfig-c" "${kubeconfig_c}"
 
     local dual_cidr_vars=""
     if [ -n "${CLUSTER_A_POD_CIDR_DUAL}" ]; then
-        local host2_ipv6 host3_ipv6
+        local host1_ipv6 host2_ipv6 host3_ipv6
+        host1_ipv6=$(get_host_ipv6 host1) || return 1
         host2_ipv6=$(get_host_ipv6 host2) || return 1
         host3_ipv6=$(get_host_ipv6 host3) || return 1
         dual_cidr_vars+=" --variable CLUSTER_A_POD_CIDR_DUAL:${CLUSTER_A_POD_CIDR_DUAL}"
@@ -292,6 +298,7 @@ c2cc_run_tests() {
         dual_cidr_vars+=" --variable CLUSTER_B_SVC_CIDR_DUAL:${CLUSTER_B_SVC_CIDR_DUAL}"
         dual_cidr_vars+=" --variable CLUSTER_C_POD_CIDR_DUAL:${CLUSTER_C_POD_CIDR_DUAL}"
         dual_cidr_vars+=" --variable CLUSTER_C_SVC_CIDR_DUAL:${CLUSTER_C_SVC_CIDR_DUAL}"
+        dual_cidr_vars+=" --variable HOST1_IPV6:${host1_ipv6}"
         dual_cidr_vars+=" --variable HOST2_IPV6:${host2_ipv6}"
         dual_cidr_vars+=" --variable HOST3_IPV6:${host3_ipv6}"
     fi
@@ -301,6 +308,7 @@ c2cc_run_tests() {
         --variable "CLUSTER_A_POD_CIDR:${CLUSTER_A_POD_CIDR}" \
         --variable "CLUSTER_A_SVC_CIDR:${CLUSTER_A_SVC_CIDR}" \
         --variable "CLUSTER_A_DOMAIN:${CLUSTER_A_DOMAIN}" \
+        --variable "KUBECONFIG_A:${kubeconfig_a}" \
         --variable "CLUSTER_B_POD_CIDR:${CLUSTER_B_POD_CIDR}" \
         --variable "CLUSTER_B_SVC_CIDR:${CLUSTER_B_SVC_CIDR}" \
         --variable "CLUSTER_B_DOMAIN:${CLUSTER_B_DOMAIN}" \

--- a/test/resources/c2cc.resource
+++ b/test/resources/c2cc.resource
@@ -16,6 +16,8 @@ Resource            microshift-host.resource
 ${CLUSTER_A_POD_CIDR}           ${EMPTY}
 ${CLUSTER_A_SVC_CIDR}           ${EMPTY}
 ${CLUSTER_A_DOMAIN}             ${EMPTY}
+${KUBECONFIG_A}                 ${EMPTY}
+${HOST1_IPV6}                   ${EMPTY}
 ${CLUSTER_B_POD_CIDR}           ${EMPTY}
 ${CLUSTER_B_SVC_CIDR}           ${EMPTY}
 ${CLUSTER_B_DOMAIN}             ${EMPTY}
@@ -68,14 +70,6 @@ ${IP_CMD}                       ${{'ip -6' if '${IP_FAMILY}' == 'ipv6' else 'ip 
 
 
 *** Keywords ***
-Register Local Cluster
-    [Documentation]    Register the primary cluster (host1) for use with generic cluster keywords.
-    ...    Must be called after Login MicroShift Host and Setup Kubeconfig.
-    [Arguments]    ${alias}
-    ${conn}=    SSHLibrary.Get Connection
-    Set To Dictionary    ${C2CC_KUBECONFIGS}    ${alias}    ${KUBECONFIG}
-    Set To Dictionary    ${C2CC_SSH_IDS}    ${alias}    ${conn.index}
-
 Register Remote Cluster
     [Documentation]    Open an SSH connection to a remote cluster and register it by alias.
     [Arguments]    ${alias}    ${host}    ${ssh_port}    ${kubeconfig}
@@ -93,21 +87,19 @@ Register Remote Cluster
     Set To Dictionary    ${C2CC_SSH_IDS}    ${alias}    ${alias}
     Append To List    ${C2CC_REMOTE_ALIASES}    ${alias}
 
+Register All C2CC Clusters
+    [Documentation]    Register all three C2CC clusters as remote clusters.
+    Register Remote Cluster    cluster-a    ${USHIFT_HOST}    ${SSH_PORT}    ${KUBECONFIG_A}
+    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
+    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+
 Teardown All Remote Clusters
     [Documentation]    Close SSH connections for all registered remote clusters.
-    ...    If cluster-a was registered as a local cluster, switch back to it
-    ...    so that Logout MicroShift Host can close it. If all clusters were
-    ...    registered as remote (e.g. upgrade tests), skip the switch-back.
-    ${has_local}=    Evaluate    'cluster-a' not in ${C2CC_REMOTE_ALIASES}
     FOR    ${alias}    IN    @{C2CC_REMOTE_ALIASES}
         SSHLibrary.Switch Connection    ${alias}
         SSHLibrary.Close Connection
     END
     VAR    @{C2CC_REMOTE_ALIASES}=    @{EMPTY}    scope=SUITE
-    IF    ${has_local}
-        ${local_conn}=    Get From Dictionary    ${C2CC_SSH_IDS}    cluster-a
-        SSHLibrary.Switch Connection    ${local_conn}
-    END
 
 Command On Cluster
     [Documentation]    Run a shell command on the specified cluster via SSH.

--- a/test/suites/c2cc-ipsec/ipsec.robot
+++ b/test/suites/c2cc-ipsec/ipsec.robot
@@ -141,11 +141,7 @@ IPsec Tunnel Recovers After Remote Stop Start
 Setup
     [Documentation]    Register all clusters, verify IPsec tunnels, deploy test workloads.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
     Deploy Test Workloads
 
 Teardown
@@ -153,8 +149,6 @@ Teardown
     Cleanup Test Workloads
     Ensure IPsec Running On All Clusters
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Ensure IPsec Running On All Clusters
     [Documentation]    Make sure ipsec service is running on all clusters.

--- a/test/suites/c2cc/cleanup.robot
+++ b/test/suites/c2cc/cleanup.robot
@@ -143,19 +143,13 @@ C2CC Controller Logged Cleanup
 Setup
     [Documentation]    Register clusters, then disable C2CC on Cluster A and wait for restart.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
     Disable C2CC On Cluster    cluster-a
 
 Teardown
     [Documentation]    Re-enable C2CC on Cluster A, then close connections.
     Enable C2CC On Cluster    cluster-a
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Disable C2CC On Cluster
     [Documentation]    Move the C2CC config drop-in aside and restart MicroShift.

--- a/test/suites/c2cc/connectivity.robot
+++ b/test/suites/c2cc/connectivity.robot
@@ -84,16 +84,10 @@ Test Dual Stack Cross Cluster Source IP Preservation
 Setup
     [Documentation]    Set up clusters and deploy test workloads on all.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
     Deploy Test Workloads
 
 Teardown
     [Documentation]    Remove test workloads and close connections.
     Cleanup Test Workloads
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host

--- a/test/suites/c2cc/custom-route-tables.robot
+++ b/test/suites/c2cc/custom-route-tables.robot
@@ -76,9 +76,7 @@ Old Default Tables Are Not Cleaned Up
 Setup
     [Documentation]    Register clusters, apply custom routing drop-in, restart MicroShift.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
+    Register Remote Cluster    cluster-a    ${USHIFT_HOST}    ${SSH_PORT}    ${KUBECONFIG_A}
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
     Apply Custom Routing Config
     Restart And Wait For Healthy
@@ -89,8 +87,6 @@ Teardown
     Restart And Wait For Healthy
     Flush Custom Tables
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Apply Custom Routing Config
     [Documentation]    Write a drop-in that overrides routing table IDs.

--- a/test/suites/c2cc/disruptive.robot
+++ b/test/suites/c2cc/disruptive.robot
@@ -150,16 +150,10 @@ Restore NICs And Reconnect
 Setup
     [Documentation]    Set up clusters and deploy test workloads.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
     Deploy Test Workloads
 
 Teardown
     [Documentation]    Remove test workloads and close connections.
     Cleanup Test Workloads
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host

--- a/test/suites/c2cc/dns.robot
+++ b/test/suites/c2cc/dns.robot
@@ -51,16 +51,10 @@ Test Curl Remote Service Via DNS
 Setup
     [Documentation]    Set up clusters and deploy test workloads on all.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
     Deploy Test Workloads
 
 Teardown
     [Documentation]    Remove test workloads and close connections.
     Cleanup Test Workloads
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host

--- a/test/suites/c2cc/healthcheck.robot
+++ b/test/suites/c2cc/healthcheck.robot
@@ -61,17 +61,11 @@ Correct Dual Stack RemoteCluster CR Spec
 Setup
     [Documentation]    Set up SSH connections and kubeconfigs for all clusters.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Wait For RemoteCluster CRD
     [Documentation]    Waits for remoteclusters.microshift.io CRD to be registered.

--- a/test/suites/c2cc/infrastructure.robot
+++ b/test/suites/c2cc/infrastructure.robot
@@ -188,14 +188,8 @@ Dual Stack Node Annotation Set
 Setup
     [Documentation]    Set up SSH connections and kubeconfigs for all clusters.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host

--- a/test/suites/c2cc/probe.robot
+++ b/test/suites/c2cc/probe.robot
@@ -140,17 +140,11 @@ RemoteCluster Has TargetResults In Dual Stack
 Setup
     [Documentation]    Set up SSH connections and kubeconfigs for all clusters.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Verify Probe Pod Is Ready
     [Documentation]    Check that the probe deployment has 1 available replica.

--- a/test/suites/c2cc/reconciliation.robot
+++ b/test/suites/c2cc/reconciliation.robot
@@ -135,16 +135,12 @@ Reconcile Dual Stack Service IP Rule After Deletion
 Setup
     [Documentation]    Set up SSH connections and kubeconfigs for all clusters.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
+    Register Remote Cluster    cluster-a    ${USHIFT_HOST}    ${SSH_PORT}    ${KUBECONFIG_A}
     Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Get Node Name On Cluster
     [Documentation]    Get the name of the first node on the given cluster.

--- a/test/suites/c2cc/sanity.robot
+++ b/test/suites/c2cc/sanity.robot
@@ -47,17 +47,11 @@ C2CC Controller Is Running On Cluster
 Setup
     [Documentation]    Set up SSH connections and kubeconfigs for all clusters.
     Check Required Env Variables
-    Login MicroShift Host
-    Setup Kubeconfig
-    Register Local Cluster    cluster-a
-    Register Remote Cluster    cluster-b    ${HOST2_IP}    ${HOST2_SSH_PORT}    ${KUBECONFIG_B}
-    Register Remote Cluster    cluster-c    ${HOST3_IP}    ${HOST3_SSH_PORT}    ${KUBECONFIG_C}
+    Register All C2CC Clusters
 
 Teardown
     [Documentation]    Close all connections and clean up kubeconfigs.
     Teardown All Remote Clusters
-    Remove Kubeconfig
-    Logout MicroShift Host
 
 Verify Cluster Is Running
     [Documentation]    Check the /readyz endpoint on the given cluster.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * C2CC test setups now register all three clusters through a shared workflow, making cluster initialization more consistent across suites.
  * Added support for using the primary cluster’s kubeconfig and IPv6 details in dual-stack test runs.

* **Bug Fixes**
  * Improved test startup reliability by waiting for readiness on all clusters before running scenarios.
  * Simplified teardown so remote cluster connections are cleaned up more consistently across suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->