### PR TITLE
USHIFT-6747: Migrate 14 QE networking/router tests to Robot Framework

### DIFF
--- a/test/assets/host-networking/hostport-pod.yaml
+++ b/test/assets/host-networking/hostport-pod.yaml
@@ -1,0 +1,27 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hostport-pod
+  labels:
+    app: hostport-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+  - name: hostport-pod
+    image: quay.io/microshift/busybox:1.36
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo -ne \"HTTP/1.0 200 OK\r\nContent-Length: 16\r\n\r\nHello MicroShift\" | nc -l -p 8080 ; done"]
+    ports:
+    - containerPort: 8080
+      hostPort: 9500
+      protocol: TCP
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      seccompProfile:
+        type: RuntimeDefault

--- a/test/assets/host-networking/udp-listener-pod.yaml
+++ b/test/assets/host-networking/udp-listener-pod.yaml
@@ -1,0 +1,26 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: udp-pod
+  labels:
+    app: udp-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+  - name: udp-listener
+    image: quay.io/microshift/busybox:1.36
+    command: ["/bin/sh"]
+    args: ["-c", "nc -u -l -p 8080 -e /bin/cat; sleep infinity"]
+    ports:
+    - containerPort: 8080
+      protocol: UDP
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      seccompProfile:
+        type: RuntimeDefault

--- a/test/assets/network-policy/netpol-allow-from-red.yaml
+++ b/test/assets/network-policy/netpol-allow-from-red.yaml
@@ -1,0 +1,11 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-red
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          type: red

--- a/test/assets/network-policy/netpol-allow-same-namespace.yaml
+++ b/test/assets/network-policy/netpol-allow-same-namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-same-namespace
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/test/assets/network-policy/netpol-allow-to-blue.yaml
+++ b/test/assets/network-policy/netpol-allow-to-blue.yaml
@@ -1,0 +1,10 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-to-blue
+spec:
+  podSelector:
+    matchLabels:
+      type: blue
+  ingress:
+  - {}

--- a/test/assets/network-policy/netpol-default-deny-ingress.yaml
+++ b/test/assets/network-policy/netpol-default-deny-ingress.yaml
@@ -1,0 +1,8 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/test/assets/network-policy/netpol-egress-ns-label.yaml
+++ b/test/assets/network-policy/netpol-egress-ns-label.yaml
@@ -1,0 +1,15 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: egress-ns-label
+spec:
+  podSelector:
+    matchLabels:
+      name: hello-microshift
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          team: openshift
+  policyTypes:
+  - Egress

--- a/test/assets/network-policy/netpol-ingress-pod-ns-label.yaml
+++ b/test/assets/network-policy/netpol-ingress-pod-ns-label.yaml
@@ -1,0 +1,18 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ingress-pod-ns-label
+spec:
+  podSelector:
+    matchLabels:
+      name: hello-microshift
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          team: operations
+      podSelector:
+        matchLabels:
+          name: test-pods
+  policyTypes:
+  - Ingress

--- a/test/assets/route-types/ingress-destca.yaml
+++ b/test/assets/route-types/ingress-destca.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-reencrypt
+  annotations:
+    route.openshift.io/destination-ca-certificate-secret: service-secret
+    route.openshift.io/termination: reencrypt
+spec:
+  rules:
+  - host: service-secure-test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: service-secure
+            port:
+              number: 27443
+        path: "/"
+        pathType: Prefix

--- a/test/assets/route-types/ingress-http.yaml
+++ b/test/assets/route-types/ingress-http.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-http
+spec:
+  rules:
+  - host: service-unsecure-test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: service-unsecure
+            port:
+              number: 27017
+        path: "/"
+        pathType: Prefix

--- a/test/assets/route-types/web-server-deploy.yaml
+++ b/test/assets/route-types/web-server-deploy.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-server-deploy
+    labels:
+      app: web-server-deploy
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        name: web-server-deploy
+    template:
+      metadata:
+        labels:
+          name: web-server-deploy
+      spec:
+        containers:
+        - name: nginx
+          image: quay.io/microshift/hello-world:latest
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+- kind: Service
+  apiVersion: v1
+  metadata:
+    labels:
+      name: service-secure
+    name: service-secure
+  spec:
+    ports:
+    - name: https
+      protocol: TCP
+      port: 27443
+      targetPort: 8443
+    selector:
+      name: web-server-deploy
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      name: service-unsecure
+    name: service-unsecure
+  spec:
+    ports:
+    - name: http
+      port: 27017
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: web-server-deploy

--- a/test/assets/route-types/web-server-deploy.yaml
+++ b/test/assets/route-types/web-server-deploy.yaml
@@ -17,6 +17,7 @@ items:
         labels:
           name: web-server-deploy
       spec:
+        automountServiceAccountToken: false
         containers:
         - name: nginx
           image: quay.io/microshift/hello-world:latest

--- a/test/assets/route-types/web-server-signed-deploy.yaml
+++ b/test/assets/route-types/web-server-signed-deploy.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: nginx-config
+  data:
+    nginx.conf: |
+      events {
+          worker_connections 1024;
+      }
+
+      http {
+          server {
+              listen       8080;
+              listen       [::]:8080;
+              location / {
+                  root /data/http;
+              }
+          }
+
+          server {
+              listen               8443 ssl http2 default;
+              listen               [::]:8443 ssl http2 default;
+              server_name          _;
+              ssl_certificate      certs/tls.crt;
+              ssl_certificate_key  certs/tls.key;
+              location / {
+                  root /data/https-default;
+              }
+          }
+      }
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-server-deploy
+    labels:
+      name: web-server-deploy
+  spec:
+    replicas: 1
+    selector:
+      matchExpressions:
+      - {key: name, operator: In, values: [web-server-deploy]}
+    template:
+      metadata:
+        labels:
+          name: web-server-deploy
+      spec:
+        containers:
+        - name: nginx
+          image: quay.io/microshift/hello-world:latest
+          volumeMounts:
+          - name: service-secret
+            mountPath: /etc/nginx/certs/
+          - name: nginx-config
+            mountPath: /etc/nginx/
+        volumes:
+        - name: service-secret
+          secret:
+            secretName: service-secret
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+- kind: Service
+  apiVersion: v1
+  metadata:
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: service-secret
+    labels:
+      name: service-secure
+    name: service-secure
+  spec:
+    ports:
+    - name: https
+      protocol: TCP
+      port: 27443
+      targetPort: 8443
+    selector:
+      name: web-server-deploy
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      name: service-unsecure
+    name: service-unsecure
+  spec:
+    ports:
+    - name: http
+      port: 27017
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: web-server-deploy

--- a/test/assets/service-types/deployment-hello-2-replicas.yaml
+++ b/test/assets/service-types/deployment-hello-2-replicas.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-deploy
+  labels:
+    app: hello-deploy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-deploy
+  template:
+    metadata:
+      labels:
+        app: hello-deploy
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: hello-microshift
+        image: quay.io/microshift/busybox:1.36
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do echo -ne \"HTTP/1.0 200 OK\r\nContent-Length: 16\r\n\r\nHello MicroShift\" | nc -l -p 8080 ; done"]
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 1001
+          seccompProfile:
+            type: RuntimeDefault

--- a/test/assets/service-types/service-clusterip.yaml
+++ b/test/assets/service-types/service-clusterip.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-deploy
+  labels:
+    app: hello-deploy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: hello-deploy

--- a/test/resources/network-testing.resource
+++ b/test/resources/network-testing.resource
@@ -1,0 +1,161 @@
+*** Settings ***
+Documentation       Reusable keywords for networking, service, route, and
+...                 infrastructure tests.
+
+Library             SSHLibrary
+Resource            oc.resource
+Resource            common.resource
+Resource            microshift-host.resource
+Resource            microshift-network.resource
+
+
+*** Keywords ***
+Create Labeled Pod
+    [Documentation]    Create a hello-microshift-style pod with the given name and labels.
+    ...    Uses 'oc run' to create the pod inline with a simple HTTP server on port 8080.
+    [Arguments]    ${name}    ${ns}    ${labels}=${EMPTY}    ${port}=8080
+    ${label_arg}=    Set Variable If    '${labels}' != '${EMPTY}'    --labels=${labels}    ${EMPTY}
+    Run With Kubeconfig
+    ...    oc run ${name} -n ${ns} ${label_arg} --image=quay.io/microshift/busybox:1.36 --command -- /bin/sh -c "while true; do echo -ne 'HTTP/1.0 200 OK\\r\\nContent-Length: 16\\r\\n\\r\\nHello MicroShift' | nc -l -p ${port}; done"
+    Labeled Pod Should Be Ready    name\=${name}    ns=${ns}
+
+Get Pod IP
+    [Documentation]    Return the IP address of the named pod.
+    [Arguments]    ${name}    ${ns}
+    ${ip}=    Oc Get JsonPath    pod    ${ns}    ${name}    .status.podIP
+    RETURN    ${ip}
+
+Curl From Pod Should Succeed
+    [Documentation]    Exec a curl from inside a pod and assert HTTP success.
+    [Arguments]    ${pod}    ${ns}    ${url}    ${timeout}=5    ${expected}=Hello
+    ${stdout}=    Run With Kubeconfig
+    ...    oc exec ${pod} -n ${ns} -- curl -s --max-time ${timeout} ${url}
+    Should Contain    ${stdout}    ${expected}
+
+Curl From Pod Should Fail
+    [Documentation]    Exec a curl from inside a pod and assert it fails (timeout or connection refused).
+    [Arguments]    ${pod}    ${ns}    ${url}    ${timeout}=5
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    KUBECONFIG\=${KUBECONFIG} oc exec ${pod} -n ${ns} -- curl -s --max-time ${timeout} ${url}
+    ...    sudo=False    return_rc=True    return_stderr=True    return_stdout=True
+    Log Many    ${stdout}    ${stderr}    ${rc}
+    Should Not Be Equal As Integers    ${rc}    0
+
+Curl From Pod Should Timeout
+    [Documentation]    Exec a curl from inside a pod and assert it returns exit code 28 (timeout).
+    [Arguments]    ${pod}    ${ns}    ${url}    ${timeout}=5
+    ${stdout}    ${stderr}    ${rc}=    SSHLibrary.Execute Command
+    ...    KUBECONFIG\=${KUBECONFIG} oc exec ${pod} -n ${ns} -- curl -s --max-time ${timeout} ${url}
+    ...    sudo=False    return_rc=True    return_stderr=True    return_stdout=True
+    Log Many    ${stdout}    ${stderr}    ${rc}
+    Should Be Equal As Integers    ${rc}    28
+    ...    msg=Expected curl timeout (rc=28) but got rc=${rc}. stdout: ${stdout}, stderr: ${stderr}
+
+Get Service ClusterIP
+    [Documentation]    Return the ClusterIP of the named service.
+    [Arguments]    ${name}    ${ns}
+    ${ip}=    Oc Get JsonPath    service    ${ns}    ${name}    .spec.clusterIP
+    RETURN    ${ip}
+
+Get Service NodePort
+    [Documentation]    Return the first NodePort of the named service.
+    [Arguments]    ${name}    ${ns}
+    ${port}=    Oc Get JsonPath    service    ${ns}    ${name}    .spec.ports[0].nodePort
+    RETURN    ${port}
+
+Wait For LoadBalancer IP
+    [Documentation]    Poll until the service has a load balancer ingress IP. Return the IP.
+    [Arguments]    ${name}    ${ns}    ${retries}=30    ${interval}=10s
+    Wait Until Keyword Succeeds    ${retries}x    ${interval}
+    ...    Service Should Have LB IP    ${name}    ${ns}
+    ${ip}=    Oc Get JsonPath    service    ${ns}    ${name}    .status.loadBalancer.ingress[0].ip
+    RETURN    ${ip}
+
+Service Should Have LB IP
+    [Documentation]    Assert that the service has a load balancer ingress IP.
+    [Arguments]    ${name}    ${ns}
+    ${ip}=    Oc Get JsonPath    service    ${ns}    ${name}    .status.loadBalancer.ingress[0].ip
+    Should Not Be Empty    ${ip}
+
+Service Should Not Have LB IP
+    [Documentation]    Assert that the service exists but does NOT have a load balancer ingress IP.
+    [Arguments]    ${name}    ${ns}
+    Run With Kubeconfig    oc get service ${name} -n ${ns}
+    ${ip}=    Run With Kubeconfig
+    ...    oc get service ${name} -n ${ns} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+    ...    allow_fail=True
+    Should Be Empty    ${ip}
+
+Get Router Pod IP
+    [Documentation]    Return the IP of the router-default pod in openshift-ingress.
+    ${ip}=    Run With Kubeconfig
+    ...    oc get pod -n openshift-ingress -l ingresscontroller.operator.openshift.io/deployment-ingresscontroller\=default -o jsonpath='{.items[0].status.podIP}'
+    Should Not Be Empty    ${ip}
+    RETURN    ${ip}
+
+Get Router LB IP
+    [Documentation]    Return the LoadBalancer IP of the router-default service.
+    ${ip}=    Oc Get JsonPath    service    openshift-ingress    router-default
+    ...    .status.loadBalancer.ingress[0].ip
+    Should Not Be Empty    ${ip}
+    RETURN    ${ip}
+
+Verify Route Is Admitted
+    [Documentation]    Assert the named route has been admitted by the router.
+    [Arguments]    ${name}    ${ns}
+    ${status}=    Run With Kubeconfig
+    ...    oc get route ${name} -n ${ns} -o jsonpath='{.status.ingress[0].conditions[?(@.type=="Admitted")].status}'
+    Should Be Equal As Strings    ${status}    True
+
+Curl Route Should Succeed
+    [Documentation]    Curl a route via --resolve and assert HTTP 200.
+    [Arguments]    ${hostname}    ${ip}    ${port}    ${scheme}=https
+    ${result}=    Run Process
+    ...    curl -k -s -o /dev/null -w "%{http_code}" --max-time 10 --resolve ${hostname}:${port}:${ip} ${scheme}://${hostname}:${port}/
+    ...    shell=True    timeout=15s
+    Log Many    stdout: ${result.stdout}    stderr: ${result.stderr}    rc: ${result.rc}
+    Should Be Equal As Integers    ${result.rc}    0
+    ...    msg=curl failed with rc=${result.rc}: ${result.stderr}
+    Should Be Equal As Strings    ${result.stdout}    200
+    ...    msg=Expected HTTP 200 but got ${result.stdout} for ${scheme}://${hostname}:${port}/
+
+Verify HAProxy Backend Exists
+    [Documentation]    Check that the haproxy config in the router contains the expected backend.
+    [Arguments]    ${backend_pattern}
+    ${config}=    Run With Kubeconfig
+    ...    oc rsh -n openshift-ingress deployment/router-default cat /var/lib/haproxy/conf/haproxy.config
+    Should Contain    ${config}    ${backend_pattern}
+
+Label Namespace
+    [Documentation]    Add a label to a namespace.
+    [Arguments]    ${ns}    ${label}
+    Run With Kubeconfig    oc label namespace ${ns} ${label} --overwrite
+
+Conntrack Should Contain
+    [Documentation]    Assert that conntrack table contains entries matching the pattern.
+    [Arguments]    ${proto}    ${port}    ${pattern}
+    ${stdout}    ${stderr}    ${rc}=    Command Execution    conntrack -L -p ${proto} --dport ${port}
+    IF    ${rc} != 0
+        Fail    conntrack command failed with rc=${rc}: ${stderr}
+    END
+    Should Contain    ${stdout}    ${pattern}
+
+Conntrack Should Not Contain
+    [Documentation]    Assert that conntrack table does NOT contain entries matching the pattern.
+    ...    conntrack returns rc=1 when no entries are found, which is acceptable.
+    [Arguments]    ${proto}    ${port}    ${pattern}
+    ${stdout}    ${stderr}    ${rc}=    Command Execution    conntrack -L -p ${proto} --dport ${port}
+    IF    ${rc} != 0 and ${rc} != 1
+        Fail    conntrack command failed with rc=${rc}: ${stderr}
+    END
+    Should Not Contain    ${stdout}    ${pattern}
+
+Wait For Router Ready
+    [Documentation]    Wait for the default router to be ready.
+    Oc Wait    namespace/openshift-ingress    --for jsonpath='{.status.phase}=Active' --timeout=5m
+    Named Deployment Should Be Available    router-default    openshift-ingress    5m
+
+Restart Router
+    [Documentation]    Restart the router and wait for readiness.
+    Run With Kubeconfig    oc rollout restart deployment router-default -n openshift-ingress
+    Wait For Router Ready

--- a/test/resources/network-testing.resource
+++ b/test/resources/network-testing.resource
@@ -15,8 +15,10 @@ Create Labeled Pod
     ...    Uses 'oc run' to create the pod inline with a simple HTTP server on port 8080.
     [Arguments]    ${name}    ${ns}    ${labels}=${EMPTY}    ${port}=8080
     ${label_arg}=    Set Variable If    '${labels}' != '${EMPTY}'    --labels=${labels}    ${EMPTY}
+    # robocop: off=line-too-long
     Run With Kubeconfig
     ...    oc run ${name} -n ${ns} ${label_arg} --image=quay.io/microshift/busybox:1.36 --command -- /bin/sh -c "while true; do echo -ne 'HTTP/1.0 200 OK\\r\\nContent-Length: 16\\r\\n\\r\\nHello MicroShift' | nc -l -p ${port}; done"
+    # robocop: on=line-too-long
     Labeled Pod Should Be Ready    name\=${name}    ns=${ns}
 
 Get Pod IP
@@ -112,7 +114,8 @@ Curl Route Should Succeed
     [Arguments]    ${hostname}    ${ip}    ${port}    ${scheme}=https
     ${result}=    Run Process
     ...    curl -k -s -o /dev/null -w "%{http_code}" --max-time 10 --resolve ${hostname}:${port}:${ip} ${scheme}://${hostname}:${port}/
-    ...    shell=True    timeout=15s
+    ...    shell=True
+    ...    timeout=15s
     Log Many    stdout: ${result.stdout}    stderr: ${result.stderr}    rc: ${result.rc}
     Should Be Equal As Integers    ${result.rc}    0
     ...    msg=curl failed with rc=${result.rc}: ${result.stderr}

--- a/test/scenarios/releases/el96-lrel@network-features.sh
+++ b/test/scenarios/releases/el96-lrel@network-features.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Sourced from scenario.sh and uses functions defined there.
+
+start_image="rhel96-brew-lrel-optional"
+
+scenario_create_vms() {
+    exit_if_commit_not_found "${start_image}"
+
+    prepare_kickstart host1 kickstart.ks.template "${start_image}"
+    launch_vm rhel-9.6 --vm_vcpus 4
+}
+
+scenario_remove_vms() {
+    exit_if_commit_not_found "${start_image}"
+
+    remove_vm host1
+}
+
+scenario_run_tests() {
+    exit_if_commit_not_found "${start_image}"
+
+    run_tests host1 \
+        suites/network/network-policy.robot \
+        suites/network/service-types.robot \
+        suites/network/host-networking.robot \
+        suites/router/route-types.robot
+}

--- a/test/suites/network/host-networking.robot
+++ b/test/suites/network/host-networking.robot
@@ -1,0 +1,89 @@
+*** Settings ***
+Documentation       Host networking tests: hostPort, br-ex NM state, conntrack cleanup.
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/oc.resource
+Resource            ../../resources/microshift-host.resource
+Resource            ../../resources/microshift-network.resource
+Resource            ../../resources/network-testing.resource
+
+Suite Setup         Setup Suite With Namespace
+Suite Teardown      Teardown Suite With Namespace
+
+Test Tags           network
+
+
+*** Variables ***
+${HOSTPORT_POD}         ./assets/host-networking/hostport-pod.yaml
+${UDP_LISTENER_POD}     ./assets/host-networking/udp-listener-pod.yaml
+${HOSTPORT}             9500
+
+
+*** Test Cases ***
+Pod Should Be Accessible Via Node IP And Host Port
+    [Documentation]    Verify a pod with hostPort is reachable from the node IP.
+    ...    Covers QE test 60550.
+    [Setup]    Create HostPort Pod
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    HostPort Should Be Reachable
+
+    [Teardown]    Oc Delete    -f ${HOSTPORT_POD} -n ${NAMESPACE}
+
+Br-ex Should Be Unmanaged By NetworkManager
+    [Documentation]    Verify that br-ex interface is not managed by NetworkManager.
+    ...    Covers QE test 65838.
+    ${stdout}=    Command Should Work    nmcli conn show
+    Should Not Contain    ${stdout}    br-ex
+
+Conntrack Entry Should Be Cleaned Up When UDP NodePort Endpoint Is Deleted
+    [Documentation]    Verify that OVN-Kubernetes removes conntrack entries for UDP
+    ...    traffic when the service endpoint pod is deleted.
+    ...    Covers QE test 64752.
+    [Setup]    Setup UDP Conntrack Test
+
+    ${udp_pod_ip}=    Get Pod IP    udp-pod    ${NAMESPACE}
+    ${node_port}=    Get Service NodePort    udp-pod    ${NAMESPACE}
+
+    Send UDP Traffic    ${node_port}
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Conntrack Should Contain    udp    8080    ${udp_pod_ip}
+
+    Oc Delete    pod/udp-pod -n ${NAMESPACE}
+    Oc Wait    pod/udp-pod -n ${NAMESPACE}    --for=delete --timeout=120s
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Conntrack Should Not Contain    udp    8080    ${udp_pod_ip}
+
+    [Teardown]    Run Keywords
+    ...    Run With Kubeconfig    oc delete service udp-pod -n ${NAMESPACE}    allow_fail=True
+    ...    AND
+    ...    Run With Kubeconfig    oc delete -f ${UDP_LISTENER_POD} -n ${NAMESPACE}    allow_fail=True
+
+
+*** Keywords ***
+Create HostPort Pod
+    [Documentation]    Create a pod with hostPort and wait for it to be ready.
+    Oc Create    -f ${HOSTPORT_POD} -n ${NAMESPACE}
+    Labeled Pod Should Be Ready    app\=hostport-pod    ns=${NAMESPACE}
+
+HostPort Should Be Reachable
+    [Documentation]    Curl the hostPort from the MicroShift host and assert success.
+    ${stdout}=    Command Should Work    curl -s --max-time 5 http://127.0.0.1:${HOSTPORT}
+    Should Contain    ${stdout}    Hello MicroShift
+
+Setup UDP Conntrack Test
+    [Documentation]    Deploy the UDP listener pod and expose it as a NodePort service.
+    Oc Create    -f ${UDP_LISTENER_POD} -n ${NAMESPACE}
+    Labeled Pod Should Be Ready    app\=udp-pod    ns=${NAMESPACE}
+    Run With Kubeconfig
+    ...    oc expose pod udp-pod --type=NodePort --port=8080 --protocol=UDP -n ${NAMESPACE}
+    ${node_port}=    Get Service NodePort    udp-pod    ${NAMESPACE}
+    Log    UDP NodePort: ${node_port}
+
+Send UDP Traffic
+    [Documentation]    Send UDP packets to the given NodePort from the host.
+    [Arguments]    ${port}
+    Command Should Work
+    ...    bash -c 'for n in 1 2 3; do echo $n > /dev/udp/127.0.0.1/${port}; sleep 0.5; done'
+    ...    sudo_mode=False

--- a/test/suites/network/network-policy.robot
+++ b/test/suites/network/network-policy.robot
@@ -1,0 +1,189 @@
+*** Settings ***
+Documentation       NetworkPolicy tests: ingress/egress rules, hairpin traffic,
+...                 podSelector-based allow/deny policies.
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/oc.resource
+Resource            ../../resources/microshift-network.resource
+Resource            ../../resources/network-testing.resource
+
+Suite Setup         Setup Suite With Namespace
+Suite Teardown      Teardown Suite With Namespace
+
+Test Tags           network    slow
+
+
+*** Variables ***
+${NETPOL_ASSETS}    ./assets/network-policy
+${CURL_TIMEOUT}     5
+
+
+*** Test Cases ***
+Mixed Ingress And Egress NetworkPolicy
+    [Documentation]    Verify that mixed ingress and egress NetworkPolicies block
+    ...    cross-namespace traffic correctly. Egress policy restricts pods to
+    ...    only reach namespaces labeled team=openshift, while ingress policy
+    ...    restricts to traffic from pods labeled name=test-pods.
+    ...    Covers QE test 60331.
+    [Setup]    Setup Mixed Policy Test
+
+    ${hello_pod_ns1}=    Set Variable    hello-microshift
+    ${hello_pod_ip_ns2}=    Get Pod IP    hello-microshift    ${NS_MIXED_2}
+
+    Wait Until Keyword Succeeds    5x    5s
+    ...    Curl From Pod Should Timeout
+    ...    ${hello_pod_ns1}    ${NS_MIXED_1}
+    ...    http://${hello_pod_ip_ns2}:8080    timeout=${CURL_TIMEOUT}
+
+    [Teardown]    Teardown Mixed Policy Test
+
+Hairpin Traffic Through Service With NetworkPolicy
+    [Documentation]    Verify that NetworkPolicy allowing same-namespace traffic works
+    ...    correctly when traffic hairpins through a service back to the same
+    ...    source pod. Tests both direct pod-to-pod and pod-to-service connectivity.
+    ...    Covers QE test 60332.
+    [Setup]    Setup Hairpin Test
+
+    ${pod1_ip}=    Get Pod IP    hello-pod1    ${NAMESPACE}
+    ${pod2_ip}=    Get Pod IP    hello-pod2    ${NAMESPACE}
+    ${svc_ip}=    Get Service ClusterIP    test-service    ${NAMESPACE}
+
+    Wait Until Keyword Succeeds    5x    2s
+    ...    Curl From Pod Should Succeed
+    ...    hello-pod1    ${NAMESPACE}    http://${pod2_ip}:8080
+    ...    expected=Hello MicroShift
+
+    Wait Until Keyword Succeeds    5x    2s
+    ...    Curl From Pod Should Succeed
+    ...    hello-pod2    ${NAMESPACE}    http://${pod1_ip}:8080
+    ...    expected=Hello MicroShift
+
+    FOR    ${i}    IN RANGE    5
+        Curl From Pod Should Succeed
+        ...    hello-pod1    ${NAMESPACE}    http://${svc_ip}:27017
+        ...    expected=Hello MicroShift
+        Curl From Pod Should Succeed
+        ...    hello-pod2    ${NAMESPACE}    http://${svc_ip}:27017
+        ...    expected=Hello MicroShift
+    END
+
+    [Teardown]    Teardown Hairpin Test
+
+PodSelector Allow To And Allow From
+    [Documentation]    Verify that podSelector-based NetworkPolicies (allow-from-red,
+    ...    allow-to-blue, default-deny-ingress) work together. Tests 6 connectivity
+    ...    scenarios across 2 namespaces with labeled pods:
+    ...    - pod-red(type=red) -> pod-plain: ALLOWED (allow-from-red)
+    ...    - pod-plain -> pod-blue(type=blue): ALLOWED (allow-to-blue)
+    ...    - pod-plain -> pod-plain: DENIED (default-deny, no matching allow)
+    ...    - ns2/pod-plain -> ns1/pod-plain: DENIED (cross-namespace, no allow)
+    ...    - ns2/pod-plain -> ns1/pod-blue: ALLOWED (allow-to-blue allows all ingress)
+    ...    - ns2/pod-plain -> ns1/pod-plain: DENIED
+    ...    Covers QE test 60426.
+    [Setup]    Setup PodSelector Test
+
+    ${pod_red_ip_ns1}=    Get Pod IP    pod-red    ${NS_SEL_1}
+    ${pod_blue_ip_ns1}=    Get Pod IP    pod-blue    ${NS_SEL_1}
+    ${pod_plain_ip_ns1}=    Get Pod IP    pod-plain    ${NS_SEL_1}
+
+    # pod-red(type=red) in ns1 -> pod-plain in ns1: ALLOWED (allow-from-red matches source label)
+    Wait Until Keyword Succeeds    5x    2s
+    ...    Curl From Pod Should Succeed
+    ...    pod-red    ${NS_SEL_1}    http://${pod_plain_ip_ns1}:8080
+    ...    expected=Hello MicroShift
+
+    # pod-plain in ns1 -> pod-blue(type=blue) in ns1: ALLOWED (allow-to-blue allows all ingress)
+    Wait Until Keyword Succeeds    5x    2s
+    ...    Curl From Pod Should Succeed
+    ...    pod-plain    ${NS_SEL_1}    http://${pod_blue_ip_ns1}:8080
+    ...    expected=Hello MicroShift
+
+    # pod-plain in ns1 -> pod-plain in ns1: DENIED (no matching allow rule)
+    Wait Until Keyword Succeeds    5x    5s
+    ...    Curl From Pod Should Timeout
+    ...    pod-plain-src    ${NS_SEL_1}    http://${pod_plain_ip_ns1}:8080
+    ...    timeout=${CURL_TIMEOUT}
+
+    # ns2/pod-plain -> ns1/pod-plain: DENIED (cross-namespace, no allow rule)
+    Wait Until Keyword Succeeds    5x    5s
+    ...    Curl From Pod Should Timeout
+    ...    pod-plain    ${NS_SEL_2}    http://${pod_plain_ip_ns1}:8080
+    ...    timeout=${CURL_TIMEOUT}
+
+    # ns2/pod-plain -> ns1/pod-blue: ALLOWED (allow-to-blue allows all ingress to blue)
+    Wait Until Keyword Succeeds    5x    2s
+    ...    Curl From Pod Should Succeed
+    ...    pod-plain    ${NS_SEL_2}    http://${pod_blue_ip_ns1}:8080
+    ...    expected=Hello MicroShift
+
+    # ns2/pod-plain -> ns1/pod-red: DENIED (default-deny, pod-plain has no matching label)
+    Wait Until Keyword Succeeds    5x    5s
+    ...    Curl From Pod Should Timeout
+    ...    pod-plain    ${NS_SEL_2}    http://${pod_red_ip_ns1}:8080
+    ...    timeout=${CURL_TIMEOUT}
+
+    [Teardown]    Teardown PodSelector Test
+
+
+*** Keywords ***
+Setup Mixed Policy Test
+    [Documentation]    Create 2 namespaces, deploy pods with labels, apply egress and ingress policies.
+    ${ns1}=    Create Random Namespace
+    ${ns2}=    Create Random Namespace
+    Set Suite Variable    ${NS_MIXED_1}    ${ns1}
+    Set Suite Variable    ${NS_MIXED_2}    ${ns2}
+
+    Create Hello MicroShift Pod    ns=${ns1}
+    Create Hello MicroShift Pod    ns=${ns2}
+
+    Oc Apply    -f ${NETPOL_ASSETS}/netpol-egress-ns-label.yaml -n ${ns1}
+    Oc Apply    -f ${NETPOL_ASSETS}/netpol-ingress-pod-ns-label.yaml -n ${ns1}
+
+Teardown Mixed Policy Test
+    [Documentation]    Delete the extra namespaces.
+    Run With Kubeconfig    oc delete namespace ${NS_MIXED_1}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${NS_MIXED_2}    allow_fail=True
+
+Setup Hairpin Test
+    [Documentation]    Create 2 pods with shared label, a ClusterIP service, and the
+    ...    allow-from-same-namespace NetworkPolicy.
+    Create Labeled Pod    hello-pod1    ${NAMESPACE}    labels=name=hello-pod
+    Create Labeled Pod    hello-pod2    ${NAMESPACE}    labels=name=hello-pod
+    Run With Kubeconfig
+    ...    oc create service clusterip test-service --tcp=27017:8080 -n ${NAMESPACE}
+    Run With Kubeconfig
+    ...    oc set selector service test-service name=hello-pod -n ${NAMESPACE}
+    Oc Apply    -f ${NETPOL_ASSETS}/netpol-allow-same-namespace.yaml -n ${NAMESPACE}
+
+Teardown Hairpin Test
+    [Documentation]    Remove hairpin test resources.
+    Run With Kubeconfig    oc delete networkpolicy allow-from-same-namespace -n ${NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete service test-service -n ${NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete pod hello-pod1 hello-pod2 -n ${NAMESPACE} --grace-period=0    allow_fail=True
+
+Setup PodSelector Test
+    [Documentation]    Create 2 namespaces with labeled pods and apply NetworkPolicies.
+    ${ns1}=    Create Random Namespace
+    ${ns2}=    Create Random Namespace
+    Set Suite Variable    ${NS_SEL_1}    ${ns1}
+    Set Suite Variable    ${NS_SEL_2}    ${ns2}
+
+    # ns1: pod-red (type=red), pod-blue (type=blue), pod-plain (no type label), pod-plain-src (curl source)
+    Create Labeled Pod    pod-red    ${ns1}    labels=name=pod-red,type=red
+    Create Labeled Pod    pod-blue    ${ns1}    labels=name=pod-blue,type=blue
+    Create Labeled Pod    pod-plain    ${ns1}    labels=name=pod-plain
+    Create Labeled Pod    pod-plain-src    ${ns1}    labels=name=pod-plain-src
+
+    # ns2: pod-red (type=red), pod-plain (no type label)
+    Create Labeled Pod    pod-red    ${ns2}    labels=name=pod-red,type=red
+    Create Labeled Pod    pod-plain    ${ns2}    labels=name=pod-plain
+
+    # Apply policies in ns1
+    Oc Apply    -f ${NETPOL_ASSETS}/netpol-default-deny-ingress.yaml -n ${ns1}
+    Oc Apply    -f ${NETPOL_ASSETS}/netpol-allow-from-red.yaml -n ${ns1}
+    Oc Apply    -f ${NETPOL_ASSETS}/netpol-allow-to-blue.yaml -n ${ns1}
+
+Teardown PodSelector Test
+    [Documentation]    Delete the extra namespaces.
+    Run With Kubeconfig    oc delete namespace ${NS_SEL_1}    allow_fail=True
+    Run With Kubeconfig    oc delete namespace ${NS_SEL_2}    allow_fail=True

--- a/test/suites/network/network-policy.robot
+++ b/test/suites/network/network-policy.robot
@@ -78,7 +78,7 @@ PodSelector Allow To And Allow From
     ...    - pod-plain -> pod-plain: DENIED (default-deny, no matching allow)
     ...    - ns2/pod-plain -> ns1/pod-plain: DENIED (cross-namespace, no allow)
     ...    - ns2/pod-plain -> ns1/pod-blue: ALLOWED (allow-to-blue allows all ingress)
-    ...    - ns2/pod-plain -> ns1/pod-plain: DENIED
+    ...    - ns2/pod-plain -> ns1/pod-red: DENIED
     ...    Covers QE test 60426.
     [Setup]    Setup PodSelector Test
 

--- a/test/suites/network/network-policy.robot
+++ b/test/suites/network/network-policy.robot
@@ -27,7 +27,7 @@ Mixed Ingress And Egress NetworkPolicy
     ...    Covers QE test 60331.
     [Setup]    Setup Mixed Policy Test
 
-    ${hello_pod_ns1}=    Set Variable    hello-microshift
+    VAR    ${hello_pod_ns1}=    hello-microshift
     ${hello_pod_ip_ns2}=    Get Pod IP    hello-microshift    ${NS_MIXED_2}
 
     Wait Until Keyword Succeeds    5x    5s
@@ -69,7 +69,7 @@ Hairpin Traffic Through Service With NetworkPolicy
 
     [Teardown]    Teardown Hairpin Test
 
-PodSelector Allow To And Allow From
+PodSelector Allow To And Allow From    # robocop: off=too-long-test-case
     [Documentation]    Verify that podSelector-based NetworkPolicies (allow-from-red,
     ...    allow-to-blue, default-deny-ingress) work together. Tests 6 connectivity
     ...    scenarios across 2 namespaces with labeled pods:
@@ -130,8 +130,8 @@ Setup Mixed Policy Test
     [Documentation]    Create 2 namespaces, deploy pods with labels, apply egress and ingress policies.
     ${ns1}=    Create Random Namespace
     ${ns2}=    Create Random Namespace
-    Set Suite Variable    ${NS_MIXED_1}    ${ns1}
-    Set Suite Variable    ${NS_MIXED_2}    ${ns2}
+    VAR    ${NS_MIXED_1}=    ${ns1}    scope=SUITE
+    VAR    ${NS_MIXED_2}=    ${ns2}    scope=SUITE
 
     Create Hello MicroShift Pod    ns=${ns1}
     Create Hello MicroShift Pod    ns=${ns2}
@@ -161,12 +161,12 @@ Teardown Hairpin Test
     Run With Kubeconfig    oc delete service test-service -n ${NAMESPACE}    allow_fail=True
     Run With Kubeconfig    oc delete pod hello-pod1 hello-pod2 -n ${NAMESPACE} --grace-period=0    allow_fail=True
 
-Setup PodSelector Test
+Setup PodSelector Test    # robocop: off=too-many-calls-in-keyword
     [Documentation]    Create 2 namespaces with labeled pods and apply NetworkPolicies.
     ${ns1}=    Create Random Namespace
     ${ns2}=    Create Random Namespace
-    Set Suite Variable    ${NS_SEL_1}    ${ns1}
-    Set Suite Variable    ${NS_SEL_2}    ${ns2}
+    VAR    ${NS_SEL_1}=    ${ns1}    scope=SUITE
+    VAR    ${NS_SEL_2}=    ${ns2}    scope=SUITE
 
     # ns1: pod-red (type=red), pod-blue (type=blue), pod-plain (no type label), pod-plain-src (curl source)
     Create Labeled Pod    pod-red    ${ns1}    labels=name=pod-red,type=red

--- a/test/suites/network/service-types.robot
+++ b/test/suites/network/service-types.robot
@@ -1,0 +1,176 @@
+*** Settings ***
+Documentation       Service type tests: LoadBalancer traffic policies, LB port binding,
+...                 and service idling/unidling.
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/oc.resource
+Resource            ../../resources/microshift-host.resource
+Resource            ../../resources/microshift-network.resource
+Resource            ../../resources/network-testing.resource
+
+Suite Setup         Setup Suite With Namespace
+Suite Teardown      Teardown Suite With Namespace
+
+Test Tags           network    slow
+
+
+*** Variables ***
+${SVC_ASSETS}       ./assets/service-types
+${LB_SVC_PORT}      27017
+
+
+*** Test Cases ***
+LoadBalancer Service With External And Internal Traffic Policies
+    [Documentation]    Verify LoadBalancer services work with different traffic policies.
+    ...    Tests ETP=Cluster (default ITP) via node debug pod, then ETP=Local/ITP=Local
+    ...    via cluster pod. Verifies cleanup removes firewalld entries after deletion.
+    ...    Covers QE test 60968.
+    [Setup]    Setup LB Traffic Policy Test
+
+    # --- ETP=Cluster, ITP=default ---
+    Create LB Service With Policies    lbtest-cluster    externalTrafficPolicy=Cluster
+    ${lb_ip}=    Wait For LoadBalancer IP    lbtest-cluster    ${NAMESPACE}
+    ${svc_port}=    Oc Get JsonPath    service    ${NAMESPACE}    lbtest-cluster    .spec.ports[0].port
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Via SSH Should Succeed    ${lb_ip}    ${svc_port}
+
+    Run With Kubeconfig    oc delete service lbtest-cluster -n ${NAMESPACE}
+
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Curl Via SSH Should Fail    ${lb_ip}    ${svc_port}
+
+    # --- ETP=Local, ITP=Local ---
+    Create LB Service With Policies    lbtest-local    externalTrafficPolicy=Local    internalTrafficPolicy=Local
+    ${lb_ip_local}=    Wait For LoadBalancer IP    lbtest-local    ${NAMESPACE}
+    ${svc_port_local}=    Oc Get JsonPath    service    ${NAMESPACE}    lbtest-local    .spec.ports[0].port
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl From Pod Should Succeed    test-pod    ${NAMESPACE}
+    ...    http://${lb_ip_local}:${svc_port_local}    expected=Hello MicroShift
+
+    Run With Kubeconfig    oc delete service lbtest-local -n ${NAMESPACE}
+
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Curl From Pod Should Timeout    test-pod    ${NAMESPACE}
+    ...    http://${lb_ip_local}:${svc_port_local}
+
+    [Teardown]    Teardown LB Traffic Policy Test
+
+Only One LoadBalancer Can Bind Same Port
+    [Documentation]    Verify that when two LoadBalancer services use the same port,
+    ...    only one gets a LoadBalancer IP. When the first is deleted, the second
+    ...    takes over the port binding.
+    ...    Covers QE test 61218.
+    [Setup]    Setup LB Port Binding Test
+
+    # Create first LB
+    Create LB Service With Policies    lbtest1    selector=hello-pod
+    ${lb_ip}=    Wait For LoadBalancer IP    lbtest1    ${NAMESPACE}
+
+    # Create second LB with same port
+    Create LB Service With Policies    lbtest2    selector=hello-pod
+
+    # First should have IP, second should not
+    Service Should Have LB IP    lbtest1    ${NAMESPACE}
+    Service Should Not Have LB IP    lbtest2    ${NAMESPACE}
+
+    # Verify first LB is accessible
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Curl Via SSH Should Succeed    ${lb_ip}    ${LB_SVC_PORT}
+
+    # Delete first, second should take over
+    Run With Kubeconfig    oc delete service lbtest1 -n ${NAMESPACE}
+
+    Wait Until Keyword Succeeds    60x    2s
+    ...    Service Should Have LB IP    lbtest2    ${NAMESPACE}
+
+    ${lb_ip2}=    Wait For LoadBalancer IP    lbtest2    ${NAMESPACE}
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Curl Via SSH Should Succeed    ${lb_ip2}    ${LB_SVC_PORT}
+
+    [Teardown]    Teardown LB Port Binding Test
+
+Service Idling And Manual Unidling
+    [Documentation]    Verify that services can be idled and manually unidled.
+    ...    MicroShift does not support automatic unidling, so manual scaling is used.
+    ...    Covers QE test 60290.
+    [Setup]    Setup Idling Test
+
+    ${output}=    Run With Kubeconfig    oc idle svc/hello-deploy -n ${NAMESPACE}
+    Should Contain    ${output}    has been marked as idled
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Deployment Should Have Zero Replicas    hello-deploy    ${NAMESPACE}
+
+    Run With Kubeconfig    oc scale deployment hello-deploy --replicas=2 -n ${NAMESPACE}
+    Named Deployment Should Be Available    hello-deploy    ${NAMESPACE}    5m
+
+    [Teardown]    Teardown Idling Test
+
+
+*** Keywords ***
+Setup LB Traffic Policy Test
+    [Documentation]    Create backend and test pods for LB traffic policy tests.
+    Create Labeled Pod    hello-pod-0    ${NAMESPACE}    labels=name=hello-pod
+    Create Labeled Pod    hello-pod-1    ${NAMESPACE}    labels=name=hello-pod
+    Create Labeled Pod    test-pod    ${NAMESPACE}    labels=name=test-pod
+
+Teardown LB Traffic Policy Test
+    [Documentation]    Clean up LB traffic policy resources.
+    Run With Kubeconfig    oc delete service lbtest-cluster lbtest-local -n ${NAMESPACE}    allow_fail=True
+    Run With Kubeconfig
+    ...    oc delete pod hello-pod-0 hello-pod-1 test-pod -n ${NAMESPACE} --grace-period=0    allow_fail=True
+
+Create LB Service With Policies
+    [Documentation]    Create a LoadBalancer service with configurable traffic policies.
+    [Arguments]    ${name}    ${externalTrafficPolicy}=${EMPTY}    ${internalTrafficPolicy}=${EMPTY}    ${selector}=hello-pod
+    Run With Kubeconfig
+    ...    oc create service loadbalancer ${name} --tcp=${LB_SVC_PORT}:8080 -n ${NAMESPACE}
+    Run With Kubeconfig
+    ...    oc set selector service ${name} name=${selector} -n ${NAMESPACE}
+    IF    '${externalTrafficPolicy}' != '${EMPTY}'
+        Run With Kubeconfig
+        ...    oc patch service ${name} -n ${NAMESPACE} -p '{"spec":{"externalTrafficPolicy":"${externalTrafficPolicy}"}}' --type=merge
+    END
+    IF    '${internalTrafficPolicy}' != '${EMPTY}'
+        Run With Kubeconfig
+        ...    oc patch service ${name} -n ${NAMESPACE} -p '{"spec":{"internalTrafficPolicy":"${internalTrafficPolicy}"}}' --type=merge
+    END
+
+Curl Via SSH Should Succeed
+    [Documentation]    Curl from the MicroShift host via SSH and assert success.
+    [Arguments]    ${ip}    ${port}
+    ${stdout}=    Command Should Work    curl -s --max-time 5 http://${ip}:${port}    sudo_mode=False
+    Should Contain    ${stdout}    Hello MicroShift
+
+Curl Via SSH Should Fail
+    [Documentation]    Curl from the MicroShift host via SSH and expect failure.
+    [Arguments]    ${ip}    ${port}
+    Command Should Fail    curl -s --max-time 5 http://${ip}:${port}    sudo_mode=False
+
+Setup LB Port Binding Test
+    [Documentation]    Create a pod for LB port binding test.
+    Create Labeled Pod    hello-pod    ${NAMESPACE}    labels=name=hello-pod
+
+Teardown LB Port Binding Test
+    [Documentation]    Clean up LB port binding resources.
+    Run With Kubeconfig    oc delete service lbtest1 lbtest2 -n ${NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete pod hello-pod -n ${NAMESPACE} --grace-period=0    allow_fail=True
+
+Setup Idling Test
+    [Documentation]    Deploy hello-deploy with 2 replicas and a ClusterIP service.
+    Oc Create    -f ${SVC_ASSETS}/deployment-hello-2-replicas.yaml -n ${NAMESPACE}
+    Oc Create    -f ${SVC_ASSETS}/service-clusterip.yaml -n ${NAMESPACE}
+    Named Deployment Should Be Available    hello-deploy    ${NAMESPACE}    5m
+
+Teardown Idling Test
+    [Documentation]    Clean up idling test resources.
+    Run With Kubeconfig    oc delete -f ${SVC_ASSETS}/service-clusterip.yaml -n ${NAMESPACE}    allow_fail=True
+    Run With Kubeconfig    oc delete -f ${SVC_ASSETS}/deployment-hello-2-replicas.yaml -n ${NAMESPACE}    allow_fail=True
+
+Deployment Should Have Zero Replicas
+    [Documentation]    Assert that a deployment has scaled to zero.
+    [Arguments]    ${name}    ${ns}
+    ${replicas}=    Oc Get JsonPath    deployment    ${ns}    ${name}    .status.replicas
+    Should Be True    '${replicas}' == '0' or '${replicas}' == '${EMPTY}'

--- a/test/suites/network/service-types.robot
+++ b/test/suites/network/service-types.robot
@@ -124,7 +124,10 @@ Teardown LB Traffic Policy Test
 
 Create LB Service With Policies
     [Documentation]    Create a LoadBalancer service with configurable traffic policies.
-    [Arguments]    ${name}    ${externalTrafficPolicy}=${EMPTY}    ${internalTrafficPolicy}=${EMPTY}    ${selector}=hello-pod
+    [Arguments]    ${name}
+    ...    ${externalTrafficPolicy}=${EMPTY}
+    ...    ${internalTrafficPolicy}=${EMPTY}
+    ...    ${selector}=hello-pod
     Run With Kubeconfig
     ...    oc create service loadbalancer ${name} --tcp=${LB_SVC_PORT}:8080 -n ${NAMESPACE}
     Run With Kubeconfig
@@ -167,7 +170,9 @@ Setup Idling Test
 Teardown Idling Test
     [Documentation]    Clean up idling test resources.
     Run With Kubeconfig    oc delete -f ${SVC_ASSETS}/service-clusterip.yaml -n ${NAMESPACE}    allow_fail=True
-    Run With Kubeconfig    oc delete -f ${SVC_ASSETS}/deployment-hello-2-replicas.yaml -n ${NAMESPACE}    allow_fail=True
+    Run With Kubeconfig
+    ...    oc delete -f ${SVC_ASSETS}/deployment-hello-2-replicas.yaml -n ${NAMESPACE}
+    ...    allow_fail=True
 
 Deployment Should Have Zero Replicas
     [Documentation]    Assert that a deployment has scaled to zero.

--- a/test/suites/router/route-types.robot
+++ b/test/suites/router/route-types.robot
@@ -1,0 +1,234 @@
+*** Settings ***
+Documentation       Route type tests: HTTP/edge/passthrough/reencrypt routes via both
+...                 Route and Ingress resources, and router-as-LoadBalancer validation.
+
+Resource            ../../resources/common.resource
+Resource            ../../resources/oc.resource
+Resource            ../../resources/microshift-network.resource
+Resource            ../../resources/network-testing.resource
+
+Suite Setup         Setup
+Suite Teardown      Teardown
+
+Test Tags           slow
+
+
+*** Variables ***
+${ROUTE_ASSETS}                 ./assets/route-types
+${WEB_SERVER_DEPLOY}            ./assets/route-types/web-server-deploy.yaml
+${WEB_SERVER_SIGNED_DEPLOY}     ./assets/route-types/web-server-signed-deploy.yaml
+${INGRESS_HTTP}                 ./assets/route-types/ingress-http.yaml
+${INGRESS_DESTCA}               ./assets/route-types/ingress-destca.yaml
+
+
+*** Test Cases ***
+HTTP Route Via Ingress
+    [Documentation]    Verify that an Ingress resource creates an HTTP route that
+    ...    correctly forwards traffic to the backend service.
+    ...    Covers QE test 60149.
+    [Setup]    Deploy Web Server Unsecure
+
+    Oc Create    -f ${INGRESS_HTTP} -n ${NAMESPACE}
+    ${route_name}=    Wait For Ingress Route    ingress-http    ${NAMESPACE}
+
+    Verify Route Is Admitted    ${route_name}    ${NAMESPACE}
+
+    ${router_ip}=    Get Router Pod IP
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    service-unsecure-test.example.com    ${router_ip}    80    scheme=http
+
+    Verify HAProxy Backend Exists    be_http:${NAMESPACE}:
+
+    [Teardown]    Run Keywords
+    ...    Run With Kubeconfig    oc delete -f ${INGRESS_HTTP} -n ${NAMESPACE}    allow_fail=True
+    ...    AND
+    ...    Teardown Web Server Unsecure
+
+Edge And Passthrough Routes
+    [Documentation]    Verify creation of edge and passthrough route types. Edge routes
+    ...    terminate TLS at the router; passthrough routes forward TLS to the backend.
+    ...    Covers QE test 60266.
+    [Setup]    Deploy Web Server Unsecure And Signed
+
+    ${router_ip}=    Get Router Pod IP
+
+    # Passthrough route -> secure service
+    Run With Kubeconfig
+    ...    oc create route passthrough ms-pass --service=service-secure --port=27443 --hostname=route-pass.example.com -n ${NAMESPACE}
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Verify Route Is Admitted    ms-pass    ${NAMESPACE}
+    ${termination}=    Oc Get JsonPath    route    ${NAMESPACE}    ms-pass    .spec.tls.termination
+    Should Be Equal As Strings    ${termination}    passthrough
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    route-pass.example.com    ${router_ip}    443
+    Verify HAProxy Backend Exists    be_tcp:${NAMESPACE}:ms-pass
+
+    # Edge route -> unsecure service
+    Run With Kubeconfig
+    ...    oc create route edge ms-edge --service=service-unsecure --port=27017 --hostname=route-edge.example.com -n ${NAMESPACE}
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Verify Route Is Admitted    ms-edge    ${NAMESPACE}
+    ${termination}=    Oc Get JsonPath    route    ${NAMESPACE}    ms-edge    .spec.tls.termination
+    Should Be Equal As Strings    ${termination}    edge
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    route-edge.example.com    ${router_ip}    443
+    Verify HAProxy Backend Exists    be_edge_http:${NAMESPACE}:ms-edge
+
+    [Teardown]    Run Keywords
+    ...    Run With Kubeconfig    oc delete route ms-pass ms-edge -n ${NAMESPACE}    allow_fail=True
+    ...    AND
+    ...    Teardown Web Server Signed
+
+HTTP And Reencrypt Routes
+    [Documentation]    Verify creation of HTTP and reencrypt route types. Reencrypt routes
+    ...    terminate client TLS at the router and re-encrypt to the backend.
+    ...    Covers QE test 60283.
+    [Setup]    Deploy Web Server Signed
+
+    ${router_ip}=    Get Router Pod IP
+
+    # HTTP route
+    Run With Kubeconfig
+    ...    oc expose svc service-unsecure --name=ms-http --hostname=route-http.example.com -n ${NAMESPACE}
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Verify Route Is Admitted    ms-http    ${NAMESPACE}
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    route-http.example.com    ${router_ip}    80    scheme=http
+    Verify HAProxy Backend Exists    be_http:${NAMESPACE}:ms-http
+
+    # Reencrypt route
+    Run With Kubeconfig
+    ...    oc create route reencrypt ms-reen --service=service-secure --port=27443 --hostname=route-reen.example.com -n ${NAMESPACE}
+    Wait Until Keyword Succeeds    10x    2s
+    ...    Verify Route Is Admitted    ms-reen    ${NAMESPACE}
+    ${termination}=    Oc Get JsonPath    route    ${NAMESPACE}    ms-reen    .spec.tls.termination
+    Should Be Equal As Strings    ${termination}    reencrypt
+
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    route-reen.example.com    ${router_ip}    443
+    Verify HAProxy Backend Exists    be_secure:${NAMESPACE}:ms-reen
+
+    [Teardown]    Run Keywords
+    ...    Run With Kubeconfig    oc delete route ms-http ms-reen -n ${NAMESPACE}    allow_fail=True
+    ...    AND
+    ...    Teardown Web Server Signed
+
+Reencrypt Route Via Ingress With Destination CA
+    [Documentation]    Verify that an Ingress with reencrypt annotation and destination CA
+    ...    certificate secret creates a working reencrypt route.
+    ...    Covers QE test 60136.
+    [Setup]    Deploy Web Server Signed
+
+    Oc Create    -f ${INGRESS_DESTCA} -n ${NAMESPACE}
+    ${route_name}=    Wait For Ingress Route    ingress-reencrypt    ${NAMESPACE}
+
+    Verify Route Is Admitted    ${route_name}    ${NAMESPACE}
+    ${termination}=    Oc Get JsonPath    route    ${NAMESPACE}    ${route_name}    .spec.tls.termination
+    Should Be Equal As Strings    ${termination}    reencrypt
+
+    ${router_ip}=    Get Router Pod IP
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    service-secure-test.example.com    ${router_ip}    443
+    Verify HAProxy Backend Exists    be_secure:${NAMESPACE}:
+
+    [Teardown]    Run Keywords
+    ...    Run With Kubeconfig    oc delete -f ${INGRESS_DESTCA} -n ${NAMESPACE}    allow_fail=True
+    ...    AND
+    ...    Teardown Web Server Signed
+
+Router As LoadBalancer Service
+    [Documentation]    Verify that the router is exposed as a LoadBalancer service and that
+    ...    all 4 route types (HTTP, edge, passthrough, reencrypt) are accessible via
+    ...    the LoadBalancer IP.
+    ...    Covers QE test 73152.
+    [Setup]    Deploy Web Server Signed
+
+    # Verify router service is type LoadBalancer
+    ${svc_type}=    Oc Get JsonPath    service    openshift-ingress    router-default    .spec.type
+    Should Be Equal As Strings    ${svc_type}    LoadBalancer
+
+    ${lb_ip}=    Get Router LB IP
+
+    # Create all 4 route types
+    Run With Kubeconfig
+    ...    oc expose svc service-unsecure --name=rt-http --hostname=rt-http.example.com -n ${NAMESPACE}
+    Run With Kubeconfig
+    ...    oc create route edge rt-edge --service=service-unsecure --port=27017 --hostname=rt-edge.example.com -n ${NAMESPACE}
+    Run With Kubeconfig
+    ...    oc create route passthrough rt-pass --service=service-secure --port=27443 --hostname=rt-pass.example.com -n ${NAMESPACE}
+    Run With Kubeconfig
+    ...    oc create route reencrypt rt-reen --service=service-secure --port=27443 --hostname=rt-reen.example.com -n ${NAMESPACE}
+
+    # Wait for all routes to be admitted
+    FOR    ${route}    IN    rt-http    rt-edge    rt-pass    rt-reen
+        Wait Until Keyword Succeeds    10x    2s
+        ...    Verify Route Is Admitted    ${route}    ${NAMESPACE}
+    END
+
+    # Curl all routes via LB IP
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    rt-http.example.com    ${lb_ip}    80    scheme=http
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    rt-edge.example.com    ${lb_ip}    443
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    rt-pass.example.com    ${lb_ip}    443
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Curl Route Should Succeed    rt-reen.example.com    ${lb_ip}    443
+
+    [Teardown]    Run Keywords
+    ...    Run With Kubeconfig    oc delete route rt-http rt-edge rt-pass rt-reen -n ${NAMESPACE}    allow_fail=True
+    ...    AND
+    ...    Teardown Web Server Signed
+
+
+*** Keywords ***
+Setup
+    [Documentation]    Suite-level setup.
+    Setup Suite With Namespace
+
+Teardown
+    [Documentation]    Suite-level teardown.
+    Teardown Suite With Namespace
+
+Deploy Web Server Unsecure
+    [Documentation]    Deploy the nginx web server without TLS.
+    Oc Create    -f ${WEB_SERVER_DEPLOY} -n ${NAMESPACE}
+    Named Deployment Should Be Available    web-server-deploy    ${NAMESPACE}    5m
+
+Deploy Web Server Signed
+    [Documentation]    Deploy the nginx web server with TLS via service-ca annotation.
+    Oc Create    -f ${WEB_SERVER_SIGNED_DEPLOY} -n ${NAMESPACE}
+    Named Deployment Should Be Available    web-server-deploy    ${NAMESPACE}    5m
+
+Deploy Web Server Unsecure And Signed
+    [Documentation]    Deploy the TLS web server (which also serves HTTP on 8080).
+    Deploy Web Server Signed
+
+Teardown Web Server Unsecure
+    [Documentation]    Delete the unsecure web server deployment.
+    Run With Kubeconfig    oc delete -f ${WEB_SERVER_DEPLOY} -n ${NAMESPACE}    allow_fail=True
+
+Teardown Web Server Signed
+    [Documentation]    Delete the signed web server deployment and associated resources.
+    Run With Kubeconfig    oc delete -f ${WEB_SERVER_SIGNED_DEPLOY} -n ${NAMESPACE}    allow_fail=True
+
+Wait For Ingress Route
+    [Documentation]    Wait for the auto-generated route from an Ingress to appear.
+    ...    Returns the route name.
+    [Arguments]    ${ingress_name}    ${ns}
+    Wait Until Keyword Succeeds    30x    2s
+    ...    Ingress Should Have Route    ${ingress_name}    ${ns}
+    ${route_name}=    Run With Kubeconfig
+    ...    oc get route -n ${ns} -o jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="${ingress_name}")].metadata.name}'
+    Should Not Be Empty    ${route_name}
+    RETURN    ${route_name}
+
+Ingress Should Have Route
+    [Documentation]    Assert that the ingress has an associated route.
+    [Arguments]    ${ingress_name}    ${ns}
+    ${route_name}=    Run With Kubeconfig
+    ...    oc get route -n ${ns} -o jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="${ingress_name}")].metadata.name}'
+    Should Not Be Empty    ${route_name}

--- a/test/suites/router/route-types.robot
+++ b/test/suites/router/route-types.robot
@@ -139,7 +139,7 @@ Reencrypt Route Via Ingress With Destination CA
     ...    AND
     ...    Teardown Web Server Signed
 
-Router As LoadBalancer Service
+Router As LoadBalancer Service    # robocop: off=too-long-test-case
     [Documentation]    Verify that the router is exposed as a LoadBalancer service and that
     ...    all 4 route types (HTTP, edge, passthrough, reencrypt) are accessible via
     ...    the LoadBalancer IP.


### PR DESCRIPTION
## Summary

Migrate 14 networking and router QE tests from openshift-tests-private (Go/Ginkgo) into
Robot Framework so they run in MicroShift's own CI. This covers NetworkPolicy, service
types (LoadBalancer traffic policies, port binding, idling), host networking (hostPort,
br-ex NM state, conntrack cleanup), and route types (HTTP, edge, passthrough, reencrypt
via both Route and Ingress resources).

## Changes

- **Shared resource**: `test/resources/network-testing.resource` — reusable keywords for
  pod creation, connectivity testing, service/route utilities, and conntrack verification
- **host-networking.robot** (3 tests): hostPort access (60550), br-ex NM check (65838),
  UDP conntrack cleanup (64752)
- **network-policy.robot** (3 tests): mixed ingress/egress policies (60331), hairpin
  traffic with NetworkPolicy (60332), podSelector allow-to/allow-from (60426)
- **service-types.robot** (3 tests): LB traffic policies (60968), LB port binding (61218),
  service idling/unidling (60290)
- **route-types.robot** (5 tests): HTTP route via Ingress (60149), edge/passthrough routes
  (60266), HTTP/reencrypt routes (60283), reencrypt via Ingress with destCA (60136),
  router as LoadBalancer (73152)
- **Release scenario**: `el96-lrel@network-features.sh` runs all 4 suites in a single VM

## Related PRs

- openshift/openshift-tests-private#30110 — removes the migrated QE tests (draft)

## Testing

- [ ] Run `el96-lrel@network-features` scenario end-to-end in CI
- [ ] Verify hello-world nginx image is available on test VMs
- [ ] Monitor first CI runs for NetworkPolicy timeout flakiness

## Jira

https://issues.redhat.com/browse/USHIFT-6747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for host networking, UDP NodePort cleanup, unmanaged bridge behavior, and secure pod configurations.
  * Added NetworkPolicy tests for ingress, egress, hairpin traffic, and pod-to-pod access controls.
  * Added service tests covering LoadBalancer traffic, port conflicts, idling, and manual unidling.
  * Added routing tests for HTTP, edge, passthrough, and re-encrypted routes, including Ingress and LoadBalancer access.
  * Added reusable networking checks and a RHEL 9.6 network-features release scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->