### PR TITLE
USHIFT-7440: Ansible: support alternate source checkouts

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -137,7 +137,7 @@ There are a few configuration files that can be configured before execution of t
 
 ### Variables
 
-Most of the following variables are defined in `vars/all.yml`. `rhel_target_version` is provided by the `setup-microshift-host` role defaults and can be set in `vars/all.yml` or passed directly with `-e`.
+Most of the following variables are defined in `vars/all.yml`. The source-build variables and `rhel_target_version` are provided by role defaults and can be set in `vars/all.yml` or passed directly with `-e`.
 
 | Variable Name  | Description | Default |
 | -------------- | ----------- | ------- |
@@ -151,12 +151,23 @@ Most of the following variables are defined in `vars/all.yml`. `rhel_target_vers
 | `prometheus_logging` | Set up logging and exporters on the nodes | `true` |
 | `install_microshift` | Install MicroShift (from packages or source) | `false` |
 | `build_microshift` | Build MicroShift from source instead of installing packages | `false` |
+| `microshift_source_dir` | Existing MicroShift Git worktree on the managed host to build instead of updating the default checkout | `""` |
+| `microshift_git_revision` | Git revision to check out when building MicroShift from source | `"release-<major.minor>"` |
+| `microshift_git_refspec` | Additional Git refspec to fetch when building MicroShift from source (e.g. `+refs/pull/123/head:refs/remotes/origin/pr-123`) | `""` |
 | `build_etcd_binary` | Build and deploy a separate etcd process | `false` |
 | `microshift_version` | MicroShift version to install (supports EC/RC prereleases) | `"4.20"` |
 | `enable_gpu` | Install NVIDIA GPU drivers and container toolkit for GPU workloads | `false` |
 | `deploy_gpu_test` | Deploy a test GPU workload to validate GPU functionality | `true` |
 | `run_workloads` | Run kube-burner performance workloads | `false` |
 | `rhel_target_version` | Pin RHEL to a specific version during upgrades (e.g., "9.8") | `undefined` |
+
+Source builds update the existing checkout in `microshift_dir` to `microshift_git_revision`. By default, the revision is the release branch derived from
+`microshift_version`; for example, both `4.21.0` and `latest-4.21` select `release-4.21`. Set it explicitly to build another branch, tag, or commit.
+A commit SHA may require `microshift_git_refspec` when the commit is not reachable from a branch or tag fetched by default. Checking out a SHA leaves the
+repository in detached HEAD state until a later branch-based run updates it.
+
+Set `microshift_source_dir` to build a complete Git worktree that is already present on the managed host. The caller is responsible for staging and
+updating the worktree, including its `.git` metadata. When set, the Git checkout task is skipped and the Git revision and refspec variables are ignored.
 
 ### Inventory Configuration
 

--- a/ansible/roles/install-microshift/defaults/main.yml
+++ b/ansible/roles/install-microshift/defaults/main.yml
@@ -10,6 +10,16 @@ microshift_dir: "{{ ansible_facts.env.HOME }}/microshift"
 microshift_repo: https://github.com/openshift/microshift.git
 microshift_rpms: []
 microshift_version: 4.22.0
+# Optional existing MicroShift Git worktree to build instead of updating
+# microshift_dir from microshift_repo.
+microshift_source_dir: ""
+# Directory used by the source build tasks.
+microshift_build_dir: "{{ microshift_source_dir | default(microshift_dir, true) }}"
+# Git revision to check out when building MicroShift from source.
+microshift_git_revision: "release-{{ (microshift_version | regex_replace('^latest-', '')).split('.')[:2] | join('.') }}"
+# Optional additional Git refspec to fetch when building from source,
+# e.g. "+refs/pull/123/head:refs/remotes/origin/pr-123"
+microshift_git_refspec: ""
 
 du_dirs:
   - /

--- a/ansible/roles/install-microshift/tasks/main.yml
+++ b/ansible/roles/install-microshift/tasks/main.yml
@@ -55,31 +55,27 @@
           - cri-tools
         state: present
 
-    - name: check if microshift dir exists
-      ansible.builtin.stat:
-        path: "{{ microshift_dir }}"
-      register: ms_dir
-
-    - name: clone microshift git repo
+    - name: ensure microshift git checkout
       ansible.builtin.git:
         repo: "{{ microshift_repo }}"
         dest: "{{ microshift_dir }}"
-        version: "{{ microshift_version }}"
-      when: not ms_dir.stat.exists
+        version: "{{ microshift_git_revision }}"
+        refspec: "{{ microshift_git_refspec | default(omit, true) }}"
+      when: not microshift_source_dir
 
     - name: make clean
       ansible.builtin.command: make clean
       args:
-        chdir: "{{ microshift_dir }}"
+        chdir: "{{ microshift_build_dir }}"
 
     - name: make rpm
       ansible.builtin.command: make rpm
       args:
-        chdir: "{{ microshift_dir }}"
+        chdir: "{{ microshift_build_dir }}"
 
     - name: find built RPMs
       ansible.builtin.find:
-        paths: "{{ microshift_dir }}"
+        paths: "{{ microshift_build_dir }}"
         patterns: '*.rpm'
         recurse: yes
       register: microshift_find


### PR DESCRIPTION
## Summary

Allow Ansible source builds to select an exact Git revision, optionally fetch an additional refspec, or build a complete Git worktree staged on the managed host.

- Separate the product version from the source selected for builds.
- Derive the default Git revision from the corresponding release branch.
- Support commits reachable only through an additional refspec.
- Converge existing Git-managed checkouts to the requested revision.
- Skip Git operations and build directly from a caller-managed worktree when one is provided.

This enables follow-up work in [USHIFT-7441](https://redhat.atlassian.net/browse/USHIFT-7441) to build the ci-operator `src` checkout, preserving the pull request's merge-commit semantics without re-fetching source from GitHub.

Package-based installations are unchanged. A Git-managed checkout with local modifications that block convergence now fails instead of silently building those modifications.

## Testing

- `ansible-playbook --syntax-check setup-node.yml`
- `git diff --check`
- `ansible-lint --profile min roles/install-microshift`
- Package-based installation on a scratch RHEL 9.8 VM
- Default source build from `release-4.22`
- Source build from a pull-request SHA using an additional refspec
- Existing-checkout transition to the pull-request SHA
- Idempotent rerun at the pull-request SHA
- Reverse transition from detached HEAD to `release-4.22`
- Staged Git worktree build with the checkout task skipped and source provenance retained in the RPM

## Issue

https://issues.redhat.com/browse/USHIFT-7440


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options for building from an existing MicroShift source worktree.
  - Added support for selecting a specific branch, tag, or commit, including optional refspecs for unreachable commits.
  - Source builds now use configurable build and source directories.

- **Documentation**
  - Documented source-build configuration, default release-branch selection, commit checkout behavior, and worktree handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->