### PR TITLE
USHIFT-7408: Add kernel-modules-extra dependency for RHEL 10

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -79,6 +79,13 @@ Requires: cri-tools >= 1.36.0, cri-tools < 1.37.0
 # the missing package when it is not available.
 Recommends: containernetworking-plugins
 Requires: iptables
+# RHEL 10 moved iptables compat kernel modules (nft_compat, xt_CT) from
+# kernel-modules-core to kernel-modules-extra. These are needed by OVN-K
+# and kubelet until OVN-K completes its nftables migration (OCPBUGS-98161).
+# The dependency is unconditional because the RPM is built on el9 (where
+# %{rhel} is 9) but cross-installed on el10, so conditionals do not work.
+# On RHEL 9 this is a no-op as the modules are already in kernel-modules-core.
+Requires: kernel-modules-extra
 Requires: microshift-selinux = %{version}
 Requires: microshift-networking = %{version}
 Requires: microshift-greenboot = %{version}


### PR DESCRIPTION
RHEL 10.2 kernel 6.12.0-211.34.1 moved iptables compat modules (nft_compat, xt_CT) from kernel-modules-core to kernel-modules-extra. Without these modules, both ovnkube-master and kubelet fail to create iptables rules, preventing MicroShift from starting.

Add an explicit Requires on kernel-modules-extra gated on RHEL 10+ to ensure the correct package is always installed. RHEL 9 is unaffected as the modules remain in kernel-modules-core there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added the required kernel modules package dependency to ensure networking compatibility on RHEL 10.
  * Maintained compatibility with RHEL 9, where the dependency has no effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->