### PR TITLE
OCPBUGS-97995: Start using openshift-v5 mirror dependencies

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -71,10 +71,8 @@ BuildRequires: systemd
 BuildRequires: golang
 # DO NOT REMOVE
 
-# TODO: The cri-o and cri-tools versions are relaxed in the transition period.
-# They need to be updated to target a single version range before the release.
-Requires: cri-o >= 1.34.0, cri-o < 1.36.0
-Requires: cri-tools >= 1.34.0, cri-tools < 1.36.0
+Requires: cri-o >= 1.36.0, cri-o < 1.37.0
+Requires: cri-tools >= 1.36.0, cri-tools < 1.37.0
 # The container networking plugins package has been removed from RHEL 10 and
 # cri-o no longer has an explicit dependency on it.
 # Ensure that the package is installed on RHEL 9 as a weak dependency, skipping

--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -130,7 +130,7 @@ RHOCP_MINOR_Y=""
 # The beta repository, containing dependencies, should point to the
 # OpenShift mirror URL. If the mirror for current minor is not
 # available yet, it should point to an older release.
-RHOCP_MINOR_Y_BETA="https://mirror.openshift.com/pub/openshift-v4/${UNAME_M}/dependencies/rpms/4.22-el9-beta"
+RHOCP_MINOR_Y_BETA="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/dependencies/rpms/5.0-el9-beta"
 export RHOCP_MAJOR_Y
 export RHOCP_MINOR_Y
 export RHOCP_MINOR_Y_BETA


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package requirements to use newer supported versions of `cri-o` and `cri-tools`, improving alignment with the current release stream.
  * Adjusted the beta dependencies source to point to the latest repository location, helping ensure builds and tests pull the correct packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->