### PR TITLE
[release-4.18] USHIFT-7451: replace nginx-unprivileged with busybox in test assets

### DIFF
--- a/docs/contributor/storage/default_csi_plugin.md
+++ b/docs/contributor/storage/default_csi_plugin.md
@@ -161,7 +161,7 @@ spec:
     - sh
     - -c
     - sleep 1d
-    image: nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     name: test-container
     securityContext:
       allowPrivilegeEscalation: false
@@ -250,7 +250,7 @@ spec:
     - sh
     - -c
     - sleep 1d
-    image: nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     name: test-container
     securityContext:
       allowPrivilegeEscalation: false

--- a/test/assets/kustomizations/base/pod-base.yaml
+++ b/test/assets/kustomizations/base/pod-base.yaml
@@ -9,7 +9,7 @@ spec:
       type: RuntimeDefault
   containers:
   - name: test-container
-    image: docker.io/nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/test/assets/reboot/pod-with-pvc.yaml
+++ b/test/assets/reboot/pod-with-pvc.yaml
@@ -21,7 +21,7 @@ spec:
       type: RuntimeDefault
   containers:
   - name: test-container
-    image: docker.io/nginxinc/nginx-unprivileged:latest
+    image: quay.io/microshift/busybox:1.36
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/test/resources/oc.resource
+++ b/test/resources/oc.resource
@@ -57,7 +57,7 @@ Oc Exec
     [Documentation]    Run 'oc exec' on a specific pod in the curret test namespace
     ...    Returns the command's combined STDOUT/STDER
     [Arguments]    ${pod}    ${cmd}    ${ns}=${NAMESPACE}
-    ${output}=    Run With Kubeconfig    oc exec -n ${ns} pod/${pod} -- /bin/bash -c '${cmd}'
+    ${output}=    Run With Kubeconfig    oc exec -n ${ns} pod/${pod} -- /bin/sh -c '${cmd}'
     RETURN    ${output}
 
 Oc Wait


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/microshift/pull/7199

The docker.io/nginxinc/nginx-unprivileged:latest image is a multi-arch manifest list with 14 platform variants. When mirroring with `skopeo copy --all --preserve-digests`, Quay v3.11.7 rejects one of the platform manifests as "manifest invalid", causing the mirror step to fail and aborting CI jobs (e.g. e2e-aws-tests-arm).

These test pods only run `sleep 1d` and do not use any nginx functionality, so replace the image with quay.io/microshift/busybox:1.36 which is already mirrored as a single-arch image. This eliminates the problematic multi-arch manifest list from the mirror set entirely.