### PR TITLE
USHIFT-7349: tolerate podman image cleanup failures in cleanup-composer.sh

### DIFF
--- a/scripts/devenv-builder/cleanup-composer.sh
+++ b/scripts/devenv-builder/cleanup-composer.sh
@@ -25,8 +25,8 @@ clean_podman_images() {
     if [ "${FULL_CLEAN}" = 1 ] ; then
         title "Cleaning up container images"
 
-        sudo podman rmi -af
-        podman rmi -af
+        sudo podman rmi -af || true
+        podman rmi -af || true
         # Ensure the user-specific container storage is deleted
         sudo rm -rf ~/.local/share/containers/
     fi


### PR DESCRIPTION
A stuck container that won't stop within the podman timeout causes `podman rmi -af` to fail, which with `set -e` kills the entire iso-build step even when all builds actually succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment cleanup reliability by allowing container image removal to continue when no removable images are found or a removal command returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->