### PR TITLE
USHIFT-7400: Increase C2CC DNS retry window to cover ConfigMap propag…

### DIFF
--- a/test/resources/c2cc.resource
+++ b/test/resources/c2cc.resource
@@ -473,9 +473,9 @@ Verify Dual Stack Source IP Preserved Between Clusters
     Should Contain    ${stdout}    source: ${curl_pod_ip}
 
 Verify DNS Resolution From Cluster
-    [Documentation]    Resolve a DNS name from curl-pod on the given cluster. Retries for up to 60s.
+    [Documentation]    Resolve a DNS name from curl-pod on the given cluster. Retries for up to 200s.
     [Arguments]    ${alias}    ${fqdn}
-    Wait Until Keyword Succeeds    12x    5s
+    Wait Until Keyword Succeeds    40x    5s
     ...    Verify DNS Lookup    ${alias}    ${fqdn}
 
 Verify DNS Lookup
@@ -495,7 +495,7 @@ Verify All RemoteClusters Healthy
 Verify Curl DNS From Cluster
     [Documentation]    Curl a service by DNS name from curl-pod on the given cluster.
     [Arguments]    ${alias}    ${fqdn}    ${port}
-    ${stdout}=    Wait Until Keyword Succeeds    12x    5s
+    ${stdout}=    Wait Until Keyword Succeeds    40x    5s
     ...    Verify Curl DNS    ${alias}    ${fqdn}    ${port}
     RETURN    ${stdout}
 


### PR DESCRIPTION
…ation delay

The 60s retry window (12x 5s) was insufficient to cover Kubernetes ConfigMap volume propagation which can take 60-120s. Increase to 200s (40x 5s) in both DNS resolution and curl verification keywords.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for cluster-based DNS resolution and curl verification checks.
  * Extended retry windows to better accommodate temporary network or DNS delays.

* **Documentation**
  * Updated timeout and retry guidance for the affected verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->