### PR TITLE
[release-5.0] NO-ISSUE: Update GITOPS_VERSION from 1.19 to 1.21

### DIFF
--- a/test/bin/common_versions.sh
+++ b/test/bin/common_versions.sh
@@ -158,7 +158,7 @@ export CNCF_SONOBUOY_VERSION=v0.57.3
 export CNCF_SYSTEMD_LOGS_VERSION=v0.4
 
 # The current version of the microshift-gitops package.
-export GITOPS_VERSION=1.19
+export GITOPS_VERSION=1.21
 
 # The brew release versions needed for release regression testing
 BREW_Y0_RELEASE_VERSION="$(get_vrel_from_rpm "${BREW_RPM_SOURCE}/${MAJOR_VERSION}.${MINOR_VERSION}-zstream/${UNAME_M}/")"


### PR DESCRIPTION
## Summary
- Update `GITOPS_VERSION` from `1.19` to `1.21` in `common_versions.sh`
- The upstream GitOps repo advanced to 1.21, causing the `manage_common_versions.sh verify` step to reject the stale 1.19 value when `common_versions.sh` is modified

## Test plan
- [x] e2e-aws-tests-cache (x86) passed with this change
- [x] e2e-aws-tests-cache-arm passed with this change