### PR TITLE
USHIFT-7364: Revert "Work around ostree permissions error on CentOS 9"

### DIFF
--- a/test/kickstart-templates/includes/main-ostreecontainer.cfg
+++ b/test/kickstart-templates/includes/main-ostreecontainer.cfg
@@ -17,22 +17,6 @@ cat > /etc/ostree/auth.json <<'EOF'
 REPLACE_PULL_SECRET
 EOF
 
-# Work around RHEL-193507 on CentOS 9: ostree-rs-ext drops skopeo to
-# 'nobody' when INVOCATION_ID is set (systemd detection), causing
-# permission denied on /proc/self/fd/100 auth file access. Replace the
-# ostree binary with a wrapper that clears the variable so skopeo runs
-# unprivileged.
-if grep -q 'CentOS Stream release 9' /etc/redhat-release 2>/dev/null; then
-    mv /usr/bin/ostree /usr/bin/ostree.real
-    cat > /usr/bin/ostree <<'EOF'
-#!/bin/bash
-unset INVOCATION_ID
-exec /usr/bin/ostree.real "$@"
-EOF
-    chmod +x /usr/bin/ostree
-    restorecon /usr/bin/ostree
-fi
-
 %end
 
 # Configure bootc


### PR DESCRIPTION
This reverts commit 155f94381633aafa1507fa22d8826e3695195c34.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated CentOS Stream 9 workaround from OSTree container setup.
  * Registry configuration and authentication behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->