### PR TITLE
USHIFT-7446: Ansible: add MicroShift 5.0 pod counts

### DIFF
--- a/ansible/vars/microshift_versions.yml
+++ b/ansible/vars/microshift_versions.yml
@@ -27,3 +27,6 @@ microshift_versions:
   "4.22":
     expected_pods: 6
     all_pods: 9
+  "5.0":
+    expected_pods: 6
+    all_pods: 9


### PR DESCRIPTION
## Summary

Add MicroShift 5.0 boot-readiness thresholds to the Ansible version map.

This prevents 5.0 source builds from failing before boot measurement and unblocks follow-up pull-request performance work in USHIFT-7441.

## Testing

- Loaded `ansible/vars/microshift_versions.yml` with `ansible-inventory`
- `ansible-playbook --syntax-check setup-node.yml`
- `ansible-lint --profile min vars/microshift_versions.yml`
- `git diff --check`
- Live MicroShift 5.0 deployment from current `main` on RHEL 9.8: service active, API ready, node Ready, six running core non-storage pods, and nine Ready core pods

## Issue

https://issues.redhat.com/browse/USHIFT-7446


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for MicroShift version 5.0.
  * Updated expected pod counts for this version: 6 expected pods and 9 total pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->