### PR TITLE
USHIFT-6676: Install osbuild-composer from RHEL production repos

### DIFF
--- a/scripts/devenv-builder/configure-composer.sh
+++ b/scripts/devenv-builder/configure-composer.sh
@@ -152,7 +152,8 @@ EOF
 source /etc/os-release
 
 # shellcheck disable=SC2153
-enable_copr_repositories       "${VERSION_ID}"
+# Uncomment to install osbuild-composer from copr repositories
+# enable_copr_repositories       "${VERSION_ID}"
 install_and_configure_composer "${VERSION_ID}"
 check_umask_and_permissions
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development environment setup no longer enables COPR repositories by default.
  * COPR configuration remains available as an optional setup step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->