### PR TITLE
NO-ISSUE: Reduce release scenario parallelism to avoid resource exhaustion

### DIFF
--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -114,7 +114,7 @@ elif [[ "${SCENARIO_SOURCES}" =~ .*releases.* ]]; then
     # from 1 into 5) and no longer fit if every scenario's VMs stay up for
     # the whole job. Shut down passed scenarios' VMs as they finish so the
     # hypervisor only ever holds the still-running scenarios' VMs.
-    jobs_arg="-j 20"
+    jobs_arg="-j 16"
     scenario_action="create-run-shutdown"
 fi
 


### PR DESCRIPTION
## Summary
- Reduce GNU parallel `-j 20` to `-j 16` for release scenario jobs to prevent `/tmp` disk exhaustion and compute resource contention on c5.metal instances

## Test plan
- [ ] Release CI jobs complete without `/tmp` disk full errors
- [ ] No node NotReady events from resource contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release scenario test runs now use a maximum of 16 parallel jobs instead of 20, helping improve stability during automated validation. Scenario selection and execution behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->