### PR TITLE
[release-4.21] USHIFT-7427: pin origin to known-good commit in openshift-tests-private build

### DIFF
--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -291,6 +291,13 @@ gettool_ginkgo() {
         return 1
     fi
 
+    # Workaround: pin origin to known-good commit to avoid cgroups/kubernetes
+    # type mismatch caused by openshift/origin bump(k8s) on Jul 24 2026.
+    # The Makefile runs 'go get -u github.com/openshift/origin@main' which
+    # pulls in incompatible dependency versions. Pin to last working commit.
+    # See: https://redhat.atlassian.net/browse/USHIFT-7427
+    sed -i 's|@main|@398edca0cfe4|g' Makefile
+
     # Build the binary
     make all
 


### PR DESCRIPTION
## Summary
Pin `openshift/origin` to the last known-good commit (`398edca0cfe4`) in the `openshift-tests-private` Makefile to fix `extended-platform-tests` binary compilation failure.

## Problem
The `openshift-tests-private` Makefile runs `go get -u github.com/openshift/origin@main` which, since Jul 24, pulls in `opencontainers/cgroups v0.0.6` (changed `PidsLimit` from `int64` to `*int64`). This is incompatible with the pinned `openshift/kubernetes` version, causing a build failure.

## Fix
Patch the Makefile before `make all` to pin origin to the last working commit.

Cherry-pick of https://github.com/openshift/microshift/pull/7108

## Jira
- Workaround: https://redhat.atlassian.net/browse/USHIFT-7427
- Upstream fix: https://redhat.atlassian.net/browse/ART-21781
- Cleanup: https://redhat.atlassian.net/browse/USHIFT-7428