### PR TITLE
[release-5.0] NO-ISSUE: Update crel mirror to ocp for rc.0 and GITOPS_VERSION to 1.21

### DIFF
--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -93,7 +93,7 @@ fi
 #
 # For a release branch, the current release repository should come from the
 # official 'rhocp' stream.
-CURRENT_RELEASE_REPO="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/microshift/ocp-dev-preview/latest-5.0/el9/os"
+CURRENT_RELEASE_REPO="https://mirror.openshift.com/pub/openshift-v5/${UNAME_M}/microshift/ocp/latest-5.0/el9/os"
 CURRENT_RELEASE_VERSION="$(get_vrel_from_beta "${CURRENT_RELEASE_REPO}")"
 export CURRENT_RELEASE_REPO
 export CURRENT_RELEASE_VERSION

--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -158,7 +158,7 @@ export CNCF_SONOBUOY_VERSION=v0.57.3
 export CNCF_SYSTEMD_LOGS_VERSION=v0.4
 
 # The current version of the microshift-gitops package.
-export GITOPS_VERSION=1.19
+export GITOPS_VERSION=1.21
 
 # The brew release versions needed for release regression testing
 BREW_Y0_RELEASE_VERSION="$(get_vrel_from_rpm "${BREW_RPM_SOURCE}/${MAJOR_VERSION}.${MINOR_VERSION}-zstream/${UNAME_M}/")"


### PR DESCRIPTION
## Summary
- Update `CURRENT_RELEASE_REPO` from `ocp-dev-preview/latest-5.0` to `ocp/latest-5.0` — the cri-o package was rebranded from 1.36.x to 5.0.0, making ec.6 RPMs on the dev-preview mirror unsatisfiable
- Update `GITOPS_VERSION` from `1.19` to `1.21` — the upstream GitOps repo advanced to 1.21

## Test plan
- [x] Verified rc.0 RPMs exist on the `ocp/latest-5.0` mirror for both x86_64 and aarch64
- [x] e2e-aws-tests-cache (x86) passed
- [x] e2e-aws-tests-cache-arm passed