### PR TITLE
USHIFT-7500: Recreate metrics-server serving cert when service-ca leaves it missing

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -247,6 +247,21 @@ func certSetup(cfg *config.Config) (*certchains.CertificateChains, error) {
 					"route-controller-manager.openshift-route-controller-manager.svc.cluster.local",
 				},
 			},
+			// Serving cert for metrics-server. Normally the service-ca operator
+			// generates the "metrics-server-tls" secret from the serving-cert
+			// annotation on the Service, but if that secret is lost it is not
+			// always regenerated (USHIFT-7500). Minting it from the same
+			// service-CA lets MicroShift recreate the secret as a safety net.
+			&certchains.ServingCertificateSigningRequestInfo{
+				CSRMeta: certchains.CSRMeta{
+					Name:     "metrics-server-serving",
+					Validity: alignValidity(cryptomaterial.ShortLivedCertificateValidity),
+				},
+				Hostnames: []string{
+					"metrics-server.openshift-monitoring.svc",
+					"metrics-server.openshift-monitoring.svc.cluster.local",
+				},
+			},
 		),
 
 		certchains.NewCertificateSigner(

--- a/pkg/components/metrics.go
+++ b/pkg/components/metrics.go
@@ -145,7 +145,77 @@ func ProvisionMetricsServerCerts(ctx context.Context, cfg *config.Config) error 
 		return fmt.Errorf("applying kubelet serving CA configmap: %w", err)
 	}
 
+	if err := ensureMetricsServerServingCert(ctx, clientset, certsDir); err != nil {
+		return fmt.Errorf("ensuring metrics-server serving cert: %w", err)
+	}
+
 	klog.Infof("Provisioned metrics-server kubelet client cert and CA bundle")
+	return nil
+}
+
+// ensureMetricsServerServingCert makes sure the metrics-server serving cert
+// secret ("metrics-server-tls") exists. In normal operation the service-ca
+// operator generates it from the serving-cert annotation on the metrics-server
+// Service. However, if that secret is lost (e.g. after a data cleanup / restart
+// storm) the operator does not always regenerate it, leaving metrics-server
+// stuck ContainerCreating and the metrics.k8s.io APIService unavailable
+// (USHIFT-7500). As a safety net, mint the serving cert from MicroShift's
+// service-CA when the secret is missing.
+//
+// The secret is only created when absent so we do not fight the operator in the
+// normal case: both sign with the same service-CA, so whichever cert is present
+// is valid against the service-CA bundle the operator injects into the
+// APIService.
+func ensureMetricsServerServingCert(ctx context.Context, clientset kubernetes.Interface, certsDir string) error {
+	const servingSecretName = "metrics-server-tls"
+
+	_, err := clientset.CoreV1().Secrets(metricsNamespace).Get(ctx, servingSecretName, metav1.GetOptions{})
+	if err == nil {
+		klog.V(2).Infof("Secret %s/%s already exists, leaving it to the service-ca operator", metricsNamespace, servingSecretName)
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("getting secret %s/%s: %w", metricsNamespace, servingSecretName, err)
+	}
+
+	servingDir := cryptomaterial.MetricsServerServingCertDir(certsDir)
+	certPEM, err := os.ReadFile(cryptomaterial.ServingCertPath(servingDir))
+	if err != nil {
+		return err
+	}
+	keyPEM, err := os.ReadFile(cryptomaterial.ServingKeyPath(servingDir))
+	if err != nil {
+		return err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      servingSecretName,
+			Namespace: metricsNamespace,
+			Annotations: map[string]string{
+				"openshift.io/owning-component": "metrics-server",
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": certPEM,
+			"tls.key": keyPEM,
+		},
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, createErr := clientset.CoreV1().Secrets(metricsNamespace).Create(ctx, secret, metav1.CreateOptions{})
+		if createErr != nil && !apierrors.IsAlreadyExists(createErr) {
+			klog.Errorf("creating metrics-server serving cert secret: %v", createErr)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("creating metrics-server serving cert secret: %w", err)
+	}
+
+	klog.Infof("Provisioned metrics-server serving cert secret %s/%s (service-ca operator secret was missing)", metricsNamespace, servingSecretName)
 	return nil
 }
 

--- a/pkg/util/cryptomaterial/certinfo.go
+++ b/pkg/util/cryptomaterial/certinfo.go
@@ -104,6 +104,10 @@ func RouteControllerManagerServingCertDir(certsDir string) string {
 	return filepath.Join(ServiceCADir(certsDir), "route-controller-manager-serving")
 }
 
+func MetricsServerServingCertDir(certsDir string) string {
+	return filepath.Join(ServiceCADir(certsDir), "metrics-server-serving")
+}
+
 func IngressCADir(certsDir string) string {
 	return filepath.Join(certsDir, "ingress-ca")
 }


### PR DESCRIPTION
## Summary

In normal operation the service-ca operator generates the metrics-server serving cert secret (`metrics-server-tls` in `openshift-monitoring`) from the `service.beta.openshift.io/serving-cert-secret-name` annotation on the metrics-server Service. After a data cleanup / restart storm the secret can be **lost and not regenerated** by the operator. metrics-server then stays `ContainerCreating` (cannot mount `metrics-server-tls`), the `metrics.k8s.io/v1beta1` aggregated APIService returns 503, and — because API discovery is then incomplete — the namespace controller can no longer finalize **any** namespace (namespaces stuck `Terminating`).

## Fix

Add a MicroShift-side safety net that reuses the PKI machinery MicroShift already has:

- **`pkg/cmd/init.go`** — add a `metrics-server-serving` serving certificate to the existing `service-ca` signer, with SANs `metrics-server.openshift-monitoring.svc[.cluster.local]` (mirrors the existing `route-controller-manager-serving` cert).
- **`pkg/util/cryptomaterial/certinfo.go`** — add `MetricsServerServingCertDir`.
- **`pkg/components/metrics.go`** — in `ProvisionMetricsServerCerts` (already provisions the metrics-server kubelet client cert + CA bundle from MicroShift's PKI on every startup), also create the `metrics-server-tls` secret from the new serving material **only when it is missing**.

Creating the secret only when absent avoids fighting the operator in the normal case: both sign with the **same** service-CA, so whichever cert is present validates against the CA bundle the operator injects into the APIService. In the failure case (secret lost, operator not regenerating), MicroShift recreates it and metrics-server / `metrics.k8s.io` recover, unblocking namespace GC.

## Scope / caveat

The root cause is upstream **service-ca-operator** not regenerating a deleted serving-cert secret; this PR is a MicroShift-side mitigation, not the upstream fix.

## Where observed

`el98-lrel@dual-stack-configuration1` release scenario during MicroShift 5.0.0-rc.0 testing (the dual-stack test restarts MicroShift; afterwards a namespace teardown hung for 10+ minutes because `metrics.k8s.io` was 503).

## Testing

- `gofmt` clean; `GOOS=linux go build` and `go vet` pass on the changed packages; `go test ./pkg/util/cryptomaterial/...` passes.
- Runtime behavior (secret recreated after loss → metrics-server recovers → namespace GC unblocks) is not unit-reproducible; it requires a cluster where the secret is deleted and the operator does not regenerate it. To be validated in CI e2e.

## Jira

https://issues.redhat.com/browse/USHIFT-7500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure serving certificates for the metrics server, including coverage for its service DNS names.
  - The metrics server now provisions and maintains its TLS Secret automatically.
  - Existing TLS Secrets are preserved, while transient creation issues are retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->