### PR TITLE
USHIFT-7267: fix conformance networking issues

### DIFF
--- a/assets/components/ovn/multi-node/master/daemonset.yaml
+++ b/assets/components/ovn/multi-node/master/daemonset.yaml
@@ -68,8 +68,8 @@ spec:
           echo "$(date -Iseconds) - starting ovn-northd"
           exec ovn-northd \
             --no-chdir "-vconsole:${OVN_LOG_LEVEL}" -vfile:off "-vPATTERN:console:%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m" \
-            --ovnnb-db "{{.OVN_NB_DB_LIST}}" \
-            --ovnsb-db "{{.OVN_SB_DB_LIST}}" \
+            --ovnnb-db "tcp:${K8S_NODE_IP}:{{.OVN_NB_PORT}}" \
+            --ovnsb-db "tcp:${K8S_NODE_IP}:{{.OVN_SB_PORT}}" \
             --pidfile /var/run/ovn/ovn-northd.pid &
 
           wait $!
@@ -179,7 +179,7 @@ spec:
                 done
 
                 #configure northd_probe_interval
-                OVN_NB_CTL="ovn-nbctl --db "{{.OVN_NB_DB_LIST}}""
+                OVN_NB_CTL="ovn-nbctl --no-leader-only"
                 northd_probe_interval=${OVN_NORTHD_PROBE_INTERVAL:-10000}
                 echo "Setting northd probe interval to ${northd_probe_interval} ms"
                 retries=0

--- a/assets/components/ovn/multi-node/master/daemonset.yaml
+++ b/assets/components/ovn/multi-node/master/daemonset.yaml
@@ -141,6 +141,8 @@ spec:
             --db-nb-cluster-local-proto=tcp \
             --no-monitor"
 
+          rm -f /run/ovn/ovnnb_db.sock
+
           echo "$(date -Iseconds) - starting nbdb"
 
           exec /usr/share/ovn/scripts/ovn-ctl \
@@ -285,6 +287,8 @@ spec:
             --db-sb-cluster-local-addr=$(bracketify ${K8S_NODE_IP}) \
             --db-sb-cluster-local-proto=tcp \
             --no-monitor"
+
+          rm -f /run/ovn/ovnsb_db.sock
 
           echo "$(date -Iseconds) - starting sbdb "
           exec /usr/share/ovn/scripts/ovn-ctl \

--- a/assets/components/ovn/multi-node/node/daemonset.yaml
+++ b/assets/components/ovn/multi-node/node/daemonset.yaml
@@ -55,6 +55,14 @@ spec:
           # K8S_NODE_IP triggers reconcilation of this daemon when node IP changes
           echo "$(date -Iseconds) - starting ovn-controller, Node: ${K8S_NODE} IP: ${K8S_NODE_IP}"
 
+          # Wait for the SBDB unix socket to appear. The sbdb container
+          # removes stale sockets and creates fresh ones on startup.
+          # Connecting to a stale socket would cause ovn-controller to
+          # cache a raft commit index higher than the fresh SBDB's.
+          echo "Waiting for SBDB socket..."
+          while [ ! -S /run/ovn/ovnsb_db.sock ]; do sleep 1; done
+          echo "SBDB socket ready"
+
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             --syslog-method="null" \

--- a/assets/components/ovn/single-node/master/daemonset.yaml
+++ b/assets/components/ovn/single-node/master/daemonset.yaml
@@ -133,6 +133,8 @@ spec:
           ovn_db_file="/etc/ovn/ovn${db}_db.db"
           OVN_ARGS="--db-nb-cluster-local-port=9643 --no-monitor"
 
+          rm -f /run/ovn/ovnnb_db.sock
+
           echo "$(date -Iseconds) - starting nbdb"
           exec /usr/share/ovn/scripts/ovn-ctl \
             ${OVN_ARGS} \
@@ -250,6 +252,8 @@ spec:
           ovn_db_file="/etc/ovn/ovn${db}_db.db"
 
           OVN_ARGS="--db-sb-cluster-local-port=9644 --no-monitor"
+
+          rm -f /run/ovn/ovnsb_db.sock
 
           echo "$(date -Iseconds) - starting sbdb "
           exec /usr/share/ovn/scripts/ovn-ctl \

--- a/assets/components/ovn/single-node/node/daemonset.yaml
+++ b/assets/components/ovn/single-node/node/daemonset.yaml
@@ -55,6 +55,14 @@ spec:
           # K8S_NODE_IP triggers reconcilation of this daemon when node IP changes
           echo "$(date -Iseconds) - starting ovn-controller, Node: ${K8S_NODE} IP: ${K8S_NODE_IP}"
 
+          # Wait for the SBDB unix socket to appear. The sbdb container
+          # removes stale sockets and creates fresh ones on startup.
+          # Connecting to a stale socket would cause ovn-controller to
+          # cache a raft commit index higher than the fresh SBDB's.
+          echo "Waiting for SBDB socket..."
+          while [ ! -S /run/ovn/ovnsb_db.sock ]; do sleep 1; done
+          echo "SBDB socket ready"
+
           exec ovn-controller unix:/var/run/openvswitch/db.sock -vfile:off \
             --no-chdir --pidfile=/var/run/ovn/ovn-controller.pid \
             --syslog-method="null" \

--- a/pkg/components/networking.go
+++ b/pkg/components/networking.go
@@ -110,13 +110,11 @@ func startCNIPlugin(ctx context.Context, cfg *config.Config, kubeconfigPath stri
 		return err
 	}
 
-	// Multinode only params: OVN_NB_DB_LIST, OVN_SB_DB_LIST, OVN_NB_PORT, OVN_SB_PORT
+	// Multinode only params: OVN_NB_PORT, OVN_SB_PORT
 	extraParams := assets.RenderParams{
 		"OVNConfig":      ovnConfig,
 		"KubeconfigPath": kubeconfigPath,
 		"KubeconfigDir":  filepath.Join(config.DataDir, "/resources/kubeadmin"),
-		"OVN_NB_DB_LIST": fmt.Sprintf("tcp:%s:%s", cfg.MultiNode.Controlplane, ovn.OVN_NB_PORT),
-		"OVN_SB_DB_LIST": fmt.Sprintf("tcp:%s:%s", cfg.MultiNode.Controlplane, ovn.OVN_SB_PORT),
 		"OVN_NB_PORT":    ovn.OVN_NB_PORT,
 		"OVN_SB_PORT":    ovn.OVN_SB_PORT,
 	}

--- a/pkg/config/multinode.go
+++ b/pkg/config/multinode.go
@@ -2,9 +2,6 @@ package config
 
 type MultiNodeConfig struct {
 	Enabled bool `json:"enabled"`
-	// only one controlplane node is supported
-	// IP address of control plane node
-	Controlplane string `json:"controlplane"`
 }
 
 // ConfigMultiNode populates multinode configurations to Config.MultiNode
@@ -13,6 +10,5 @@ func ConfigMultiNode(c *Config, enabled bool) *Config {
 		return c
 	}
 	c.MultiNode.Enabled = enabled
-	c.MultiNode.Controlplane = c.Node.NodeIP
 	return c
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OVN database startup reliability by removing stale socket files before services launch.
  * Ensured OVN controllers wait until the database socket is ready before connecting.
  * Updated multinode database connection handling to use node-specific endpoints.
  * Simplified multinode configuration by removing obsolete control-plane settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->