### PR TITLE
[release-4.22] USHIFT-7427: pin origin to known-good commit in openshift-tests-private build

### DIFF
--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -328,6 +328,11 @@ gettool_ginkgo() {
         return 1
     fi
 
+    # Workaround: use origin release branch instead of main to avoid
+    # cgroups/kubernetes type mismatch after origin bump(k8s) on Jul 24 2026.
+    # See: https://redhat.atlassian.net/browse/USHIFT-7427
+    sed -i 's|@main|@release-4.22|g' Makefile
+
     # Build the binary
     make all
 


### PR DESCRIPTION
## Summary
Pin `openshift/origin` to the last known-good commit (`398edca0cfe4`) in the `openshift-tests-private` Makefile to fix `extended-platform-tests` binary compilation failure.

## Problem
The `openshift-tests-private` Makefile runs `go get -u github.com/openshift/origin@main` which, since Jul 24, pulls in `opencontainers/cgroups v0.0.6` (changed `PidsLimit` from `int64` to `*int64`). This is incompatible with the pinned `openshift/kubernetes` version, causing a build failure.

## Fix
Patch the Makefile before `make all` to pin origin to the last working commit.

Cherry-pick of https://github.com/openshift/microshift/pull/7108

## Jira
- Workaround: https://redhat.atlassian.net/browse/USHIFT-7427
- Upstream fix: https://redhat.atlassian.net/browse/ART-21781
- Cleanup: https://redhat.atlassian.net/browse/USHIFT-7428