### PR TITLE
NO-ISSUE: Increase greenboot and robot timeouts for release scenarios

### DIFF
--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -116,6 +116,12 @@ elif [[ "${SCENARIO_SOURCES}" =~ .*releases.* ]]; then
     # hypervisor only ever holds the still-running scenarios' VMs.
     jobs_arg="-j 20"
     scenario_action="create-run-shutdown"
+    # Release scenarios run upgrade paths with LVMS workloads followed by
+    # full standard suites, which need more time than the default 30m robot
+    # timeout and 600s greenboot healthcheck — especially under I/O
+    # contention when many VMs boot and pull images in parallel.
+    export GREENBOOT_TIMEOUT=1200
+    export TEST_EXECUTION_TIMEOUT=60m
 fi
 
 TEST_OK=true

--- a/test/scenarios-bootc/el10/releases/el102-lrel@optional-sigstore.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@optional-sigstore.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Enable container signature verification for current release images,
 # including the optional components.
 # These are ec / rc / z-stream, thus must all to be signed.

--- a/test/scenarios-bootc/el10/releases/el102-lrel@optional.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@optional.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el10/releases/el102@rpm-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102@rpm-standard.sh
@@ -13,9 +13,6 @@ export SKIP_GREENBOOT=true
 # did not want to spend the resources on a new VM.
 export TEST_RANDOMIZATION=none
 
-# Add extra timeout because it run both standard1 and standard2 suites.
-export TEST_EXECUTION_TIMEOUT=60m
-
 scenario_create_vms() {
     exit_if_brew_rpms_not_found
 

--- a/test/scenarios-bootc/el9/releases/el98-lrel@optional-sigstore.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@optional-sigstore.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Enable container signature verification for current release images,
 # including the optional components.
 # These are ec / rc / z-stream, thus must all to be signed.

--- a/test/scenarios-bootc/el9/releases/el98-lrel@optional.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@optional.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere


### PR DESCRIPTION
## Summary

- Increase greenboot healthcheck timeout from 600s (10 min) to 1200s (20 min) for release scenarios
- Increase Robot Framework test execution timeout from the CI-configured 45m to 60m for release scenarios
- Both changes are scoped to release scenarios only via `ci_phase_boot_and_test.sh`

## Context

Release scenarios running upgrade paths with LVMS workloads followed by full standard suites
were hitting timeout limits under I/O contention on x86 (`c5.metal`, 4750 Mbps EBS bandwidth)
when many VMs boot and pull container images from the mirror registry in parallel. The ARM
instance (`m7g.metal`, 20000 Mbps EBS) has ~4.2x more I/O bandwidth and doesn't hit these limits.

Specific failures observed in PR #7297:
- `el96-y2@el98-lrel@lvms-standard1/2`: greenboot healthcheck failed — pods not ready within 600s
- `el98-y1@el98-lrel@lvms-standard`: Robot Framework killed by SIGTERM at 45m (44/52 tests had passed)

These timeouts are ceilings, not floors — greenboot polls and exits immediately when pods are ready,
and robot finishes whenever tests complete. The happy-path duration is unaffected.

The el10 lvms-standard scenarios and the `optional` scenario already set these values per-scenario.
This change centralizes them for all release scenarios in `ci_phase_boot_and_test.sh`.

Counterpart of https://github.com/openshift/microshift/pull/7318 for release-5.0.

## Test plan

- [ ] Verify release CI jobs pass with the new timeouts
- [ ] Confirm non-release scenarios (presubmits, periodics, c2cc) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized release-scenario timing by applying a 20-minute system startup allowance and a 60-minute test execution limit.
  * Removed scenario-specific timeout overrides so release tests use the shared timing configuration consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->