### PR TITLE
USHIFT-7412: address review feedback in configure_rpm_scenario

### DIFF
--- a/test/bin/scenario.sh
+++ b/test/bin/scenario.sh
@@ -1335,9 +1335,19 @@ configure_fast_datapath_repo() {
 configure_rpm_scenario() {
     local -r vmname="$1"
     local -r rhel_version="$2"
-    local -r reponame=$(basename "${LOCAL_REPO}")
+
+    if [[ -z "${LOCAL_REPO}" ]]; then
+        echo "ERROR: LOCAL_REPO is not set" >&2
+        return 1
+    fi
+
+    local reponame
+    reponame=$(basename "${LOCAL_REPO}")
+    local -r reponame
     local -r repo_url="${WEB_SERVER_URL}/rpm-repos/${reponame}"
-    local -r target_version=$(local_rpm_version)
+    local target_version
+    target_version=$(local_rpm_version)
+    local -r target_version
 
     configure_vm_firewall "${vmname}"
     subscription_manager_register "${vmname}"


### PR DESCRIPTION
## Summary

Follow-up to #7175 addressing review feedback from @copejon:

- **SC2155 fix**: Split `local` declaration from command substitution for `reponame` and `target_version` so that `set -e` properly catches failures instead of `local` masking the exit code
- **Empty `LOCAL_REPO` guard**: Fail early with an error if `LOCAL_REPO` is empty, preventing `basename ""` from returning `.` and producing a bogus `rpm-repos/.` URL that would cause dnf 404 errors

## Test plan

- [ ] Verify shellcheck passes on `test/bin/scenario.sh` (confirmed locally)
- [ ] CI presubmit jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scenario validation when a local repository is not configured.
  * Added a clearer diagnostic message to help identify missing repository configuration.
  * Updated setup handling to ensure repository and target version values are initialized consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->