### PR TITLE
NO-ISSUE: align statefulset/log-scan tests with the main-branch versions

### DIFF
--- a/test/suites/otp-workloads/statefulset-pvc.robot
+++ b/test/suites/otp-workloads/statefulset-pvc.robot
@@ -13,8 +13,8 @@ Suite Teardown      Teardown Suite
 
 *** Variables ***
 ${STATEFULSET_YAML}     ./assets/otp-workloads/statefulset-pvc.yaml
+${STATEFULSET_NAME}     hello-statefulset
 ${PVC_NAME}             www-hello-statefulset-0
-${POD_NAME}             hello-statefulset-0
 
 
 *** Test Cases ***
@@ -24,11 +24,8 @@ Custom Label For PVC In StatefulSets
     ...    OCP-28018
     [Setup]    Create StatefulSet Resources
 
-    # The StatefulSet controller creates pod-0 asynchronously; wait for it to
-    # exist before checking readiness, since `oc wait` on a named pod fails
-    # immediately if the pod is not created yet.
-    Wait Until Resource Exists    pod    ${POD_NAME}    ns=${NAMESPACE}
-    Named Pod Should Be Ready    ${POD_NAME}    ns=${NAMESPACE}    timeout=5m
+    Command Should Work
+    ...    microshift healthcheck --namespace ${NAMESPACE} --statefulsets ${STATEFULSET_NAME} --timeout 5m
     Wait Until Keyword Succeeds    60s    5s
     ...    PVC Should Have Label    ${PVC_NAME}    ${NAMESPACE}    app    hello-pod
 

--- a/test/suites/standard2/log-scan.robot
+++ b/test/suites/standard2/log-scan.robot
@@ -13,7 +13,7 @@ Test Tags           restart    slow
 
 
 *** Variables ***
-${CURSOR}                   ${EMPTY}    # Journal cursor for the current boot; set by Boot And Scan Journal
+${CURSOR}                   ${EMPTY}    # Journal cursor for the current service startup; set by Service Startup And Scan Journal
 
 # Known-benign "forbidden" log lines to ignore during the log scan.
 # On a fresh/clean start the cert-manager operator creates the cainjector,
@@ -29,18 +29,18 @@ ${CURSOR}                   ${EMPTY}    # Journal cursor for the current boot; s
 
 *** Test Cases ***
 Log Scan
-    [Documentation]    Scan the journal of a clean first boot and then of a
-    ...    restart. Both boots are checked, but the "forbidden" check runs only
-    ...    on the restart: a clean first boot logs a benign "forbidden" while
-    ...    components initialize (see ${FORBIDDEN_EXCEPTIONS}), whereas a restart
-    ...    must be free of it.
+    [Documentation]    Scan the journal of a clean first service startup and then
+    ...    of a restart. Both service startups are checked, but the "forbidden"
+    ...    check runs only on the restart: a clean first service startup logs a
+    ...    benign "forbidden" while components initialize (see
+    ...    ${FORBIDDEN_EXCEPTIONS}), whereas a restart must be free of it.
     Cleanup MicroShift    --all    --keep-images
     Enable MicroShift
 
-    # Clean first boot: skip the forbidden check.
-    Boot And Scan Journal    check_forbidden=False
+    # Clean first service startup: skip the forbidden check.
+    Service Startup And Scan Journal    check_forbidden=False
     # Restart: forbidden messages must not reappear.
-    Boot And Scan Journal
+    Service Startup And Scan Journal
 
 
 *** Keywords ***
@@ -57,10 +57,10 @@ Teardown
     Logout MicroShift Host
     Remove Kubeconfig
 
-Boot And Scan Journal
+Service Startup And Scan Journal
     [Documentation]    Record the journal cursor, start MicroShift, wait until it
-    ...    is initialized, stop it, and scan this boot's journal for wanted and
-    ...    unwanted messages.
+    ...    is initialized, stop it, and scan this service startup's journal for
+    ...    wanted and unwanted messages.
     [Arguments]    ${check_forbidden}=True
     ${cursor}=    Get Journal Cursor
     VAR    ${CURSOR}=    ${cursor}    scope=SUITE
@@ -70,11 +70,11 @@ Boot And Scan Journal
     Wait For MicroShift Healthcheck Success
     Stop MicroShift
 
-    Scan Boot Journal    check_forbidden=${check_forbidden}
+    Scan Service Startup Journal    check_forbidden=${check_forbidden}
 
-Scan Boot Journal
-    [Documentation]    Assert this boot's journal contains the expected readiness
-    ...    messages and none of the unwanted ones.
+Scan Service Startup Journal
+    [Documentation]    Assert this service startup's journal contains the expected
+    ...    readiness messages and none of the unwanted ones.
     [Arguments]    ${check_forbidden}=True
     IF    ${check_forbidden}    Should Not Find Forbidden
     Should Not Find Cannot Patch Resource


### PR DESCRIPTION
## Summary

The test/script consolidation PR merged to `release-5.0` (#7327) before two follow-up refinements landed on its `main`-branch equivalent (#7326). This brings those two refinements to `release-5.0` so the branches stay consistent. Test-only.

## Changes

- **`otp-workloads/statefulset-pvc.robot`** — wait for the StatefulSet via `microshift healthcheck --namespace ${NAMESPACE} --statefulsets hello-statefulset --timeout 5m` instead of the `oc wait` on a named pod (`Wait Until Resource Exists` + `Named Pod Should Be Ready`). Cleaner and uses the product healthcheck directly (`--statefulsets` is supported on release-5.0, `pkg/cmd/healthcheck.go`). Renames `${POD_NAME}` → `${STATEFULSET_NAME}`.
- **`standard2/log-scan.robot`** — rename `Boot And Scan Journal` → `Service Startup And Scan Journal` and `Scan Boot Journal` → `Scan Service Startup Journal` (plus wording), since the test restarts the MicroShift service rather than rebooting the host.

## Testing

- robocop check + format clean on both suites.

## Notes

Backport of the delta between #7326 (main) and the already-merged #7327 (release-5.0).
