### PR TITLE
OCPBUGS-105445: Fix shell arithmetic comparison in multus daemonset

### DIFF
--- a/assets/components/multus/06-daemonset.yaml
+++ b/assets/components/multus/06-daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             start=$(date +%s);
             while [ ! -f /host/etc/cni/net.d/10-ovn-kubernetes.conf ]; do
               now=$(date +%s);
-              if $(( now - start > 5 * 60 )); then
+              if [ "$((now - start))" -gt 300 ]; then
                 echo "$(date --iso-8601=seconds) Timed out waiting for /etc/cni/net.d/10-ovn-kubernetes.conf";
                 exit 1;
               fi;


### PR DESCRIPTION
The init container's timeout check used `if $(( now - start > 5 * 60 ))` which performs arithmetic expansion and returns the result as a string that `if` interprets as a command name. This causes the timeout logic to never trigger correctly.

Replace with POSIX `test` syntax `if [ "$((now - start))" -gt 300 ]` which properly compares the elapsed seconds against the 300-second (5 minute) threshold.

OCPBUGS-105445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Multus DaemonSet timeout handling to reliably enforce the five-minute wait limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->