### PR TITLE
USHIFT-7345: Ansible: Deploy logging Prometheus via rootless podman

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -128,8 +128,7 @@ The following text files are created for each run:
 - `images.txt` — container image sizes (compressed and uncompressed)
 - `network.txt` — network transfer (RX/TX) via Prometheus when `prometheus_logging` is enabled
 
-If Prometheus was enabled, the performance metrics will be uploaded to the Ansible control node, where users can view all the captured performance data using the `http://<ansible-server-ip>:9091` URL. These metrics can be conveniently visualized in the Grafana dashboards accessible at the `http://<ansible-server-ip>:3000` site.
-> Use `admin:admin` credentials to log into the Grafana server.
+When Prometheus is enabled, it runs on the logging host in a Podman container managed by Quadlet. Captured metrics can be queried through the Prometheus web UI at `http://<logging-host-ip>:9091`.
 
 ## Configuration Overview
 

--- a/ansible/roles/add-kubelet-logging/defaults/main.yml
+++ b/ansible/roles/add-kubelet-logging/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # add-kubelet-logging default vars
 
-prometheus_dir: /etc/prometheus
-prometheus_config: "{{ prometheus_dir }}/prometheus.yml"
-kubelet_auth_token_file: "{{ prometheus_dir }}/token"
+prometheus_kubelet_scrape_config: "{{ prometheus_scrape_config_dir }}/kubelet.yml"
+kubelet_auth_token_file: "{{ prometheus_config_dir }}/token"
+prometheus_container_token_path: /etc/prometheus/token

--- a/ansible/roles/add-kubelet-logging/tasks/main.yml
+++ b/ansible/roles/add-kubelet-logging/tasks/main.yml
@@ -1,82 +1,150 @@
 ---
 # add-kubelet-logging tasks
 
-- name: Check to ensure promdir target exists
-  ansible.builtin.stat:
-    path: "{{ prometheus_dir }}"
-  register: promdir
-
-- name: Check if the file exists
-  ansible.builtin.stat:
-    path: "{{ sa_token_file }}"
-  register: token_file
-  delegate_to: localhost
-  become: false
-
-- name: Deal with metrics service account token file
-  when: token_file.stat.exists
+- name: Configure kubelet targets for managed Prometheus container
+  when: prometheus_container_managed | default(false) | bool
   block:
-    - name: Load sa-token file from localhost
-      ansible.builtin.slurp:
-        src: "{{ sa_token_file }}"
-      register: bearer_token_slurp
-      delegate_to: localhost
-      become: false
-      no_log: true
+    - name: Check Prometheus config directory
+      ansible.builtin.stat:
+        path: "{{ prometheus_config_dir }}"
+      register: promdir
 
-    - name: Decode bearer token
-      ansible.builtin.set_fact:
-        bearer_token: "{{ bearer_token_slurp.content | b64decode }}"
-      no_log: true
+    - name: Check Prometheus scrape config directory
+      ansible.builtin.stat:
+        path: "{{ prometheus_scrape_config_dir }}"
+      register: prometheus_scrape_dir
 
-    - name: Create metrics service account token file in prometheus folder
-      ansible.builtin.copy:
-        content: "{{ bearer_token }}"
-        dest: "{{ kubelet_auth_token_file }}"
-        mode: '0644'
-      when: promdir.stat.exists
-      no_log: true
+    - name: Verify Prometheus config directories
+      ansible.builtin.assert:
+        that:
+          - promdir.stat.isdir | default(false)
+          - prometheus_scrape_dir.stat.isdir | default(false)
+        fail_msg: "Prometheus configuration directories do not exist"
 
-    - name: Remove the sa-token file
-      ansible.builtin.file:
+    - name: Check for new metrics service account token
+      ansible.builtin.stat:
         path: "{{ sa_token_file }}"
-        state: absent
+      register: token_file
       delegate_to: localhost
       become: false
 
-- name: Append kubelet scrape config target to prometheus config
-  ansible.builtin.blockinfile:
-    path: "{{ prometheus_config }}"
-    block: |
-      # kubelet targets
-      {% for host in groups['microshift'] %}
-        - job_name: kubelet-{{ host }}
-          scheme: https
-          authorization:
-            credentials_file: "{{ kubelet_auth_token_file }}"
-          tls_config:
-            insecure_skip_verify: true
-          static_configs:
-            - targets:
-                - {{ hostvars[host].ansible_host }}:10250
-              labels:
-                instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
+    - name: Install new metrics service account token
+      when: token_file.stat.exists
+      block:
+        - name: Verify new metrics service account token
+          ansible.builtin.assert:
+            that:
+              - token_file.stat.size | default(0) | int > 0
+            fail_msg: "Metrics service account token {{ sa_token_file }} is empty"
 
-        - job_name: kubelet-{{ host }}-cadvisor
-          scheme: https
-          authorization:
-            credentials_file: "{{ kubelet_auth_token_file }}"
-          tls_config:
-            insecure_skip_verify: true
-          metrics_path: /metrics/cadvisor
-          static_configs:
-            - targets:
-                - {{ hostvars[host].ansible_host }}:10250
-              labels:
-                instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
-      {% endfor %}
+        - name: Load metrics service account token
+          ansible.builtin.slurp:
+            src: "{{ sa_token_file }}"
+          register: bearer_token_slurp
+          delegate_to: localhost
+          become: false
+          no_log: true
 
-- name: Restart prometheus to pick up new target
-  ansible.builtin.systemd:
-    state: restarted
-    name: prometheus
+        - name: Write Prometheus metrics service account token
+          ansible.builtin.copy:
+            content: "{{ bearer_token_slurp.content | b64decode }}"
+            dest: "{{ kubelet_auth_token_file }}"
+            mode: '0644'
+            setype: container_file_t
+          register: prometheus_token_install
+          no_log: true
+
+        - name: Remove temporary metrics service account token
+          ansible.builtin.file:
+            path: "{{ sa_token_file }}"
+            state: absent
+          delegate_to: localhost
+          become: false
+
+    - name: Check installed metrics service account token
+      ansible.builtin.stat:
+        path: "{{ kubelet_auth_token_file }}"
+      register: prometheus_token
+
+    - name: Verify installed metrics service account token
+      ansible.builtin.assert:
+        that:
+          - prometheus_token.stat.isreg | default(false)
+          - prometheus_token.stat.size | default(0) | int > 0
+        fail_msg: "Prometheus metrics token {{ kubelet_auth_token_file }} is missing or empty"
+
+    # Normalize retained tokens when no replacement token was supplied.
+    - name: Set Prometheus metrics service account token permissions
+      ansible.builtin.file:
+        path: "{{ kubelet_auth_token_file }}"
+        state: file
+        mode: '0644'
+        setype: container_file_t
+      register: prometheus_token_permissions
+
+    - name: Write and validate Prometheus kubelet configuration
+      block:
+        - name: Write Prometheus kubelet configuration
+          ansible.builtin.template:
+            src: kubelet.yml.j2
+            dest: "{{ prometheus_kubelet_scrape_config }}"
+            mode: '0644'
+            setype: container_file_t
+            backup: true
+          register: prometheus_kubelet_config_template
+
+        - name: Validate Prometheus configuration with kubelet targets
+          ansible.builtin.command:
+            argv:
+              - podman
+              - exec
+              - "{{ prometheus_managed_container_name }}"
+              - /bin/promtool
+              - check
+              - config
+              - /etc/prometheus/prometheus.yml
+          changed_when: false
+
+      rescue:
+        - name: Restore previous Prometheus kubelet configuration
+          ansible.builtin.copy:
+            src: "{{ prometheus_kubelet_config_template.backup_file }}"
+            dest: "{{ prometheus_kubelet_scrape_config }}"
+            remote_src: true
+            mode: '0644'
+            setype: container_file_t
+          when:
+            - prometheus_kubelet_config_template is defined
+            - prometheus_kubelet_config_template.backup_file is defined
+
+        - name: Remove invalid new Prometheus kubelet configuration
+          ansible.builtin.file:
+            path: "{{ prometheus_kubelet_scrape_config }}"
+            state: absent
+          when:
+            - prometheus_kubelet_config_template is defined
+            - prometheus_kubelet_config_template.changed | default(false)
+            - prometheus_kubelet_config_template.backup_file is not defined
+
+        - name: Report Prometheus kubelet configuration validation failure
+          ansible.builtin.fail:
+            msg: >-
+              {{ ansible_failed_result.stderr
+              | default(ansible_failed_result.stdout, true)
+              | default(ansible_failed_result.msg, true)
+              | default('Prometheus kubelet configuration could not be written or validated', true) }}
+
+    # POST applies managed changes immediately; auto-reload converges later disk changes.
+    - name: Reload Prometheus to pick up kubelet targets
+      ansible.builtin.uri:
+        url: "{{ prometheus_local_url }}/-/reload"
+        method: POST
+        status_code: 200
+      register: prometheus_reload
+      retries: 5
+      delay: 3
+      until: prometheus_reload.status == 200
+      when: >-
+        prometheus_kubelet_config_template.changed
+        or (prometheus_token_install.changed | default(false))
+        or prometheus_token_permissions.changed

--- a/ansible/roles/add-kubelet-logging/templates/kubelet.yml.j2
+++ b/ansible/roles/add-kubelet-logging/templates/kubelet.yml.j2
@@ -1,0 +1,36 @@
+{% macro prometheus_target(address, port) -%}
+{% set address = address | string -%}
+{{ ('[' ~ address ~ ']') if ':' in address and not address.startswith('[') else address }}:{{ port }}
+{%- endmacro %}
+{% set microshift_hosts = groups.get('microshift', []) %}
+{% if microshift_hosts | length > 0 %}
+scrape_configs:
+{% for host in microshift_hosts %}
+  - job_name: kubelet-{{ host }}
+    scheme: https
+    authorization:
+      credentials_file: "{{ prometheus_container_token_path }}"
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets:
+          - '{{ prometheus_target(hostvars[host].ansible_host | default(host), 10250) }}'
+        labels:
+          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
+
+  - job_name: kubelet-{{ host }}-cadvisor
+    scheme: https
+    authorization:
+      credentials_file: "{{ prometheus_container_token_path }}"
+    tls_config:
+      insecure_skip_verify: true
+    metrics_path: /metrics/cadvisor
+    static_configs:
+      - targets:
+          - '{{ prometheus_target(hostvars[host].ansible_host | default(host), 10250) }}'
+        labels:
+          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
+{% endfor %}
+{% else %}
+scrape_configs: []
+{% endif %}

--- a/ansible/roles/install-logging/defaults/main.yml
+++ b/ansible/roles/install-logging/defaults/main.yml
@@ -1,19 +1,20 @@
 ---
 # install-logging default vars
 
-logging_packages:
-  - golang-github-prometheus
-  - grafana
-
-logging_services:
-  - prometheus
-  - grafana-server
-
-grafana_setup: false
-grafana_username: admin
-grafana_password: admin
-grafana_host_address: "192.168.1.100"
-grafana_port: 3000
-
+prometheus_image: quay.io/prometheus/prometheus:v3.13.1
+prometheus_container_name: microshift-prometheus
+prometheus_quadlet_name: microshift-prometheus
+prometheus_data_volume: microshift-prometheus-data
+prometheus_enable_linger: true
+prometheus_stop_timeout: 60
 prometheus_port: 9091
-prometheus_vars_file: /etc/default/prometheus
+prometheus_container_port: 9090
+prometheus_host_address: 0.0.0.0
+prometheus_exporter_scrape_config: "{{ prometheus_scrape_config_dir }}/exporters.yml"
+prometheus_auto_reload_interval: 30s
+
+prometheus_scrape_interval: 5s
+prometheus_evaluation_interval: 15s
+prometheus_scrape_timeout: 5s
+prometheus_retention_time: 7d
+prometheus_retention_size: ""

--- a/ansible/roles/install-logging/tasks/main.yml
+++ b/ansible/roles/install-logging/tasks/main.yml
@@ -1,78 +1,457 @@
 ---
 # install-logging tasks
 
-- name: RPM tasks
-  when: (ansible_facts.distribution == "CentOS") or (ansible_facts.distribution == "RedHat") or (ansible_facts.distribution == "Fedora")
+- name: Record rootless Prometheus user facts
+  ansible.builtin.set_fact:
+    prometheus_rootless: "{{ ansible_facts['user_uid'] | int != 0 }}"
+    prometheus_rootless_user: "{{ ansible_facts['user_id'] }}"
+    prometheus_rootless_home: "{{ ansible_facts['user_dir'] }}"
+    prometheus_user_runtime_dir: "/run/user/{{ ansible_facts['user_uid'] }}"
+    prometheus_systemd_environment: "{{ {'XDG_RUNTIME_DIR': '/run/user/' ~ ansible_facts['user_uid']} if (ansible_facts['user_uid'] | int != 0) else {} }}"
+    prometheus_systemd_unit: "{{ prometheus_quadlet_name }}.service"
+
+- name: Check existing managed Prometheus user unit
+  ansible.builtin.command:
+    argv:
+      - systemctl
+      - --user
+      - is-active
+      - "{{ prometheus_systemd_unit }}"
+  register: prometheus_existing_managed_user_unit
+  changed_when: false
+  failed_when: false
+  environment:
+    XDG_RUNTIME_DIR: "{{ prometheus_user_runtime_dir }}"
+  when: prometheus_rootless | bool
+
+- name: Check existing managed Prometheus system unit
+  ansible.builtin.command:
+    argv:
+      - systemctl
+      - is-active
+      - "{{ prometheus_systemd_unit }}"
+  register: prometheus_existing_managed_system_unit
+  changed_when: false
+  failed_when: false
+  when: not (prometheus_rootless | bool)
+
+- name: Record managed Prometheus unit status
+  ansible.builtin.set_fact:
+    prometheus_existing_managed_unit_rc: >-
+      {{
+        prometheus_existing_managed_user_unit.rc
+        if (prometheus_rootless | bool)
+        else prometheus_existing_managed_system_unit.rc
+      }}
+
+- name: Gather service facts for monitoring conflict detection
+  ansible.builtin.service_facts:
+
+- name: Detect active or enabled Prometheus services
+  ansible.builtin.set_fact:
+    prometheus_host_service_conflicts: >-
+      {{
+        (
+          ansible_facts.services | default({}) | dict2items
+          | selectattr('key', 'equalto', 'prometheus.service')
+          | selectattr('value.state', 'equalto', 'running')
+          | map(attribute='key')
+          | list
+        )
+        | union(
+          ansible_facts.services | default({}) | dict2items
+          | selectattr('key', 'equalto', 'prometheus.service')
+          | selectattr('value.status', 'defined')
+          | selectattr('value.status', 'match', '^enabled')
+          | map(attribute='key')
+          | list
+        )
+        | difference(
+          [prometheus_systemd_unit]
+          if (prometheus_existing_managed_unit_rc | int) == 0
+          else []
+        )
+      }}
+
+- name: Check Prometheus port listener
+  ansible.builtin.command: "ss -H -ltn sport = :{{ prometheus_port }}"
+  register: prometheus_port_check
+  changed_when: false
+  failed_when: false
+
+- name: Check for existing Prometheus processes
+  ansible.builtin.command:
+    argv:
+      - pgrep
+      - --exact
+      - prometheus
+  register: prometheus_process_check
+  changed_when: false
+  failed_when: false
+
+- name: Record host monitoring conflicts
+  ansible.builtin.set_fact:
+    prometheus_existing_monitoring_conflicts: >-
+      {{
+        prometheus_host_service_conflicts
+        + (
+            ['port:' ~ prometheus_port]
+            if prometheus_port_check.stdout | length > 0 and (prometheus_existing_managed_unit_rc | int) != 0
+            else []
+          )
+        + (
+            ['process:prometheus']
+            if prometheus_process_check.rc == 0 and (prometheus_existing_managed_unit_rc | int) != 0
+            else []
+          )
+      }}
+
+- name: Skip Prometheus deployment when existing monitoring is present
+  ansible.builtin.set_fact:
+    prometheus_container_managed: false
+    prometheus_skip_reason: "Existing monitoring detected: {{ prometheus_existing_monitoring_conflicts | join(', ') }}"
+  when: prometheus_existing_monitoring_conflicts | length > 0
+
+- name: Report skipped Prometheus deployment
+  ansible.builtin.debug:
+    msg: "{{ prometheus_skip_reason }}"
+  when: not (prometheus_container_managed | default(true) | bool)
+
+- name: Deploy Prometheus with quadlet
+  when: prometheus_container_managed | default(true) | bool
   block:
-    - name: Install prometheus & grafana
-      ansible.builtin.dnf:
-        name: "{{ logging_packages }}"
-        state: present
-        update_cache: true
-
-    - name: Check that the prometheus cli vars file exists
-      ansible.builtin.stat:
-        path: "{{ prometheus_vars_file }}"
-      register: prometheus_vars
-
-    - name: Set prometheus args to change listen port
-      ansible.builtin.replace:
-        path: "{{ prometheus_vars_file }}"
-        regexp: "ARGS=''"
-        replace: "ARGS='--web.listen-address=0.0.0.0:{{ prometheus_port }}'"
-      when: prometheus_vars.stat.exists
-
-- name: Copy prometheus config
-  ansible.builtin.template:
-    src: prometheus.yml.j2
-    dest: /etc/prometheus/prometheus.yml
-    mode: '0640'
-    backup: true
-
-- name: Start and enable prometheus & grafana service(s)
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    state: restarted
-    enabled: true
-  loop: "{{ logging_services }}"
-  when: item != 'grafana-server' or (grafana_setup | bool)
-
-- name: Configure Grafana dashboards and datasources
-  when: grafana_setup | bool
-  block:
-    - name: Get content of microshift grafana dashboard
+    - name: Record Prometheus path and service facts
       ansible.builtin.set_fact:
-        microshift_dashboard: "{{ lookup('ansible.builtin.file', 'microshift_perf.json') }}"
+        prometheus_config_dir: >-
+          {{ (prometheus_rootless_home ~ '/.config/microshift-prometheus')
+          if (prometheus_rootless | bool) else '/etc/microshift-prometheus' }}
+        prometheus_quadlet_dir: >-
+          {{ (prometheus_rootless_home ~ '/.config/containers/systemd')
+          if (prometheus_rootless | bool) else '/etc/containers/systemd' }}
+        prometheus_quadlet_file: >-
+          {{ ((prometheus_rootless_home ~ '/.config/containers/systemd')
+          if (prometheus_rootless | bool) else '/etc/containers/systemd')
+          }}/{{ prometheus_quadlet_name }}.container
+        prometheus_local_url: >-
+          http://{{ '127.0.0.1' if prometheus_host_address == '0.0.0.0'
+          else prometheus_host_address }}:{{ prometheus_port }}
+        prometheus_managed_container_name: "{{ prometheus_container_name }}"
+        prometheus_systemd_scope: "{{ 'user' if (prometheus_rootless | bool) else 'system' }}"
 
-    # The following URI commands fail without accessing some external network
-    - name: Wake up network access
-      ansible.builtin.command: curl github.com
+    - name: Record Prometheus scrape config directory
+      ansible.builtin.set_fact:
+        prometheus_scrape_config_dir: "{{ prometheus_config_dir }}/scrape_configs.d"
 
-    - name: Create prometheus datasource in grafana
-      ansible.builtin.uri:
-        url: http://{{ grafana_host_address | default(ansible_facts.default_ipv4.address) }}:{{ grafana_port }}/api/datasources
-        url_username: "{{ grafana_username }}"
-        url_password: "{{ grafana_password }}"
-        status_code: [200, 409]
-        force_basic_auth: true
-        method: POST
-        body_format: json
-        headers:
-          Accept: application/json
-          Content-Type: application/json
-        body: "{{ lookup('ansible.builtin.template', 'prometheus_datasource.json.j2') }}"
-      no_log: true
+    - name: Check rootless Prometheus user linger
+      ansible.builtin.command:
+        argv:
+          - loginctl
+          - show-user
+          - "{{ prometheus_rootless_user }}"
+          - --property=Linger
+          - --value
+      register: prometheus_linger_check
+      changed_when: false
+      failed_when: false
+      when:
+        - prometheus_rootless | bool
+        - prometheus_enable_linger | bool
 
-    - name: Create microshift perf dashboard in grafana
-      ansible.builtin.uri:
-        url: http://{{ grafana_host_address | default(ansible_facts.default_ipv4.address) }}:{{ grafana_port }}/api/dashboards/db
-        url_username: "{{ grafana_username }}"
-        url_password: "{{ grafana_password }}"
-        force_basic_auth: true
-        method: POST
-        body_format: json
-        headers:
-          Accept: application/json
-          Content-Type: application/json
-        body: "{{ lookup('ansible.builtin.template', 'grafana_dashboard.json.j2') }}"
-      no_log: true
+    - name: Enable linger for rootless Prometheus user
+      ansible.builtin.command:
+        argv:
+          - loginctl
+          - enable-linger
+          - "{{ prometheus_rootless_user }}"
+      become: true
+      changed_when: true
+      when:
+        - prometheus_rootless | bool
+        - prometheus_enable_linger | bool
+        - prometheus_linger_check.stdout | default('') != 'yes'
+
+    - name: Wait for user systemd runtime directory
+      ansible.builtin.wait_for:
+        path: "{{ prometheus_user_runtime_dir }}"
+        timeout: 30
+        msg: >-
+          User systemd is not available for {{ prometheus_rootless_user }}
+          because {{ prometheus_user_runtime_dir }} does not exist.
+      when: prometheus_rootless | bool
+
+    - name: Verify podman is available
+      ansible.builtin.command:
+        argv:
+          - podman
+          - --version
+      changed_when: false
+
+    - name: Check Prometheus image
+      ansible.builtin.command:
+        argv:
+          - podman
+          - image
+          - exists
+          - "{{ prometheus_image }}"
+      register: prometheus_image_check
+      changed_when: false
+      failed_when: false
+
+    - name: Pull Prometheus image
+      ansible.builtin.command:
+        argv:
+          - podman
+          - pull
+          - "{{ prometheus_image }}"
+      register: prometheus_image_pull
+      retries: 3
+      delay: 5
+      until: prometheus_image_pull.rc == 0
+      changed_when: true
+      when: prometheus_image_check.rc != 0
+
+    - name: Create Prometheus config and quadlet directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - "{{ prometheus_config_dir }}"
+        - "{{ prometheus_scrape_config_dir }}"
+        - "{{ prometheus_quadlet_dir }}"
+
+    - name: Check Prometheus data volume
+      ansible.builtin.command:
+        argv:
+          - podman
+          - volume
+          - exists
+          - "{{ prometheus_data_volume }}"
+      register: prometheus_data_volume_check
+      changed_when: false
+      failed_when: false
+
+    - name: Create Prometheus data volume
+      ansible.builtin.command:
+        argv:
+          - podman
+          - volume
+          - create
+          - "{{ prometheus_data_volume }}"
+      changed_when: true
+      when: prometheus_data_volume_check.rc != 0
+
+    # Validate every fragment; rollback is limited to files managed by this role.
+    - name: Write and validate Prometheus configuration
+      block:
+        - name: Write Prometheus exporter configuration
+          ansible.builtin.template:
+            src: exporters.yml.j2
+            dest: "{{ prometheus_exporter_scrape_config }}"
+            mode: '0644'
+            setype: container_file_t
+            backup: true
+          register: prometheus_exporter_config_template
+
+        - name: Write Prometheus configuration
+          ansible.builtin.template:
+            src: prometheus.yml.j2
+            dest: "{{ prometheus_config_dir }}/prometheus.yml"
+            mode: '0644'
+            setype: container_file_t
+            backup: true
+          register: prometheus_config_template
+
+        - name: Validate Prometheus configuration
+          ansible.builtin.command:
+            argv:
+              - podman
+              - run
+              - --rm
+              - --entrypoint
+              - /bin/promtool
+              - --volume
+              - "{{ prometheus_config_dir }}:/etc/prometheus:ro,z"
+              - "{{ prometheus_image }}"
+              - check
+              - config
+              - /etc/prometheus/prometheus.yml
+          changed_when: false
+
+      rescue:
+        - name: Restore previous Prometheus exporter configuration
+          ansible.builtin.copy:
+            src: "{{ prometheus_exporter_config_template.backup_file }}"
+            dest: "{{ prometheus_exporter_scrape_config }}"
+            remote_src: true
+            mode: '0644'
+            setype: container_file_t
+          when:
+            - prometheus_exporter_config_template is defined
+            - prometheus_exporter_config_template.backup_file is defined
+
+        - name: Remove invalid new Prometheus exporter configuration
+          ansible.builtin.file:
+            path: "{{ prometheus_exporter_scrape_config }}"
+            state: absent
+          when:
+            - prometheus_exporter_config_template is defined
+            - prometheus_exporter_config_template.changed | default(false)
+            - prometheus_exporter_config_template.backup_file is not defined
+
+        - name: Restore previous Prometheus configuration
+          ansible.builtin.copy:
+            src: "{{ prometheus_config_template.backup_file }}"
+            dest: "{{ prometheus_config_dir }}/prometheus.yml"
+            remote_src: true
+            mode: '0644'
+            setype: container_file_t
+          when:
+            - prometheus_config_template is defined
+            - prometheus_config_template.backup_file is defined
+
+        - name: Remove invalid new Prometheus configuration
+          ansible.builtin.file:
+            path: "{{ prometheus_config_dir }}/prometheus.yml"
+            state: absent
+          when:
+            - prometheus_config_template is defined
+            - prometheus_config_template.changed | default(false)
+            - prometheus_config_template.backup_file is not defined
+
+        - name: Report Prometheus configuration validation failure
+          ansible.builtin.fail:
+            msg: >-
+              {{ ansible_failed_result.stderr
+              | default(ansible_failed_result.stdout, true)
+              | default(ansible_failed_result.msg, true)
+              | default('Prometheus configuration could not be written or validated', true) }}
+
+    - name: Write Prometheus quadlet
+      ansible.builtin.template:
+        src: prometheus.container.j2
+        dest: "{{ prometheus_quadlet_file }}"
+        mode: '0644'
+      register: prometheus_quadlet_template
+
+    - name: Reset failed Prometheus user unit state
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - --user
+          - reset-failed
+          - "{{ prometheus_systemd_unit }}"
+      changed_when: false
+      failed_when: false
+      environment:
+        XDG_RUNTIME_DIR: "{{ prometheus_user_runtime_dir }}"
+      when: prometheus_rootless | bool
+
+    - name: Reset failed Prometheus system unit state
+      ansible.builtin.command:
+        argv:
+          - systemctl
+          - reset-failed
+          - "{{ prometheus_systemd_unit }}"
+      changed_when: false
+      failed_when: false
+      when: not (prometheus_rootless | bool)
+
+    # Quadlet derives boot persistence from [Install]; generated units are not enabled directly.
+    - name: Start Prometheus service
+      ansible.builtin.systemd:
+        name: "{{ prometheus_systemd_unit }}"
+        scope: "{{ prometheus_systemd_scope }}"
+        daemon_reload: true
+        state: >-
+          {{ (
+            prometheus_config_template.changed
+            or prometheus_exporter_config_template.changed
+            or prometheus_quadlet_template.changed
+          ) | ternary('restarted', 'started') }}
+      environment:
+        "{{ prometheus_systemd_environment }}"
+
+    - name: Verify Prometheus readiness
+      block:
+        - name: Wait for Prometheus readiness
+          ansible.builtin.uri:
+            url: "{{ prometheus_local_url }}/-/ready"
+            status_code: 200
+          register: prometheus_ready
+          retries: 12
+          delay: 5
+          until: prometheus_ready.status == 200
+
+      rescue:
+        - name: Collect Prometheus user service journal
+          ansible.builtin.command:
+            argv:
+              - journalctl
+              - --user
+              - --unit
+              - "{{ prometheus_systemd_unit }}"
+              - --lines
+              - "50"
+              - --no-pager
+          register: prometheus_user_journal
+          changed_when: false
+          failed_when: false
+          environment:
+            XDG_RUNTIME_DIR: "{{ prometheus_user_runtime_dir }}"
+          when: prometheus_rootless | bool
+
+        - name: Collect Prometheus system service journal
+          ansible.builtin.command:
+            argv:
+              - journalctl
+              - --unit
+              - "{{ prometheus_systemd_unit }}"
+              - --lines
+              - "50"
+              - --no-pager
+          register: prometheus_system_journal
+          changed_when: false
+          failed_when: false
+          when: not (prometheus_rootless | bool)
+
+        - name: Collect Prometheus container logs
+          ansible.builtin.command:
+            argv:
+              - podman
+              - logs
+              - --tail
+              - "50"
+              - "{{ prometheus_managed_container_name }}"
+          register: prometheus_container_logs
+          changed_when: false
+          failed_when: false
+
+        - name: Report Prometheus readiness failure
+          ansible.builtin.fail:
+            msg: |-
+              Prometheus did not become ready: {{ ansible_failed_result.msg | default('readiness check failed') }}
+
+              systemd journal:
+              {{
+                (
+                  prometheus_user_journal.stdout
+                  | default(prometheus_user_journal.stderr, true)
+                  | default('No user journal output', true)
+                )
+                if (prometheus_rootless | bool)
+                else (
+                  prometheus_system_journal.stdout
+                  | default(prometheus_system_journal.stderr, true)
+                  | default('No system journal output', true)
+                )
+              }}
+
+              container logs:
+              {{ prometheus_container_logs.stdout
+              | default(prometheus_container_logs.stderr, true)
+              | default('No container log output', true) }}
+
+    - name: Mark Prometheus as managed
+      ansible.builtin.set_fact:
+        prometheus_container_managed: true

--- a/ansible/roles/install-logging/templates/exporters.yml.j2
+++ b/ansible/roles/install-logging/templates/exporters.yml.j2
@@ -1,0 +1,33 @@
+{% macro prometheus_target(address, port) -%}
+{% set address = address | string -%}
+{{ ('[' ~ address ~ ']') if ':' in address and not address.startswith('[') else address }}:{{ port }}
+{%- endmacro %}
+{% set microshift_hosts = groups.get('microshift', []) %}
+{% if microshift_hosts | length > 0 %}
+scrape_configs:
+  - job_name: node
+    static_configs:
+{% for host in microshift_hosts %}
+      - targets: ['{{ prometheus_target(hostvars[host].ansible_host | default(host), 9100) }}']
+        labels:
+          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
+{% endfor %}
+
+  - job_name: process
+    static_configs:
+{% for host in microshift_hosts %}
+      - targets: ['{{ prometheus_target(hostvars[host].ansible_host | default(host), 9256) }}']
+        labels:
+          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
+{% endfor %}
+
+  - job_name: crio
+    static_configs:
+{% for host in microshift_hosts %}
+      - targets: ['{{ prometheus_target(hostvars[host].ansible_host | default(host), 9537) }}']
+        labels:
+          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
+{% endfor %}
+{% else %}
+scrape_configs: []
+{% endif %}

--- a/ansible/roles/install-logging/templates/prometheus.container.j2
+++ b/ansible/roles/install-logging/templates/prometheus.container.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=MicroShift Prometheus
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+Image={{ prometheus_image }}
+ContainerName={{ prometheus_container_name }}
+PublishPort={{ prometheus_host_address }}:{{ prometheus_port }}:{{ prometheus_container_port }}
+Volume={{ prometheus_config_dir }}:/etc/prometheus:ro,z
+Volume={{ prometheus_data_volume }}:/prometheus
+StopTimeout={{ prometheus_stop_timeout }}
+Exec=--config.file=/etc/prometheus/prometheus.yml --config.auto-reload --config.auto-reload-interval={{ prometheus_auto_reload_interval }} --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.listen-address=0.0.0.0:{{ prometheus_container_port }} --storage.tsdb.retention.time={{ prometheus_retention_time }}{% if prometheus_retention_size | length > 0 %} --storage.tsdb.retention.size={{ prometheus_retention_size }}{% endif %}
+
+[Service]
+Restart=always
+TimeoutStartSec=120
+TimeoutStopSec={{ (prometheus_stop_timeout | int) + 10 }}
+
+[Install]
+WantedBy=default.target

--- a/ansible/roles/install-logging/templates/prometheus.yml.j2
+++ b/ansible/roles/install-logging/templates/prometheus.yml.j2
@@ -1,50 +1,17 @@
 global:
-  scrape_interval:     5s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  scrape_timeout:      5s
+  scrape_interval: {{ prometheus_scrape_interval }}
+  evaluation_interval: {{ prometheus_evaluation_interval }}
+  scrape_timeout: {{ prometheus_scrape_timeout }}
 
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
   external_labels:
-      monitor: 'example'
+    monitor: microshift-ci
 
-# Alertmanager configuration
-alerting:
-  alertmanagers:
-  - static_configs:
-    - targets: ['localhost:9093']
+rule_files: []
 
-# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
-rule_files:
-  # - "first_rules.yml"
-  # - "second_rules.yml"
+scrape_config_files:
+  - scrape_configs.d/*.yml
 
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:{{ prometheus_port }}']
-
-  - job_name: node
-    static_configs:
-{% for host in groups['microshift'] %}
-      - targets: ['{{ host }}:9100']
-        labels:
-          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
-{% endfor %}
-
-  - job_name: process
-    static_configs:
-{% for host in groups['microshift'] %}
-      - targets: ['{{ host }}:9256']
-        labels:
-          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
-{% endfor %}
-
-  - job_name: crio
-    static_configs:
-{% for host in groups['microshift'] %}
-      - targets: ['{{ host }}:9537']
-        labels:
-          instance: '{{ hostvars[host].kubernetes_nodename | default(host) }}'
-{% endfor %}
+      - targets: ['localhost:{{ prometheus_container_port }}']

--- a/ansible/setup-node.yml
+++ b/ansible/setup-node.yml
@@ -58,7 +58,6 @@
 
 - name: Set up logging node
   hosts: logging
-  become: yes
   vars_files:
   - vars/all.yml
   roles:
@@ -74,7 +73,6 @@
 
 - name: Add kubelet endpoint to prometheus
   hosts: logging
-  become: true
   gather_facts: false
   vars_files:
     - vars/all.yml


### PR DESCRIPTION
Replace the RPM Prometheus+Grafana install in the ansible logging roles with a rootless podman Quadlet deployment that is versioned, self-contained, and better suited to ephemeral CI hosts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Prometheus is now deployed as a Podman-managed container via Quadlet on a dedicated logging host.
  - Automatic metric scraping for MicroShift components (node/process/CRI-O) plus kubelet and cAdvisor endpoints.
  - Prometheus scrape configuration is validated before applying, persisted with rollbacks on failure, and hot-reloaded when changes occur.
  - Deployment includes readiness checks and clearer diagnostics if startup fails; it also avoids conflicts with existing Prometheus services/ports.
- **Documentation**
  - Updated instructions to access metrics via the Prometheus web UI on the logging host (`http://<logging-host-ip>:9091`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->