### PR TITLE
USHIFT-7407: Wire prometheus receiver scrape.d drop-ins for metrics exporters

### DIFF
--- a/assets/optional/observability/02-cluster-role.yaml
+++ b/assets/optional/observability/02-cluster-role.yaml
@@ -7,10 +7,11 @@ rules:
   - apiGroups: [""]
     resources: ["nodes/stats"]
     verbs: ["get"]
-  # OpenTelemetry Component: k8s_event receiver
+  # OpenTelemetry Component: k8s_event receiver, prometheus receiver (endpoints SD)
   - apiGroups:
     - ""
     resources:
+    - endpoints
     - events
     - namespaces
     - namespaces/status
@@ -64,7 +65,7 @@ rules:
       - get
       - list
       - watch
-  # OpenTelemetry Component: prometheus receiver scraping metrics-server
+  # OpenTelemetry Component: prometheus receiver (kube-rbac-proxy authorization)
   - nonResourceURLs:
       - /metrics
     verbs:

--- a/assets/optional/observability/02-cluster-role.yaml
+++ b/assets/optional/observability/02-cluster-role.yaml
@@ -64,3 +64,8 @@ rules:
       - get
       - list
       - watch
+  # OpenTelemetry Component: prometheus receiver scraping metrics-server
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get

--- a/packaging/observability/opentelemetry-collector-large.yaml
+++ b/packaging/observability/opentelemetry-collector-large.yaml
@@ -112,7 +112,7 @@ service:
       receivers: [ journald ]
       processors: [ resourcedetection/system ]
       exporters: [ otlp ]
-    metrics/pods:
+    metrics/scrape:
       receivers: [ prometheus ]
       processors: [ batch ]
       exporters: [ otlp ]

--- a/packaging/observability/opentelemetry-collector-large.yaml
+++ b/packaging/observability/opentelemetry-collector-large.yaml
@@ -4,6 +4,7 @@
 # - Host's CPU, memory, disk, and network usage metrics
 # - System journals for selected MicroShift services and dependencies, priority < Info
 # - Metrics exposed by Pods that have "prometheus.io/scrape": "true" annotation
+# - Metrics from optional component scrape configs (scrape.d drop-ins)
 
 receivers:
   kubeletstats:

--- a/packaging/observability/opentelemetry-collector-large.yaml
+++ b/packaging/observability/opentelemetry-collector-large.yaml
@@ -40,6 +40,8 @@ receivers:
     priority: info
   prometheus:
     config:
+      scrape_config_files:
+        - /etc/microshift/observability/scrape.d/*.yaml
       scrape_configs:
         - job_name: k8s
           scrape_interval: 10s

--- a/packaging/observability/opentelemetry-collector-medium.yaml
+++ b/packaging/observability/opentelemetry-collector-medium.yaml
@@ -4,6 +4,10 @@
 # - System journal for MicroShift service, priority < Info
 
 receivers:
+  prometheus:
+    config:
+      scrape_config_files:
+        - /etc/microshift/observability/scrape.d/*.yaml
   kubeletstats:
     auth_type: tls
     ca_file: /var/lib/microshift/certs/ca-bundle/client-ca.crt
@@ -48,6 +52,10 @@ extensions:
 service:
   extensions: [ file_storage ]
   pipelines:
+    metrics/scrape:
+      receivers: [ prometheus ]
+      processors: [ batch ]
+      exporters: [ otlp ]
     metrics/kubeletstats:
       receivers: [ kubeletstats ]
       processors: [ batch ]

--- a/packaging/observability/opentelemetry-collector-medium.yaml
+++ b/packaging/observability/opentelemetry-collector-medium.yaml
@@ -2,6 +2,7 @@
 # - Resource usage metrics of MicroShift's Containers, Pods, Volumes, and Node
 # - Kubernetes Events
 # - System journal for MicroShift service, priority < Info
+# - Metrics from optional component scrape configs (scrape.d drop-ins)
 
 receivers:
   prometheus:

--- a/packaging/observability/opentelemetry-collector-small.yaml
+++ b/packaging/observability/opentelemetry-collector-small.yaml
@@ -1,6 +1,7 @@
 # Following file contains OpenTelemetry Collector configuration that exports:
 # - Resource usage metrics of MicroShift's Containers, Pods, Volumes, and Node
 # - Kubernetes Events
+# - Metrics from optional component scrape configs (scrape.d drop-ins)
 
 receivers:
   prometheus:

--- a/packaging/observability/opentelemetry-collector-small.yaml
+++ b/packaging/observability/opentelemetry-collector-small.yaml
@@ -3,6 +3,10 @@
 # - Kubernetes Events
 
 receivers:
+  prometheus:
+    config:
+      scrape_config_files:
+        - /etc/microshift/observability/scrape.d/*.yaml
   kubeletstats:
     auth_type: tls
     ca_file: /var/lib/microshift/certs/ca-bundle/client-ca.crt
@@ -43,6 +47,10 @@ extensions:
 service:
   extensions: [ file_storage ]
   pipelines:
+    metrics/scrape:
+      receivers: [ prometheus ]
+      processors: [ batch ]
+      exporters: [ otlp ]
     metrics/kubeletstats:
       receivers: [ kubeletstats ]
       processors: [ batch ]

--- a/packaging/observability/scrape.d/kube-state-metrics.yaml
+++ b/packaging/observability/scrape.d/kube-state-metrics.yaml
@@ -1,0 +1,37 @@
+scrape_configs:
+  - job_name: kube-state-metrics
+    scrape_interval: 30s
+    scheme: https
+    tls_config:
+      ca_file: /var/lib/microshift/certs/service-ca/ca.crt
+      cert_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.crt
+      key_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.key
+      server_name: kube-state-metrics.openshift-monitoring.svc
+    kubernetes_sd_configs:
+      - kubeconfig_file: /var/lib/microshift/resources/observability-client/kubeconfig
+        role: endpoints
+        namespaces:
+          names:
+            - openshift-monitoring
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: kube-state-metrics;https-main
+  - job_name: kube-state-metrics-self
+    scrape_interval: 30s
+    scheme: https
+    tls_config:
+      ca_file: /var/lib/microshift/certs/service-ca/ca.crt
+      cert_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.crt
+      key_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.key
+      server_name: kube-state-metrics.openshift-monitoring.svc
+    kubernetes_sd_configs:
+      - kubeconfig_file: /var/lib/microshift/resources/observability-client/kubeconfig
+        role: endpoints
+        namespaces:
+          names:
+            - openshift-monitoring
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: kube-state-metrics;https-self

--- a/packaging/observability/scrape.d/kube-state-metrics.yaml
+++ b/packaging/observability/scrape.d/kube-state-metrics.yaml
@@ -1,6 +1,6 @@
 scrape_configs:
   - job_name: kube-state-metrics
-    scrape_interval: 30s
+    scrape_interval: 10s
     scheme: https
     tls_config:
       ca_file: /var/lib/microshift/certs/service-ca/ca.crt
@@ -18,7 +18,7 @@ scrape_configs:
         action: keep
         regex: kube-state-metrics;https-main
   - job_name: kube-state-metrics-self
-    scrape_interval: 30s
+    scrape_interval: 10s
     scheme: https
     tls_config:
       ca_file: /var/lib/microshift/certs/service-ca/ca.crt

--- a/packaging/observability/scrape.d/metrics-server.yaml
+++ b/packaging/observability/scrape.d/metrics-server.yaml
@@ -1,6 +1,6 @@
 scrape_configs:
   - job_name: metrics-server
-    scrape_interval: 30s
+    scrape_interval: 10s
     scheme: https
     tls_config:
       ca_file: /var/lib/microshift/certs/service-ca/ca.crt

--- a/packaging/observability/scrape.d/metrics-server.yaml
+++ b/packaging/observability/scrape.d/metrics-server.yaml
@@ -1,0 +1,19 @@
+scrape_configs:
+  - job_name: metrics-server
+    scrape_interval: 30s
+    scheme: https
+    tls_config:
+      ca_file: /var/lib/microshift/certs/service-ca/ca.crt
+      cert_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.crt
+      key_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.key
+      server_name: metrics-server.openshift-monitoring.svc
+    kubernetes_sd_configs:
+      - kubeconfig_file: /var/lib/microshift/resources/observability-client/kubeconfig
+        role: endpoints
+        namespaces:
+          names:
+            - openshift-monitoring
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: metrics-server;https

--- a/packaging/observability/scrape.d/node-exporter.yaml
+++ b/packaging/observability/scrape.d/node-exporter.yaml
@@ -1,6 +1,6 @@
 scrape_configs:
   - job_name: node-exporter
-    scrape_interval: 30s
+    scrape_interval: 10s
     scheme: https
     tls_config:
       ca_file: /var/lib/microshift/certs/service-ca/ca.crt

--- a/packaging/observability/scrape.d/node-exporter.yaml
+++ b/packaging/observability/scrape.d/node-exporter.yaml
@@ -1,0 +1,19 @@
+scrape_configs:
+  - job_name: node-exporter
+    scrape_interval: 30s
+    scheme: https
+    tls_config:
+      ca_file: /var/lib/microshift/certs/service-ca/ca.crt
+      cert_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.crt
+      key_file: /var/lib/microshift/certs/admin-kubeconfig-signer/openshift-observability-client/client.key
+      server_name: node-exporter.openshift-monitoring.svc
+    kubernetes_sd_configs:
+      - kubeconfig_file: /var/lib/microshift/resources/observability-client/kubeconfig
+        role: endpoints
+        namespaces:
+          names:
+            - openshift-monitoring
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: node-exporter;https

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -623,6 +623,7 @@ install -p -m644 assets/optional/ai-model-serving/release-ai-model-serving-x86_6
 
 # observability
 install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/observability
+install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d
 install -p -m644 packaging/observability/*.yaml -D %{buildroot}%{_sysconfdir}/microshift/observability/
 # Explicit copy of large config as default. Not using symlink to avoid accidental package upgrade overwriting user config if the user edits the config without copying (i.e. edits the target of symlink).
 install -p -m644 packaging/observability/opentelemetry-collector-large.yaml -D %{buildroot}%{_sysconfdir}/microshift/observability/opentelemetry-collector.yaml
@@ -681,6 +682,9 @@ cat assets/optional/metrics-server/kustomization.aarch64.yaml >> %{buildroot}/%{
 cat assets/optional/metrics-server/kustomization.x86_64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server/kustomization.yaml
 %endif
 
+install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d
+install -p -m644 packaging/observability/scrape.d/metrics-server.yaml %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d/
+
 # metrics-server-release-info
 mkdir -p -m755 %{buildroot}%{_datadir}/microshift/release
 install -p -m644 assets/optional/metrics-server/release-metrics-server-{x86_64,aarch64}.json %{buildroot}%{_datadir}/microshift/release/
@@ -705,6 +709,9 @@ cat assets/optional/node-exporter/kustomization.aarch64.yaml >> %{buildroot}/%{_
 cat assets/optional/node-exporter/kustomization.x86_64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter/kustomization.yaml
 %endif
 
+install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d
+install -p -m644 packaging/observability/scrape.d/node-exporter.yaml %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d/
+
 # node-exporter-release-info
 mkdir -p -m755 %{buildroot}%{_datadir}/microshift/release
 install -p -m644 assets/optional/node-exporter/release-node-exporter-{x86_64,aarch64}.json %{buildroot}%{_datadir}/microshift/release/
@@ -727,6 +734,9 @@ cat assets/optional/kube-state-metrics/kustomization.aarch64.yaml >> %{buildroot
 %ifarch x86_64
 cat assets/optional/kube-state-metrics/kustomization.x86_64.yaml >> %{buildroot}/%{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics/kustomization.yaml
 %endif
+
+install -d -m755 %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d
+install -p -m644 packaging/observability/scrape.d/kube-state-metrics.yaml %{buildroot}/%{_sysconfdir}/microshift/observability/scrape.d/
 
 # kube-state-metrics-release-info
 mkdir -p -m755 %{buildroot}%{_datadir}/microshift/release
@@ -923,6 +933,7 @@ fi
 %files observability
 %dir %{_prefix}/lib/microshift/manifests.d/003-microshift-observability
 %dir %{_sysconfdir}/microshift/observability/
+%dir %{_sysconfdir}/microshift/observability/scrape.d/
 %{_unitdir}/microshift-observability.service
 %config(noreplace) %{_sysconfdir}/microshift/observability/opentelemetry-collector.yaml
 %{_sysconfdir}/microshift/observability/opentelemetry-collector-*.yaml
@@ -938,6 +949,7 @@ fi
 %files metrics-server
 %dir %{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server
 %{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server/*
+%config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/metrics-server.yaml
 
 %files metrics-server-release-info
 %{_datadir}/microshift/release/release-metrics-server-{x86_64,aarch64}.json
@@ -945,12 +957,14 @@ fi
 %files metrics-node-exporter
 %dir %{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter
 %{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter/*
+%config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/node-exporter.yaml
 
 %files metrics-node-exporter-release-info
 %{_datadir}/microshift/release/release-node-exporter-{x86_64,aarch64}.json
 %files metrics-kube-state
 %dir %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics
 %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics/*
+%config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/kube-state-metrics.yaml
 
 %files metrics-kube-state-release-info
 %{_datadir}/microshift/release/release-kube-state-metrics-{x86_64,aarch64}.json

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -949,6 +949,7 @@ fi
 %files metrics-server
 %dir %{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server
 %{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server/*
+%dir %{_sysconfdir}/microshift/observability/scrape.d
 %config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/metrics-server.yaml
 
 %files metrics-server-release-info
@@ -957,6 +958,7 @@ fi
 %files metrics-node-exporter
 %dir %{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter
 %{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter/*
+%dir %{_sysconfdir}/microshift/observability/scrape.d
 %config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/node-exporter.yaml
 
 %files metrics-node-exporter-release-info
@@ -964,6 +966,7 @@ fi
 %files metrics-kube-state
 %dir %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics
 %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics/*
+%dir %{_sysconfdir}/microshift/observability/scrape.d
 %config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/kube-state-metrics.yaml
 
 %files metrics-kube-state-release-info

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -950,6 +950,7 @@ fi
 %files metrics-server
 %dir %{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server
 %{_prefix}/lib/microshift/manifests.d/080-microshift-metrics-server/*
+%dir %{_sysconfdir}/microshift/observability
 %dir %{_sysconfdir}/microshift/observability/scrape.d
 %config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/metrics-server.yaml
 
@@ -959,6 +960,7 @@ fi
 %files metrics-node-exporter
 %dir %{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter
 %{_prefix}/lib/microshift/manifests.d/082-microshift-node-exporter/*
+%dir %{_sysconfdir}/microshift/observability
 %dir %{_sysconfdir}/microshift/observability/scrape.d
 %config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/node-exporter.yaml
 
@@ -968,6 +970,7 @@ fi
 %files metrics-kube-state
 %dir %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics
 %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics/*
+%dir %{_sysconfdir}/microshift/observability
 %dir %{_sysconfdir}/microshift/observability/scrape.d
 %config(noreplace) %{_sysconfdir}/microshift/observability/scrape.d/kube-state-metrics.yaml
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -303,6 +303,7 @@ Requires: microshift-release-info = %{version}
 The microshift-metrics-node-exporter-release-info package provides release information files for this
 release. These files contain the list of container image references used by node-exporter
 and can be used to embed those images into osbuilder blueprints or bootc containerfiles.
+
 %package metrics-kube-state
 Summary: Kubernetes kube-state-metrics for MicroShift
 ExclusiveArch: x86_64 aarch64
@@ -963,6 +964,7 @@ fi
 
 %files metrics-node-exporter-release-info
 %{_datadir}/microshift/release/release-node-exporter-{x86_64,aarch64}.json
+
 %files metrics-kube-state
 %dir %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics
 %{_prefix}/lib/microshift/manifests.d/081-microshift-kube-state-metrics/*

--- a/test/assets/observability/otel_config.yaml
+++ b/test/assets/observability/otel_config.yaml
@@ -1,5 +1,9 @@
 # This OTEL config is only for testing purposes
 receivers:
+  prometheus:
+    config:
+      scrape_config_files:
+        - /etc/microshift/observability/scrape.d/*.yaml
   hostmetrics:
     root_path: /
     collection_interval: 10s
@@ -67,6 +71,10 @@ extensions:
 service:
   extensions: [ file_storage ]
   pipelines:
+    metrics/scrape:
+      receivers: [ prometheus ]
+      processors: [ resourcedetection/system ]
+      exporters: [ prometheus, prometheusremotewrite ]
     metrics/hostmetrics:
       receivers: [ hostmetrics ]
       processors: [ resourcedetection/system ]

--- a/test/suites/optional/metrics.robot
+++ b/test/suites/optional/metrics.robot
@@ -114,9 +114,6 @@ Scrape Metrics From
     ...    ${METRICS_NS}
     ...    ${metrics_service}
     ...    .subsets[0].addresses[0].ip
-    ${ep_ip}=    Get Regexp Matches    ${ep_ip}    \\d+\\.\\d+\\.\\d+\\.\\d+
-    Length Should Be    ${ep_ip}    1
-    VAR    ${ep_ip}=    ${ep_ip}[0]
     VAR    ${svc_host}=    ${metrics_service}.${METRICS_NS}.svc
     ${stdout}=    Command Should Work
     ...    curl -s --resolve ${svc_host}:${port}:${ep_ip} --cacert ${SERVICE_CA} --cert ${CLIENT_CERT} --key ${CLIENT_KEY} https://${svc_host}:${port}/metrics

--- a/test/suites/optional/metrics.robot
+++ b/test/suites/optional/metrics.robot
@@ -109,11 +109,10 @@ Scrape Metrics From
     ...    with mTLS client certs. Resolves the IP from the Endpoints object
     ...    to validate that the headless Service selector matches the pod.
     [Arguments]    ${metrics_service}    ${port}
-    ${ep_ip}=    Oc Get JsonPath
-    ...    endpoints
-    ...    ${METRICS_NS}
-    ...    ${metrics_service}
-    ...    .subsets[0].addresses[0].ip
+    # Oc Get JsonPath uses Run With Kubeconfig which merges stderr into stdout;
+    # the v1 Endpoints deprecation warning from K8s 1.33+ pollutes the IP value.
+    ${ep_ip}=    Command Should Work
+    ...    oc get endpoints -n ${METRICS_NS} ${metrics_service} -o jsonpath\='{.subsets[0].addresses[0].ip}' --kubeconfig\=/var/lib/microshift/resources/kubeadmin/kubeconfig
     VAR    ${svc_host}=    ${metrics_service}.${METRICS_NS}.svc
     ${stdout}=    Command Should Work
     ...    curl -s --resolve ${svc_host}:${port}:${ep_ip} --cacert ${SERVICE_CA} --cert ${CLIENT_CERT} --key ${CLIENT_KEY} https://${svc_host}:${port}/metrics

--- a/test/suites/optional/observability.robot
+++ b/test/suites/optional/observability.robot
@@ -74,11 +74,9 @@ Node Exporter Metrics Are Exported Via Scrape Drop-In
 Metrics Server Metrics Are Exported Via Scrape Drop-In
     [Documentation]    The prometheus receiver should scrape metrics-server via the
     ...    scrape.d drop-in and export metrics to the prometheus exporter.
-    ...    TODO: replace rest_client_requests_total with a metrics-server-specific metric
-    ...    once confirmed against actual metrics-server /metrics output.
 
     Wait Until Keyword Succeeds    60s    5s
-    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    rest_client_requests_total
+    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    metrics_server_kubelet_request_total
 
 Logs Should Not Contain Receiver Errors
     [Documentation]    Internal receiver errors are not treated as fatal. Typically these are due to a misconfiguration

--- a/test/suites/optional/observability.robot
+++ b/test/suites/optional/observability.robot
@@ -57,6 +57,29 @@ Kube Events Logs Are Exported
     Wait Until Keyword Succeeds    10x    5s
     ...    Check Loki Query    ${LOKI_HOST}    ${LOKI_PORT}    {service_name="kube_events"}
 
+KSM Metrics Are Exported Via Scrape Drop-In
+    [Documentation]    The prometheus receiver should scrape kube-state-metrics via the
+    ...    scrape.d drop-in and export kube_node_info to the prometheus exporter.
+
+    Wait Until Keyword Succeeds    60s    5s
+    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    kube_node_info
+
+Node Exporter Metrics Are Exported Via Scrape Drop-In
+    [Documentation]    The prometheus receiver should scrape node-exporter via the
+    ...    scrape.d drop-in and export node_cpu_seconds_total to the prometheus exporter.
+
+    Wait Until Keyword Succeeds    60s    5s
+    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    node_cpu_seconds_total
+
+Metrics Server Metrics Are Exported Via Scrape Drop-In
+    [Documentation]    The prometheus receiver should scrape metrics-server via the
+    ...    scrape.d drop-in and export metrics to the prometheus exporter.
+    ...    TODO: replace rest_client_requests_total with a metrics-server-specific metric
+    ...    once confirmed against actual metrics-server /metrics output.
+
+    Wait Until Keyword Succeeds    60s    5s
+    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    rest_client_requests_total
+
 Logs Should Not Contain Receiver Errors
     [Documentation]    Internal receiver errors are not treated as fatal. Typically these are due to a misconfiguration
     ...    and thus indicate the provided default config should be reviewed.
@@ -71,7 +94,11 @@ Setup Suite And Prepare Test Host
     [Documentation]    The service starts after MicroShift starts and thus will start generating pertinent log data
     ...    right away. When the suite is executed, immediately get the cursor for the microshift-observability unit.
     Setup Suite
-    Setup MicroShift With Optionals    003-microshift-observability
+    Setup MicroShift With Optionals
+    ...    003-microshift-observability
+    ...    080-microshift-metrics-server
+    ...    081-microshift-kube-state-metrics
+    ...    082-microshift-node-exporter
     ${ns}    Create Unique Namespace
     VAR    ${NAMESPACE}    ${ns}    scope=SUITE
     Configure Firewall And Observability

--- a/test/suites/optional/observability.robot
+++ b/test/suites/optional/observability.robot
@@ -61,22 +61,25 @@ KSM Metrics Are Exported Via Scrape Drop-In
     [Documentation]    The prometheus receiver should scrape kube-state-metrics via the
     ...    scrape.d drop-in and export kube_node_info to the prometheus exporter.
 
-    Wait Until Keyword Succeeds    60s    5s
-    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    kube_node_info
+    VAR    ${METRIC}    kube_node_info    scope=TEST
+    Check Prometheus Query    ${PROMETHEUS_HOST}    ${PROMETHEUS_PORT}    ${METRIC}
+    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    ${METRIC}
 
 Node Exporter Metrics Are Exported Via Scrape Drop-In
     [Documentation]    The prometheus receiver should scrape node-exporter via the
     ...    scrape.d drop-in and export node_cpu_seconds_total to the prometheus exporter.
 
-    Wait Until Keyword Succeeds    60s    5s
-    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    node_cpu_seconds_total
+    VAR    ${METRIC}    node_cpu_seconds_total    scope=TEST
+    Check Prometheus Query    ${PROMETHEUS_HOST}    ${PROMETHEUS_PORT}    ${METRIC}
+    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    ${METRIC}
 
 Metrics Server Metrics Are Exported Via Scrape Drop-In
     [Documentation]    The prometheus receiver should scrape metrics-server via the
     ...    scrape.d drop-in and export metrics to the prometheus exporter.
 
-    Wait Until Keyword Succeeds    60s    5s
-    ...    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    metrics_server_kubelet_request_total
+    VAR    ${METRIC}    metrics_server_kubelet_request_total    scope=TEST
+    Check Prometheus Query    ${PROMETHEUS_HOST}    ${PROMETHEUS_PORT}    ${METRIC}
+    Check Prometheus Exporter    ${USHIFT_HOST}    ${PROM_EXPORTER_PORT}    ${METRIC}
 
 Logs Should Not Contain Receiver Errors
     [Documentation]    Internal receiver errors are not treated as fatal. Typically these are due to a misconfiguration


### PR DESCRIPTION
## Summary

- Adds `scrape_config_files: ["/etc/microshift/observability/scrape.d/*.yaml"]` to all three otel-col profiles (small/medium/large), enabling prometheus receiver to auto-discover drop-in scrape configs
- Ships three drop-in configs (`kube-state-metrics.yaml`, `node-exporter.yaml`, `metrics-server.yaml`) that use `kubernetes_sd_configs` with `role: endpoints` and mTLS to scrape each exporter's kube-rbac-proxy sidecar
- Each metrics RPM subpackage (`microshift-observability-metrics-server`, `-metrics-kube-state`, `-metrics-node-exporter`) owns its drop-in file with `%config(noreplace)`, so installing the metrics package automatically enables scraping when observability is present
- Grants `endpoints` list/watch to the `openshift-observability-client` ClusterRole for kubernetes_sd endpoint discovery
- Adds Robot Framework test cases that verify each exporter's characteristic metric appears in the otel-col prometheus export endpoint

## Design

The scrape.d directory uses a glob-based drop-in pattern: the otel-col prometheus receiver watches `/etc/microshift/observability/scrape.d/*.yaml` and picks up any file placed there. Each metrics RPM subpackage installs its own scrape config, so the set of active scrape targets is determined entirely by which packages are installed — no manual configuration needed.

All three exporters are scraped over HTTPS using the observability-client certificate (mTLS through kube-rbac-proxy) and discovered via kubernetes_sd `role: endpoints` in the `openshift-monitoring` namespace.

## Test plan

- [x] `test/suites/optional/observability.robot` — three new test cases verify characteristic metrics from each exporter (`kube_node_info`, `node_cpu_seconds_total`, `metrics_server_kubelet_request_total`)
- [x] `test/suites/optional/metrics.robot` — existing metrics test suite validates exporter deployment and service wiring
- [x] Manual verification on `ushift-devel-el98`: confirmed all three exporters scraped successfully with live mTLS

## JIRA

https://issues.redhat.com/browse/USHIFT-7407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metric scraping for metrics-server, node-exporter, and kube-state-metrics.
  * Added support for configurable scrape drop-ins across all OpenTelemetry Collector deployment sizes.
  * Enabled observability receivers to discover Kubernetes endpoints and access required metrics.

* **Bug Fixes**
  * Improved endpoint address resolution for metrics collection tests.

* **Tests**
  * Added coverage validating metrics from the newly supported observability components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->