### PR TITLE
USHIFT-4304: Rework image mode documentation for source builds

### DIFF
--- a/docs/config/Containerfile.bootc-rhel9
+++ b/docs/config/Containerfile.bootc-rhel9
@@ -1,6 +1,6 @@
-FROM registry.redhat.io/rhel9-eus/rhel-9.6-bootc:9.6
+FROM registry.redhat.io/rhel9-eus/rhel-9.8-bootc:9.8
 
-ARG USHIFT_VER=4.18
+ARG USHIFT_VER=4.22
 # hadolint ignore=SC1091
 RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
     dnf config-manager \
@@ -24,7 +24,7 @@ RUN useradd -m -d /var/home/redhat -G wheel redhat && \
 RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
     firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
     firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
-    firewall-offline-cmd --zone=trusted --add-source=fd01::/48
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48w
     # Application-specific firewall configuration
 RUN firewall-offline-cmd --zone=public --add-port=80/tcp && \
     firewall-offline-cmd --zone=public --add-port=443/tcp && \

--- a/docs/config/Containerfile.bootc-rhel9
+++ b/docs/config/Containerfile.bootc-rhel9
@@ -24,7 +24,7 @@ RUN useradd -m -d /var/home/redhat -G wheel redhat && \
 RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
     firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
     firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
-    firewall-offline-cmd --zone=trusted --add-source=fd01::/48w
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48
     # Application-specific firewall configuration
 RUN firewall-offline-cmd --zone=public --add-port=80/tcp && \
     firewall-offline-cmd --zone=public --add-port=443/tcp && \

--- a/docs/config/Containerfile.bootc-source-rhel9
+++ b/docs/config/Containerfile.bootc-source-rhel9
@@ -25,7 +25,6 @@ COPY . /tmp/microshift-local
 # Configure the local source RPM repository, then install MicroShift built from
 # source. Its dependencies are resolved from the base RHEL repositories (via the
 # host subscription) and from the OpenShift dependencies repository above.
-# hadolint ignore=SC1091,DL3059
 RUN cat > /etc/yum.repos.d/microshift-local.repo <<'EOF'
 [microshift-local]
 name=MicroShift RPMs built from source
@@ -34,6 +33,7 @@ enabled=1
 gpgcheck=0
 EOF
 
+# hadolint ignore=SC1091,DL3059
 RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
     dnf install -y \
         --repofrompath="openshift-deps,${DEPS_REPO_URL}" \

--- a/docs/config/Containerfile.bootc-source-rhel9
+++ b/docs/config/Containerfile.bootc-source-rhel9
@@ -1,0 +1,83 @@
+FROM registry.redhat.io/rhel9-eus/rhel-9.8-bootc:9.8
+
+# URL of the OpenShift "dependencies" repository that provides the MicroShift
+# runtime dependencies which are NOT part of base RHEL: cri-o, cri-tools,
+# openshift-clients and openvswitch. The version of these packages must match
+# the MicroShift source being built.
+#
+# The default below tracks the current pre-release development stream. For the
+# authoritative value matching the current source tree, see the
+# RHOCP_MINOR_Y_BETA variable in test/bin/common_versions.sh. When building a
+# MicroShift version that is already released through the 'rhocp' stream, replace
+# this repository with the matching 'rhocp-<ver>-for-rhel-9-$(uname -m)-rpms' and
+# 'fast-datapath-for-rhel-9-$(uname -m)-rpms' repositories from your Red Hat
+# subscription instead (see docs/config/Containerfile.bootc-rhel9).
+#
+# NOTE: the URL is architecture specific. Override it with '--build-arg' when
+# building for aarch64 (replace 'x86_64' with 'aarch64').
+ARG DEPS_REPO_URL=https://mirror.openshift.com/pub/openshift-v5/x86_64/dependencies/rpms/5.0-el9-beta
+
+# Copy the locally built MicroShift RPM repository (the RPMs produced by
+# 'make rpm' together with the 'repodata' created by 'createrepo_c') into the
+# image. The build context must be the directory that contains them.
+COPY . /tmp/microshift-local
+
+# Configure the local source RPM repository, then install MicroShift built from
+# source. Its dependencies are resolved from the base RHEL repositories (via the
+# host subscription) and from the OpenShift dependencies repository above.
+# hadolint ignore=SC1091,DL3059
+RUN cat > /etc/yum.repos.d/microshift-local.repo <<'EOF'
+[microshift-local]
+name=MicroShift RPMs built from source
+baseurl=file:///tmp/microshift-local
+enabled=1
+gpgcheck=0
+EOF
+
+RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
+    dnf install -y \
+        --repofrompath="openshift-deps,${DEPS_REPO_URL}" \
+        --setopt=openshift-deps.gpgcheck=0 \
+        firewalld jq microshift microshift-release-info && \
+    systemctl enable microshift && \
+    rm -f /etc/yum.repos.d/microshift-local.repo && \
+    rm -rf /tmp/microshift-local && \
+    dnf clean all
+
+# Create a default 'redhat' user with the specified password.
+# Add it to the 'wheel' group to allow for running sudo commands.
+ARG USER_PASSWD
+RUN if [ -z "${USER_PASSWD}" ] ; then \
+        echo USER_PASSWD is a mandatory build argument && exit 1 ; \
+    fi
+# hadolint ignore=DL4006
+RUN useradd -m -d /var/home/redhat -G wheel redhat && \
+    echo "redhat:${USER_PASSWD}" | chpasswd
+
+# Mandatory firewall configuration
+RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \
+    firewall-offline-cmd --zone=trusted --add-source=10.42.0.0/16 && \
+    firewall-offline-cmd --zone=trusted --add-source=169.254.169.1 && \
+    firewall-offline-cmd --zone=trusted --add-source=fd01::/48
+    # Application-specific firewall configuration
+RUN firewall-offline-cmd --zone=public --add-port=80/tcp && \
+    firewall-offline-cmd --zone=public --add-port=443/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/tcp && \
+    firewall-offline-cmd --zone=public --add-port=30000-32767/udp
+
+# Create a systemd unit to recursively make the root filesystem subtree
+# shared as required by OVN images
+RUN cat > /usr/lib/systemd/system/microshift-make-rshared.service <<'EOF'
+[Unit]
+Description=Make root filesystem shared
+Before=microshift.service
+ConditionVirtualization=container
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mount --make-rshared /
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# hadolint ignore=DL3059
+RUN systemctl enable microshift-make-rshared.service

--- a/docs/config/Containerfile.bootc-source-rhel9
+++ b/docs/config/Containerfile.bootc-source-rhel9
@@ -46,13 +46,14 @@ RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}" && \
 
 # Create a default 'redhat' user with the specified password.
 # Add it to the 'wheel' group to allow for running sudo commands.
-ARG USER_PASSWD
-RUN if [ -z "${USER_PASSWD}" ] ; then \
-        echo USER_PASSWD is a mandatory build argument && exit 1 ; \
-    fi
+# The password is passed via a build secret to avoid exposing it in image metadata.
 # hadolint ignore=DL4006
-RUN useradd -m -d /var/home/redhat -G wheel redhat && \
-    echo "redhat:${USER_PASSWD}" | chpasswd
+RUN --mount=type=secret,id=user_passwd \
+    if [ ! -f /run/secrets/user_passwd ]; then \
+        echo "user_passwd secret is required" && exit 1; \
+    fi && \
+    useradd -m -d /var/home/redhat -G wheel redhat && \
+    echo "redhat:$(cat /run/secrets/user_passwd)" | chpasswd
 
 # Mandatory firewall configuration
 RUN firewall-offline-cmd --zone=public --add-port=22/tcp && \

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -6,19 +6,22 @@ use it for installing a new RHEL operating system.
 
 This document demonstrates how to run a `bootc` image using `podman`.
 
-> **NOTE**:<br>
+> **NOTE**:  
+>
 > Use the `podman` approach only for development purposes to benefit from
 > the fast turnaround times it allows. Do not use it for production use cases.
 
 The procedures described below require the following setup:
-* A `RHEL 9.6 host` with an active Red Hat subscription for building MicroShift `bootc`
+
+- A `RHEL 9.8 host` with an active Red Hat subscription for building MicroShift `bootc`
 images and running containers
-* A `remote registry` (e.g. `quay.io`) for storing and accessing `bootc` images
+- A `remote registry` (e.g. `quay.io`) for storing and accessing `bootc` images
+
+
 
 ## Run MicroShift Bootc Image
 
-Log into the `RHEL 9.6 host` using the user credentials that have SUDO
-permissions configured.
+Log into the `RHEL 9.8 host` using the user credentials that have `sudo` permissions configured.
 
 ### Configure CNI
 
@@ -32,10 +35,10 @@ kernel versions are different.
 
 ```bash
 $ find /lib/modules/$(uname -r) -name "openvswitch*"
-/lib/modules/6.9.9-200.fc40.x86_64/kernel/net/openvswitch
-/lib/modules/6.9.9-200.fc40.x86_64/kernel/net/openvswitch/openvswitch.ko.xz
+/lib/modules/5.14.0-687.34.1.el9_8.x86_64/kernel/net/openvswitch
+/lib/modules/5.14.0-687.34.1.el9_8.x86_64/kernel/net/openvswitch/openvswitch.ko.xz
 
-$ IMAGE_NAME=microshift-4.18-bootc
+$ IMAGE_NAME=microshift-4.22-bootc
 $ sudo podman inspect "${IMAGE_NAME}" | grep kernel-core
         "created_by": "kernel-core-5.14.0-427.26.1.el9_4.x86_64"
 ```
@@ -96,15 +99,18 @@ the next section.
 > sudo rm -f "${VGFILE}"
 > ```
 
+
+
 ### Run Container
 
 Run the following commands to start the MicroShift `bootc` image in an interactive
 terminal session.
 
 The host shares the following configuration with the container:
-* The `openvswitch` kernel module to be used by the Open vSwitch service
-* A pull secret file for downloading the required OpenShift container images
-* Host container storage for reusing available container images
+
+- The `openvswitch` kernel module to be used by the Open vSwitch service
+- A pull secret file for downloading the required OpenShift container images
+- Host container storage for reusing available container images
 
 ```bash
 PULL_SECRET=~/.pull-secret.json
@@ -140,6 +146,8 @@ watch sudo oc get pods -A \
 ```
 
 > Run the `sudo shutdown now` command to stop the container.
+
+
 
 ## Appendix A: Multi-Architecture Image Build
 
@@ -178,7 +186,7 @@ the platform-specific `amd64` and `arm64` images to the remote registry as descr
 in the [Publish Image](#publish-image) section.
 
 > Cross-platform `podman` builds are not in the scope of this document. Log into
-> the RHEL 9.6 host running on the appropriate architecture to perform the container
+> the RHEL 9.8 host running on the appropriate architecture to perform the container
 > image builds and publish the platform-specific image to the remote registry.
 
 Finally, create a manifest containing the platform-specific image references
@@ -225,11 +233,12 @@ the manifest list.
 Refer to RHEL documentation for generic instructions on upgrading `rpm-ostree`
 systems to Image Mode. The upgrade process should be planned carefully considering
 the following guidelines:
-* Follow instructions in RHEL documentation for converting `rpm-ostree` blueprints to
-  Image Mode container files
-* Consider using [rpm-ostree compose container-encapsulate](https://coreos.github.io/rpm-ostree/container/#converting-ostree-commits-to-new-base-images)
-  to experiment with Image Mode based on the existing `ostree` commits
-* Invest in defining a proper container build pipeline for fully adopting Image Mode
+
+- Follow instructions in RHEL documentation for converting `rpm-ostree` blueprints to
+Image Mode container files
+- Consider using [rpm-ostree compose container-encapsulate](https://coreos.github.io/rpm-ostree/container/#converting-ostree-commits-to-new-base-images)
+to experiment with Image Mode based on the existing `ostree` commits
+- Invest in defining a proper container build pipeline for fully adopting Image Mode
 
 If reinstalling MicroShift devices from scratch is not an option, read the remainder
 of this section that outlines the upgrade details specific to MicroShift.
@@ -262,3 +271,5 @@ ExecStartPre=/bin/sh -c '/bin/getent group hugetlbfs >/dev/null || groupadd -r h
 ExecStartPre=/sbin/usermod -a -G hugetlbfs openvswitch
 ExecStartPre=/bin/chown -Rhv openvswitch. /etc/openvswitch
 EOF
+```
+

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -1,10 +1,11 @@
 # Image Mode for MicroShift Contributors
 
-Follow the instructions in [Image Mode for MicroShift Users](../user/image_mode.md)
-to create a bootable container image, store this image in a remote registry and
-use it for installing a new RHEL operating system.
+Follow the instructions in [Image Mode for MicroShift (from source)](../user/image_mode.md)
+to build a `bootc` image containing MicroShift built from source.
 
-This document demonstrates how to run a `bootc` image using `podman`.
+This document demonstrates how to run that `bootc` image directly using `podman`,
+which is the fastest way to exercise a source build without installing it on a
+host.
 
 > **NOTE**:  
 >
@@ -38,9 +39,9 @@ $ find /lib/modules/$(uname -r) -name "openvswitch*"
 /lib/modules/5.14.0-687.34.1.el9_8.x86_64/kernel/net/openvswitch
 /lib/modules/5.14.0-687.34.1.el9_8.x86_64/kernel/net/openvswitch/openvswitch.ko.xz
 
-$ IMAGE_NAME=microshift-4.22-bootc
+$ IMAGE_NAME=microshift-source-bootc
 $ sudo podman inspect "${IMAGE_NAME}" | grep kernel-core
-        "created_by": "kernel-core-5.14.0-427.26.1.el9_4.x86_64"
+        "created_by": "kernel-core-5.14.0-687.39.1.el9_8.x86_64"
 ```
 
 When a `bootc` image is started as a container, it uses the host kernel, which is
@@ -114,7 +115,7 @@ The host shares the following configuration with the container:
 
 ```bash
 PULL_SECRET=~/.pull-secret.json
-IMAGE_NAME=microshift-4.18-bootc
+IMAGE_NAME=microshift-source-bootc
 
 sudo modprobe openvswitch
 sudo podman run --rm -it --privileged \
@@ -156,34 +157,40 @@ them under the same registry URL using manifest lists.
 
 > See [podman-manifest](https://docs.podman.io/en/latest/markdown/podman-manifest.1.html) for more information.
 
-The [Build Image](#build-image) procedure needs to be adjusted in the following
-manner to create multi-architecture images.
+The [Build a MicroShift bootc image from source](../user/image_mode.md#build-a-microshift-bootc-image-from-source)
+procedure needs to be adjusted in the following manner to create
+multi-architecture images.
 
 ```bash
 PULL_SECRET=~/.pull-secret.json
 USER_PASSWD="<your_redhat_user_password>"
 IMAGE_ARCH=amd64 # Use amd64 or arm64 depending on the current platform
 IMAGE_PLATFORM="linux/${IMAGE_ARCH}"
-IMAGE_NAME="microshift-4.18-bootc:linux-${IMAGE_ARCH}"
+IMAGE_NAME="microshift-source-bootc:linux-${IMAGE_ARCH}"
 
+# The MicroShift RPMs must have been built for ${IMAGE_ARCH} and published to the
+# local repository first. The OpenShift dependencies repository is architecture
+# specific, so override DEPS_REPO_URL for arm64 (replace 'x86_64' with 'aarch64').
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --platform "${IMAGE_PLATFORM}" \
     --build-arg USER_PASSWD="${USER_PASSWD}" \
-    -f Containerfile
+    -f docs/config/Containerfile.bootc-source-rhel9 \
+    _output/rpmbuild/RPMS
 ```
 
-Verify that the local MicroShift 4.18 `bootc` image was created for the specified
+Verify that the local MicroShift `bootc` image was created for the specified
 platform.
 
 ```bash
 $ sudo podman images "${IMAGE_NAME}"
-REPOSITORY                       TAG          IMAGE ID      CREATED         SIZE
-localhost/microshift-4.18-bootc  linux-amd64  3f7e136fccb5  13 minutes ago  2.19 GB
+REPOSITORY                          TAG          IMAGE ID      CREATED         SIZE
+localhost/microshift-source-bootc   linux-amd64  3f7e136fccb5  13 minutes ago  2.89 GB
 ```
 
 Repeat the procedure on the other platform (i.e. `arm64`) and proceed by publishing
 the platform-specific `amd64` and `arm64` images to the remote registry as described
-in the [Publish Image](#publish-image) section.
+in the openshift-docs [Publishing the bootc image to the remote registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+section.
 
 > Cross-platform `podman` builds are not in the scope of this document. Log into
 > the RHEL 9.8 host running on the appropriate architecture to perform the container
@@ -198,7 +205,7 @@ and publish it to the remote registry.
 ```bash
 REGISTRY_URL=quay.io
 REGISTRY_ORG=myorg/mypath
-BASE_NAME=microshift-4.18-bootc
+BASE_NAME=microshift-source-bootc
 MANIFEST_NAME="${BASE_NAME}:latest"
 
 sudo podman manifest create -a "localhost/${MANIFEST_NAME}" \
@@ -224,7 +231,7 @@ $ sudo podman manifest inspect \
 ```
 
 It is now possible to access images using the manifest name with the `latest` tag
-(e.g. `quay.io/myorg/mypath/microshift-4.18-bootc:latest`). The image for the
+(e.g. `quay.io/myorg/mypath/microshift-source-bootc:latest`). The image for the
 current platform will automatically be pulled from the registry if it is part of
 the manifest list.
 

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -189,7 +189,7 @@ localhost/microshift-source-bootc   linux-amd64  3f7e136fccb5  13 minutes ago  2
 
 Repeat the procedure on the other platform (i.e. `arm64`) and proceed by publishing
 the platform-specific `amd64` and `arm64` images to the remote registry as described
-in the openshift-docs [Publishing the bootc image to the remote registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+in the openshift-docs [Publishing the bootc image to the remote registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
 section.
 
 > Cross-platform `podman` builds are not in the scope of this document. Log into

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -189,7 +189,7 @@ localhost/microshift-source-bootc   linux-amd64  3f7e136fccb5  13 minutes ago  2
 
 Repeat the procedure on the other platform (i.e. `arm64`) and proceed by publishing
 the platform-specific `amd64` and `arm64` images to the remote registry as described
-in the openshift-docs [Publishing the bootc image to the remote registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
+in the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
 section.
 
 > Cross-platform `podman` builds are not in the scope of this document. Log into

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -176,7 +176,7 @@ DEPS_ARCH=$([ "${IMAGE_ARCH}" = "arm64" ] && echo aarch64 || echo x86_64)
 DEPS_REPO_URL="https://mirror.openshift.com/pub/openshift-v5/${DEPS_ARCH}/dependencies/rpms/5.0-el9-beta"
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --platform "${IMAGE_PLATFORM}" \
-    --build-arg USER_PASSWD="${USER_PASSWD}" \
+    --secret id=user_passwd,env=USER_PASSWD \
     --build-arg DEPS_REPO_URL="${DEPS_REPO_URL}" \
     -f docs/config/Containerfile.bootc-source-rhel9 \
     _output/rpmbuild/RPMS

--- a/docs/contributor/image_mode.md
+++ b/docs/contributor/image_mode.md
@@ -170,10 +170,14 @@ IMAGE_NAME="microshift-source-bootc:linux-${IMAGE_ARCH}"
 
 # The MicroShift RPMs must have been built for ${IMAGE_ARCH} and published to the
 # local repository first. The OpenShift dependencies repository is architecture
-# specific, so override DEPS_REPO_URL for arm64 (replace 'x86_64' with 'aarch64').
+# specific and uses RPM arch names (x86_64 / aarch64) rather than the amd64 /
+# arm64 names, so derive DEPS_REPO_URL from ${IMAGE_ARCH} and pass it explicitly.
+DEPS_ARCH=$([ "${IMAGE_ARCH}" = "arm64" ] && echo aarch64 || echo x86_64)
+DEPS_REPO_URL="https://mirror.openshift.com/pub/openshift-v5/${DEPS_ARCH}/dependencies/rpms/5.0-el9-beta"
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --platform "${IMAGE_PLATFORM}" \
     --build-arg USER_PASSWD="${USER_PASSWD}" \
+    --build-arg DEPS_REPO_URL="${DEPS_REPO_URL}" \
     -f docs/config/Containerfile.bootc-source-rhel9 \
     _output/rpmbuild/RPMS
 ```

--- a/docs/contributor/layered_product_ci.md
+++ b/docs/contributor/layered_product_ci.md
@@ -14,8 +14,8 @@ can be conducted manually or integrated into the package CI/CD processes. See
 
 ## Build and Publish MicroShift Container Image
 
-Follow the instructions in the [Build Image](./image_mode.md#build-image) section
-to implement the MicroShift container image layer build procedure.
+Follow the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+instructions to implement the MicroShift container image layer build procedure.
 
 > Prebuilt MicroShift bootc container images are not currently available for
 > download.
@@ -23,13 +23,13 @@ to implement the MicroShift container image layer build procedure.
 Customize the `Containerfile` file according to the requirements of the layered
 product to be tested. A typical customization would be to select a custom version
 of MicroShift, which may also include pre-released ones that are published at
-[OpenShift Mirror](mirror.openshift.com).
+[OpenShift Mirror](https://mirror.openshift.com).
 
 > For a given MicroShift `4.y` version, it is always recommended to use the
 > production builds of MicroShift RPMs as soon as they are available at the
 > `rhocp-4.y-for-rhel-9-$(uname -m)-rpms` repository.
 > Otherwise, use pre-released engineering or release candidate packages from
-> [OpenShift Mirror](mirror.openshift.com).
+> [OpenShift Mirror](https://mirror.openshift.com).
 
 **Example: MicroShift 4.17 Engineering Candidate Packages (fragment)**
 
@@ -87,13 +87,13 @@ RUN dnf install -y firewalld microshift && \
     dnf clean all
 ```
 
-Finally, follow the instructions in the [Publish Image](./image_mode.md#publish-image)
-section to push the MicroShift images to a container registry.
+Finally, follow the same openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+instructions to push the MicroShift images to a container registry.
 
 ## Build and Publish Layered Product Container Image
 
-Follow the instructions in the [Build Image](./image_mode.md#build-image) section
-to implement the Layered Product container image layer build procedure.
+Follow the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+instructions to implement the Layered Product container image layer build procedure.
 
 Customize the `Containerfile` file according to the requirements of the layered
 product to be tested. A typical customization would be to select a custom version
@@ -113,8 +113,8 @@ RUN dnf install -y microshift-gitops && \
 > The `FROM` statement should be updated to denote a valid reference to the base
 > MicroShift container image.
 
-Finally, follow the instructions in the [Publish Image](./image_mode.md#publish-image)
-section to push the Layered Product images to a container registry.
+Finally, follow the same openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+instructions to push the Layered Product images to a container registry.
 
 ## Run Layered Product Container Image
 

--- a/docs/contributor/layered_product_ci.md
+++ b/docs/contributor/layered_product_ci.md
@@ -14,7 +14,7 @@ can be conducted manually or integrated into the package CI/CD processes. See
 
 ## Build and Publish MicroShift Container Image
 
-Follow the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+Follow the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
 instructions to implement the MicroShift container image layer build procedure.
 
 > Prebuilt MicroShift bootc container images are not currently available for
@@ -87,12 +87,12 @@ RUN dnf install -y firewalld microshift && \
     dnf clean all
 ```
 
-Finally, follow the same openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+Finally, follow the same openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
 instructions to push the MicroShift images to a container registry.
 
 ## Build and Publish Layered Product Container Image
 
-Follow the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+Follow the openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
 instructions to implement the Layered Product container image layer build procedure.
 
 Customize the `Containerfile` file according to the requirements of the layered
@@ -113,7 +113,7 @@ RUN dnf install -y microshift-gitops && \
 > The `FROM` statement should be updated to denote a valid reference to the base
 > MicroShift container image.
 
-Finally, follow the same openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image)
+Finally, follow the same openshift-docs [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image)
 instructions to push the Layered Product images to a container registry.
 
 ## Run Layered Product Container Image

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -22,5 +22,5 @@ List of the documents in alphabetical file name order.
 - [How To Configure a Workload with Custom Security Context](./howto_pod_security.md)
 - [MicroShift Mitigation of System Configuration Changes](./howto_sysconf_watch.md)
 - [Running MicroShift Fully Offline](./howto_test_offline.md)
-- [Image Mode for MicroShift Users](./image_mode.md)
+- [Image Mode for MicroShift (from source)](./image_mode.md)
 - [Known Limitations](./known_limitations.md)

--- a/docs/user/image_mode.md
+++ b/docs/user/image_mode.md
@@ -1,235 +1,168 @@
-# Image Mode for MicroShift Users
+# Image Mode for MicroShift (from source)
 
-Image mode is a new approach to operating system deployment that lets users build,
+Image mode is an approach to operating system deployment that lets you build,
 deploy, and manage Red Hat Enterprise Linux as a bootable container (`bootc`)
-image. Such an image uses standard OCI/Docker containers as a transport and delivery
-format for base operating system updates. A `bootc` image includes a Linux kernel,
-which is used to boot.
+image. Such an image uses standard OCI/Docker containers as a transport and
+delivery format for base operating system updates. A `bootc` image includes a
+Linux kernel, which is used to boot.
 
 MicroShift build and deployment procedures can utilize bootable containers to
 benefit from this technology.
 
-This document demonstrates how to create a bootable container image, store this
-image in a remote registry and use it for installing a new RHEL operating system.
-
 > See [Image mode for Red Hat Enterprise Linux](https://developers.redhat.com/products/rhel-image-mode/overview)
-for more information.
+> for more information.
+
+> **Source of truth:**<br>
+> The [Installing with RHEL image mode](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-about-rhel-image-mode)
+> chapter of the Red Hat build of MicroShift documentation is the authoritative
+> reference for building, publishing, and installing image mode systems using
+> **released** MicroShift RPMs.
+>
+> This document does **not** duplicate that content. It supplements it for users
+> and contributors who need to deploy MicroShift built **from source** (i.e. from
+> this repository) rather than from the released `rhocp` repositories. Only the
+> image build differs; once you have a source-built image, the publish, Kickstart,
+> and virtual machine steps are identical and are linked below.
+
+> **Note:**<br>
+> The openshift-docs links in this document are pinned to version `4.19`. Use the
+> version selector on those pages to match the MicroShift release you are working
+> with.
 
 The procedures described below require the following setup:
-* A `RHEL 9.8 host` with an active Red Hat subscription for building MicroShift `bootc`
-images. For development purposes, you can use the [Red Hat Developer subscription](https://developers.redhat.com/products/rhel/download),
+* A `RHEL 9.8 host` with an active Red Hat subscription for building MicroShift
+`bootc` images. For development purposes, you can use the [Red Hat Developer subscription](https://developers.redhat.com/products/rhel/download),
 which is free of charge.
 * A `hypervisor host` with a virtualization technology that supports RHEL. In
 this documentation, [libvirt](https://libvirt.org/) virtualization is used as
 an example.
 * A `remote registry` (e.g. `quay.io`) for storing and accessing `bootc` images
 
-## Build MicroShift Bootc Image
+## Build a MicroShift bootc image from source
 
-Log into the `RHEL 9.8 host` using the user credentials that have SUDO
-permissions configured.
+Unlike the released flow documented in openshift-docs — which installs MicroShift
+from the `rhocp` and `fast-datapath` repositories — a source build installs the
+MicroShift RPMs that you compile from this repository into the `bootc` image.
 
-### Build Image
+Log into the `RHEL 9.8 host` using the user credentials that have `sudo`
+permissions configured, and clone this repository.
 
-Download the [Containerfile](../config/Containerfile.bootc-rhel9) using the following
-command and use it for subsequent image builds.
+### Build the MicroShift RPMs
 
-```bash
-URL=https://raw.githubusercontent.com/openshift/microshift/refs/heads/main/docs/config/Containerfile.bootc-rhel9
-
-curl -s -o Containerfile "${URL}"
-```
-
-> **Important:**<br>
-> When building a container image, podman uses host subscription information and
-> repositories inside the container. With only `BaseOS` and `AppStream` system
-> repositories enabled by default, we need to enable the `rhocp` and `fast-datapath`
-> repositories for installing MicroShift and its dependencies. These repositories
-> must be accessible in the host subscription, but not necessarily enabled on the host.
-
-Examine the `rhocp` and `fast-datapath` repositories that are available in the host
-subscription.
+Build the MicroShift RPMs from the current source tree by running the following
+command at the repository root:
 
 ```bash
-sudo subscription-manager repos --list | \
-    grep '^Repo ID:' | \
-    grep -E 'fast-datapath|rhocp-4.*-for-rhel' | sort
+make rpm
 ```
 
-Run the following image build command to create a local `bootc` image.
+> Use `make rpm-podman` to build the RPMs inside a container if the host is not
+> set up with the Go toolchain and build dependencies.
+
+The RPMs are written under `_output/rpmbuild/RPMS`:
+
+```bash
+$ find _output/rpmbuild/RPMS -name '*.rpm' | head
+_output/rpmbuild/RPMS/x86_64/microshift-5.0.0_0.nightly...el9.x86_64.rpm
+_output/rpmbuild/RPMS/x86_64/microshift-networking-5.0.0_0.nightly...el9.x86_64.rpm
+_output/rpmbuild/RPMS/noarch/microshift-release-info-5.0.0_0.nightly...el9.noarch.rpm
+...
+```
+
+> The version string encodes the source commit (for example
+> `5.0.0_0.nightly_..._<git-sha>`), so it differs from any released MicroShift
+> version. This is how you confirm the resulting image contains your source build
+> rather than a released RPM.
+
+### Create a local RPM repository
+
+Turn the built RPMs into a `dnf` repository so they can be consumed during the
+image build:
+
+```bash
+createrepo_c _output/rpmbuild/RPMS
+```
+
+This creates `_output/rpmbuild/RPMS/repodata`, indexing the RPMs in the `noarch`
+and `x86_64` subdirectories.
+
+### Build the bootc image
+
+Use the [Containerfile.bootc-source-rhel9](../config/Containerfile.bootc-source-rhel9)
+source build Containerfile from a clone of this repository.
+
+Unlike the released Containerfile, it:
+* copies the local RPM repository into the image and installs `microshift` from it
+* pulls the MicroShift runtime dependencies that are not part of base RHEL (cri-o,
+  cri-tools, openshift-clients and openvswitch) from the public OpenShift
+  dependencies mirror rather than from `rhocp`/`fast-datapath`, because the
+  matching versions for a pre-release source build are not yet available in those
+  subscription repositories
+
+> The dependencies mirror URL tracks the current development stream and is
+> architecture specific. See the comments in the Containerfile and the
+> `RHOCP_MINOR_Y_BETA` variable in
+> [test/bin/common_versions.sh](../../test/bin/common_versions.sh) for the
+> authoritative value, and override `DEPS_REPO_URL` with `--build-arg` when
+> building for another architecture.
 
 Note how secrets are used during the image build:
 * The podman `--authfile` argument is required to pull the base image from the
 `registry.redhat.io` registry
 * The build `USER_PASSWD` argument is used to set a password for the `redhat` user
 
+Run the following command, using `_output/rpmbuild/RPMS` as the build context so
+the local repository is available to the build:
+
 ```bash
 PULL_SECRET=~/.pull-secret.json
 USER_PASSWD="<your_redhat_user_password>"
-IMAGE_NAME=microshift-4.18-bootc
+IMAGE_NAME=microshift-source-bootc
 
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --build-arg USER_PASSWD="${USER_PASSWD}" \
-    -f Containerfile
+    -f docs/config/Containerfile.bootc-source-rhel9 \
+    _output/rpmbuild/RPMS
 ```
 
 > **Important:**<br>
-> If `dnf upgrade` command is used in the container image build procedure, it
-> may cause unintended operating system version upgrade (e.g. from `9.8` to
-> `9.8`). To prevent this from happening, use the following command instead.
-> ```
-> RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}"
-> ```
+> The `Containerfile` runs `dnf upgrade` pinned to the base image release version
+> (`dnf upgrade -y --releasever="${VERSION_ID}"`). Pinning `--releasever` prevents
+> an unintended minor version upgrade of the operating system (for example, from
+> `9.8` to a later RHEL `9.y`) that a plain `dnf upgrade` could otherwise perform,
+> keeping the image on the same RHEL version as its base.
 
-Verify that the local MicroShift 4.18 `bootc` image was created.
+Verify that the local MicroShift `bootc` image was created:
 
 ```bash
 $ sudo podman images "${IMAGE_NAME}"
-REPOSITORY                       TAG         IMAGE ID      CREATED        SIZE
-localhost/microshift-4.18-bootc  latest      193425283c00  2 minutes ago  2.31 GB
+REPOSITORY                          TAG     IMAGE ID      CREATED        SIZE
+localhost/microshift-source-bootc   latest  193425283c00  2 minutes ago  2.89 GB
 ```
 
-### Push Image to Registry
+> To run this image directly as a `podman` container for fast development
+> turnaround — the quickest way to exercise a source build without installing it
+> on a host — see [Image Mode for MicroShift Contributors](../contributor/image_mode.md).
 
-Run the following commands to log into a remote registry and push the image to
-a remote registry.
+## Deploy the source-built image
 
-> The image from the remote registry can be used for running the container on
-> another host, or when installing a new operating system with the `bootc`
-> image layer.
+Publishing the image to a registry, preparing a Kickstart file, and installing the
+image into a virtual machine are identical for a source-built image and a released
+image. Rather than duplicate those procedures, follow the openshift-docs
+instructions and substitute your source-built image reference wherever a MicroShift
+image is required:
 
-```bash
-REGISTRY_URL=<myreg>
-REGISTRY_IMG=<myorg>/<mypath>/"${IMAGE_NAME}"
+* [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image) —
+  skip the "get a published image" step (you built the image locally above) and
+  push `localhost/microshift-source-bootc` to your remote registry.
+* [Running the bootc image in a virtual machine](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-running-bootc-image-vm) —
+  set the image reference used by the `ostreecontainer` Kickstart directive to your
+  source-built image (for example
+  `<myreg>/<myorg>/<mypath>/microshift-source-bootc`).
 
-sudo podman login "${REGISTRY_URL}"
-sudo podman push localhost/"${IMAGE_NAME}" "${REGISTRY_URL}/${REGISTRY_IMG}"
-```
-
-> Replace `<myreg>` with the URL to your remote registry, and `<myorg>/<mypath>`
-> with your organization name and path inside your remote registry.
-
-## Run MicroShift Bootc Virtual Machine
-
-Log into the `physical hypervisor host` using the user credentials that have
-SUDO permissions configured.
-
-### Prepare Kickstart File
-
-Set variables pointing to secret files that are included in `kickstart.ks` for
-gaining access to private container registries:
-* `AUTH_CONFIG` file contents are copied to `/etc/ostree/auth.json` at the
-pre-install stage to authenticate `<myreg>/<myorg>` registry access
-* `PULL_SECRET` file contents are copied to `/etc/crio/openshift-pull-secret`
-at the post-install stage to authenticate OpenShift registry access
-* `IMAGE_REF` variable contains the MicroShift bootc container image reference
-to be installed
-
-```bash
-AUTH_CONFIG=~/.registry-auth.json
-PULL_SECRET=~/.pull-secret.json
-IMAGE_REF="<myreg>/<myorg>/<mypath>/microshift-4.18-bootc"
-```
-
-> Replace `<myreg>` with the URL to your remote registry, and `<myorg>/<mypath>`
-> with your organization name and path inside your remote registry.
-
-> See the `containers-auth.json(5)` manual pages for more information on the
-> syntax of the `AUTH_CONFIG` registry authentication file.
-
-Run the following commands to create the `kickstart.ks` file to be used during
-the virtual machine installation.
-
-```bash
-cat > kickstart.ks <<EOFKS
-lang en_US.UTF-8
-keyboard us
-timezone UTC
-text
-reboot
-
-# Partition the disk with hardware-specific boot and swap partitions, adding an
-# LVM volume that contains a 10GB+ system root. The remainder of the volume will
-# be used by the CSI driver for storing data.
-zerombr
-clearpart --all --initlabel
-# Create boot and swap partitions as required by the current hardware platform
-reqpart --add-boot
-# Add an LVM volume group and allocate a system root logical volume
-part pv.01 --grow
-volgroup rhel pv.01
-logvol / --vgname=rhel --fstype=xfs --size=10240 --name=root
-
-# Lock root user account
-rootpw --lock
-
-# Configure network to use DHCP and activate on boot
-network --bootproto=dhcp --device=link --activate --onboot=on
-
-%pre-install --log=/dev/console --erroronfail
-
-# Create a 'bootc' image registry authentication file
-mkdir -p /etc/ostree
-cat > /etc/ostree/auth.json <<'EOF'
-$(cat "${AUTH_CONFIG}")
-EOF
-
-%end
-
-# Pull a 'bootc' image from a remote registry
-ostreecontainer --url "${IMAGE_REF}"
-
-%post --log=/dev/console --erroronfail
-
-# Create an OpenShift pull secret file
-cat > /etc/crio/openshift-pull-secret <<'EOF'
-$(cat "${PULL_SECRET}")
-EOF
-chmod 600 /etc/crio/openshift-pull-secret
-
-%end
-EOFKS
-```
-
-The kickstart file uses a special [ostreecontainer](https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#ostreecontainer)
-directive to pull a `bootc` image from the remote registry and use it to install
-the RHEL operating system.
-
-### Create Virtual Machine
-
-Download a RHEL boot ISO image from https://developers.redhat.com/products/rhel/download.
-Copy the downloaded file to the `/var/lib/libvirt/images` directory.
-
-Run the following commands to create a RHEL virtual machine with 2 cores, 2GB of
-RAM and 20GB of storage. The command uses the kickstart file prepared in the
-previous step to pull a `bootc` image from the remote registry and use it to install
-the RHEL operating system.
-
-```bash
-VMNAME=microshift-4.18-bootc
-NETNAME=default
-
-sudo virt-install \
-    --name ${VMNAME} \
-    --vcpus 2 \
-    --memory 2048 \
-    --disk path=/var/lib/libvirt/images/${VMNAME}.qcow2,size=20 \
-    --network network=${NETNAME},model=virtio \
-    --events on_reboot=restart \
-    --location /var/lib/libvirt/images/rhel-9.8-$(uname -m)-boot.iso \
-    --initrd-inject kickstart.ks \
-    --extra-args "inst.ks=file:/kickstart.ks" \
-    --wait
-```
-
-Log into the virtual machine using the `redhat:<password>` credentials.
-Run the following command to verify that all the MicroShift pods are up and running
-without errors.
-
-```bash
-watch sudo oc get pods -A \
-    --kubeconfig /var/lib/microshift/resources/kubeadmin/kubeconfig
-```
+The remaining sections cover workflows that are **not** part of the openshift-docs
+image mode documentation: building a self-contained installation ISO with
+`bootc-image-builder`, and embedding container images for offline installation.
 
 ## Using Bootc Image Builder (BIB)
 
@@ -298,7 +231,7 @@ EOFKS
 
 ```bash
 PULL_SECRET=~/.pull-secret.json
-IMAGE_NAME=microshift-4.18-bootc
+IMAGE_NAME=microshift-source-bootc
 
 mkdir ./output
 sudo podman run --authfile ${PULL_SECRET} --rm -it \
@@ -322,7 +255,7 @@ Run the following commands to copy the `./output/install.iso` file to the
 `/var/lib/libvirt/images` directory and create a virtual machine.
 
 ```bash
-VMNAME=microshift-4.18-bootc
+VMNAME=microshift-source-bootc
 NETNAME=default
 
 sudo cp -Z ./output/bootiso/install.iso /var/lib/libvirt/images/${VMNAME}.iso
@@ -375,7 +308,8 @@ curl -s -o Containerfile.embedded "${URL}"
 
 Run the following image build command to create a local `bootc` image with embedded
 container dependencies. It is using a base image built according to the instructions
-in the [Build Image](#build-image) section.
+in the [Build a MicroShift bootc image from source](#build-a-microshift-bootc-image-from-source)
+section.
 
 Note how secrets are used during the image build:
 * The podman `--authfile` argument is required to pull the base image from the
@@ -385,9 +319,9 @@ OpenShift container registries.
 
 ```bash
 PULL_SECRET=~/.pull-secret.json
-BASE_IMAGE_NAME=microshift-4.18-bootc
+BASE_IMAGE_NAME=microshift-source-bootc
 BASE_IMAGE_TAG=latest
-IMAGE_NAME=microshift-4.18-bootc-embedded
+IMAGE_NAME=microshift-source-bootc-embedded
 
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --secret "id=pullsecret,src=${PULL_SECRET}" \
@@ -396,12 +330,12 @@ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     -f Containerfile.embedded
 ```
 
-Verify that the local MicroShift 4.18 `bootc` image was created.
+Verify that the local MicroShift `bootc` image was created.
 
 ```bash
 $ sudo podman images "${IMAGE_NAME}"
-REPOSITORY                                TAG         IMAGE ID      CREATED             SIZE
-localhost/microshift-4.18-bootc-embedded  latest      6490d8f5752a  About a minute ago  3.75 GB
+REPOSITORY                                  TAG     IMAGE ID      CREATED             SIZE
+localhost/microshift-source-bootc-embedded  latest  6490d8f5752a  About a minute ago  3.75 GB
 ```
 
 ### Build Installation Image
@@ -409,7 +343,7 @@ localhost/microshift-4.18-bootc-embedded  latest      6490d8f5752a  About a minu
 Follow the instructions in [Create ISO Image Using BIB](#create-iso-image-using-bib)
 to build an ISO from the container image with embedded container dependencies.
 
-> Note: Make sure to set the `IMAGE_NAME` variable to `microshift-4.18-bootc-embedded`
+> Note: Make sure to set the `IMAGE_NAME` variable to `microshift-source-bootc-embedded`
 
 ### Prepare Kickstart File
 
@@ -420,7 +354,7 @@ gaining access to private container registries:
 
 ```bash
 PULL_SECRET=~/.pull-secret.json
-IMAGE_NAME=microshift-4.18-bootc-embedded
+IMAGE_NAME=microshift-source-bootc-embedded
 ```
 
 Run the following command to create the `kickstart.ks` file to be used during
@@ -500,7 +434,7 @@ sudo virsh net-autostart "${VM_ISOLATED_NETWORK}"
 
 ### Create Virtual Machine
 
-Follow the instructions in [Create Virtual Machine](#create-virtual-machine-1)
+Follow the instructions in [Create Virtual Machine](#create-virtual-machine)
 to bootstrap a virtual machine from the ISO with embedded container dependencies.
 
 > Note: Make sure to set the `NETNAME` variable to the `VM_ISOLATED_NETWORK`

--- a/docs/user/image_mode.md
+++ b/docs/user/image_mode.md
@@ -13,7 +13,7 @@ benefit from this technology.
 > for more information.
 
 > **Source of truth:**<br>
-> The [Installing with RHEL image mode](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-about-rhel-image-mode)
+> The [Installing with image mode for RHEL](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html-single/installing_with_image_mode_for_rhel/index)
 > chapter of the Red Hat build of MicroShift documentation is the authoritative
 > reference for building, publishing, and installing image mode systems using
 > **released** MicroShift RPMs.
@@ -25,9 +25,9 @@ benefit from this technology.
 > and virtual machine steps are identical and are linked below.
 
 > **Note:**<br>
-> The openshift-docs links in this document are pinned to version `4.19`. Use the
-> version selector on those pages to match the MicroShift release you are working
-> with.
+> The openshift-docs links in this document point to the `latest` version of the
+> documentation. Use the version selector on those pages to match the MicroShift
+> release you are working with.
 
 The procedures described below require the following setup:
 * A `RHEL 9.8 host` with an active Red Hat subscription for building MicroShift
@@ -155,7 +155,7 @@ image is required:
 * [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image) —
   skip the "get a published image" step (you built the image locally above) and
   push `localhost/microshift-source-bootc` to your remote registry.
-* [Running the bootc image in a virtual machine](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-running-bootc-image-vm) —
+* [Running the bootc image in a virtual machine](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-running-bootc-image-in-vm) —
   set the image reference used by the `ostreecontainer` Kickstart directive to your
   source-built image (for example
   `<myreg>/<myorg>/<mypath>/microshift-source-bootc`).
@@ -171,7 +171,7 @@ containerized tool to create disk images from bootc images. You can use the tool
 to generate various image artifacts and deploy them in different environments,
 such as the edge, server, and clouds.
 
-Log into the `RHEL 9.8 host` using the user credentials that have SUDO
+Log into the `RHEL 9.8 host` using the user credentials that have `sudo`
 permissions configured.
 
 ### Prepare Kickstart File
@@ -251,7 +251,7 @@ sudo podman run --authfile ${PULL_SECRET} --rm -it \
 
 ### Create Virtual Machine
 
-Run the following commands to copy the `./output/install.iso` file to the
+Run the following commands to copy the `./output/bootiso/install.iso` file to the
 `/var/lib/libvirt/images` directory and create a virtual machine.
 
 ```bash
@@ -294,17 +294,11 @@ external dependencies on startup.
 
 ### Build Container Image
 
-Download the [Containerfile.embedded](../config/Containerfile.bootc-embedded-rhel9) using
-the following command and use it for subsequent image builds.
+Use the [Containerfile.bootc-embedded-rhel9](../config/Containerfile.bootc-embedded-rhel9)
+Containerfile from a clone of this repository for the embedded image build.
 
-```bash
-URL=https://raw.githubusercontent.com/openshift/microshift/refs/heads/main/docs/config/Containerfile.bootc-embedded-rhel9
-
-curl -s -o Containerfile.embedded "${URL}"
-```
-
-> Review comments in the `Containerfile.embedded` file to understand how container
-> dependencies are embedded during the `bootc` image build.
+> Review the comments in the `Containerfile.bootc-embedded-rhel9` file to understand
+> how container dependencies are embedded during the `bootc` image build.
 
 Run the following image build command to create a local `bootc` image with embedded
 container dependencies. It is using a base image built according to the instructions
@@ -327,7 +321,8 @@ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     --secret "id=pullsecret,src=${PULL_SECRET}" \
     --build-arg USHIFT_BASE_IMAGE_NAME="${BASE_IMAGE_NAME}" \
     --build-arg USHIFT_BASE_IMAGE_TAG="${BASE_IMAGE_TAG}" \
-    -f Containerfile.embedded
+    -f docs/config/Containerfile.bootc-embedded-rhel9 \
+    .
 ```
 
 Verify that the local MicroShift `bootc` image was created.

--- a/docs/user/image_mode.md
+++ b/docs/user/image_mode.md
@@ -16,7 +16,7 @@ image in a remote registry and use it for installing a new RHEL operating system
 for more information.
 
 The procedures described below require the following setup:
-* A `RHEL 9.6 host` with an active Red Hat subscription for building MicroShift `bootc`
+* A `RHEL 9.8 host` with an active Red Hat subscription for building MicroShift `bootc`
 images. For development purposes, you can use the [Red Hat Developer subscription](https://developers.redhat.com/products/rhel/download),
 which is free of charge.
 * A `hypervisor host` with a virtualization technology that supports RHEL. In
@@ -26,7 +26,7 @@ an example.
 
 ## Build MicroShift Bootc Image
 
-Log into the `RHEL 9.6 host` using the user credentials that have SUDO
+Log into the `RHEL 9.8 host` using the user credentials that have SUDO
 permissions configured.
 
 ### Build Image
@@ -75,8 +75,8 @@ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
 
 > **Important:**<br>
 > If `dnf upgrade` command is used in the container image build procedure, it
-> may cause unintended operating system version upgrade (e.g. from `9.6` to
-> `9.6`). To prevent this from happening, use the following command instead.
+> may cause unintended operating system version upgrade (e.g. from `9.8` to
+> `9.8`). To prevent this from happening, use the following command instead.
 > ```
 > RUN . /etc/os-release && dnf upgrade -y --releasever="${VERSION_ID}"
 > ```
@@ -216,7 +216,7 @@ sudo virt-install \
     --disk path=/var/lib/libvirt/images/${VMNAME}.qcow2,size=20 \
     --network network=${NETNAME},model=virtio \
     --events on_reboot=restart \
-    --location /var/lib/libvirt/images/rhel-9.6-$(uname -m)-boot.iso \
+    --location /var/lib/libvirt/images/rhel-9.8-$(uname -m)-boot.iso \
     --initrd-inject kickstart.ks \
     --extra-args "inst.ks=file:/kickstart.ks" \
     --wait
@@ -238,7 +238,7 @@ containerized tool to create disk images from bootc images. You can use the tool
 to generate various image artifacts and deploy them in different environments,
 such as the edge, server, and clouds.
 
-Log into the `RHEL 9.6 host` using the user credentials that have SUDO
+Log into the `RHEL 9.8 host` using the user credentials that have SUDO
 permissions configured.
 
 ### Prepare Kickstart File

--- a/docs/user/image_mode.md
+++ b/docs/user/image_mode.md
@@ -13,7 +13,7 @@ benefit from this technology.
 > for more information.
 
 > **Source of truth:**<br>
-> The [Installing with RHEL image mode](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-about-rhel-image-mode)
+> The [Installing with RHEL image mode](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-about-rhel-image-mode)
 > chapter of the Red Hat build of MicroShift documentation is the authoritative
 > reference for building, publishing, and installing image mode systems using
 > **released** MicroShift RPMs.
@@ -152,10 +152,10 @@ image. Rather than duplicate those procedures, follow the openshift-docs
 instructions and substitute your source-built image reference wherever a MicroShift
 image is required:
 
-* [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-bootc-image) —
+* [Installing and publishing a bootc image to a registry](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-bootc-image) —
   skip the "get a published image" step (you built the image locally above) and
   push `localhost/microshift-source-bootc` to your remote registry.
-* [Running the bootc image in a virtual machine](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/installing_with_rhel_image_mode/microshift-install-running-bootc-image-vm) —
+* [Running the bootc image in a virtual machine](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html/installing_with_image_mode_for_rhel/microshift-install-running-bootc-image-vm) —
   set the image reference used by the `ostreecontainer` Kickstart directive to your
   source-built image (for example
   `<myreg>/<myorg>/<mypath>/microshift-source-bootc`).

--- a/docs/user/image_mode.md
+++ b/docs/user/image_mode.md
@@ -109,7 +109,8 @@ Unlike the released Containerfile, it:
 Note how secrets are used during the image build:
 * The podman `--authfile` argument is required to pull the base image from the
 `registry.redhat.io` registry
-* The build `USER_PASSWD` argument is used to set a password for the `redhat` user
+* The build secret `user_passwd` is used to set a password for the `redhat` user
+without exposing it in image metadata
 
 Run the following command, using `_output/rpmbuild/RPMS` as the build context so
 the local repository is available to the build:
@@ -120,7 +121,7 @@ USER_PASSWD="<your_redhat_user_password>"
 IMAGE_NAME=microshift-source-bootc
 
 sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
-    --build-arg USER_PASSWD="${USER_PASSWD}" \
+    --secret id=user_passwd,env=USER_PASSWD \
     -f docs/config/Containerfile.bootc-source-rhel9 \
     _output/rpmbuild/RPMS
 ```


### PR DESCRIPTION
## [USHIFT-4304](https://redhat.atlassian.net/browse/USHIFT-4304): Rework image mode documentation for source builds

Reworks the in-repo image mode docs so they cover deploying **MicroShift from the latest source code** via bootc image mode, and delegate the shared publish / kickstart / VM steps to the authoritative [openshift-docs](https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/latest/html-single/installing_with_image_mode_for_rhel/index) instead of duplicating them.

JIRA: https://issues.redhat.com/browse/USHIFT-4304

### What changed

- **New `docs/config/Containerfile.bootc-source-rhel9`** — builds a bootc image from locally-built source RPMs (`make rpm` → `createrepo_c` → a local `file://` repo). Non-RHEL runtime dependencies (cri-o, cri-tools, openshift-clients, openvswitch) come from the OpenShift dependencies mirror that matches the source tree (`RHOCP_MINOR_Y_BETA` in `test/bin/common_versions.sh`). It does **not** enable `rhocp`/`fast-datapath`, since those carry released RPMs, not source.
- **`docs/user/image_mode.md`** — retitled *"Image Mode for MicroShift (from source)"*. Adds the build-from-source recipe, delegates publish/kickstart/VM to openshift-docs, and keeps the topics unique to source/offline users: bootc-image-builder (BIB) self-contained ISO, embedding container images for offline installs, and the isolated libvirt network.
- **`docs/contributor/image_mode.md`** — contributor dev loop against the **source** image: configure CNI/CSI, run as a privileged podman container, verify pods; plus the multi-arch manifest and rpm-ostree → image-mode upgrade appendices.
- **`docs/config/Containerfile.bootc-rhel9`** (released-RPM variant) bumped to RHEL 9.8 / MicroShift 4.22.
- openshift-docs links updated to the renamed book `installing_with_image_mode_for_rhel` using the version-proof `/latest/` path (no hardcoded version).
- Review fixes: relocated the `hadolint ignore=SC1091` directive in the source Containerfile so it covers the correct `RUN`, and aligned mismatched openshift-docs link text between the user and contributor docs.

### Verification

- `make verify` passes (includes the containerfile hadolint check via `ghcr.io/hadolint/hadolint:2.12.0`).
- All version references (RHEL 9.8, MicroShift 4.22 released / 5.0 dev, `5.0-el9-beta` deps mirror) reconciled against `test/bin/common_versions.sh`.
- Docs-only change: no `pkg/config`, no rebase-managed files (`vendor/`, `deps/`, `assets/`, `pkg/release/*`, Makefile version vars); not a new optional component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building a MicroShift bootable container image from locally built source RPMs.
  - Added a RHEL 9.8-based source-build image configuration.
- **Documentation**
  - Updated Image Mode guides for source-based builds on RHEL 9.8.
  - Revised image names, build commands, paths, and multi-architecture instructions.
  - Linked publishing and registry instructions to the external OpenShift documentation.
  - Updated references to the latest MicroShift version and bootable container image procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->