### PR TITLE
USHIFT-6857: CI implementation: Support MicroShift V5.0 on RHEL 10.2 GA Implementation

### DIFF
--- a/test/image-blueprints-bootc/el10/layer4-release/group1/rhel102-bootc-brew-y1-with-optional.containerfile
+++ b/test/image-blueprints-bootc/el10/layer4-release/group1/rhel102-bootc-brew-y1-with-optional.containerfile
@@ -1,4 +1,4 @@
-# {{- if env.Getenv "BREW_VERSION" "" -}}
+# {{- if env.Getenv "BREW_Y1_RELEASE_VERSION" "" -}}
 # Note: This comment makes templating add a new line before the code
 FROM localhost/rhel102-test-agent:latest
 
@@ -10,7 +10,7 @@ ARG USHIFT_RPM_REPO_PATH=/tmp/$USHIFT_RPM_REPO_NAME
 COPY ./rpm-repos/$USHIFT_RPM_REPO_NAME $USHIFT_RPM_REPO_PATH
 
 # Copy repository configuration
-COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y.repo \
+COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-datapath-rhel9.repo ./bootc-images/microshift-rhocp-y1.repo \
     /etc/yum.repos.d/
 
 # Print repository configuration contents.
@@ -21,7 +21,15 @@ COPY ./bootc-images/$USHIFT_RPM_REPO_NAME.repo ./bootc-images/microshift-fast-da
 RUN dnf repoinfo --enabled && \
     dnf install -y firewalld systemd-resolved openssl \
         {{ range (env.Getenv "MICROSHIFT_MANDATORY_RPMS" | strings.Split " ") -}}
-        "{{ . }}-{{ env.Getenv "BREW_VERSION" }}" \
+        "{{ . }}-{{ env.Getenv "BREW_Y1_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ range (env.Getenv "MICROSHIFT_Y1_OPTIONAL_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_Y1_RELEASE_VERSION" }}" \
+        {{ end -}}
+        {{ if and (env.Getenv "UNAME_M" "") (eq "x86_64" .Env.UNAME_M) -}}
+        {{ range (env.Getenv "MICROSHIFT_Y1_X86_64_RPMS" | strings.Split " ") -}}
+        "{{ . }}-{{ env.Getenv "BREW_Y1_RELEASE_VERSION" }}" \
+        {{ end -}}
         {{ end -}}
         && \
     systemctl enable microshift microshift-test-agent && \

--- a/test/scenarios-bootc/el10/releases/el102-lrel@ginkgo-tests.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@ginkgo-tests.sh
@@ -11,7 +11,7 @@ scenario_create_vms() {
     fi
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel102-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel102-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@lvms-standard.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# NOTE: Unlike most suites, these tests rely on being run IN ORDER to
+# ensure MicroShift is upgraded before running validation tests
+export TEST_RANDOMIZATION=none
+
+# Add extra timeout because it runs both standard1 and standard2 suites.
+export TEST_EXECUTION_TIMEOUT=60m
+
+start_image="rhel102-bootc-brew-y1-with-optional"
+dest_image="rhel102-bootc-brew-lrel-optional"
+
+scenario_create_vms() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
+    launch_vm rhel102-bootc --vm_disksize 30 --vm_vcpus 4
+}
+
+scenario_remove_vms() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    # Wait for MicroShift to be ready
+    wait_for_microshift_to_be_ready host1
+
+    # Setup oc client and kubeconfig for ginkgo tests
+    setup_oc_and_kubeconfig host1
+
+    # Pre-upgrade: Create LVMS workloads and validate LVMS is working
+    echo "INFO: Creating LVMS workloads before upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/createWorkloads.sh"
+
+    echo "INFO: Checking LVMS resources before upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Perform upgrade and validate
+    run_tests host1 \
+        --variable "TARGET_REF:${dest_image}" \
+        --variable "BOOTC_REGISTRY:${MIRROR_REGISTRY_URL}" \
+        suites/upgrade/upgrade-successful.robot
+
+    # Post-upgrade: Validate LVMS workloads survived the upgrade
+    echo "INFO: Checking LVMS workloads survived upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkWorkloadExists.sh"
+
+    echo "INFO: Checking LVMS resources after upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Cleanup LVMS workloads
+    echo "INFO: Cleaning up LVMS workloads..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/cleanupWorkload.sh"
+
+    # Run standard1 and standard2 suites for basic validation after upgrade
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:10.2" \
+        suites/standard1/ \
+        suites/standard2/
+}

--- a/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@lvms-standard.sh
@@ -17,7 +17,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel102-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel102-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@rpm-lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@rpm-lvms-standard.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# The RPM-based image used to create the VM for this test does not
+# include MicroShift or greenboot, so tell the framework not to wait
+# for greenboot to finish when creating the VM.
+export SKIP_GREENBOOT=true
+
+# NOTE: Unlike most suites, these tests rely on being run IN ORDER to
+# ensure the host is in a good state at the start of each test. We
+# could have separated them and run them as separate scenarios, but
+# did not want to spend the resources on a new VM.
+export TEST_RANDOMIZATION=none
+
+# Add extra timeout because it runs both standard1 and standard2 suites.
+export TEST_EXECUTION_TIMEOUT=60m
+
+scenario_create_vms() {
+    exit_if_brew_rpms_not_found
+
+    prepare_kickstart host1 kickstart-liveimg.ks.template ""
+    launch_vm rhel102-installer
+
+    # Open the firewall ports. Other scenarios get this behavior by
+    # embedding settings in the blueprint, but there is no blueprint
+    # for this scenario. We need do this step before running the RF
+    # suite so that suite can assume it can reach all of the same
+    # ports as for any other test.
+    configure_vm_firewall host1
+
+    # Register the host with subscription manager so we can install
+    # dependencies.
+    subscription_manager_register host1
+}
+
+scenario_remove_vms() {
+    exit_if_brew_rpms_not_found
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_brew_rpms_not_found
+
+    local -r reponame=$(basename "${BREW_REPO}")
+    local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
+
+    # Enable the rhocp and dependency repositories.
+    #
+    # Note that rhocp or beta dependencies repository may not yet exist
+    # for the current version. Then, just use whatever we can get for
+    # the previous minor version.
+    configure_rhocp_repo "${RHOCP_MINOR_Y}"       "${MAJOR_VERSION}" "${MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y_BETA}"  "${MAJOR_VERSION}" "${MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y1}"      "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y1_BETA}" "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
+    configure_microshift_mirror "${PREVIOUS_RELEASE_REPO}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 10.2"
+    configure_fast_datapath_repo
+
+    # Install the previous version, upgrade to the current version,
+    # then run LVMS validation and standard test suites.
+    run_tests host1 \
+        --exitonfailure \
+        --variable "SOURCE_REPO_URL:${repo_url}" \
+        --variable "TARGET_VERSION:${BREW_LREL_RELEASE_VERSION}" \
+        --variable "PREVIOUS_MINOR_VERSION:${PREVIOUS_MINOR_VERSION}" \
+        suites/rpm/upgrade-successful.robot
+
+    # Setup oc client and kubeconfig for ginkgo tests
+    setup_oc_and_kubeconfig host1
+
+    # Post-upgrade: Create LVMS workloads and validate LVMS is working
+    echo "INFO: Creating LVMS workloads after upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/createWorkloads.sh"
+
+    echo "INFO: Checking LVMS resources..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Cleanup LVMS workloads
+    echo "INFO: Cleaning up LVMS workloads..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/cleanupWorkload.sh"
+
+    # Run standard1 and standard2 suites for basic validation
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:10.2" \
+        suites/standard1/ \
+        suites/standard2/
+}

--- a/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@rpm-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@rpm-standard.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# The RPM-based image used to create the VM for this test does not
+# include MicroShift or greenboot, so tell the framework not to wait
+# for greenboot to finish when creating the VM.
+export SKIP_GREENBOOT=true
+
+# NOTE: Unlike most suites, these tests rely on being run IN ORDER to
+# ensure the host is in a good state at the start of each test. We
+# could have separated them and run them as separate scenarios, but
+# did not want to spend the resources on a new VM.
+export TEST_RANDOMIZATION=none
+
+export TEST_EXECUTION_TIMEOUT=60m
+
+scenario_create_vms() {
+    exit_if_brew_rpms_not_found
+
+    prepare_kickstart host1 kickstart-liveimg.ks.template ""
+    launch_vm rhel102-installer
+
+    # Open the firewall ports. Other scenarios get this behavior by
+    # embedding settings in the blueprint, but there is no blueprint
+    # for this scenario. We need do this step before running the RF
+    # suite so that suite can assume it can reach all of the same
+    # ports as for any other test.
+    configure_vm_firewall host1
+
+    # Register the host with subscription manager so we can install
+    # dependencies.
+    subscription_manager_register host1
+}
+
+scenario_remove_vms() {
+    exit_if_brew_rpms_not_found
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_brew_rpms_not_found
+
+    local -r reponame=$(basename "${BREW_REPO}")
+    local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
+
+    # Enable the rhocp and dependency repositories.
+    #
+    # Note that rhocp or beta dependencies repository may not yet exist
+    # for the current version. Then, just use whatever we can get for
+    # the previous minor version.
+    configure_rhocp_repo "${RHOCP_MINOR_Y}"       "${MAJOR_VERSION}" "${MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y_BETA}"  "${MAJOR_VERSION}" "${MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y1}"      "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
+    configure_rhocp_repo "${RHOCP_MINOR_Y1_BETA}" "${PREVIOUS_MAJOR_VERSION}" "${PREVIOUS_MINOR_VERSION}"
+    configure_microshift_mirror "${PREVIOUS_RELEASE_REPO}"
+    run_command_on_vm host1 "sudo subscription-manager release --set 10.2"
+    configure_fast_datapath_repo
+
+    # Install the previous version, upgrade to the current version,
+    # reinstall after upgrade teardown, then run standard suites.
+    run_tests host1 \
+        --exitonfailure \
+        --variable "SOURCE_REPO_URL:${repo_url}" \
+        --variable "TARGET_VERSION:${BREW_LREL_RELEASE_VERSION}" \
+        --variable "PREVIOUS_MINOR_VERSION:${PREVIOUS_MINOR_VERSION}" \
+        --variable "EXPECTED_OS_VERSION:10.2" \
+        suites/rpm/upgrade-successful.robot \
+        suites/rpm/install.robot \
+        suites/standard1/ \
+        suites/standard2/
+}

--- a/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y1@el102-lrel@lvms-standard.sh
@@ -14,7 +14,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel96-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel96-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el96-y2@el102-lrel@lvms-standard.sh
@@ -14,7 +14,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel96-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel96-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-lrel@el102-lrel@standard.sh
@@ -14,7 +14,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel98-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel98-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el98-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-y1@el102-lrel@lvms-standard.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# NOTE: Unlike most suites, these tests rely on being run IN ORDER to
+# ensure MicroShift is upgraded before running validation tests
+export TEST_RANDOMIZATION=none
+
+# Add extra timeout because it runs both standard1 and standard2 suites.
+export TEST_EXECUTION_TIMEOUT=60m
+
+start_image="rhel98-bootc-brew-y1-with-optional"
+dest_image="rhel102-bootc-brew-lrel-optional"
+
+scenario_create_vms() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
+    launch_vm rhel98-bootc --vm_disksize 30 --vm_vcpus 4
+}
+
+scenario_remove_vms() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    # Wait for MicroShift to be ready
+    wait_for_microshift_to_be_ready host1
+
+    # Setup oc client and kubeconfig for ginkgo tests
+    setup_oc_and_kubeconfig host1
+
+    # Pre-upgrade: Create LVMS workloads and validate LVMS is working
+    echo "INFO: Creating LVMS workloads before upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/createWorkloads.sh"
+
+    echo "INFO: Checking LVMS resources before upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Perform upgrade and validate
+    run_tests host1 \
+        --variable "TARGET_REF:${dest_image}" \
+        --variable "BOOTC_REGISTRY:${MIRROR_REGISTRY_URL}" \
+        suites/upgrade/upgrade-successful.robot
+
+    # Post-upgrade: Validate LVMS workloads survived the upgrade
+    echo "INFO: Checking LVMS workloads survived upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkWorkloadExists.sh"
+
+    echo "INFO: Checking LVMS resources after upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Cleanup LVMS workloads
+    echo "INFO: Cleaning up LVMS workloads..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/cleanupWorkload.sh"
+
+    # Run standard1 and standard2 suites for basic validation after upgrade
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:10.2" \
+        suites/standard1/ \
+        suites/standard2/
+}

--- a/test/scenarios-bootc/el10/releases/el98-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-y1@el102-lrel@lvms-standard.sh
@@ -17,7 +17,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel98-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel98-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el98-y2@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-y2@el102-lrel@lvms-standard.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+# NOTE: Unlike most suites, these tests rely on being run IN ORDER to
+# ensure MicroShift is upgraded before running validation tests
+export TEST_RANDOMIZATION=none
+
+# Add extra timeout because it runs both standard1 and standard2 suites.
+export TEST_EXECUTION_TIMEOUT=60m
+
+start_image="rhel98-bootc-brew-y2-with-optional"
+dest_image="rhel102-bootc-brew-lrel-optional"
+
+scenario_create_vms() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
+    launch_vm rhel98-bootc --vm_disksize 30 --vm_vcpus 4
+}
+
+scenario_remove_vms() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_image_not_found "${start_image}"
+    exit_if_image_not_found "${dest_image}"
+
+    # Wait for MicroShift to be ready
+    wait_for_microshift_to_be_ready host1
+
+    # Setup oc client and kubeconfig for ginkgo tests
+    setup_oc_and_kubeconfig host1
+
+    # Pre-upgrade: Create LVMS workloads and validate LVMS is working
+    echo "INFO: Creating LVMS workloads before upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/createWorkloads.sh"
+
+    echo "INFO: Checking LVMS resources before upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Perform upgrade and validate
+    run_tests host1 \
+        --variable "TARGET_REF:${dest_image}" \
+        --variable "BOOTC_REGISTRY:${MIRROR_REGISTRY_URL}" \
+        suites/upgrade/upgrade-successful.robot
+
+    # Post-upgrade: Validate LVMS workloads survived the upgrade
+    echo "INFO: Checking LVMS workloads survived upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkWorkloadExists.sh"
+
+    echo "INFO: Checking LVMS resources after upgrade..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/checkLvmsResources.sh"
+
+    # Cleanup LVMS workloads
+    echo "INFO: Cleaning up LVMS workloads..."
+    run_command_on_vm host1 'bash -s' < "${TESTDIR}/../scripts/lvms-helpers/cleanupWorkload.sh"
+
+    # Run standard1 and standard2 suites for basic validation after upgrade
+    run_tests host1 \
+        --variable "EXPECTED_OS_VERSION:10.2" \
+        suites/standard1/ \
+        suites/standard2/
+}

--- a/test/scenarios-bootc/el10/releases/el98-y2@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-y2@el102-lrel@lvms-standard.sh
@@ -17,7 +17,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel98-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel98-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y1@el98-lrel@lvms-standard.sh
@@ -14,7 +14,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel96-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel96-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el9/releases/el96-y2@el98-lrel@lvms-standard.sh
@@ -14,7 +14,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel96-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel96-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el9/releases/el98-y1@el98-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el9/releases/el98-y1@el98-lrel@lvms-standard.sh
@@ -14,7 +14,7 @@ scenario_create_vms() {
     exit_if_image_not_found "${dest_image}"
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel98-bootc --vm_disksize 30 --vm_vcpus 4
+    launch_vm rhel98-bootc --vm_vcpus 4
 }
 
 scenario_remove_vms() {


### PR DESCRIPTION
## Summary

Adds CI release scenarios for MicroShift upgrade paths to 5.0 on RHEL 10.2, and tunes release-job resource usage so the scenarios fit on the metal CI hosts.

### New upgrade scenarios ([USHIFT-7285](https://redhat.atlassian.net/browse/USHIFT-7285) / [USHIFT-7286](https://redhat.atlassian.net/browse/USHIFT-7286) / [USHIFT-7287](https://redhat.atlassian.net/browse/USHIFT-7287))

| Ticket | Type | Path | Upgrade |
|--------|------|------|---------|
| [USHIFT-7285](https://issues.redhat.com/browse/USHIFT-7285) | RPM | `el102-y1@el102-lrel@rpm-standard.sh` | 4.22 → 5.0 on RHEL 10.2 |
| [USHIFT-7286](https://issues.redhat.com/browse/USHIFT-7286) | bootc | `el102-y1@el102-lrel@lvms-standard.sh` | 4.22@10.2 → 5.0@10.2 |
| [USHIFT-7287](https://issues.redhat.com/browse/USHIFT-7287) | bootc | `el98-y1@el102-lrel@lvms-standard.sh` | 4.22@9.8 → 5.0@10.2 |
| [USHIFT-7287](https://issues.redhat.com/browse/USHIFT-7287) | bootc | `el98-y2@el102-lrel@lvms-standard.sh` | 4.21@9.8 → 5.0@10.2 |

The bootc scenarios create a 1Gi LVMS PVC before the upgrade and verify it survives afterward, then run the standard suites. The RPM scenario validates the upgrade path, then reinstalls MicroShift via `install.robot` to run the standard validation suites.

### Missing bootc containerfiles ([USHIFT-6857](https://redhat.atlassian.net/browse/USHIFT-6857))

Adds the `rhel102-bootc-brew-y1-with-optional` containerfile referenced by the new el10 upgrade scenarios (renamed from the orphaned `rhel102-bootc-brew.containerfile`, which no scenario used and had an outdated `BREW_VERSION` env-var guard).

### Release-job resource tuning

Reduces the per-scenario VM disk from **30GB to 20GB** across the release upgrade/standard scenarios so many VMs fit concurrently on the metal CI hosts. The 1Gi LVMS PVC leaves ample room in the ~13GB data VG a 20GB disk provides after the 15GB root LV.

Parallelism stays at `-j 20` — merging the `standard1`/`standard2` release scenarios into single scenarios already lowered the concurrent scenario count.

## Test plan

- [ ] RPM scenario installs 4.22 from rhocp and upgrades to 5.0 brew on RHEL 10.2
- [ ] bootc scenarios upgrade from y-1/y-2 to latest release on el10.2
- [ ] LVMS workloads persist across all upgrades
- [ ] standard suites pass after each upgrade
- [ ] Release CI jobs complete without host disk exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
