### PR TITLE
USHIFT-7066: Remove rhel-9.8.json GPG workaround from configure-composer.sh

### DIFF
--- a/scripts/devenv-builder/configure-composer.sh
+++ b/scripts/devenv-builder/configure-composer.sh
@@ -160,17 +160,6 @@ check_umask_and_permissions
 enable_rt_repositories          "${VERSION_ID}" "/etc/osbuild-composer/repositories/rhel-${VERSION_ID}.json"
 enable_beta_or_eus_repositories "${VERSION_ID}" "/etc/osbuild-composer/repositories/rhel-${VERSION_ID}.json"
 
-# Create the RHEL 9.8 composer configuration from the host OS template when
-# the host is not yet running RHEL 9.8, so osbuild-composer can build 9.8 images.
-if [[ "${VERSION_ID}" != "9.8" ]]; then
-    sudo cp "/etc/osbuild-composer/repositories/rhel-${VERSION_ID}.json" \
-            "/etc/osbuild-composer/repositories/rhel-9.8.json"
-    sudo sed -i "s|/${VERSION_ID}/|/9.8/|g" "/etc/osbuild-composer/repositories/rhel-9.8.json"
-    # Disable GPG check for 9.8 repos — the RHEL 9.6 host's rpmkeys cannot
-    # handle RHEL 9.8's post-quantum key 4 until the host is upgraded.
-    sudo sed -i 's/"check_gpg": true/"check_gpg": false/g' "/etc/osbuild-composer/repositories/rhel-9.8.json"
-fi
-
 # This step must come in the end to make sure all the potential configuration
 # changes are picked up by the service
 enable_or_restart_composer_services


### PR DESCRIPTION
## Summary
- Remove the temporary `rhel-9.8.json` GPG workaround from `scripts/devenv-builder/configure-composer.sh`
- The devenv host now runs RHEL 9.8, so osbuild-composer ships `rhel-9.8.json` natively
- The workaround (added in [USHIFT-6499](https://redhat.atlassian.net/browse/USHIFT-6499) / PR #6704) copied the host OS template and disabled GPG checks because the RHEL 9.6 host's `rpmkeys` could not handle RHEL 9.8's post-quantum key 4

## Test plan
- [ ] Verify `configure-composer.sh` runs successfully on a RHEL 9.8 devenv host
- [ ] Verify osbuild-composer can build RHEL 9.8 images without the workaround
- [ ] CI presubmit passes on RHEL 9.8 infrastructure

[USHIFT-7066](https://redhat.atlassian.net/browse/USHIFT-7066)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composer setup so it no longer applies an extra repository configuration when the host version does not match the target release.
  * Streamlined repository handling to move directly into service startup after existing repository adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->