### PR TITLE
USHIFT-7499: Ansible: fix service-account lookup

### DIFF
--- a/ansible/roles/microshift-start/tasks/main.yml
+++ b/ansible/roles/microshift-start/tasks/main.yml
@@ -94,7 +94,8 @@
     reboot: false
 
 - name: create service account task(s)
-  include_tasks: roles/create-service-account/tasks/main.yml
+  ansible.builtin.include_role:
+    name: create-service-account
 
 - name: finish pbench capture
   become: yes


### PR DESCRIPTION
MicroShift deployment fails when `microshift-start` copies `metrics-sa.yaml`: #7185 moved the manifest into the `create-service-account` role's `files/` directory, but the caller still includes its task file directly, retaining the parent role's file lookup context.

Invoke `create-service-account` through `ansible.builtin.include_role` so Ansible finds the manifest in that role's own directory.

Validation: a local Ansible harness reproduced the original missing-file failure and passed with the corrected include using the real role and a mocked `oc`. The playbook syntax check, focused `ansible-lint --profile min`, and `git diff --check` passed. Live VM and CI rehearsal validation remain outstanding; the scratch VM was shut off when checked.

Jira: https://redhat.atlassian.net/browse/USHIFT-7499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated service account setup handling during MicroShift startup.
  - No changes to exported interfaces or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->