### PR TITLE
USHIFT-6920: feat: add crypto_scan auto-rebase for cbom generation

### DIFF
--- a/scripts/auto-rebase/crypto_scan.sh
+++ b/scripts/auto-rebase/crypto_scan.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+SCANNER_IMAGE="images.paas.redhat.com/exd-sp-guild-security/rh-crypto-scanner-image:latest"
+REPOROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/../..")"
+CBOM_OUTPUT="${REPOROOT}/cbom-microshift.json"
+SPDX_OUTPUT="${REPOROOT}/sbom-microshift-crypto.spdx.json"
+
+echo "Running crypto scanner against MicroShift source..."
+echo "Scanner image: ${SCANNER_IMAGE}"
+echo "Source directory: ${REPOROOT}"
+
+if ! podman pull "${SCANNER_IMAGE}"; then
+  echo "WARNING: failed to pull scanner image, skipping CBOM generation" >&2
+  exit 0
+fi
+
+# The scanner skips directories named "vendor/" by default.
+# Mount vendor directories under non-skipped names so the scanner
+# processes them. The "deps/" directory is excluded because it is a
+# patched copy of upstream Kubernetes vendor and would duplicate
+# findings already covered by "vendor/".
+# We stage a scan directory with only the sources we want scanned.
+SCAN_DIR=$(mktemp -d)
+trap 'rm -rf "${SCAN_DIR}"' EXIT
+
+cp -a "${REPOROOT}/pkg" "${SCAN_DIR}/pkg"
+cp -a "${REPOROOT}/cmd" "${SCAN_DIR}/cmd"
+cp -a "${REPOROOT}/vendor" "${SCAN_DIR}/vendor-deps"
+cp -a "${REPOROOT}/etcd/cmd" "${SCAN_DIR}/etcd-cmd"
+cp -a "${REPOROOT}/etcd/vendor" "${SCAN_DIR}/etcd-deps"
+
+if ! podman run --rm \
+  -v "${SCAN_DIR}:/workspace:z" \
+  "${SCANNER_IMAGE}" \
+  /workspace > "${CBOM_OUTPUT}"; then
+  echo "WARNING: crypto scan failed, skipping CBOM generation" >&2
+  exit 0
+fi
+
+echo "CBOM generated: "
+ls -lh "${CBOM_OUTPUT}"
+
+# SPDX 2.3 has no native crypto asset support. As a workaround agreed
+# with prod sec, cryptoProperties are serialized into the SPDX package
+# "comment" field.
+if ! jq '{
+  spdxVersion: "SPDX-2.3",
+  dataLicense: "CC0-1.0",
+  SPDXID: "SPDXRef-DOCUMENT",
+  name: "MicroShift-CBOM",
+  documentNamespace: "https://microshift.io/spdx/cbom",
+  packages: (
+    [{
+      SPDXID: "SPDXRef-Package-RootPackage",
+      name: "microshift",
+      downloadLocation: "NOASSERTION",
+      filesAnalyzed: false
+    }] +
+    [.components[] | {
+      SPDXID: ("SPDXRef-Package-" + (.name | gsub("[^a-zA-Z0-9.-]"; "-"))),
+      name: .name,
+      comment: (.cryptoProperties | tojson),
+      description: "Converted CBOM component from CycloneDX to SPDX",
+      downloadLocation: "NOASSERTION",
+      filesAnalyzed: false
+    }]
+  ),
+  relationships: (
+    [{
+      spdxElementId: "SPDXRef-DOCUMENT",
+      relatedSpdxElement: "SPDXRef-Package-RootPackage",
+      relationshipType: "DESCRIBES"
+    }] +
+    [.components[] | {
+      spdxElementId: "SPDXRef-Package-RootPackage",
+      relatedSpdxElement: ("SPDXRef-Package-" + (.name | gsub("[^a-zA-Z0-9.-]"; "-"))),
+      relationshipType: "CONTAINS"
+    }]
+  )
+}' "${CBOM_OUTPUT}" > "${SPDX_OUTPUT}"; then
+  echo "WARNING: SPDX conversion failed" >&2
+  exit 0
+fi
+
+echo "SPDX generated: "
+ls -lh "${SPDX_OUTPUT}"

--- a/scripts/auto-rebase/crypto_scan.sh
+++ b/scripts/auto-rebase/crypto_scan.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+SCANNER_IMAGE="images.paas.redhat.com/exd-sp-guild-security/rh-crypto-scanner-image:latest"
+REPOROOT="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/../..")"
+CBOM_OUTPUT="${REPOROOT}/cbom-microshift.json"
+SPDX_OUTPUT="${REPOROOT}/sbom-microshift-crypto.spdx.json"
+
+# Setup rootless podman when running in a CI container where the
+# current user may not have a passwd entry or subuid/subgid ranges.
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+
+if [ -w /etc/subuid ] || [ ! -f /etc/subuid ]; then
+    PODMAN_USER=$(whoami)
+    PODMAN_START_ID=$(( $(id -u) + 1 ))
+    PODMAN_COUNT=$(( 65536 - PODMAN_START_ID ))
+    echo "${PODMAN_USER}:${PODMAN_START_ID}:${PODMAN_COUNT}" > /etc/subuid
+    echo "${PODMAN_USER}:${PODMAN_START_ID}:${PODMAN_COUNT}" > /etc/subgid
+fi
+
+mkdir -p "${HOME}/.config/containers"
+if [ ! -f "${HOME}/.config/containers/registries.conf" ]; then
+  cat > "${HOME}/.config/containers/registries.conf" <<EOF
+unqualified-search-registries = [
+  "registry.access.redhat.com",
+  "registry.redhat.io",
+  "docker.io"
+]
+short-name-mode = "enforcing"
+EOF
+fi
+if [ ! -f "${HOME}/.config/containers/storage.conf" ] && [ ! -d "${HOME}/.local/share/containers/storage" ]; then
+  cat > "${HOME}/.config/containers/storage.conf" <<EOF
+[storage]
+driver = "vfs"
+EOF
+fi
+
+echo "Running crypto scanner against MicroShift source..."
+echo "Scanner image: ${SCANNER_IMAGE}"
+echo "Source directory: ${REPOROOT}"
+
+if ! podman pull "${SCANNER_IMAGE}"; then
+  echo "WARNING: failed to pull scanner image, skipping CBOM generation" >&2
+  exit 0
+fi
+
+# The scanner skips directories named "vendor/" by default.
+# Mount vendor directories under non-skipped names so the scanner
+# processes them. The "deps/" directory is excluded because it is a
+# patched copy of upstream Kubernetes vendor and would duplicate
+# findings already covered by "vendor/".
+# We stage a scan directory with only the sources we want scanned.
+SCAN_DIR=$(mktemp -d)
+trap 'rm -rf "${SCAN_DIR}"' EXIT
+
+cp -a "${REPOROOT}/pkg" "${SCAN_DIR}/pkg"
+cp -a "${REPOROOT}/cmd" "${SCAN_DIR}/cmd"
+cp -a "${REPOROOT}/vendor" "${SCAN_DIR}/vendor-deps"
+cp -a "${REPOROOT}/etcd/cmd" "${SCAN_DIR}/etcd-cmd"
+cp -a "${REPOROOT}/etcd/vendor" "${SCAN_DIR}/etcd-deps"
+
+if ! podman run --rm \
+  -v "${SCAN_DIR}:/workspace:z" \
+  "${SCANNER_IMAGE}" \
+  /workspace > "${CBOM_OUTPUT}"; then
+  echo "WARNING: crypto scan failed, skipping CBOM generation" >&2
+  exit 0
+fi
+
+echo "CBOM generated: "
+ls -lh "${CBOM_OUTPUT}"
+
+# SPDX 2.3 has no native crypto asset support. As a workaround agreed
+# with prod sec, cryptoProperties are serialized into the SPDX package
+# "comment" field.
+if ! jq '{
+  spdxVersion: "SPDX-2.3",
+  dataLicense: "CC0-1.0",
+  SPDXID: "SPDXRef-DOCUMENT",
+  name: "MicroShift-CBOM",
+  documentNamespace: "https://microshift.io/spdx/cbom",
+  packages: (
+    [{
+      SPDXID: "SPDXRef-Package-RootPackage",
+      name: "microshift",
+      downloadLocation: "NOASSERTION",
+      filesAnalyzed: false
+    }] +
+    [.components[] | {
+      SPDXID: ("SPDXRef-Package-" + (.name | gsub("[^a-zA-Z0-9.-]"; "-"))),
+      name: .name,
+      comment: (.cryptoProperties | tojson),
+      description: "Converted CBOM component from CycloneDX to SPDX",
+      downloadLocation: "NOASSERTION",
+      filesAnalyzed: false
+    }]
+  ),
+  relationships: (
+    [{
+      spdxElementId: "SPDXRef-DOCUMENT",
+      relatedSpdxElement: "SPDXRef-Package-RootPackage",
+      relationshipType: "DESCRIBES"
+    }] +
+    [.components[] | {
+      spdxElementId: "SPDXRef-Package-RootPackage",
+      relatedSpdxElement: ("SPDXRef-Package-" + (.name | gsub("[^a-zA-Z0-9.-]"; "-"))),
+      relationshipType: "CONTAINS"
+    }]
+  )
+}' "${CBOM_OUTPUT}" > "${SPDX_OUTPUT}"; then
+  echo "WARNING: SPDX conversion failed" >&2
+  exit 0
+fi
+
+echo "SPDX generated: "
+ls -lh "${SPDX_OUTPUT}"

--- a/scripts/auto-rebase/rebase.sh
+++ b/scripts/auto-rebase/rebase.sh
@@ -1331,6 +1331,19 @@ rebase_to() {
         echo "No changes to buildfiles."
     fi
 
+    # Generate CBOM (Cryptographic Bill of Materials)
+    if [[ "${SKIP_CRYPTOSCAN:-}" != "true" ]]; then
+        title "## Generating CBOM (Cryptographic Bill of Materials)"
+        ./scripts/auto-rebase/crypto_scan.sh
+        if [[ -n "$(git status -s cbom-microshift.json sbom-microshift-crypto.spdx.json)" ]]; then
+            echo "Updating CBOM"
+            git add cbom-microshift.json sbom-microshift-crypto.spdx.json
+            git commit -m "update cbom"
+        else
+            echo "No changes to CBOM."
+        fi        
+    fi
+
     title "# Removing staging directory"
     rm -rf "${STAGING_DIR}"
 }

--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -22,6 +22,17 @@ check_semver_no_suffix() {
 }
 
 
+# Generate CBOM (Cryptographic Bill of Materials)
+if [[ "${CRYPTO_SCAN:-}" == "true" ]]; then
+    ./scripts/auto-rebase/crypto_scan.sh
+    if [[ -n "$(git status -s cbom-microshift.json sbom-microshift-crypto.spdx.json)" ]]; then
+        echo "Updating CBOM"
+        git add cbom-microshift.json sbom-microshift-crypto.spdx.json
+        git commit -m "update cbom"
+    fi
+    exit 0
+fi
+
 echo "Environment:"
 printenv
 


### PR DESCRIPTION
added auto-rebase crypto_scan.sh script for cbom generation. This script uses crypto-scanner-iamge to generate a CycloneDX document. It also provides a SPDX one, by implementing the [mapping](https://docs.google.com/document/d/1IvnOrCy0Lc5mUjNY2tI0yzzlvXvFF9SkX1Q2tPX5aXo) suggested by the prod sec team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated cryptographic scanning workflow that generates cryptographic inventory artifacts from the source tree.
  * Produces both CBOM (JSON) and SPDX 2.3 (JSON) reports, including cryptographic properties and component relationship mapping.
* **Automation / Improvements**
  * Enhanced the rebase job to optionally run the scan after rebasing, detect changes to the generated reports, and auto-stage and commit updates when needed.
  * Scan failures degrade gracefully by not blocking the rebase process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->