### PR TITLE
OCPBUGS-105445: Fix shell arithmetic comparison in multus daemonset

### DIFF
--- a/assets/components/multus/06-daemonset.yaml
+++ b/assets/components/multus/06-daemonset.yaml
@@ -61,7 +61,7 @@ spec:
             start=$(date +%s);
             while [ ! -f /host/etc/cni/net.d/10-ovn-kubernetes.conf ]; do
               now=$(date +%s);
-              if $(( now - start > 5 * 60 )); then
+              if [ "$((now - start))" -gt 300 ]; then
                 echo "$(date --iso-8601=seconds) Timed out waiting for /etc/cni/net.d/10-ovn-kubernetes.conf";
                 exit 1;
               fi;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Multus DaemonSet startup timeout handling by reliably enforcing a five-minute wait limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->