### PR TITLE
[release-5.0] NO-ISSUE: Disable journald rate limiting in logging test

### DIFF
--- a/test/resources/systemd.resource
+++ b/test/resources/systemd.resource
@@ -85,3 +85,21 @@ Systemctl Daemon Reload
     ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
     Log Many    ${stdout}    ${stderr}
     Should Be Equal As Integers    0    ${rc}
+
+Disable Journal Rate Limiting
+    [Documentation]    Disable journald rate limiting by writing a drop-in that
+    ...    sets RateLimitBurst=0, then restarting the journal service.
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    printf '[Journal]\nRateLimitBurst=0\n' > /etc/systemd/journald.conf.d/disable-ratelimit.conf && systemctl restart systemd-journald
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    Log Many    ${stdout}    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+
+Enable Journal Rate Limiting
+    [Documentation]    Re-enable default journald rate limiting by removing the
+    ...    drop-in created by Disable Journal Rate Limiting.
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    rm -f /etc/systemd/journald.conf.d/disable-ratelimit.conf && systemctl restart systemd-journald
+    ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
+    Log Many    ${stdout}    ${stderr}
+    Should Be Equal As Integers    0    ${rc}

--- a/test/suites/configuration2/logging.robot
+++ b/test/suites/configuration2/logging.robot
@@ -4,6 +4,7 @@ Documentation       Tests for case-insensitive log level parsing
 Resource            ../../resources/common.resource
 Resource            ../../resources/microshift-config.resource
 Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/systemd.resource
 Library             ../../resources/journalctl.py
 
 Suite Setup         Setup
@@ -29,10 +30,12 @@ Setup
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig
+    Disable Journal Rate Limiting
 
 Teardown
     [Documentation]    Test suite teardown
     Remove Drop In MicroShift Config    10-loglevel
+    Enable Journal Rate Limiting
     Restart MicroShift
     Logout MicroShift Host
     Remove Kubeconfig


### PR DESCRIPTION
## Summary
Backport of https://github.com/openshift/microshift/pull/7304 to release-5.0.

- The "Case Insensitive Log Levels" RF test fails on ARM when testing `TraceAll` because klog verbosity 10 generates ~144K journal messages, exceeding journald's default rate limit (10K messages / 30s). The suppressed messages include the startup config dump line (`logLevel.*TraceAll`) that the test greps for via `journalctl --grep`, making the assertion impossible to satisfy.
- Adds `Disable Journal Rate Limiting` / `Enable Journal Rate Limiting` keywords to `systemd.resource` that write/remove a journald drop-in with `RateLimitBurst=0` and restart the journal service.
- Scopes the fix to the logging suite only: disables rate limiting in suite setup and re-enables in teardown.

## Test plan
- [ ] Verify the logging test passes on ARM with `TraceAll` (was the failing case)
- [ ] Verify the logging test still passes for `normal`, `Debug`, `TRACE` levels
- [ ] Verify journald rate limiting is re-enabled after the test suite completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)