### PR TITLE
USHIFT-7405: pass timeout to oc wait in Named VolumeSnapshot Should B…

### DIFF
--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -151,7 +151,9 @@ Named VolumeSnapshot Should Be Ready
     ...    ${name}    Name of volumesnapshot to wait for
     ...    ${timeout}    Period of time to wait for volumeSnapshot ready "readyToUse" state.
     [Arguments]    ${name}    ${timeout}=${DEFAULT_WAIT_TIMEOUT}
-    Oc Wait    volumesnapshot/${name} -n ${NAMESPACE}    --for=jsonpath='{.status.readyToUse}=true'
+    Oc Wait
+    ...    volumesnapshot/${name} -n ${NAMESPACE}
+    ...    --for=jsonpath='{.status.readyToUse}=true' --timeout=${timeout}
 
 Named VolumeSnapshot Should Be Deleted
     [Documentation]    Wait for volumesnapshot with ${name} to be deleted


### PR DESCRIPTION
…e Ready

The keyword accepted a timeout parameter but never forwarded it to the Oc Wait call, causing oc wait to use its 30s default instead of the intended 120s DEFAULT_WAIT_TIMEOUT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Volume snapshot readiness checks now honor the configured timeout, preventing waits from running indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->