### PR TITLE
[release-5.0] OCPBUGS-120720: Wire monitoring rebase into automated rebase pipeline

### DIFF
--- a/scripts/auto-rebase/rebase_job_entrypoint.sh
+++ b/scripts/auto-rebase/rebase_job_entrypoint.sh
@@ -88,6 +88,10 @@ SRIOV_RELEASE=${sriov_release} \
 OPM_RELEASE=${opm_release} \
 ./scripts/auto-rebase/rebase.py
 
+# Monitoring images (metrics-server, kube-state-metrics, node-exporter) are
+# part of the OCP release payload and must be rebased with every nightly.
+./scripts/auto-rebase/rebase_cluster_monitoring_operator.sh to "${PULLSPEC_RELEASE_AMD64}" "${PULLSPEC_RELEASE_ARM64}"
+
 # LVMS is not tracked in the OCP release image. Instead, rely on the
 # latest z-stream for a given X.Y version. Only the X.Y needs manual
 # updating between releases.


### PR DESCRIPTION
## Summary

- Backport of main PR: adds `rebase_cluster_monitoring_operator.sh` call to `rebase_job_entrypoint.sh` so monitoring images (metrics-server, kube-state-metrics, node-exporter) are updated on every automated rebase
- The rebase script already exists and is fully functional (added in [USHIFT-6951](https://redhat.atlassian.net/browse/USHIFT-6951)) but was never wired into the automated pipeline
- Monitoring images have been stuck on the June 19 nightly (`5.0.0-0.nightly-2026-06-19-155631`) since [USHIFT-6951](https://redhat.atlassian.net/browse/USHIFT-6951) was merged — 73 days stale
- This caused the `optional-sigstore` CI scenario to fail on all 4 bootc release jobs in PR #7284 (RC.0 release testing) because the stale images lack sigstore signatures or have been garbage collected

## Test plan

- [ ] Verify the rebase job runs `rebase_cluster_monitoring_operator.sh` successfully
- [ ] Verify monitoring image references in `assets/optional/{metrics-server,kube-state-metrics,node-exporter}/` are updated to the current nightly after a rebase
- [ ] Verify `optional-sigstore` scenario passes with updated images

🤖 Generated with [Claude Code](https://claude.com/claude-code)