### PR TITLE
USHIFT-7487: Bump CRI-O dependency to 5.1.0 for release-5.1

### DIFF
--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -71,7 +71,7 @@ BuildRequires: systemd
 BuildRequires: golang
 # DO NOT REMOVE
 
-Requires: cri-o >= 1.36.0, cri-o < 1.37.0
+Requires: cri-o >= 5.1.0, cri-o < 5.2.0
 Requires: cri-tools >= 1.36.0, cri-tools < 1.37.0
 # The container networking plugins package has been removed from RHEL 10 and
 # cri-o no longer has an explicit dependency on it.

--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -71,11 +71,11 @@ get_vrel_from_rpm() {
 # The current release version (e.g. '4.17') affects
 # the definition of previous and fake next versions.
 export MAJOR_VERSION=5
-export MINOR_VERSION=0
-export PREVIOUS_MAJOR_VERSION=4
-export PREVIOUS_MINOR_VERSION=22
+export MINOR_VERSION=1
+export PREVIOUS_MAJOR_VERSION=5
+export PREVIOUS_MINOR_VERSION=0
 export YMINUS2_MAJOR_VERSION=4
-export YMINUS2_MINOR_VERSION=21
+export YMINUS2_MINOR_VERSION=22
 # Handle cross-major version boundary (e.g. 4.22 -> 5.0)
 declare -A LAST_MINOR_FOR_MAJOR=([4]=22)
 if [[ -n "${LAST_MINOR_FOR_MAJOR[${MAJOR_VERSION}]:-}" && \
@@ -93,8 +93,8 @@ fi
 #
 # For a release branch, the current release repository should come from the
 # official 'rhocp' stream.
-CURRENT_RELEASE_REPO="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/microshift/ocp-dev-preview/latest-5.0/el9/os"
-CURRENT_RELEASE_VERSION="$(get_vrel_from_beta "${CURRENT_RELEASE_REPO}")"
+CURRENT_RELEASE_REPO=""
+CURRENT_RELEASE_VERSION=""
 export CURRENT_RELEASE_REPO
 export CURRENT_RELEASE_VERSION
 
@@ -109,16 +109,16 @@ export CURRENT_RELEASE_VERSION
 # For a release branch, the previous release repository should come from the
 # official 'rhocp' stream.# The previous release repository value should either
 # point to the OpenShift mirror URL or the 'rhocp' repository name.
-PREVIOUS_RELEASE_REPO="rhocp-4.22-for-rhel-9-${UNAME_M}-rpms"
-PREVIOUS_RELEASE_VERSION="$(get_vrel_from_rhsm "${PREVIOUS_RELEASE_REPO}")"
+PREVIOUS_RELEASE_REPO="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/microshift/ocp-dev-preview/latest-5.0/el9/os"
+PREVIOUS_RELEASE_VERSION="$(get_vrel_from_beta "${PREVIOUS_RELEASE_REPO}")"
 export PREVIOUS_RELEASE_REPO
 export PREVIOUS_RELEASE_VERSION
 
 # The y-2 release repository value should either point to the OpenShift
 # mirror URL or the 'rhocp' repository name. It should always come from
 # the 'rhocp' stream.
-YMINUS2_RELEASE_REPO="rhocp-4.21-for-rhel-9-${UNAME_M}-rpms"
-YMINUS2_RELEASE_VERSION="$(get_vrel_from_rhsm "${YMINUS2_RELEASE_REPO}")"
+YMINUS2_RELEASE_REPO="https://mirror.openshift.com/pub/openshift-v4/${UNAME_M}/microshift/ocp/latest-4.22/el9/os"
+YMINUS2_RELEASE_VERSION="$(get_vrel_from_beta "${YMINUS2_RELEASE_REPO}")"
 export YMINUS2_RELEASE_REPO
 export YMINUS2_RELEASE_VERSION
 
@@ -130,7 +130,7 @@ RHOCP_MINOR_Y=""
 # The beta repository, containing dependencies, should point to the
 # OpenShift mirror URL. If the mirror for current minor is not
 # available yet, it should point to an older release.
-RHOCP_MINOR_Y_BETA="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/dependencies/rpms/5.0-el9-beta"
+RHOCP_MINOR_Y_BETA="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/dependencies/rpms/5.1-el9-beta"
 export RHOCP_MAJOR_Y
 export RHOCP_MINOR_Y
 export RHOCP_MINOR_Y_BETA
@@ -138,19 +138,19 @@ export RHOCP_MINOR_Y_BETA
 # The 'rhocp_major_y1' and 'rhocp_minor_y1' variables should be the previous major
 # and minor version numbers, if the previous release is available through the
 # 'rhocp' stream, otherwise empty.
-RHOCP_MAJOR_Y1=4
-RHOCP_MINOR_Y1=22
+RHOCP_MAJOR_Y1=""
+RHOCP_MINOR_Y1=""
 # The beta repository, containing dependencies, should point to the
 # OpenShift mirror URL. The mirror for previous release should always
 # be available.
-RHOCP_MINOR_Y1_BETA="https://mirror.openshift.com/pub/openshift-v4/${UNAME_M}/dependencies/rpms/4.22-el9-beta"
+RHOCP_MINOR_Y1_BETA="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/dependencies/rpms/5.0-el9-beta"
 export RHOCP_MAJOR_Y1
 export RHOCP_MINOR_Y1
 export RHOCP_MINOR_Y1_BETA
 
 # The 'rhocp_major_y2' and 'rhocp_minor_y2' should always be the y-2 version numbers.
 export RHOCP_MAJOR_Y2=4
-export RHOCP_MINOR_Y2=21
+export RHOCP_MINOR_Y2=22
 
 export CNCF_SONOBUOY_VERSION=v0.57.3
 


### PR DESCRIPTION
## Summary
- Update CRI-O version requirement from `>= 1.36.0, < 1.37.0` to `>= 5.1.0, < 5.2.0` in the RPM spec to match the OCP 5.1 dependency repo
- `cri-tools` stays at `1.36.0` as that is the version shipped in the [5.1-el9-beta repo](https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rpms/5.1-el9-beta/)

## Test plan
- [ ] Verify RPM builds successfully with the updated dependency
- [ ] Verify MicroShift installs with cri-o-5.1.0 from the 5.1 repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MicroShift RPM package to require a compatible CRI-O version in the 5.1.x release range.
  * Updated beta dependency references to use the 5.1 repository path.

* **Chores**
  * Updated release metadata and repository mappings for the 5.1 release cycle, including compatibility with 5.0 and 4.22 repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->