### PR TITLE
WIP: test OCPQE-32095 fix from mffiedler

### DIFF
--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -343,9 +343,9 @@ gettool_ginkgo() {
     # shellcheck source=test/bin/common_versions.sh
     source "${SCRIPT_DIR}/../test/bin/common_versions.sh"
 
-    local -r repo_url="https://${GITHUB_TOKEN}@github.com/openshift/openshift-tests-private.git"
-    local -r repo_branch="${OPENSHIFT_TESTS_PRIVATE_REPO_BRANCH}"
-    local -r repo_commit="${OPENSHIFT_TESTS_PRIVATE_REPO_COMMIT}"
+    local -r repo_url="https://${GITHUB_TOKEN}@github.com/mffiedler/openshift-tests-private.git"
+    local -r repo_branch="fix-build-docker-api-and-kubernetes-dep"
+    local -r repo_commit=""
     local clone_dir="${WORK_DIR}/openshift-tests-private"
     
     local -r binary_path="${GINKGO_TEST_BINARY}"
@@ -362,7 +362,7 @@ gettool_ginkgo() {
     mkdir -p "$(dirname "${binary_path}")"
 
     # Clone repository with release branch preference
-    if ! git clone --depth 1000 --branch "${repo_branch}" "${repo_url}" "${clone_dir}" 2>/dev/null; then
+    if ! git clone --depth 1 --branch "${repo_branch}" "${repo_url}" "${clone_dir}" 2>/dev/null; then
         echo "Error: Failed to clone repository"
         return 1
     fi
@@ -370,17 +370,12 @@ gettool_ginkgo() {
     pushd "${clone_dir}" &>/dev/null
 
     # Checkout a valid commit to be sure ginkgo tests are working
-    if ! (git checkout --quiet "${repo_commit}"); then
-        echo "Error: Failed to checkout specific commit"
-        return 1
+    if [[ -n "${repo_commit}" ]]; then
+        if ! (git checkout --quiet "${repo_commit}"); then
+            echo "Error: Failed to checkout specific commit"
+            return 1
+        fi
     fi
-
-    # Workaround: pin origin to known-good commit to avoid cgroups/kubernetes
-    # type mismatch caused by openshift/origin bump(k8s) on Jul 24 2026.
-    # The Makefile runs 'go get -u github.com/openshift/origin@main' which
-    # pulls in incompatible dependency versions. Pin to last working commit.
-    # See: https://redhat.atlassian.net/browse/USHIFT-7427
-    sed -i 's|@main|@398edca0cfe4|g' Makefile
 
     # Build the binary
     make all

--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -343,8 +343,9 @@ gettool_ginkgo() {
     # shellcheck source=test/bin/common_versions.sh
     source "${SCRIPT_DIR}/../test/bin/common_versions.sh"
 
-    local -r repo_url="https://${GITHUB_TOKEN}@github.com/mffiedler/openshift-tests-private.git"
-    local -r repo_branch="fix-build-docker-api-and-kubernetes-dep"
+    local -r repo_url="https://${GITHUB_TOKEN}@github.com/openshift/openshift-tests-private.git"
+    local -r repo_branch="main"
+    local -r repo_pr="30086"
     local -r repo_commit=""
     local clone_dir="${WORK_DIR}/openshift-tests-private"
     
@@ -369,8 +370,14 @@ gettool_ginkgo() {
 
     pushd "${clone_dir}" &>/dev/null
 
-    # Checkout a valid commit to be sure ginkgo tests are working
-    if [[ -n "${repo_commit}" ]]; then
+    # Fetch PR head ref to test mffiedler's fix for OCPQE-32095
+    if [[ -n "${repo_pr}" ]]; then
+        if ! git fetch origin "pull/${repo_pr}/head:pr-${repo_pr}" || \
+           ! git checkout "pr-${repo_pr}"; then
+            echo "Error: Failed to fetch/checkout PR #${repo_pr}"
+            return 1
+        fi
+    elif [[ -n "${repo_commit}" ]]; then
         if ! (git checkout --quiet "${repo_commit}"); then
             echo "Error: Failed to checkout specific commit"
             return 1


### PR DESCRIPTION
## Summary

- Temporarily points the `ginkgo` tool build to `mffiedler/openshift-tests-private` branch `fix-build-docker-api-and-kubernetes-dep` to validate that [PR #30086](https://github.com/openshift/openshift-tests-private/pull/30086) resolves the MicroShift CI build failures caused by cgroups/kubernetes dependency skew
- Removes the [USHIFT-7427](https://redhat.atlassian.net/browse/USHIFT-7427) origin pin workaround since Mike's branch updates all dependencies to compatible versions

## Test plan

- [ ] CI jobs that build `extended-platform-tests` from `openshift-tests-private` succeed (clone + `make all`)
- [ ] Ginkgo test binary is produced and functional

**This is a test-only draft PR — do not merge.**

Related: [OCPQE-32095](https://redhat.atlassian.net/browse/OCPQE-32095)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the tooling retrieval process to pull from a designated branch and a pinned pull request when applicable.
  * Reduced download history to make setup faster.
  * Improved checkout behavior by switching between pull request head and specific commit only when those values are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->