### PR TITLE
[release-5.0] NO-ISSUE: Fix OVN failure after hostname change in cleanup script

### DIFF
--- a/scripts/microshift-cleanup-data.sh
+++ b/scripts/microshift-cleanup-data.sh
@@ -107,6 +107,11 @@ function clean_processes() {
         for pname in conmon pause ovn-controller ovn-northd ; do
             pkill -9 --exact ${pname} || true
         done
+        # OVS must be restarted to clear stale flow state left by the
+        # stopped ovsdb-server, otherwise OVN cannot reinitialize on
+        # the next MicroShift start.
+        echo Restarting openvswitch service
+        systemctl restart openvswitch.service 2>/dev/null || true
     fi
 }
 

--- a/test/suites/standard1/hostname.robot
+++ b/test/suites/standard1/hostname.robot
@@ -13,7 +13,7 @@ Test Tags           restart    slow
 
 
 *** Variables ***
-${NEW_HOSTNAME}     microshift.local
+${NEW_HOSTNAME}     microshift-test.example
 ${OLD_HOSTNAME}     ${EMPTY}
 
 
@@ -29,7 +29,7 @@ Verify Local Host Name
     Should Contain    ${hostname}    standard
 
 Verify Local Host Name Resolution
-    [Documentation]    Verify correct host name resolution through mDNS
+    [Documentation]    Verify MicroShift restarts correctly after a hostname change
     [Setup]    Configure New Hostname
 
     Named Deployment Should Be Available    router-default    timeout=${DEFAULT_WAIT_TIMEOUT}    ns=openshift-ingress


### PR DESCRIPTION
## Summary

Manual backport of #7302 to release-5.0.

- **Restart openvswitch service after OVN cleanup** in `microshift-cleanup-data.sh`. The script was stopping `ovsdb-server` without restarting the `openvswitch` service, leaving `ovs-vswitchd` running without its database. This stale OVS state prevented OVN from reinitializing on the next MicroShift start, causing all pods to get stuck in `FailedCreatePodSandBox`.
- **Change hostname test from `.local` to `.example`**. The `.local` TLD is reserved for mDNS (RFC 6762) and can cause DNS interference with OVN initialization, especially on systems with Avahi/systemd-resolved.

## Root Cause

Found during RC.0 release testing ([PR #7284](https://github.com/openshift/microshift/pull/7284)). The hostname RF test (`suites/standard1/hostname.robot`) was failing in all release scenarios that use optional images (`*-lrel-optional`). The failure chain:

1. Test changes hostname to `microshift.local` and calls `microshift-cleanup-data --all --keep-images`
2. Cleanup script stops `ovsdb-server.service` (line 106) but never restarts `openvswitch.service`
3. `ovs-vswitchd` continues running without its database
4. MicroShift starts, `microshift.service` has `Wants=openvswitch.service` — if systemd considers it still "active", it won't restart it
5. OVN-Kubernetes fails: on RPM (`error clearing stale ovs flow targets`), on bootc (readiness probe returns empty)
6. CNI conf `/etc/cni/net.d/10-ovn-kubernetes.conf` is never created → all pods stuck in `FailedCreatePodSandBox`
7. With optional components installed (~20 workloads), the 600s healthcheck timeout is exceeded

This was masked in non-release scenarios because those use images without optional components — fewer workloads meant the system could recover in time despite the stale OVS state.

## Test plan

- [ ] Verify hostname RF test passes in `standard1` scenarios with optional images
- [ ] Verify `microshift-cleanup-data --all` followed by `systemctl start microshift` results in healthy OVN
- [ ] Verify no regression in non-release standard1 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)