### PR TITLE
USHIFT-6953: document observability metric-exporter scraping

### DIFF
--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -14,6 +14,7 @@ List of the documents in alphabetical file name order, including sub-directories
 - [Quay Mirror Registry Setup for Testing](./howto_quay_mirror.md)
 - [Image Mode for MicroShift Contributors](./image_mode.md)
 - [Layered Product Testing with MicroShift](./layered_product_ci.md)
+- [Observability: Scraping the Optional Metric Exporters](./observability_metric_exporters.md)
 - [OpenShift CI for MicroShift](./openshift_ci.md)
 - [Install MicroShift on RHEL for Edge](./rhel4edge_iso.md)
 - [RPM Packages for Development and Testing](./rpm_packages.md)

--- a/docs/contributor/architecture.md
+++ b/docs/contributor/architecture.md
@@ -163,11 +163,16 @@ Additional functionality is delivered as optional RPM subpackages:
 | `microshift-cert-manager` | `manifests.d/060-microshift-cert-manager` | Certificate Manager |
 | `microshift-sriov` | `manifests.d/070-microshift-sriov` | SR-IOV Network Operator |
 | `microshift-observability` | `manifests.d/003-microshift-observability` + systemd service | OpenTelemetry Collector |
+| `microshift-metrics-server` | `manifests.d/080-microshift-metrics-server` + observability `scrape.d` drop-in | metrics-server (Kubernetes Metrics API, `kubectl top`) |
+| `microshift-metrics-kube-state` | `manifests.d/081-microshift-kube-state-metrics` + observability `scrape.d` drop-in | kube-state-metrics (Kubernetes object-state metrics) |
+| `microshift-metrics-node-exporter` | `manifests.d/082-microshift-node-exporter` + observability `scrape.d` drop-in | Prometheus node-exporter (host hardware/OS metrics) |
 | `microshift-ai-model-serving` | `manifests.d/010-*-kserve`, `050-*-runtimes` | AI Model Serving (KServe) |
 | `microshift-multus` | config file in `/etc/microshift/config.d/` + CRI-O config | Multus CNI (enables via config, not manifests) |
 | `microshift-low-latency` | tuned profile | Baseline low-latency workload configuration |
 
 Most optional components also have a `-release-info` RPM containing container image references used by image builder blueprints.
+
+The optional metric-exporter RPMs (`microshift-metrics-node-exporter`, `microshift-metrics-kube-state`, `microshift-metrics-server`) integrate with `microshift-observability` via Prometheus scrape drop-ins in `/etc/microshift/observability/scrape.d/`. See [Observability: Scraping the Optional Metric Exporters](./observability_metric_exporters.md).
 
 ### Discovery Mechanism
 

--- a/docs/contributor/observability_metric_exporters.md
+++ b/docs/contributor/observability_metric_exporters.md
@@ -39,8 +39,8 @@ cases with no extra wiring:
 - **Observability without metrics** — `scrape.d/` is empty; the receiver loads no configs
   and reports no error.
 - **Observability with a subset of exporters** — only the installed exporters are scraped.
-- **Exporters without observability** — the drop-in files exist on disk but are never read;
-  no side effects.
+- **Exporters without observability** — the drop-in files exist on disk but are never read,
+  so no scraping occurs (the exporter workload still deploys and serves its endpoint).
 
 ### Package ownership
 
@@ -85,5 +85,4 @@ Keep the collector presets, the drop-ins, and the RPM packaging in sync with the
 
 End-to-end behavior is exercised by `test/suites/optional/observability.robot`
 (USHIFT-7407), which enables the exporters alongside observability and asserts that
-kube-state-metrics and node-exporter series appear in the collector output and that
-metrics-server is scraped without `403` errors.
+kube-state-metrics, node-exporter, and metrics-server series appear in the collector output.

--- a/docs/contributor/observability_metric_exporters.md
+++ b/docs/contributor/observability_metric_exporters.md
@@ -1,0 +1,89 @@
+# Observability: Scraping the Optional Metric Exporters
+
+MicroShift ships the `microshift-observability` RPM, which runs the Red Hat build of the
+OpenTelemetry Collector as a host `systemd` service, plus three optional metric-exporter
+RPMs. When the collector and one or more exporters are installed together, the collector
+automatically scrapes each exporter's `/metrics` endpoint and forwards the data to the
+configured OTLP backend — with no manual configuration.
+
+This document is **contributor-facing**: it describes the `scrape.d` drop-in integration so
+maintainers can keep the collector presets, the drop-in files, and the RPM packaging in
+sync. Admin-facing usage of the OpenTelemetry Collector lives in **openshift-docs**
+(assembly *"Using MicroShift Observability"*,
+`microshift_running_apps/microshift-observability-service.adoc`).
+
+## The `scrape.d` drop-in mechanism
+
+Each optional metrics RPM installs a Prometheus scrape-config drop-in into
+`/etc/microshift/observability/scrape.d/`. All three collector presets
+(`packaging/observability/opentelemetry-collector-{small,medium,large}.yaml`) load whatever
+drop-ins are present at startup via a `prometheus` receiver:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_config_files:
+        - /etc/microshift/observability/scrape.d/*.yaml
+service:
+  pipelines:
+    metrics/scrape:
+      receivers: [ prometheus ]
+      processors: [ batch ]
+      exporters: [ otlp ]
+```
+
+Because the receiver globs only the files that are on disk, the design satisfies three
+cases with no extra wiring:
+
+- **Observability without metrics** — `scrape.d/` is empty; the receiver loads no configs
+  and reports no error.
+- **Observability with a subset of exporters** — only the installed exporters are scraped.
+- **Exporters without observability** — the drop-in files exist on disk but are never read;
+  no side effects.
+
+### Package ownership
+
+The `microshift-observability` subpackage owns the `scrape.d/` **directory**; each metrics
+subpackage owns its **drop-in file** as `%config(noreplace)` (see
+`packaging/rpm/microshift.spec`).
+
+| Exporter | RPM package | Drop-in file (`.../scrape.d/`) | Service (ns `openshift-monitoring`) | Port(s) | Exposes | Auth |
+|---|---|---|---|---|---|---|
+| node-exporter | `microshift-metrics-node-exporter` | `node-exporter.yaml` | `node-exporter` | 9100 (`https`) | host CPU/memory/disk/network/OS metrics | kube-rbac-proxy static cert |
+| kube-state-metrics | `microshift-metrics-kube-state` | `kube-state-metrics.yaml` | `kube-state-metrics` | 8443 (`https-main`), 9443 (`https-self`) | Kubernetes object-state metrics | kube-rbac-proxy static cert |
+| metrics-server | `microshift-metrics-server` | `metrics-server.yaml` | `metrics-server` | 443 (`https`) | metrics-server's own serving metrics | Kubernetes RBAC |
+
+The exporter RPMs are `ExclusiveArch: x86_64 aarch64`.
+
+### Authentication model
+
+The drop-ins authenticate with the `openshift-observability-client` cert (issued from the
+`admin-kubeconfig-signer` CA) against the service-CA-signed exporter endpoints.
+
+- **kube-state-metrics** and **node-exporter** sit behind `kube-rbac-proxy` configured with
+  static authorization — any client cert signed by the trusted CA is admitted, with no
+  RBAC `SubjectAccessReview`. The observability client cert is sufficient.
+- **metrics-server** delegates to the Kubernetes API for authorization, so it requires an
+  RBAC rule. The observability `ClusterRole` therefore includes
+  `nonResourceURLs: ["/metrics"]` — already shipped in
+  `assets/optional/observability/02-cluster-role.yaml`. No additional RBAC is needed.
+
+> **Note:** Scraping metrics-server's `/metrics` collects metrics-server's *own* serving
+> metrics. Node/pod resource metrics for `kubectl top` are served through the aggregated
+> Metrics API (`metrics.k8s.io`), **not** through this scrape.
+
+### Source-of-truth files
+
+Keep the collector presets, the drop-ins, and the RPM packaging in sync with these:
+
+- `packaging/observability/scrape.d/{node-exporter,kube-state-metrics,metrics-server}.yaml`
+- `packaging/observability/opentelemetry-collector-{small,medium,large}.yaml`
+- `assets/optional/{node-exporter,kube-state-metrics,metrics-server}/04-service.yaml`
+- `assets/optional/observability/02-cluster-role.yaml`
+- `packaging/rpm/microshift.spec` (subpackages and `scrape.d` file ownership)
+
+End-to-end behavior is exercised by `test/suites/optional/observability.robot`
+(USHIFT-7407), which enables the exporters alongside observability and asserts that
+kube-state-metrics and node-exporter series appear in the collector output and that
+metrics-server is scraped without `403` errors.


### PR DESCRIPTION
## What this does

Adds a contributor doc, `docs/contributor/observability_metric_exporters.md`, describing how the three optional metric-exporter RPMs integrate with `microshift-observability`:

- **The `scrape.d` drop-in mechanism** — each metrics RPM installs a Prometheus scrape-config drop-in into `/etc/microshift/observability/scrape.d/`, and all three collector presets load whatever is present via the `prometheus` receiver's `scrape_config_files` glob plus a `metrics/scrape` pipeline. Covers the empty / subset / exporters-without-collector cases.
- **Package ownership** — which subpackage owns the `scrape.d/` directory vs. each `%config(noreplace)` drop-in file, plus an endpoint/port/exposes/auth table for node-exporter, kube-state-metrics, and metrics-server.
- **Authentication model** — kube-rbac-proxy static-cert auth vs. metrics-server's Kubernetes RBAC (and the already-shipped `nonResourceURLs: ["/metrics"]` ClusterRole rule), plus the metrics-server-vs-Metrics-API clarification.
- **Source-of-truth files** maintainers must keep in sync, and the [USHIFT-7407](https://redhat.atlassian.net/browse/USHIFT-7407) Robot test that exercises the behavior end to end.

Also lists the three metric-exporter RPMs in the `architecture.md` optional-components table and adds the doc to the contributor index.

## Scope

Docs only — no code or manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for optional metric exporter observability.
  * Documented metrics-server, kube-state-metrics, and node-exporter integration.
  * Added details on automatic metric discovery, exporter endpoints, authentication, authorization, package ownership, and installation combinations.
  * Documented source-of-truth files and end-to-end test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->