### PR TITLE
NO-ISSUE: skip CAPI IPAM test incompatible with MicroShift

### DIFF
--- a/origin/skip.txt
+++ b/origin/skip.txt
@@ -216,3 +216,4 @@
 "[sig-node] ContainerTerminationMetrics Validation should report terminated_containers_total metric"
 "[sig-api-machinery] health handlers should contain necessary checks [Suite:openshift/conformance/parallel] [Suite:k8s]"
 "[sig-api-machinery] health handlers should contain necessary checks"
+"[OTP][Jira:OCPCLOUD][sig-cluster-lifecycle] Cluster_Infrastructure CAPI IPAM should have IPAM CRDs installed"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an Origin skip entry for the Cluster Infrastructure CAPI IPAM test when the required IPAM CRDs are not installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->