### PR TITLE
NO-ISSUE: use reqpart in devenv kickstart for RHEL 10 BIOS+GPT compatibility

### DIFF
--- a/scripts/devenv-builder/config/kickstart.ks.template
+++ b/scripts/devenv-builder/config/kickstart.ks.template
@@ -7,22 +7,22 @@ reboot
 # Configure network to use DHCP and activate on boot
 network --bootproto=dhcp --device=link --activate --onboot=on --hostname=REPLACE_HOST_NAME --noipv6
 
-# Partition disk with a 1GB boot XFS partition and an LVM volume containing system root
-# The remainder of the volume will be used by the CSI driver for storing data
+# Partition disk with an LVM volume containing system root.
+# Boot partitions are created automatically by anaconda based on the
+# firmware type (UEFI or BIOS) using the reqpart directive.
+# The remainder of the volume will be used by the CSI driver for storing data.
 #
-# For example, a 50GB disk with 45GB system root would be partitioned in the following way:
+# For example, a 50GB disk with 45GB system root would be partitioned as:
 #
 # NAME          MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
-# sda             8:0    0  50G  0 disk 
-# ├─sda1          8:1    0 200M  0 part /boot/efi
-# ├─sda2          8:1    0 800M  0 part /boot
-# └─sda2          8:2    0  49G  0 part 
+# sda             8:0    0  50G  0 disk
+# ├─sda1          8:1    0   1G  0 part /boot
+# └─sda2          8:2    0  49G  0 part
 #  └─rhel-root  253:0    0  45G  0 lvm  /sysroot
 #
 zerombr
 clearpart --all --initlabel
-part /boot/efi --fstype=efi --size=200
-part /boot --fstype=xfs --asprimary --size=800
+reqpart --add-boot
 part swap --fstype=swap --size=REPLACE_SWAP_SIZE
 part pv.01 --grow
 volgroup rhel pv.01

--- a/scripts/devenv-builder/manage-vm.sh
+++ b/scripts/devenv-builder/manage-vm.sh
@@ -61,6 +61,12 @@ function get_base_isofile {
         9.*)
             echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
             ;;
+        10)
+            echo "rhel-10.2-$(uname -m)-dvd.iso"
+            ;;
+        10.*)
+            echo "rhel-${rhel_version}-$(uname -m)-dvd.iso"
+            ;;
         *)
             echo "Unknown RHEL version ${rhel_version}" 1>&2
             exit 1


### PR DESCRIPTION
RHEL 10 anaconda defaults to GPT disk labels even in BIOS mode, which
requires a biosboot partition that the hard-coded EFI partition layout
did not provide. Replace the explicit boot partition directives with
reqpart --add-boot, matching the pattern used by all other kickstart
templates in the repo. This lets anaconda auto-create the correct
platform partition for any firmware type.

Also add RHEL 10 support to get_base_isofile in manage-vm.sh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for provisioning RHEL 10 installation ISO images.
  * Updated installation disk setup so required boot partitions are created automatically based on firmware type (UEFI vs BIOS).
* **Bug Fixes**
  * Improved virtual machine installation disk initialization and partition handling for more reliable provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->