### PR TITLE
USHIFT-7501: Stop openvswitch after OVN cleanup in microshift-cleanup-data

### DIFF
--- a/scripts/microshift-cleanup-data.sh
+++ b/scripts/microshift-cleanup-data.sh
@@ -107,6 +107,10 @@ function clean_processes() {
         for pname in conmon pause ovn-controller ovn-northd ; do
             pkill -9 --exact ${pname} || true
         done
+        # Stop OVS so the stale flow state left by the stopped ovsdb-server is cleared,
+        # otherwise OVN cannot reinitialize on the next MicroShift start.
+        systemctl stop openvswitch.service \
+            || echo "WARN: failed to stop openvswitch.service; stale OVS flow state may persist" >&2
     fi
 }
 


### PR DESCRIPTION
## Summary

After `microshift-cleanup-data --all` (or `--ovn`) stops `ovsdb-server` and kills the OVN processes, `ovs-vswitchd` is left running without its database, leaving stale OVS datapath/flow state. On the next MicroShift start, `ovnkube-node` fatals during init while clearing stale OVS flow targets:

```
failed to init default node network controller: error clearing stale ovs flow targets: "exit status 1"
```

`ovnkube-node` then crash-loops, never writes the node chassis / gateway config, and every pod is stuck `FailedCreatePodSandBox` / `NetworkPluginNotReady` until the healthcheck times out.

## Fix

Stop `openvswitch.service` after the OVN process cleanup in `clean_processes()`, so the stale OVS state is cleared. The next MicroShift start brings `openvswitch` back up via `microshift.service`'s `Wants=` and `microshift-ovs-init.service`'s `Requires=`, giving OVN a clean slate to reinitialize. Unlike the best-effort kills above, a real stop failure here has a correctness impact, so it is surfaced (WARN to stderr) rather than discarded.

The underlying fragility — `ovnkube-node` treating the `ovs-vsctl` failure as fatal — is upstream ovn-kubernetes; this change removes the precondition on the MicroShift side.

## Where observed

Intermittently under heavy full-optional load, e.g. the `el98-lrel@optional` release scenario (MicroShift 5.0.0-rc.0 testing). Also implicated in the intermittent `standard1` Hostname `Verify MicroShift restarts correctly` flake, which exercises the same clean-data + restart + healthcheck path.

## Testing

Not unit-testable in isolation — reproduction requires a running cluster where `microshift-cleanup-data --all` + restart is followed by OVN reinit under load. Mechanism confirmed from ovnkube-node logs and the OVS service dependency graph. Will validate via CI e2e once the PR runs.

## Jira

https://issues.redhat.com/browse/USHIFT-7501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup now stops the Open vSwitch service after terminating OVN-related processes.
  * A warning appears if the service cannot be stopped, indicating that stale flow state may remain.
  * Cleanup results now provide clearer visibility into any residual networking state requiring follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->