### PR TITLE
USHIFT-7451: replace nginx-unprivileged with busybox in test assets

### DIFF
--- a/docs/contributor/storage/default_csi_plugin.md
+++ b/docs/contributor/storage/default_csi_plugin.md
@@ -161,7 +161,7 @@ spec:
     - sh
     - -c
     - sleep 1d
-    image: nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     name: test-container
     securityContext:
       allowPrivilegeEscalation: false
@@ -250,7 +250,7 @@ spec:
     - sh
     - -c
     - sleep 1d
-    image: nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     name: test-container
     securityContext:
       allowPrivilegeEscalation: false

--- a/test/assets/kustomizations/base/pod-base.yaml
+++ b/test/assets/kustomizations/base/pod-base.yaml
@@ -9,7 +9,7 @@ spec:
       type: RuntimeDefault
   containers:
   - name: test-container
-    image: docker.io/nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/test/assets/reboot/pod-with-pvc.yaml
+++ b/test/assets/reboot/pod-with-pvc.yaml
@@ -21,7 +21,7 @@ spec:
       type: RuntimeDefault
   containers:
   - name: test-container
-    image: docker.io/nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -57,7 +57,7 @@ Oc Exec
     [Documentation]    Run 'oc exec' on a specific pod in the curret test namespace
     ...    Returns the command's combined STDOUT/STDER
     [Arguments]    ${pod}    ${cmd}    ${ns}=${NAMESPACE}    ${type}=pod
-    ${output}=    Run With Kubeconfig    oc exec -n ${ns} ${type}/${pod} -- /bin/bash -c '${cmd}'
+    ${output}=    Run With Kubeconfig    oc exec -n ${ns} ${type}/${pod} -- /bin/sh -c '${cmd}'
     RETURN    ${output}
 
 Oc Wait


### PR DESCRIPTION
## Summary

The `docker.io/nginxinc/nginx-unprivileged:latest` image is a multi-arch manifest list with 14 platform variants. When mirroring with `skopeo copy --all --preserve-digests`, Quay v3.11.7 rejects one of the platform manifests as `manifest invalid`, causing the mirror step to fail and aborting CI jobs.

### Error

```
copying image 8/14 from manifest list: writing manifest: uploading manifest
sha256:ddbcc3430e9adf29268405986e973c18acdc4bd3e7b0860ee0b4e5e8d1840c36
to 192.168.122.1:5000/microshift/nginxinc/nginx-unprivileged: manifest invalid
```

Example failure: [e2e-aws-tests-arm build log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_microshift/7196/pull-ci-openshift-microshift-release-4.18-e2e-aws-tests-arm/2089258463719854080/build-log.txt)

### Root cause

The `skopeo_opts_for_image()` function in `scripts/mirror-images.sh` detects manifest lists and passes `--all` to `skopeo copy`, which copies all 14 architectures (amd64, arm64, arm/v5, arm/v6, arm/v7, 386, mips64le, ppc64le, s390x, etc.). One of these platform manifests is rejected by the local Quay v3.11.7 registry. After 3 retries, the mirror step fails and the job aborts.

### Fix

These test pods (`pod-base.yaml`, `pod-with-pvc.yaml`) only run `sleep 1d` and do not use any nginx functionality. Replace the image with `quay.io/microshift/busybox:1.36`, which is already mirrored as a single-arch image for other tests. This eliminates the problematic multi-arch manifest list from the mirror set entirely.

### Files changed

- `test/assets/kustomizations/base/pod-base.yaml` — base pod used by storage snapshot and greenboot tests
- `test/assets/reboot/pod-with-pvc.yaml` — pod used by storage reboot and PVC resize tests
- `docs/contributor/storage/default_csi_plugin.md` — documentation examples updated to match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated storage snapshot and test pod examples to use the MicroShift BusyBox image.
  * Improved consistency and reliability of container image references across examples and test assets.
  * Updated command execution in test resources to use `/bin/sh`, improving compatibility with the refreshed test container image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->