### PR TITLE
USHIFT-7428: fix openshift-tests-private build on main

### DIFF
--- a/scripts/fetch_tools.sh
+++ b/scripts/fetch_tools.sh
@@ -375,6 +375,10 @@ gettool_ginkgo() {
         return 1
     fi
 
+    # Download Go modules before building — the Makefile's patch-bindata
+    # target needs the origin module in the cache before go build runs.
+    go mod download
+
     # Build the binary
     make all
 


### PR DESCRIPTION
## Summary

Fix the `e2e-aws-tests-release` job failure on main caused by a missing
Go module in the cache when building openshift-tests-private.

## Root cause

PR #7143 bumped `OPENSHIFT_TESTS_PRIVATE_REPO_COMMIT` from `7f4370e` to
`1a6ccbc` and removed a `sed` workaround that pinned the origin version.

The old OTP commit (`7f4370e`) had this in its Makefile:
```
build: update-origin patch-bindata
```

The new OTP commit (`1a6ccbc`) changed it to:
```
build: patch-bindata
```

`update-origin` ran `go get -u github.com/openshift/origin@main` which
downloaded the origin module into the Go module cache. Without it,
`patch-bindata` tries to `chmod` a file in the module cache that doesn't
exist yet (the module hasn't been downloaded), causing:

```
chmod: cannot access '.../origin@.../compat_otp/testdata/bindata.go': No such file or directory
make: *** [Makefile:34: patch-bindata] Error 1
```

This only affects `main` — `release-4.22` pins an older OTP commit that
still has `update-origin` in the build dependency chain.

## Fix

Add `go mod download` in `fetch_tools.sh` before `make all` to ensure
the Go module cache is populated before the Makefile's `patch-bindata`
target runs.

## Test plan

Verify that RF and ginkgo scenarios start successfully on release CI jobs:
- [ ] `/test e2e-aws-tests-release`
- [ ] `/test e2e-aws-tests-release-arm`
- [ ] `/test e2e-aws-tests-bootc-release-el9`
- [ ] `/test e2e-aws-tests-bootc-release-el10`
- [ ] `/test e2e-aws-tests-bootc-release-arm-el9`
- [ ] `/test e2e-aws-tests-bootc-release-arm-el10`