### PR TITLE
USHIFT-7485: Ansible: provide dependency repos for source builds

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -169,6 +169,12 @@ repository in detached HEAD state until a later branch-based run updates it.
 Set `microshift_source_dir` to build a complete Git worktree that is already present on the managed host. The caller is responsible for staging and
 updating the worktree, including its `.git` metadata. When set, the Git checkout task is skipped and the Git revision and refspec variables are ignored.
 
+When repository management is enabled, source builds provision runtime dependencies from the stream's OpenShift repository when it is available. If
+that repository is unavailable, or
+`microshift_version` identifies a prerelease, dependencies are provided by the `dependencies/rpms/<major.minor>-el9-beta` mirror instead. Package-based
+repository selection is unchanged. Repository probes verify that `cri-o` is present; installation of the built RPMs enforces version compatibility.
+If the OpenShift repository becomes usable on a later run, the corresponding fallback mirror is removed.
+
 ### Inventory Configuration
 
 The inventory configuration file is located at `inventory/inventory`.

--- a/ansible/roles/manage-repos/defaults/main.yml
+++ b/ansible/roles/manage-repos/defaults/main.yml
@@ -3,13 +3,21 @@
 
 microshift_version: 4.20
 microshift_version_clean: "{{ microshift_version | regex_replace('^latest-', '') }}"
-ocp_version: "{{ microshift_version_clean.split('.')[0] }}.{{ microshift_version_clean.split('.')[1] }}"
+ocp_major_version: "{{ microshift_version_clean.split('.')[0] }}"
+ocp_version: "{{ ocp_major_version }}.{{ microshift_version_clean.split('.')[1] }}"
 microshift_base_url: "{{ 'ocp-dev-preview' if 'ec' in microshift_version else 'ocp' }}"
-repo_list:
+microshift_mirror_repos:
   - repo_name: 'microshift-{{ ocp_version }}-for-rhel-{{ ansible_facts.distribution_major_version }}-mirrorbeta-{{ ansible_facts.architecture }}-rpms'
+    repo_description: 'MicroShift {{ ocp_version }} RPMs for RHEL {{ ansible_facts.distribution_major_version }}'
     repo_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_facts.architecture }}/microshift/{{ microshift_base_url }}/{{ microshift_version }}/el9/os/"
+microshift_deps_repos:
   - repo_name: 'microshift-{{ ocp_version }}-deps-for-rhel-{{ ansible_facts.distribution_major_version }}-mirrorbeta-{{ ansible_facts.architecture }}-rpms'
-    repo_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_facts.architecture }}/dependencies/rpms/{{ ocp_version }}-el9-beta/"
+    repo_description: 'MicroShift {{ ocp_version }} dependencies for RHEL {{ ansible_facts.distribution_major_version }}'
+    repo_url: >-
+      {{ 'https://mirror.openshift.com/pub/openshift-v' ~ ocp_major_version ~
+         '/' ~ ansible_facts.architecture ~ '/dependencies/rpms/' ~
+         ocp_version ~ '-el9-beta/' }}
+repo_list: "{{ microshift_mirror_repos + microshift_deps_repos }}"
 
 rhel_beta: ''
 rhel_base_repos:

--- a/ansible/roles/manage-repos/tasks/create-mirrors.yaml
+++ b/ansible/roles/manage-repos/tasks/create-mirrors.yaml
@@ -1,26 +1,17 @@
-- name: Create mirrors block
-  block:
-    - name: Check if microshift_version is valid for pre-release
-      ansible.builtin.uri:
-        url: "{{ item.repo_url }}"
-        method: GET
-        status_code: 200
-        timeout: 5
+- name: Install repository mirror
+  ansible.builtin.template:
+    src: ocpbeta.repo.j2
+    dest: "/etc/yum.repos.d/{{ item.repo_name }}.repo"
+    mode: '0644'
+  register: microshift_mirror_repo
 
-    - name: Install microshift mirror repo for pre-releases
-      ansible.builtin.template:
-        src: ocpbeta.repo.j2
-        dest: "/etc/yum.repos.d/{{ item.repo_name }}.repo"
-        mode: '0644'
-      register: microshift_mirror_repo
-
-    - name: Clean stale metadata for updated pre-release repo
-      ansible.builtin.command:
-        argv:
-          - dnf
-          - clean
-          - metadata
-          - "--disablerepo=*"
-          - "--enablerepo={{ item.repo_name }}"
-      changed_when: true
-      when: microshift_mirror_repo.changed
+- name: Clean stale metadata for updated repository
+  ansible.builtin.command:
+    argv:
+      - dnf
+      - clean
+      - metadata
+      - "--disablerepo=*"
+      - "--enablerepo={{ item.repo_name }}"
+  changed_when: true
+  when: microshift_mirror_repo.changed

--- a/ansible/roles/manage-repos/tasks/main.yml
+++ b/ansible/roles/manage-repos/tasks/main.yml
@@ -45,9 +45,138 @@
     community.general.rhsm_repository:
       name: "{{ rhel_base_repos }}"
 
-  - name: Create microshift prerelease mirrors
-    include_tasks: create-mirrors.yaml
+  - name: Provision dependency repos for source builds
+    when: build_microshift | bool
+    block:
+      - name: Enable OpenShift repo for source-build dependencies
+        community.general.rhsm_repository:
+          name: "{{ rhel_ocp_repos }}"
+        register: microshift_source_rhsm_repo
+        when: not (microshift_prerelease | bool)
+
+      - name: Check OpenShift repo provides source-build dependencies
+        # This matches scripts/get-latest-rhocp-repo.sh: repository routing
+        # checks package presence, while RPM installation enforces compatibility.
+        ansible.builtin.command:
+          argv:
+            - dnf
+            - --refresh
+            - repository-packages
+            - --showduplicates
+            - "--disablerepo=*"
+            - "--enablerepo={{ item }}"
+            - "{{ item }}"
+            - info
+            - cri-o
+        loop: "{{ rhel_ocp_repos }}"
+        register: microshift_source_rhsm_probe
+        changed_when: false
+        when: not (microshift_prerelease | bool)
+    rescue:
+      - name: Disable unusable OpenShift repo for source-build dependencies
+        community.general.rhsm_repository:
+          name: "{{ rhel_ocp_repos }}"
+          state: disabled
+        when:
+          - microshift_source_rhsm_repo is defined
+          - not ((microshift_source_rhsm_repo.failed | default(false)) | bool)
+
+      - name: Check fallback dependency mirror for source builds
+        block:
+          - name: Probe fallback dependency mirror for source builds
+            ansible.builtin.include_tasks: probe-mirror.yaml
+            loop: "{{ microshift_deps_repos }}"
+            loop_control:
+              label: "{{ item.repo_name }}"
+            vars:
+              repository_probe_package: cri-o
+        rescue:
+          - name: Report unavailable source-build dependency repositories
+            ansible.builtin.fail:
+              msg: >-
+                Neither the entitled OpenShift repositories
+                ({{ rhel_ocp_repos | join(', ') }}) nor the dependency mirrors
+                ({{ microshift_deps_repos | map(attribute='repo_url') | join(', ') }})
+                provide cri-o for MicroShift {{ ocp_version }}.
+
+      - name: Install fallback dependency mirror for source builds
+        ansible.builtin.include_tasks: create-mirrors.yaml
+        loop: "{{ microshift_deps_repos }}"
+        loop_control:
+          label: "{{ item.repo_name }}"
+
+  - name: Remove fallback dependency mirrors after OpenShift repo recovers
+    ansible.builtin.file:
+      path: "/etc/yum.repos.d/{{ item.repo_name }}.repo"
+      state: absent
+    loop: "{{ microshift_deps_repos }}"
+    loop_control:
+      label: "{{ item.repo_name }}"
+    register: microshift_removed_fallback_repos
+    when:
+      - build_microshift | bool
+      - not (microshift_prerelease | bool)
+      - microshift_source_rhsm_probe is defined
+      - not ((microshift_source_rhsm_probe.failed | default(true)) | bool)
+
+  - name: Clean metadata after removing fallback dependency mirrors
+    ansible.builtin.command:
+      argv:
+        - dnf
+        - clean
+        - metadata
+    changed_when: true
+    when:
+      - build_microshift | bool
+      - not (microshift_prerelease | bool)
+      - microshift_source_rhsm_probe is defined
+      - not ((microshift_source_rhsm_probe.failed | default(true)) | bool)
+      - microshift_removed_fallback_repos is defined
+      - (microshift_removed_fallback_repos.changed | default(false)) | bool
+
+  - name: Check dependency mirror for prerelease source builds
+    when:
+      - build_microshift | bool
+      - microshift_prerelease | bool
+    block:
+      - name: Probe dependency mirror for prerelease source builds
+        ansible.builtin.include_tasks: probe-mirror.yaml
+        loop: "{{ microshift_deps_repos }}"
+        loop_control:
+          label: "{{ item.repo_name }}"
+        vars:
+          repository_probe_package: cri-o
+    rescue:
+      - name: Report unavailable prerelease dependency mirrors
+        ansible.builtin.fail:
+          msg: >-
+            The dependency mirrors
+            ({{ microshift_deps_repos | map(attribute='repo_url') | join(', ') }})
+            do not provide cri-o for MicroShift {{ ocp_version }}.
+
+  - name: Create dependency mirror for prerelease source builds
+    ansible.builtin.include_tasks: create-mirrors.yaml
+    loop: "{{ microshift_deps_repos }}"
+    loop_control:
+      label: "{{ item.repo_name }}"
+    when:
+      - build_microshift | bool
+      - microshift_prerelease | bool
+
+  - name: Check microshift prerelease mirrors
+    ansible.builtin.include_tasks: probe-mirror.yaml
     loop: "{{ repo_list }}"
+    loop_control:
+      label: "{{ item.repo_name }}"
+    when:
+      - microshift_prerelease | bool
+      - not (build_microshift | bool)
+
+  - name: Create microshift prerelease mirrors
+    ansible.builtin.include_tasks: create-mirrors.yaml
+    loop: "{{ repo_list }}"
+    loop_control:
+      label: "{{ item.repo_name }}"
     when:
       - microshift_prerelease | bool
       - not (build_microshift | bool)
@@ -57,6 +186,7 @@
       name: "{{ rhel_ocp_repos }}"
     when:
       - not (microshift_prerelease | bool)
+      - not (build_microshift | bool)
 
   - name: Install EPEL repo
     ansible.builtin.dnf:

--- a/ansible/roles/manage-repos/tasks/probe-mirror.yaml
+++ b/ansible/roles/manage-repos/tasks/probe-mirror.yaml
@@ -1,0 +1,22 @@
+- name: Check repository mirror is available
+  ansible.builtin.uri:
+    url: "{{ item.repo_url }}"
+    method: GET
+    status_code: 200
+    timeout: 5
+
+- name: Check repository mirror provides required package
+  ansible.builtin.command:
+    argv:
+      - dnf
+      - --refresh
+      - repository-packages
+      - --showduplicates
+      - "--disablerepo=*"
+      - --repofrompath
+      - "microshift-dependency-probe,{{ item.repo_url }}"
+      - microshift-dependency-probe
+      - info
+      - "{{ repository_probe_package }}"
+  changed_when: false
+  when: (repository_probe_package | default('') | length) > 0

--- a/ansible/roles/manage-repos/templates/ocpbeta.repo.j2
+++ b/ansible/roles/manage-repos/templates/ocpbeta.repo.j2
@@ -1,5 +1,5 @@
 [{{ item.repo_name }}]
-name=MicroShift {{ ocp_version }} RPMs for RHEL {{ ansible_facts.distribution_major_version }}
+name={{ item.repo_description | default('MicroShift ' ~ ocp_version ~ ' RPMs for RHEL ' ~ ansible_facts.distribution_major_version) }}
 baseurl={{ item.repo_url }}
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
Source builds need runtime dependencies even though they build the MicroShift RPM locally. This updates the Ansible repository-management role to prefer the entitled OpenShift repository for released streams and fall back to the major-version dependency mirror when the entitled repository is unavailable; prerelease source builds use the dependency mirror directly.

Repository candidates are probed for `cri-o` before selection, and repository routing fails clearly when neither source is usable. Package-based installation behavior remains unchanged.

Testing:

- `ansible-playbook --syntax-check setup-node.yml`
- `ansible-lint --profile min roles/manage-repos`
- Explicit production-profile comparison: 13 findings on the upstream baseline and 12 on this change, with all remaining findings on pre-existing lines (zero new lint debt, net minus one)
- `git diff --check`
- Live RHEL 9.8 source-build repository routing for released 4.22 through `rhocp-4.22`
- Live RHEL 9.8 fallback for 5.0 from unavailable `rhocp-5.0` to the `openshift-v5` dependency mirror, including a successful `cri-o 5.0.0` package probe
- Live fallback-recovery transition from the 4.22 dependency mirror back to `rhocp-4.22`, including removal of the same-stream mirror and metadata cleanup
- Controlled template failure after successful mirror probing, confirming repository-configuration errors retain their original diagnostics

The current 5.0 RPM transaction reaches dependency resolution and then stops at MicroShift's existing `cri-o < 1.37.0` specification bound after the external CRI-O package renumbering. This change intentionally addresses repository selection without changing MicroShift's package-version policy.

[USHIFT-7485](https://issues.redhat.com/browse/USHIFT-7485)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source builds now automatically select compatible OpenShift repositories or dependency mirrors.
  * Added checks for required `cri-o` packages and clearer errors when dependencies are unavailable.
  * Prerelease builds use dependency mirrors directly when needed.
  * Repository listings now display more descriptive names.

* **Documentation**
  * Updated repository configuration guidance to explain selection, fallback behavior, and RPM compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->