### PR TITLE
NO-JIRA: scripts: prefer locally built RPMs over product repos in configure-vm.sh

### DIFF
--- a/scripts/devenv-builder/configure-vm.sh
+++ b/scripts/devenv-builder/configure-vm.sh
@@ -309,10 +309,15 @@ function build_and_install_microshift_rpms() {
         "${DNF_RETRY}" "localinstall" "$(find ~/microshift/_output/rpmbuild/RPMS -type f -name "*.rpm" $(printf ' -not -name *%s* ' ${SKIPPED_RPMS}))"
     else
         createrepo "${HOME}/microshift/_output/rpmbuild"
+        # Set the highest priority on the local repository to ensure that the
+        # locally built RPMs are preferred over any RPMs published in product
+        # repositories (e.g. rhocp-4.y), whose release versions may sort higher
+        # than the locally built nightly versions.
         "${DNF_RETRY}" "install" \
             "microshift microshift-release-info \
             --repofrompath=microshift-local,${HOME}/microshift/_output/rpmbuild \
-            --setopt=microshift-local.gpgcheck=0"
+            --setopt=microshift-local.gpgcheck=0 \
+            --setopt=microshift-local.priority=1"
     fi
 }
 


### PR DESCRIPTION
## What

Set `priority=1` on the `microshift-local` repository used by `configure-vm.sh` so dnf always installs the locally built RPMs instead of any `microshift` RPMs published in enabled product repositories.

Same change as https://github.com/openshift/microshift/pull/7257 (release-4.21), applied to this branch since the script is identical here and equally exposed.

## Why

On release-4.21, all conformance CI jobs permafailed because dnf resolved `microshift` from `rhocp-4.21-for-rhel-9-x86_64-rpms` (released NEVRA `4.21.29-...` sorts higher than the locally built nightly version) instead of the source-built RPMs in the `--repofrompath` local repo. The released RPM pins an outdated ovn-kubernetes image (missing the OCPBUGS-105440 fix), so CI kept hitting an already-fixed bug. See #7257 for the full investigation.

The same silent version-ordering hazard exists on every branch once a matching product repo publishes a higher-versioned microshift RPM. With repository priority 1 on the local repo, dnf prefers packages from it regardless of version ordering, so CI tests what it built.

## How was this tested

`bash -n` and `shellcheck` on the modified script (no new findings). Behavioral verification comes from CI on this PR; not verified locally.

---
This PR description was generated using AI. Please verify before acting on it.
Assisted-By: Claude Fable 5