### PR TITLE
[release-5.0] NO-ISSUE: Test and script fixes found during 5.0.0-rc.0 testing

### DIFF
--- a/test/bin/ci_phase_boot_and_test.sh
+++ b/test/bin/ci_phase_boot_and_test.sh
@@ -116,9 +116,12 @@ elif [[ "${SCENARIO_SOURCES}" =~ .*releases.* ]]; then
     # hypervisor only ever holds the still-running scenarios' VMs.
     jobs_arg="-j 20"
     scenario_action="create-run-shutdown"
-
-    # Give release scenarios a longer per-scenario execution timeout since
-    # many now run both the standard1 and standard2 suites.
+    # Release scenarios run upgrade paths with LVMS workloads followed by
+    # full standard suites (many now run both standard1 and standard2), which
+    # need more time than the default 30m robot timeout and 600s greenboot
+    # healthcheck — especially under I/O contention when many VMs boot and
+    # pull images in parallel.
+    export GREENBOOT_TIMEOUT=1200
     export TEST_EXECUTION_TIMEOUT=60m
 fi
 

--- a/test/resources/journalctl.py
+++ b/test/resources/journalctl.py
@@ -1,6 +1,7 @@
 from robot.libraries.BuiltIn import BuiltIn
 
 import libostree
+import re
 import time
 
 _log = BuiltIn().log
@@ -27,28 +28,55 @@ def get_journal_cursor(unit="microshift") -> str:
     return cursor
 
 
-def get_log_output_with_pattern(cursor: str, pattern: str, unit="microshift") -> tuple[str, int]:
+def get_log_output_with_pattern(cursor: str, pattern: str, unit="microshift", exceptions=None) -> tuple[str, int]:
     """
     Get the logs since the cursor matching the pattern and return the log content and exit code.
     Optional argument `unit` may be used to specify a systemd unit other than microshift,
     for example microshift-observability.service.
     Note that this function ignores case when matching the pattern.
+
+    Optional argument `exceptions` is a list of regular expressions describing
+    known-benign log lines to ignore. Matching lines are dropped from the
+    result; if every matched line is an exception, the return code is
+    downgraded to 1 (no relevant match) so callers treat it as "not found".
     """
     stdout, rc = libostree.remote_sudo_rc(
         f"journalctl -u {unit} --cursor='{cursor}' --no-pager --case-sensitive=false --grep '{pattern}'"
     )
+    if exceptions and rc == 0:
+        matched = [line for line in stdout.splitlines() if line.strip()]
+        remaining = [
+            line for line in matched
+            if not any(re.search(exc, line, re.IGNORECASE) for exc in exceptions)
+        ]
+        dropped = len(matched) - len(remaining)
+        if dropped:
+            # Make the suppression visible: a benign exception that turns
+            # persistent (e.g. a ServiceAccount that never lands) would
+            # otherwise be masked silently.
+            BuiltIn().log(
+                f"Ignored {dropped} known-benign '{pattern}' line(s) via exceptions", "WARN"
+            )
+        if not remaining:
+            # All matches were known-benign exceptions; report no relevant match.
+            rc = 1
+        stdout = "\n".join(remaining)
     BuiltIn().log(f"log lines matching '{pattern}':\n{stdout}")
     return stdout, rc
 
 
-def pattern_should_not_appear_in_log_output(cursor, pattern, unit="microshift", retries=30, wait=10):
-    """Get the logs since the cursor and verify that the pattern does not appear."""
+def pattern_should_not_appear_in_log_output(cursor, pattern, unit="microshift", retries=30, wait=10, exceptions=None):
+    """Get the logs since the cursor and verify that the pattern does not appear.
+
+    Optional argument `exceptions` is a list of regular expressions describing
+    known-benign log lines that should not count as a match.
+    """
     # The grep argument causes journalctl to exit with an error if the
     # pattern is not found, therefore we want the return code to be 1,
     # indicating that there was no match.
 
     for attempt in range(1, retries + 2):
-        stdout, rc = get_log_output_with_pattern(cursor, pattern, unit)
+        stdout, rc = get_log_output_with_pattern(cursor, pattern, unit, exceptions)
         if rc == 1 or attempt > retries:
             BuiltIn().should_be_equal_as_integers(rc, 1)
             return

--- a/test/resources/kubeconfig.resource
+++ b/test/resources/kubeconfig.resource
@@ -92,6 +92,21 @@ Create Random Namespace
     RETURN    test-${rand}
 
 Remove Namespace
-    [Documentation]    Removes the given namespace.
+    [Documentation]    Removes the given namespace and waits until it is actually
+    ...    gone so a subsequent test can safely reuse the name. The delete
+    ...    tolerates failure (allow_fail) so a slow deletion killed at the Run
+    ...    With Kubeconfig process timeout under load does not fail the teardown.
     [Arguments]    ${ns}
-    Run With Kubeconfig    oc delete namespace ${ns}
+    Run With Kubeconfig    oc delete namespace ${ns}    allow_fail=True
+    Wait Until Keyword Succeeds    5m    5s    Namespace Should Not Exist    ${ns}
+
+Namespace Should Not Exist
+    [Documentation]    Fails unless the namespace is reported NotFound, so that a
+    ...    transient API error (which also exits non-zero) is not mistaken for a
+    ...    successful deletion.
+    [Arguments]    ${ns}
+    ${stdout}    ${rc}=    Run With Kubeconfig    oc get namespace ${ns}
+    ...    allow_fail=True    return_rc=True
+    Should Not Be Equal As Integers    ${rc}    0    Namespace ${ns} still exists
+    Should Contain    ${stdout}    NotFound
+    ...    msg=oc get namespace ${ns} failed for a reason other than NotFound: ${stdout}

--- a/test/resources/systemd.resource
+++ b/test/resources/systemd.resource
@@ -85,3 +85,27 @@ Systemctl Daemon Reload
     ...    sudo=True    return_stdout=True    return_stderr=True    return_rc=True
     Log Many    ${stdout}    ${stderr}
     Should Be Equal As Integers    0    ${rc}
+
+Disable Journal Rate Limiting
+    [Documentation]    Disable journald rate limiting by writing a drop-in that
+    ...    sets RateLimitBurst=0, then restarting the journal service.
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    bash -c "mkdir -p /etc/systemd/journald.conf.d && printf '[Journal]\nRateLimitBurst=0\n' > /etc/systemd/journald.conf.d/disable-ratelimit.conf && systemctl restart systemd-journald"
+    ...    sudo=True
+    ...    return_stdout=True
+    ...    return_stderr=True
+    ...    return_rc=True
+    Log Many    ${stdout}    ${stderr}
+    Should Be Equal As Integers    0    ${rc}
+
+Enable Journal Rate Limiting
+    [Documentation]    Re-enable default journald rate limiting by removing the
+    ...    drop-in created by Disable Journal Rate Limiting.
+    ${stdout}    ${stderr}    ${rc}=    Execute Command
+    ...    bash -c "rm -f /etc/systemd/journald.conf.d/disable-ratelimit.conf && systemctl restart systemd-journald"
+    ...    sudo=True
+    ...    return_stdout=True
+    ...    return_stderr=True
+    ...    return_rc=True
+    Log Many    ${stdout}    ${stderr}
+    Should Be Equal As Integers    0    ${rc}

--- a/test/scenarios-bootc/el10/releases/el102-lrel@ginkgo-tests.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@ginkgo-tests.sh
@@ -11,7 +11,7 @@ scenario_create_vms() {
     fi
 
     prepare_kickstart host1 kickstart-bootc.ks.template "${start_image}"
-    launch_vm rhel102-bootc --vm_vcpus 4
+    launch_vm rhel102-bootc --vm_disksize 30 --vm_vcpus 4
 }
 
 scenario_remove_vms() {

--- a/test/scenarios-bootc/el10/releases/el102-lrel@optional-sigstore.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@optional-sigstore.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Enable container signature verification for current release images,
 # including the optional components.
 # These are ec / rc / z-stream, thus must all to be signed.

--- a/test/scenarios-bootc/el10/releases/el102-lrel@optional.sh
+++ b/test/scenarios-bootc/el10/releases/el102-lrel@optional.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@lvms-standard.sh
@@ -6,9 +6,6 @@
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none
 
-# Add extra timeout because it runs both standard1 and standard2 suites.
-export TEST_EXECUTION_TIMEOUT=60m
-
 start_image="rhel102-bootc-brew-y1-with-optional"
 dest_image="rhel102-bootc-brew-lrel-optional"
 

--- a/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@rpm-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102-y1@el102-lrel@rpm-standard.sh
@@ -13,8 +13,6 @@ export SKIP_GREENBOOT=true
 # did not want to spend the resources on a new VM.
 export TEST_RANDOMIZATION=none
 
-export TEST_EXECUTION_TIMEOUT=60m
-
 scenario_create_vms() {
     exit_if_brew_rpms_not_found
 

--- a/test/scenarios-bootc/el10/releases/el102@rpm-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el102@rpm-standard.sh
@@ -13,9 +13,6 @@ export SKIP_GREENBOOT=true
 # did not want to spend the resources on a new VM.
 export TEST_RANDOMIZATION=none
 
-# Add extra timeout because it run both standard1 and standard2 suites.
-export TEST_EXECUTION_TIMEOUT=60m
-
 scenario_create_vms() {
     exit_if_brew_rpms_not_found
 

--- a/test/scenarios-bootc/el10/releases/el98-y1@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-y1@el102-lrel@lvms-standard.sh
@@ -6,9 +6,6 @@
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none
 
-# Add extra timeout because it runs both standard1 and standard2 suites.
-export TEST_EXECUTION_TIMEOUT=60m
-
 start_image="rhel98-bootc-brew-y1-with-optional"
 dest_image="rhel102-bootc-brew-lrel-optional"
 

--- a/test/scenarios-bootc/el10/releases/el98-y2@el102-lrel@lvms-standard.sh
+++ b/test/scenarios-bootc/el10/releases/el98-y2@el102-lrel@lvms-standard.sh
@@ -6,9 +6,6 @@
 # ensure MicroShift is upgraded before running validation tests
 export TEST_RANDOMIZATION=none
 
-# Add extra timeout because it runs both standard1 and standard2 suites.
-export TEST_EXECUTION_TIMEOUT=60m
-
 start_image="rhel98-bootc-brew-y2-with-optional"
 dest_image="rhel102-bootc-brew-lrel-optional"
 

--- a/test/scenarios-bootc/el9/releases/el98-lrel@optional-sigstore.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@optional-sigstore.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Enable container signature verification for current release images,
 # including the optional components.
 # These are ec / rc / z-stream, thus must all to be signed.

--- a/test/scenarios-bootc/el9/releases/el98-lrel@optional.sh
+++ b/test/scenarios-bootc/el9/releases/el98-lrel@optional.sh
@@ -2,15 +2,6 @@
 
 # Sourced from scenario.sh and uses functions defined there.
 
-# Each optional suite restarts MicroShift with its own kustomizePaths config,
-# adding ~10 minutes of restart overhead to the total execution time.
-# shellcheck disable=SC2034  # used elsewhere
-TEST_EXECUTION_TIMEOUT=60m
-
-# shellcheck disable=SC2034  # used elsewhere
-# Increase greenboot timeout for optional packages (more services to start)
-GREENBOOT_TIMEOUT=1200
-
 # Redefine network-related settings to use the dedicated network bridge
 VM_BRIDGE_IP="$(get_vm_bridge_ip "${VM_MULTUS_NETWORK}")"
 # shellcheck disable=SC2034  # used elsewhere

--- a/test/suites/ai-model-serving/ai-model-serving-online.robot
+++ b/test/suites/ai-model-serving/ai-model-serving-online.robot
@@ -48,7 +48,10 @@ Deploy OpenVINO Serving Runtime
     ...    /usr/lib/microshift/manifests.d/050-microshift-ai-model-serving-runtimes/ovms-kserve.yaml
     ...    ${OVMS_KSERVE_MANIFEST}
     Local Command Should Work    sed -i "s,image: ovms-image,image: ${ovms_image}," "${OVMS_KSERVE_MANIFEST}"
-    Oc Apply    -n ${NAMESPACE} -f ${OVMS_KSERVE_MANIFEST}
+    # Retry until the kserve validating webhook has endpoints; a bare apply
+    # fails if the webhook pod is not serving yet.
+    Wait Until Keyword Succeeds    15x    2s
+    ...    Oc Apply    -n ${NAMESPACE} -f ${OVMS_KSERVE_MANIFEST}
 
 Deploy OpenVINO Resnet Model
     [Documentation]    Deploys InferenceService object to create Deployment and Service to serve the model.

--- a/test/suites/configuration2/logging.robot
+++ b/test/suites/configuration2/logging.robot
@@ -4,6 +4,7 @@ Documentation       Tests for case-insensitive log level parsing
 Resource            ../../resources/common.resource
 Resource            ../../resources/microshift-config.resource
 Resource            ../../resources/microshift-process.resource
+Resource            ../../resources/systemd.resource
 Library             ../../resources/journalctl.py
 
 Suite Setup         Setup
@@ -29,10 +30,12 @@ Setup
     Check Required Env Variables
     Login MicroShift Host
     Setup Kubeconfig
+    Disable Journal Rate Limiting
 
 Teardown
     [Documentation]    Test suite teardown
     Remove Drop In MicroShift Config    10-loglevel
+    Enable Journal Rate Limiting
     Restart MicroShift
     Logout MicroShift Host
     Remove Kubeconfig

--- a/test/suites/otp-workloads/statefulset-pvc.robot
+++ b/test/suites/otp-workloads/statefulset-pvc.robot
@@ -24,6 +24,10 @@ Custom Label For PVC In StatefulSets
     ...    OCP-28018
     [Setup]    Create StatefulSet Resources
 
+    # The StatefulSet controller creates pod-0 asynchronously; wait for it to
+    # exist before checking readiness, since `oc wait` on a named pod fails
+    # immediately if the pod is not created yet.
+    Wait Until Resource Exists    pod    ${POD_NAME}    ns=${NAMESPACE}
     Named Pod Should Be Ready    ${POD_NAME}    ns=${NAMESPACE}    timeout=5m
     Wait Until Keyword Succeeds    60s    5s
     ...    PVC Should Have Label    ${PVC_NAME}    ${NAMESPACE}    app    hello-pod

--- a/test/suites/standard1/hostname.robot
+++ b/test/suites/standard1/hostname.robot
@@ -13,7 +13,7 @@ Test Tags           restart    slow
 
 
 *** Variables ***
-${NEW_HOSTNAME}     microshift.local
+${NEW_HOSTNAME}     microshift-test.example
 ${OLD_HOSTNAME}     ${EMPTY}
 
 
@@ -29,7 +29,7 @@ Verify Local Host Name
     Should Contain    ${hostname}    standard
 
 Verify Local Host Name Resolution
-    [Documentation]    Verify correct host name resolution through mDNS
+    [Documentation]    Verify MicroShift restarts correctly after a hostname change
     [Setup]    Configure New Hostname
 
     Named Deployment Should Be Available    router-default    timeout=${DEFAULT_WAIT_TIMEOUT}    ns=openshift-ingress

--- a/test/suites/standard2/log-scan.robot
+++ b/test/suites/standard2/log-scan.robot
@@ -13,25 +13,34 @@ Test Tags           restart    slow
 
 
 *** Variables ***
-${CURSOR}       ${EMPTY}    # The journal cursor before restarting MicroShift
+${CURSOR}                   ${EMPTY}    # Journal cursor for the current boot; set by Boot And Scan Journal
+
+# Known-benign "forbidden" log lines to ignore during the log scan.
+# On a fresh/clean start the cert-manager operator creates the cainjector,
+# controller and webhook Deployments and their ServiceAccounts dynamically.
+# The kube-controller-manager ReplicaSet controller can briefly try to create
+# a pod before the matching ServiceAccount is observed, logging a transient
+# "forbidden: error looking up service account" that it retries away once the
+# SA lands. These pods are operator-managed (not MicroShift manifests), so the
+# ordering is not under MicroShift's control and this is a benign startup race.
+@{FORBIDDEN_EXCEPTIONS}
+...                         is forbidden: error looking up service account cert-manager/[^ ]+: serviceaccount .* not found
 
 
 *** Test Cases ***
 Log Scan
-    [Documentation]    Run log scan tests in a specific order.
-    # Clean up and enable MicroShift to start from scratch
+    [Documentation]    Scan the journal of a clean first boot and then of a
+    ...    restart. Both boots are checked, but the "forbidden" check runs only
+    ...    on the restart: a clean first boot logs a benign "forbidden" while
+    ...    components initialize (see ${FORBIDDEN_EXCEPTIONS}), whereas a restart
+    ...    must be free of it.
     Cleanup MicroShift    --all    --keep-images
     Enable MicroShift
 
-    ${cursor}=    Get Journal Cursor
-    VAR    ${CURSOR}=    ${cursor}    scope=SUITE
-    # Start, stop and check logs after clean startup
-    Start Stop And Check Logs    check_forbidden=False
-
-    ${cursor}=    Get Journal Cursor
-    VAR    ${CURSOR}=    ${cursor}    scope=SUITE
-    # Restart, stop and check logs
-    Start Stop And Check Logs
+    # Clean first boot: skip the forbidden check.
+    Boot And Scan Journal    check_forbidden=False
+    # Restart: forbidden messages must not reappear.
+    Boot And Scan Journal
 
 
 *** Keywords ***
@@ -48,16 +57,25 @@ Teardown
     Logout MicroShift Host
     Remove Kubeconfig
 
-Start Stop And Check Logs
-    [Documentation]    Start, wait until initialized, stop and check for errors.
+Boot And Scan Journal
+    [Documentation]    Record the journal cursor, start MicroShift, wait until it
+    ...    is initialized, stop it, and scan this boot's journal for wanted and
+    ...    unwanted messages.
     [Arguments]    ${check_forbidden}=True
+    ${cursor}=    Get Journal Cursor
+    VAR    ${CURSOR}=    ${cursor}    scope=SUITE
     Start MicroShift
     Setup Kubeconfig
 
     Wait For MicroShift Healthcheck Success
     Stop MicroShift
 
-    # Note: The 'forbidden' messages appear on clean startup
+    Scan Boot Journal    check_forbidden=${check_forbidden}
+
+Scan Boot Journal
+    [Documentation]    Assert this boot's journal contains the expected readiness
+    ...    messages and none of the unwanted ones.
+    [Arguments]    ${check_forbidden}=True
     IF    ${check_forbidden}    Should Not Find Forbidden
     Should Not Find Cannot Patch Resource
     Services Should Not Timeout When Stopping
@@ -65,8 +83,9 @@ Start Stop And Check Logs
     Should Find MicroShift Is Ready
 
 Should Not Find Forbidden
-    [Documentation]    Logs should not say "forbidden"
-    Pattern Should Not Appear In Log Output    ${CURSOR}    forbidden
+    [Documentation]    Logs should not say "forbidden", excluding known-benign
+    ...    startup races listed in ${FORBIDDEN_EXCEPTIONS}.
+    Pattern Should Not Appear In Log Output    ${CURSOR}    forbidden    exceptions=${FORBIDDEN_EXCEPTIONS}
 
 Should Not Find Cannot Patch Resource
     [Documentation]    Logs should not say "cannot patch resource"


### PR DESCRIPTION
## Summary

Backport of #7326 to `release-5.0`. A consolidation of test-harness and CI fixes discovered while running the 5.0.0-rc.0 release test suites. All changes are test/CI-only (no product code): they address CI flakes and failures — resource exhaustion, teardown cascades, log-scan false positives, timeout limits, and asynchronous-resource races.

Parent PR (main): openshift/microshift#7326 — the commits here are identical to that PR, rebased onto `release-5.0`.

## Changes

- **Namespace teardowns**: `Remove Namespace` now deletes with `allow_fail=True` (matching the existing repo idiom) and polls until the namespace is actually gone — asserting a real `NotFound` — so a slow deletion killed at the 300s process timeout no longer cascades into a suite-teardown failure, while still guaranteeing the name is free for reuse.
- **Release scenario timeouts**: centralize `GREENBOOT_TIMEOUT=1200` and `TEST_EXECUTION_TIMEOUT=60m` in `ci_phase_boot_and_test.sh` for release scenarios and remove the now-redundant per-scenario overrides.
- **ginkgo VM disk**: restore `--vm_disksize 30` for the ginkgo scenario, whose storage specs exhaust the topolvm VG at the 20GB default.
- **log-scan cert-manager race**: allowlist the benign, transient cert-manager ServiceAccount "forbidden" startup race in the standard2 Log Scan test (a scoped, namespace-specific regex; genuine `forbidden` regressions still fail), and clarify the double-boot test with a `Boot And Scan Journal` keyword.
- **journald rate limiting**: disable journald rate limiting for the logging suite (drop-in wrapped in `bash -c` for correct sudo redirection, with `mkdir -p` for self-containment) so high-verbosity log output isn't dropped.
- **hostname test**: use the reserved `.example` TLD instead of `.local` to avoid mDNS interference.
- **flaky async-resource waits**: `statefulset-pvc` waits for the StatefulSet pod to exist before the readiness check, and `ai-model-serving-online` retries the kserve `ServingRuntime` apply until the validating webhook has endpoints.

## Testing

- Robot Framework suites lint clean (robocop check + format).
- Python helper (`journalctl.py`) passes flake8; shell scripts pass shellcheck.
- Validated against the 5.0.0-rc.0 release jobs where these failures were originally observed (arm/x86 el9/el10 release scenarios).
