### PR TITLE
USHIFT-7487: Bump CRI-O dependency to 5.1.0 for release-5.1

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -71,7 +71,7 @@ BuildRequires: systemd
 BuildRequires: golang
 # DO NOT REMOVE
 
-Requires: cri-o >= 1.36.0, cri-o < 1.37.0
+Requires: cri-o >= 5.1.0, cri-o < 5.2.0
 Requires: cri-tools >= 1.36.0, cri-tools < 1.37.0
 # The container networking plugins package has been removed from RHEL 10 and
 # cri-o no longer has an explicit dependency on it.


### PR DESCRIPTION
## Summary
- Update CRI-O version requirement from `>= 1.36.0, < 1.37.0` to `>= 5.1.0, < 5.2.0` in the RPM spec to match the OCP 5.1 dependency repo
- `cri-tools` stays at `1.36.0` as that is the version shipped in the [5.1-el9-beta repo](https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rpms/5.1-el9-beta/)

## Test plan
- [ ] Verify RPM builds successfully with the updated dependency
- [ ] Verify MicroShift installs with cri-o-5.1.0 from the 5.1 repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)