### PR TITLE
USHIFT-7394: Test restart optimizations

### DIFF
--- a/test/suites/configuration1/configuration.robot
+++ b/test/suites/configuration1/configuration.robot
@@ -106,9 +106,7 @@ Deploy MicroShift With LVMS By Default
     [Setup]    Deploy Storage Config    ${LVMS_DEFAULT}
     LVMS Is Deployed
     CSI Snapshot Controller Is Deployed
-    [Teardown]    Run Keywords
-    ...    Remove Storage Drop In Config
-    ...    Restart MicroShift
+    [Teardown]    Remove Storage Drop In Config
 
 Deploy MicroShift Without LVMS
     [Documentation]    Verify that LVMS is not deployed when storage.driver == none, and that CSI snapshotting
@@ -119,9 +117,7 @@ Deploy MicroShift Without LVMS
     # Reduce the default timeout to 2 minutes for a quicker failure
     Run Keyword And Expect Error    1 != 0
     ...    LVMS Is Deployed    timeout=${DEFAULT_WAIT_TIMEOUT}
-    [Teardown]    Run Keywords
-    ...    Remove Storage Drop In Config
-    ...    Restart MicroShift
+    [Teardown]    Remove Storage Drop In Config
 
 Deploy MicroShift Without CSI Snapshotter
     [Documentation]    Verify that only LVMS is deployed when .storage.optionalCsiComponents is an empty array.
@@ -132,9 +128,7 @@ Deploy MicroShift Without CSI Snapshotter
     Run Keyword And Expect Error    1 != 0
     ...    CSI Snapshot Controller Is Deployed    timeout=${DEFAULT_WAIT_TIMEOUT}
 
-    [Teardown]    Run Keywords
-    ...    Remove Storage Drop In Config
-    ...    Restart MicroShift
+    [Teardown]    Remove Storage Drop In Config
 
 Crio Uses Crun Runtime
     [Documentation]    Verify that crio uses crun as its default runtime
@@ -163,12 +157,14 @@ Setup
     Save Journal Cursor
 
 Teardown
-    [Documentation]    Test suite teardown
+    [Documentation]    Restart MicroShift to restore clean state after the last test
+    ...    (per-test teardowns skip the restart), then clean up.
     Remove Drop In MicroShift Config    10-loglevel
     Remove Drop In MicroShift Config    10-audit
+    Remove Drop In MicroShift Config    10-storage
     Restart MicroShift
-    Logout MicroShift Host
     Remove Kubeconfig
+    Logout MicroShift Host
 
 Save Journal Cursor
     [Documentation]

--- a/test/suites/configuration1/dns-resource-configuration.robot
+++ b/test/suites/configuration1/dns-resource-configuration.robot
@@ -66,7 +66,7 @@ ${DNS_LIMIT_LESS_THAN_REQUEST}      SEPARATOR=\n
 *** Test Cases ***
 Default DNS Resources
     [Documentation]    Verify default DNS resources when no custom config is applied
-    [Setup]    Remove DNS Resource Config
+    [Setup]    Run Keywords    Remove DNS Resource Config    AND    Restart MicroShift
     DNS Resource Value Should Be    ${DNS_RESOURCE_PATH}.requests.cpu    50m
     DNS Resource Value Should Be    ${DNS_RESOURCE_PATH}.requests.memory    70Mi
 
@@ -107,13 +107,13 @@ Invalid Resource Quantity Prevents Start
     [Documentation]    Verify MicroShift fails to start with invalid resource quantity
     [Setup]    Apply Invalid DNS Resource Config    ${DNS_INVALID_QUANTITY}
     Pattern Should Appear In Log Output    ${CURSOR}    invalid dns resource request
-    [Teardown]    Remove DNS Resource Config
+    [Teardown]    Run Keywords    Remove DNS Resource Config    AND    Restart MicroShift
 
 Limit Less Than Request Prevents Start
     [Documentation]    Verify MicroShift fails to start when limit is less than request
     [Setup]    Apply Invalid DNS Resource Config    ${DNS_LIMIT_LESS_THAN_REQUEST}
     Pattern Should Appear In Log Output    ${CURSOR}    must be greater than or equal to request
-    [Teardown]    Remove DNS Resource Config
+    [Teardown]    Run Keywords    Remove DNS Resource Config    AND    Restart MicroShift
 
 DNS Resolution After Resource Change
     [Documentation]    Verify CoreDNS resolves cluster-local services after resource change
@@ -180,6 +180,7 @@ Apply Invalid DNS Resource Config
     [Documentation]    Apply an invalid DNS resource config that should prevent MicroShift from starting
     [Arguments]    ${config}
     Remove Drop In MicroShift Config    ${DNS_DROPIN}
+    Restart MicroShift
     Drop In MicroShift Config    ${config}    ${DNS_DROPIN}
     ${cursor}=    Get Journal Cursor
     VAR    ${CURSOR}=    ${cursor}    scope=TEST

--- a/test/suites/configuration1/dns-resource-configuration.robot
+++ b/test/suites/configuration1/dns-resource-configuration.robot
@@ -132,7 +132,10 @@ Setup
     Setup Kubeconfig
 
 Teardown
-    [Documentation]    Test suite teardown
+    [Documentation]    Restart MicroShift to restore clean state after the last test
+    ...    (per-test teardowns skip the restart), then clean up.
+    Remove Drop In MicroShift Config    ${DNS_DROPIN}
+    Restart MicroShift
     Remove Kubeconfig
     Logout MicroShift Host
 
@@ -169,20 +172,20 @@ DNS Resource Value Should Match Empty
 Apply DNS Resource Config
     [Documentation]    Remove any existing drop-in, apply a new DNS resource config and restart MicroShift
     [Arguments]    ${config}
-    Remove DNS Resource Config
+    Remove Drop In MicroShift Config    ${DNS_DROPIN}
     Drop In MicroShift Config    ${config}    ${DNS_DROPIN}
     Restart MicroShift
 
 Apply Invalid DNS Resource Config
     [Documentation]    Apply an invalid DNS resource config that should prevent MicroShift from starting
     [Arguments]    ${config}
-    Remove DNS Resource Config
+    Remove Drop In MicroShift Config    ${DNS_DROPIN}
     Drop In MicroShift Config    ${config}    ${DNS_DROPIN}
     ${cursor}=    Get Journal Cursor
     VAR    ${CURSOR}=    ${cursor}    scope=TEST
     Run Keyword And Expect Error    0 != 1    Restart MicroShift
 
 Remove DNS Resource Config
-    [Documentation]    Remove the DNS resource drop-in config and restart MicroShift
+    [Documentation]    Remove the DNS resource drop-in config without restarting.
+    ...    The next test's setup will restart MicroShift.
     Remove Drop In MicroShift Config    ${DNS_DROPIN}
-    Restart MicroShift

--- a/test/suites/configuration2/audit-log.robot
+++ b/test/suites/configuration2/audit-log.robot
@@ -65,7 +65,9 @@ Invalid Audit Profile Prevents Startup
     Stop MicroShift
     Command Should Fail    timeout 30 systemctl start microshift
 
-    [Teardown]    Remove Drop In MicroShift Config    10-audit
+    [Teardown]    Run Keywords
+    ...    Remove Drop In MicroShift Config    10-audit
+    ...    AND    Restart MicroShift
 
 Invalid Audit Rotation Values Prevent Startup
     [Documentation]    Non-integer rotation parameters should prevent MicroShift from starting.
@@ -73,7 +75,9 @@ Invalid Audit Rotation Values Prevent Startup
     Stop MicroShift
     Command Should Fail    timeout 30 systemctl start microshift
 
-    [Teardown]    Remove Drop In MicroShift Config    10-audit
+    [Teardown]    Run Keywords
+    ...    Remove Drop In MicroShift Config    10-audit
+    ...    AND    Restart MicroShift
 
 Audit Profile None Produces No Logs
     [Documentation]    With profile None, no audit entries should be written.

--- a/test/suites/configuration2/audit-log.robot
+++ b/test/suites/configuration2/audit-log.robot
@@ -65,10 +65,7 @@ Invalid Audit Profile Prevents Startup
     Stop MicroShift
     Command Should Fail    timeout 30 systemctl start microshift
 
-    [Teardown]    Run Keywords
-    ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
+    [Teardown]    Remove Drop In MicroShift Config    10-audit
 
 Invalid Audit Rotation Values Prevent Startup
     [Documentation]    Non-integer rotation parameters should prevent MicroShift from starting.
@@ -76,10 +73,7 @@ Invalid Audit Rotation Values Prevent Startup
     Stop MicroShift
     Command Should Fail    timeout 30 systemctl start microshift
 
-    [Teardown]    Run Keywords
-    ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
+    [Teardown]    Remove Drop In MicroShift Config    10-audit
 
 Audit Profile None Produces No Logs
     [Documentation]    With profile None, no audit entries should be written.
@@ -96,8 +90,6 @@ Audit Profile None Produces No Logs
     ...    Oc Delete    configmap ${cm_name} -n ${TEST_NS} --ignore-not-found
     ...    AND
     ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
 
 Audit Profile Default Logs Metadata Only
     [Documentation]    Default profile should log metadata but not request/response bodies.
@@ -118,8 +110,6 @@ Audit Profile Default Logs Metadata Only
     ...    Oc Delete    configmap ${cm_name} -n ${TEST_NS} --ignore-not-found
     ...    AND
     ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
 
 Audit Profile WriteRequestBodies Logs Write Operations
     [Documentation]    WriteRequestBodies should log request bodies for write operations
@@ -141,8 +131,6 @@ Audit Profile WriteRequestBodies Logs Write Operations
     ...    Oc Delete    configmap ${cm_name} -n ${TEST_NS} --ignore-not-found
     ...    AND
     ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
 
 Audit Profile AllRequestBodies Logs All Operations
     [Documentation]    AllRequestBodies should log request bodies for all operations.
@@ -163,8 +151,6 @@ Audit Profile AllRequestBodies Logs All Operations
     ...    Oc Delete    configmap ${cm_name} -n ${TEST_NS} --ignore-not-found
     ...    AND
     ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
 
 Audit Log File Exists With Correct Permissions
     [Documentation]    Verify the audit log file exists at the expected path with correct
@@ -182,10 +168,7 @@ Audit Log Rotation Respects Max File Size And Count
     Wait Until Keyword Succeeds    60x    5s
     ...    Audit Backup Files Should Match    2
 
-    [Teardown]    Run Keywords
-    ...    Remove Drop In MicroShift Config    10-audit
-    ...    AND
-    ...    Restart MicroShift
+    [Teardown]    Remove Drop In MicroShift Config    10-audit
 
 
 *** Keywords ***
@@ -198,10 +181,13 @@ Setup
     Oc Create    namespace ${TEST_NS}
 
 Teardown
-    [Documentation]    Test suite teardown
+    [Documentation]    Restart MicroShift to restore clean state after the last test
+    ...    (per-test teardowns skip the restart), then clean up.
+    Remove Drop In MicroShift Config    10-audit
+    Restart MicroShift
     Oc Delete    namespace ${TEST_NS} --ignore-not-found
-    Logout MicroShift Host
     Remove Kubeconfig
+    Logout MicroShift Host
 
 Grep Audit Log Count
     [Documentation]    Count audit log entries matching the resource name

--- a/test/suites/configuration2/kustomize-sources.robot
+++ b/test/suites/configuration2/kustomize-sources.robot
@@ -91,7 +91,6 @@ Multiple Kustomize Paths
     ...    AND    Remove Manifest Directory    ${MANIFEST_DIR_2}
     ...    AND    Oc Delete    namespace ksrc-multi-ns-1 --ignore-not-found
     ...    AND    Oc Delete    namespace ksrc-multi-ns-2 --ignore-not-found
-    ...    AND    Restart MicroShift
 
 Path Without Kustomization File Is Ignored
     [Documentation]    A path that exists but has no kustomization.yaml should be silently ignored.
@@ -103,7 +102,6 @@ Path Without Kustomization File Is Ignored
     [Teardown]    Run Keywords
     ...    Remove Drop In MicroShift Config    10-kustomize
     ...    AND    Remove Manifest Directory    ${MANIFEST_DIR_1}
-    ...    AND    Restart MicroShift
 
 Non Existent Path Is Ignored
     [Documentation]    A non-existent path in kustomizePaths should be silently ignored.
@@ -111,9 +109,7 @@ Non Existent Path Is Ignored
 
     Restart MicroShift
 
-    [Teardown]    Run Keywords
-    ...    Remove Drop In MicroShift Config    10-kustomize
-    ...    AND    Restart MicroShift
+    [Teardown]    Remove Drop In MicroShift Config    10-kustomize
 
 Unset Kustomize Paths Uses Defaults
     [Documentation]    Setting kustomizePaths to null should result in the default paths.
@@ -146,7 +142,6 @@ Glob Patterns In Kustomize Paths
     ...    AND    Remove Manifest Directory    ${GLOB_BASE}
     ...    AND    Oc Delete    namespace ksrc-glob-ns-a --ignore-not-found
     ...    AND    Oc Delete    namespace ksrc-glob-ns-b --ignore-not-found
-    ...    AND    Restart MicroShift
 
 
 *** Keywords ***
@@ -157,15 +152,18 @@ Setup
     Setup Kubeconfig
 
 Teardown
-    [Documentation]    Test suite teardown
-    Logout MicroShift Host
+    [Documentation]    Restart MicroShift to restore clean state after the last test
+    ...    (per-test teardowns skip the restart), then clean up.
+    Remove Drop In MicroShift Config    10-kustomize
+    Restart MicroShift
     Remove Kubeconfig
+    Logout MicroShift Host
 
 Cleanup Kustomize Test
-    [Documentation]    Standard cleanup for a single-path kustomize test
+    [Documentation]    Standard cleanup for a single-path kustomize test without restarting.
+    ...    The next test's setup will restart MicroShift.
     [Arguments]    ${namespace}    ${manifest_dir}
     Run Keywords
     ...    Remove Drop In MicroShift Config    10-kustomize
     ...    AND    Remove Manifest Directory    ${manifest_dir}
     ...    AND    Oc Delete    namespace ${namespace} --ignore-not-found
-    ...    AND    Restart MicroShift

--- a/test/suites/standard1/etcd.robot
+++ b/test/suites/standard1/etcd.robot
@@ -79,7 +79,7 @@ Set MemoryHigh Limit Unlimited
     [Tags]    configuration    restart    slow
     [Setup]    Setup With Custom Config    ${MEMLIMIT0}
     Expect MemoryHigh    infinity
-    [Teardown]    Restore Default Config
+    [Teardown]    Remove Drop In MicroShift Config    10-etcd
 
 Set MemoryHigh Limit 256MB
     [Documentation]    Set the memory limit for etcd to 256MB and ensure it takes effect
@@ -87,7 +87,7 @@ Set MemoryHigh Limit 256MB
     [Setup]    Setup With Custom Config    ${MEMLIMIT256}
     # Expecting the setting to be 256 * 1024 * 1024
     Expect MemoryHigh    268435456
-    [Teardown]    Restore Default Config
+    [Teardown]    Remove Drop In MicroShift Config    10-etcd
 
 
 *** Keywords ***

--- a/test/suites/standard2/feature-gates.robot
+++ b/test/suites/standard2/feature-gates.robot
@@ -84,9 +84,13 @@ Setup
     Setup Kubeconfig    # for readiness checks
 
 Teardown
-    [Documentation]    Test suite teardown
-    Logout MicroShift Host
+    [Documentation]    Start MicroShift to restore clean state after the last test
+    ...    (per-test teardowns leave MicroShift stopped), then clean up.
+    Remove Drop In MicroShift Config    10-featuregates
+    Remove Feature Gate Lock File If Exists
+    Restart MicroShift
     Remove Kubeconfig
+    Logout MicroShift Host
 
 Save Journal Cursor
     [Documentation]
@@ -105,11 +109,11 @@ Setup Custom Feature Gates Test
     Feature Gate Lock File Should Exist
 
 Teardown Custom Feature Gates Test
-    [Documentation]    Remove custom feature gates config and restart MicroShift
+    [Documentation]    Remove custom feature gates config without restarting.
+    ...    The next test's setup will start MicroShift.
     Stop MicroShift
     Remove Drop In MicroShift Config    10-featuregates
     Remove Feature Gate Lock File If Exists
-    Start MicroShift
 
 Remove Feature Gate Lock File If Exists
     [Documentation]    Remove the feature gate lock file if it exists, for test cleanup

--- a/test/suites/telemetry/telemetry.robot
+++ b/test/suites/telemetry/telemetry.robot
@@ -110,10 +110,14 @@ Setup
     Setup Kubeconfig
 
 Teardown
-    [Documentation]    Test suite teardown
+    [Documentation]    Restart MicroShift to restore clean state after the last test
+    ...    (per-test teardowns skip the restart), then clean up.
+    Remove Drop In MicroShift Config    10-telemetry
+    Restore Pull Secrets
+    Restart MicroShift
     Wait For MicroShift Healthcheck Success
-    Logout MicroShift Host
     Remove Kubeconfig
+    Logout MicroShift Host
 
 Check Required Telemetry Variables
     [Documentation]    Check if the required telemetry variables are set
@@ -140,10 +144,9 @@ Setup Telemetry Configuration
 
 Remove Telemetry Configuration
     [Documentation]    Removes the telemetry feature from MicroShift configuration file
-    ...    and restarts microshift.service
+    ...    without restarting. The next test's setup will restart MicroShift.
     Remove Drop In MicroShift Config    10-telemetry
     Restore Pull Secrets
-    Restart MicroShift
 
 Configure Pull Secrets
     [Documentation]    Sets up the pull secrets for the MicroShift cluster.


### PR DESCRIPTION
Due to the latest rebase PRs, MicroShift may take a bit more time to fully restart because there are more containers that need to signal readiness.
Because of this, there is a need to have efficient test cases that minimize the number of restarts while keeping the functional checks and correct MicroShift behavior, which is what this PR is addressing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup consistency across multiple configuration suites.
  * Restarts now happen at suite teardown in several cases, reducing leftover state between tests.
  * Updated configuration cleanup so removed settings are fully cleared before the next test runs.
  * Adjusted telemetry and feature-gate test teardown flow to better restore a clean system state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->