### PR TITLE
USHIFT-7430: Fix uncore-cache test regex for kubelet JSON log format

### DIFF
--- a/test/suites/tuned/uncore-cache.robot
+++ b/test/suites/tuned/uncore-cache.robot
@@ -62,7 +62,7 @@ Verify Uncore-cache Feature Is Enabled
     ...    wait=5
     Pattern Should Appear In Log Output
     ...    ${cursor}
-    ...    kubelet I.*CPUManagerPolicyBetaOptions:true
+    ...    kubelet I.*CPUManagerPolicyBetaOptions":true
     ...    unit=microshift
     ...    wait=5
     Pattern Should Appear In Log Output


### PR DESCRIPTION
## Summary

- Fix `uncore-cache.robot` test regex that fails to match kubelet's JSON-formatted feature gate log output
- The kubelet logs `"CPUManagerPolicyBetaOptions":true` (JSON-quoted key), but the test pattern expected `CPUManagerPolicyBetaOptions:true` (no quote before colon), causing a ~154s retry loop and test failure
- Aligns with the existing pattern on line 70 which already uses JSON format (`prefer-align-cpus-by-uncorecache":"true"`)

## Test plan

- [ ] Verify `el98-src@low-latency` scenario passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated uncore-cache verification to recognize the current kubelet log format for `CPUManagerPolicyBetaOptions=true`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->